### PR TITLE
Bugfix in mcscf.addons.project_init_guess

### DIFF
--- a/pyscf/mcscf/addons.py
+++ b/pyscf/mcscf/addons.py
@@ -356,7 +356,7 @@ def project_init_guess(casscf, init_mo, prev_mol=None):
 
     def project(mfmo, init_mo, ncore, s):
         s_init_mo = numpy.einsum('pi,pi->i', init_mo.conj(), s.dot(init_mo))
-        if abs(s_init_mo - 1).max() < 1e-7:
+        if abs(s_init_mo - 1).max() < 1e-7 and mfmo.shape[1] == init_mo.shape[1]:
             # Initial guess orbitals are orthonormal
             return init_mo
 # TODO: test whether the canonicalized orbitals are better than the projected orbitals


### PR DESCRIPTION
Checks completeness of projected orbitals, as well as orthonormality.
Certain basis set hierarchies like ANO-RCC-VnZP are subsets of each
other with the same primitives and generate orthonormal orbitals when
projected into higher n, but still need additional virtuals constructed.

See attached example.  Without this fix, the output is
```
Oxygen atom mo array shapes:
Dunning double-zeta: (23, 23)
Dunning triple-zeta: (46, 46)
ANO double-zeta: (14, 14)
ANO triple-zeta: (30, 14)
Oxygen atom CASSCF(6,4) energies:
Dunning double-zeta: -74.70961017094967
Dunning triple-zeta: -74.72629113960565
ANO double-zeta: -74.72141327634483
ANO triple-zeta: -74.72141327634485
```
 
The triple-zeta basis is effectively reduced to the double-zeta basis in the calculation because 16 MOs have been thrown away by project_init_guess.  With the fix, the output becomes

```
Oxygen atom mo array shapes:
Dunning double-zeta: (23, 23)
Dunning triple-zeta: (46, 46)
ANO double-zeta: (14, 14)
ANO triple-zeta: (30, 30)
Oxygen atom CASSCF(6,4) energies:
Dunning double-zeta: -74.70961017101496
Dunning triple-zeta: -74.72629113959913
ANO double-zeta: -74.72141327643462
ANO triple-zeta: -74.72475690201102
```

[Oatom_mcscf_project_example.zip](https://github.com/pyscf/pyscf/files/2818600/Oatom_mcscf_project_example.zip)


