### PR TITLE
Dev

### DIFF
--- a/pyscf/cc/gintermediates.py
+++ b/pyscf/cc/gintermediates.py
@@ -223,6 +223,8 @@ def get_t3p2_imds_slow(cc, t1, t2, eris=None, t3p2_ip_out=None, t3p2_ea_out=None
 
     ccsd_energy = cc.energy(t1, t2, eris)
     dtype = np.result_type(t1, t2)
+    if np.issubdtype(dtype, np.dtype(complex).type):
+        logger.error(cc, 't3p2 imds has not been strictly checked for use with complex integrals')
 
     if t3p2_ip_out is None:
         t3p2_ip_out = np.zeros((nocc,nvir,nocc,nocc), dtype=dtype)

--- a/pyscf/cc/rintermediates.py
+++ b/pyscf/cc/rintermediates.py
@@ -260,7 +260,7 @@ def get_t3p2_imds_slow(cc, t1, t2, eris=None, t3p2_ip_out=None, t3p2_ea_out=None
     fvv = fock[nocc:, nocc:].diagonal()
     dtype = np.result_type(t1, t2)
     if np.issubdtype(dtype, np.dtype(complex).type):
-        logger.warn(cc, 't3p2 imds has not been strictly checked for use with complex integrals')
+        logger.error(cc, 't3p2 imds has not been strictly checked for use with complex integrals')
 
     mo_e_o = eris.mo_energy[:nocc]
     mo_e_v = eris.mo_energy[nocc:]

--- a/pyscf/cc/rintermediates.py
+++ b/pyscf/cc/rintermediates.py
@@ -259,7 +259,7 @@ def get_t3p2_imds_slow(cc, t1, t2, eris=None, t3p2_ip_out=None, t3p2_ea_out=None
     foo = fock[:nocc, :nocc].diagonal()
     fvv = fock[nocc:, nocc:].diagonal()
     dtype = np.result_type(t1, t2)
-    if np.issubdtype(dtype, np.complex):
+    if np.issubdtype(dtype, np.dtype(complex).type):
         logger.warn(cc, 't3p2 imds has not been strictly checked for use with complex integrals')
 
     mo_e_o = eris.mo_energy[:nocc]

--- a/pyscf/cc/rintermediates.py
+++ b/pyscf/cc/rintermediates.py
@@ -259,14 +259,16 @@ def get_t3p2_imds_slow(cc, t1, t2, eris=None, t3p2_ip_out=None, t3p2_ea_out=None
     foo = fock[:nocc, :nocc].diagonal()
     fvv = fock[nocc:, nocc:].diagonal()
     dtype = np.result_type(t1, t2)
+    if np.issubdtype(dtype, np.complex):
+        logger.warn(cc, 't3p2 imds has not been strictly checked for use with complex integrals')
 
     mo_e_o = eris.mo_energy[:nocc]
     mo_e_v = eris.mo_energy[nocc:]
 
     ovov = _cp(eris.ovov)
     ovvv = _cp(eris.get_ovvv())
-    eris_vvov = eris.get_ovvv().conj().transpose(1,3,0,2)
-    eris_vooo = eris.ovoo[:].conj().transpose(1,0,3,2)
+    eris_vvov = eris.get_ovvv().conj().transpose(1,3,0,2)  # Physicist notation
+    eris_vooo = eris.ovoo[:].conj().transpose(1,0,3,2)  # Chemist notation
 
     ccsd_energy = cc.energy(t1, t2, eris)
     dtype = np.result_type(t1, t2)
@@ -280,7 +282,7 @@ def get_t3p2_imds_slow(cc, t1, t2, eris=None, t3p2_ip_out=None, t3p2_ea_out=None
     Wcbej = t3p2_ea_out
 
     tmp_t3  = np.einsum('abif,kjcf->ijkabc', eris_vvov, t2)
-    tmp_t3 -= np.einsum('aijm,mkbc->ijkabc', eris_vooo, t2)
+    tmp_t3 -= np.einsum('aimj,mkbc->ijkabc', eris_vooo, t2)
 
     tmp_t3 = (tmp_t3 + tmp_t3.transpose(0,2,1,3,5,4)
                      + tmp_t3.transpose(1,0,2,4,3,5)

--- a/pyscf/cc/test/test_eom_gccsd.py
+++ b/pyscf/cc/test/test_eom_gccsd.py
@@ -237,11 +237,11 @@ class KnownValues(unittest.TestCase):
         myt1 = mycc1.t1.copy()
         myt2 = mycc1.t2.copy()
         e, pt1, pt2, Wmcik, Wacek = gintermediates.get_t3p2_imds_slow(mycc1, myt1, myt2, eris=eris1)
-        self.assertAlmostEqual(lib.finger(e), -13810450.064880637, 5)
-        self.assertAlmostEqual(lib.finger(pt1), (14525.466845738476+1145.7490899866602j), 6)
-        self.assertAlmostEqual(lib.finger(pt2), (-34943.95360794282+29728.34747703709j), 6)
-        self.assertAlmostEqual(lib.finger(Wmcik), (271010.439304044-201703.96483952703j), 6)
-        self.assertAlmostEqual(lib.finger(Wacek), (316710.3913587458+99554.48507036189j), 6)
+        self.assertAlmostEqual(lib.finger(e), -13810450.064880637, 3)
+        self.assertAlmostEqual(lib.finger(pt1), (14525.466845738476+1145.7490899866602j), 4)
+        self.assertAlmostEqual(lib.finger(pt2), (-34943.95360794282+29728.34747703709j), 4)
+        self.assertAlmostEqual(lib.finger(Wmcik), (271010.439304044-201703.96483952703j), 4)
+        self.assertAlmostEqual(lib.finger(Wacek), (316710.3913587458+99554.48507036189j), 4)
 
     def test_t3p2_intermediates_real(self):
         myt1 = mycc1.t1.real.copy()

--- a/pyscf/cc/test/test_eom_rccsd.py
+++ b/pyscf/cc/test/test_eom_rccsd.py
@@ -23,7 +23,7 @@ from pyscf import gto
 from pyscf import scf
 from pyscf import cc
 from pyscf import ao2mo
-from pyscf.cc import ccsd, rccsd, eom_rccsd, rintermediates
+from pyscf.cc import ccsd, rccsd, eom_rccsd, rintermediates, gintermediates
 
 mol = gto.Mole()
 mol.atom = [
@@ -84,13 +84,13 @@ mycc2.__dict__.update(mycc.__dict__)
 mycc21.__dict__.update(mycc1.__dict__)
 eris21 = mycc21.ao2mo()
 
-mycc3 = ccsd.CCSD(mf)
-mycc31 = ccsd.CCSD(mf1)
-mycc3.__dict__.update(mycc.__dict__)
-mycc31.__dict__.update(mycc1.__dict__)
-mycc3 = mycc3.set(max_memory=0, direct=True)
-mycc31 = mycc31.set(max_memory=0, direct=True)
-eris31 = mycc31.ao2mo()
+#mycc3 = ccsd.CCSD(mf)
+#mycc31 = ccsd.CCSD(mf1)
+#mycc3.__dict__.update(mycc.__dict__)
+#mycc31.__dict__.update(mycc1.__dict__)
+#mycc3 = mycc3.set(max_memory=0, direct=True)
+#mycc31 = mycc31.set(max_memory=0, direct=True)
+#eris31 = mycc31.ao2mo()
 
 
 def tearDownModule():
@@ -815,6 +815,21 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(lib.finger(pt2), 46.19512409958347, 6)
         self.assertAlmostEqual(lib.finger(Wmcik), -18.47928005593598, 6)
         self.assertAlmostEqual(lib.finger(Wacek), -7.101360230151883, 6)
+
+    def test_t3p2_intermediates_against_so(self):
+        from pyscf.cc.addons import convert_to_gccsd
+        myt1 = mycc1.t1.copy()
+        myt2 = mycc1.t2.copy()
+        e, pt1, pt2, Wmcik, Wacek = rintermediates.get_t3p2_imds_slow(mycc1, myt1, myt2)
+
+        mygcc = convert_to_gccsd(mycc1)
+        mygt1 = mygcc.t1.copy()
+        mygt2 = mygcc.t2.copy()
+        ge, gpt1, gpt2, gWmcik, gWacek = gintermediates.get_t3p2_imds_slow(mygcc, mygt1, mygt2)
+        self.assertAlmostEqual(lib.finger(pt1), -2.6094405706617727, 6)
+        self.assertAlmostEqual(lib.finger(pt2), 23.097562049844235, 6)
+        self.assertAlmostEqual(lib.finger(pt1), lib.finger(gpt1[::2,::2]), 6)
+        self.assertAlmostEqual(lib.finger(pt2), lib.finger(gpt2[::2,1::2,::2,1::2]), 6)
 
     def test_h2o_star(self):
         mol_h2o = gto.Mole()

--- a/pyscf/cc/test/test_eom_rccsd.py
+++ b/pyscf/cc/test/test_eom_rccsd.py
@@ -84,13 +84,13 @@ mycc2.__dict__.update(mycc.__dict__)
 mycc21.__dict__.update(mycc1.__dict__)
 eris21 = mycc21.ao2mo()
 
-#mycc3 = ccsd.CCSD(mf)
-#mycc31 = ccsd.CCSD(mf1)
-#mycc3.__dict__.update(mycc.__dict__)
-#mycc31.__dict__.update(mycc1.__dict__)
-#mycc3 = mycc3.set(max_memory=0, direct=True)
-#mycc31 = mycc31.set(max_memory=0, direct=True)
-#eris31 = mycc31.ao2mo()
+mycc3 = ccsd.CCSD(mf)
+mycc31 = ccsd.CCSD(mf1)
+mycc3.__dict__.update(mycc.__dict__)
+mycc31.__dict__.update(mycc1.__dict__)
+mycc3 = mycc3.set(max_memory=0, direct=True)
+mycc31 = mycc31.set(max_memory=0, direct=True)
+eris31 = mycc31.ao2mo()
 
 
 def tearDownModule():
@@ -798,12 +798,12 @@ class KnownValues(unittest.TestCase):
         myt1 = mycc1.t1 + 1j * numpy.sin(mycc1.t1) * mycc1.t1
         myt2 = mycc1.t2 + 1j * numpy.sin(mycc1.t2) * mycc1.t2
         myt2 = myt2 + myt2.transpose(1,0,3,2)
-        e, pt1, pt2, Wmcik, Wacek = rintermediates.get_t3p2_imds_slow(mycc1, myt1, myt2)
-        self.assertAlmostEqual(lib.finger(e), 23230.479347478944, 6)
-        self.assertAlmostEqual(lib.finger(pt1), (-5.218888542372856+6.26563618296775e-05j), 6)
-        self.assertAlmostEqual(lib.finger(pt2), (46.19512409968981-0.0007574997568293397j), 6)
-        self.assertAlmostEqual(lib.finger(Wmcik), (-18.479280056078426+0.00039725891265209376j), 6)
-        self.assertAlmostEqual(lib.finger(Wacek), (-7.101360230612007-0.00019032711858324745j), 6)
+        e, pt1, pt2, Wmcik, Wacek = rintermediates.get_t3p2_imds_slow(mycc1, myt1, myt2, eris=erisi)
+        self.assertAlmostEqual(lib.finger(e), 23223.465490572264, 6)
+        self.assertAlmostEqual(lib.finger(pt1), (-5.2202836452466705-0.09570164571057749j), 6)
+        self.assertAlmostEqual(lib.finger(pt2), (46.188012063609506-1.303867687778909j), 6)
+        self.assertAlmostEqual(lib.finger(Wmcik), (-18.438930654297778+1.5734161307568773j), 6)
+        self.assertAlmostEqual(lib.finger(Wacek), (-7.187576764072701+0.7399185332889747j), 6)
 
     def test_t3p2_intermediates_real(self):
         myt1 = mycc1.t1.copy()

--- a/pyscf/pbc/cc/eom_kccsd_ghf.py
+++ b/pyscf/pbc/cc/eom_kccsd_ghf.py
@@ -37,6 +37,8 @@ from pyscf.lib.parameters import LOOSE_ZERO_TOL, LARGE_DENOM
 from pyscf.pbc.lib.kpts_helper import member, gamma_point
 from pyscf import __config__
 from pyscf.pbc.cc import kintermediates as imd
+from pyscf.pbc.cc.kccsd_rhf import _get_epq
+from pyscf.pbc.cc.kccsd_t_rhf import _get_epqr
 from pyscf.pbc.mp.kmp2 import (get_frozen_mask, get_nocc, get_nmo,
                                padded_mo_coeff, padding_k_idx)
 
@@ -540,8 +542,8 @@ def ipccsd_star_contract(eom, ipccsd_evals, ipccsd_evecs, lipccsd_evecs, kshift,
 
         deltaE = 0.0 + 1j*0.0
         for ka, kb in itertools.product(range(nkpts), repeat=2):
-            lijkab = np.zeros((nkpts,nkpts,nkpts,nocc,nocc,nocc,nvir,nvir),dtype=dtype)
-            rijkab = np.zeros((nkpts,nkpts,nkpts,nocc,nocc,nocc,nvir,nvir),dtype=dtype)
+            lijkab = np.zeros((nkpts,nkpts,nocc,nocc,nocc,nvir,nvir),dtype=dtype)
+            rijkab = np.zeros((nkpts,nkpts,nocc,nocc,nocc,nvir,nvir),dtype=dtype)
             kklist = kpts_helper.get_kconserv3(eom._cc._scf.cell, eom._cc.kpts,
                           [ka,kb,kshift,range(nkpts),range(nkpts)])
 
@@ -551,52 +553,65 @@ def ipccsd_star_contract(eom, ipccsd_evals, ipccsd_evecs, lipccsd_evecs, kshift,
 
                 # lijkab update
                 if kk == kshift and kb == kconserv[ki,ka,kj]:
-                    lijkab[ki,kj,kk] += lib.einsum('ijab,k->ijkab', eris.oovv[ki,kj,ka], l1)
+                    lijkab[ki,kj] += lib.einsum('ijab,k->ijkab', eris.oovv[ki,kj,ka], l1)
 
                 km = kconserv[kj,ka,ki]
                 tmp = lib.einsum('jima,mkb->ijkab', eris.ooov[kj,ki,km], l2[km,kk])
                 km = kconserv[kj,kb,ki]
                 tmpT = lib.einsum('jimb,mka->ijkab', eris.ooov[kj,ki,km], l2[km,kk])
-                lijkab[ki,kj,kk] += (-tmp + tmpT)
+                lijkab[ki,kj] += (-tmp + tmpT)
 
                 ke = kconserv[ka,ki,kb]
-                lijkab[ki,kj,kk] += lib.einsum('ieab,jke->ijkab', eris.ovvv[ki,ke,ka], l2[kj,kk])
+                lijkab[ki,kj] += lib.einsum('ieab,jke->ijkab', eris.ovvv[ki,ke,ka], l2[kj,kk])
 
                 # rijkab update
                 tmp = lib.einsum('mbke,m->bke', eris.ovov[kshift,kb,kk], r1)
                 tmp = lib.einsum('bke,ijae->ijkab', tmp, t2[ki,kj,ka])
                 tmpT = lib.einsum('make,m->ake', eris.ovov[kshift,ka,kk], r1)
                 tmpT = lib.einsum('ake,ijbe->ijkab', tmpT, t2[ki,kj,kb])
-                rijkab[ki,kj,kk] -= (tmp - tmpT)
+                rijkab[ki,kj] -= (tmp - tmpT)
 
                 km = kconserv[kj,kshift,kk]
                 tmp = lib.einsum('mnjk,n->mjk', eris.oooo[km,kshift,kj], r1)
                 tmp = lib.einsum('mjk,imab->ijkab', tmp, t2[ki,km,ka])
-                rijkab[ki,kj,kk] += tmp
+                rijkab[ki,kj] += tmp
 
                 km = kconserv[kj,ka,ki]
                 tmp = lib.einsum('jima,mkb->ijkab', eris.ooov[kj,ki,km].conj(), r2[km,kk])
                 km = kconserv[kj,kb,ki]
                 tmpT = lib.einsum('jimb,mka->ijkab', eris.ooov[kj,ki,km].conj(), r2[km,kk])
-                rijkab[ki,kj,kk] -= (tmp - tmpT)
+                rijkab[ki,kj] -= (tmp - tmpT)
 
                 ke = kconserv[ka,ki,kb]
-                rijkab[ki,kj,kk] += lib.einsum('ieab,jke->ijkab', eris.ovvv[ki,ke,ka].conj(), r2[kj,kk])
+                rijkab[ki,kj] += lib.einsum('ieab,jke->ijkab', eris.ovvv[ki,ke,ka].conj(), r2[kj,kk])
 
-            # P(ijk)
-            lijkab = lijkab + lijkab.transpose(1,2,0,4,5,3,6,7) + lijkab.transpose(2,0,1,5,3,4,6,7)
-            rijkab = rijkab + rijkab.transpose(1,2,0,4,5,3,6,7) + rijkab.transpose(2,0,1,5,3,4,6,7)
+            eijk = np.zeros((nkpts,nkpts,nocc,nocc,nocc), dtype=dtype)
+            Plijkab = np.zeros_like(lijkab)
+            Prijkab = np.zeros_like(rijkab)
+            for ki, kj in itertools.product(range(nkpts), repeat=2):
+                kk = kklist[ki,kj]
+                # P(ijk)
+                Plijkab[ki,kj] = (lijkab[ki,kj] + lijkab[kj,kk].transpose(2,0,1,3,4) +
+                                                  lijkab[kk,ki].transpose(1,2,0,3,4))
+
+                Prijkab[ki,kj] = (rijkab[ki,kj] + rijkab[kj,kk].transpose(2,0,1,3,4) +
+                                                  rijkab[kk,ki].transpose(1,2,0,3,4))
+
+
+                eijk[ki,kj] = _get_epqr([0,nocc,ki,mo_e_o,eom.nonzero_opadding],
+                                        [0,nocc,kj,mo_e_o,eom.nonzero_opadding],
+                                        [0,nocc,kk,mo_e_o,eom.nonzero_opadding])
 
             # Creating denominator
-            eijk = (mo_e_o[:, None, None, :, None, None] + mo_e_o[None, :, None, None, :, None] +
-                    mo_e_o[None, None, :, None, None, :])
-            eab = mo_e_v[ka][:, None] + mo_e_v[kb][None, :]
-            eijkab = (eijk[:, :, :, :, :, :, None, None] -
-                      eab[None, None, None, None, None, None, :, :])
+            eab = _get_epq([0,nvir,ka,mo_e_v,eom.nonzero_vpadding],
+                           [0,nvir,kb,mo_e_v,eom.nonzero_vpadding],
+                           fac=[-1.,-1.])
+            eijkab = (eijk[:, :, :, :, :, None, None] +
+                      eab[None, None, None, None, None, :, :])
             denom = eijkab + ip_eval
             denom = 1. / denom
 
-            deltaE += lib.einsum('xyzijkab,xyzijkab,xyzijkab', lijkab, rijkab, denom)
+            deltaE += lib.einsum('xyijkab,xyijkab,xyijkab', Plijkab, Prijkab, denom)
 
         deltaE *= 1./12
         deltaE = deltaE.real
@@ -1095,8 +1110,8 @@ def eaccsd_star_contract(eom, eaccsd_evals, eaccsd_evecs, leaccsd_evecs, kshift,
 
         deltaE = 0.0 + 1j*0.0
         for ki, kj in itertools.product(range(nkpts), repeat=2):
-            lijabc = np.zeros((nkpts,nkpts,nkpts,nocc,nocc,nvir,nvir,nvir),dtype=dtype)
-            rijabc = np.zeros((nkpts,nkpts,nkpts,nocc,nocc,nvir,nvir,nvir),dtype=dtype)
+            lijabc = np.zeros((nkpts,nkpts,nocc,nocc,nvir,nvir,nvir),dtype=dtype)
+            rijabc = np.zeros((nkpts,nkpts,nocc,nocc,nvir,nvir,nvir),dtype=dtype)
             kklist = kpts_helper.get_kconserv3(eom._cc._scf.cell, eom._cc.kpts,
                           [ki,kj,kshift,range(nkpts),range(nkpts)])
 
@@ -1106,22 +1121,22 @@ def eaccsd_star_contract(eom, eaccsd_evals, eaccsd_evecs, leaccsd_evecs, kshift,
 
                 # lijabc update
                 if kc == kshift and kb == kconserv[ki,ka,kj]:
-                    lijabc[ka,kb,kc] -= lib.einsum('ijab,c->ijabc', eris.oovv[ki,kj,ka], l1)
+                    lijabc[ka,kb] -= lib.einsum('ijab,c->ijabc', eris.oovv[ki,kj,ka], l1)
 
                 km = kconserv[kj,ka,ki]
-                lijabc[ka,kb,kc] -= lib.einsum('jima,mbc->ijabc', eris.ooov[kj,ki,km], l2[km,kb])
+                lijabc[ka,kb] -= lib.einsum('jima,mbc->ijabc', eris.ooov[kj,ki,km], l2[km,kb])
 
                 ke = kconserv[ka,ki,kb]
                 tmp = lib.einsum('ieab,jce->ijabc', eris.ovvv[ki,ke,ka], l2[kj,kc])
                 ke = kconserv[ka,kj,kb]
                 tmpT = lib.einsum('jeab,ice->ijabc', eris.ovvv[kj,ke,ka], l2[ki,kc])
-                lijabc[ka,kb,kc] -= (tmp - tmpT)
+                lijabc[ka,kb] -= (tmp - tmpT)
 
                 # rijabc update
                 ke = kconserv[kb,kshift,kc]
                 tmp = lib.einsum('bcef,f->bce', eris.vvvv[kb,kc,ke], r1)
                 tmp = lib.einsum('bce,ijae->ijabc', tmp, t2[ki,kj,ka])
-                rijabc[ka,kb,kc] -= tmp
+                rijabc[ka,kb] -= tmp
 
                 km = kconserv[kj,kc,kshift]
                 tmp = lib.einsum('mcje,e->mcj', eris.ovov[km,kc,kj], r1)
@@ -1129,31 +1144,44 @@ def eaccsd_star_contract(eom, eaccsd_evals, eaccsd_evecs, leaccsd_evecs, kshift,
                 km = kconserv[ki,kc,kshift]
                 tmpT = lib.einsum('mcie,e->mci', eris.ovov[km,kc,ki], r1)
                 tmpT = lib.einsum('mci,jmab->ijabc', tmpT, t2[kj,km,ka])
-                rijabc[ka,kb,kc] += (tmp - tmpT)
+                rijabc[ka,kb] += (tmp - tmpT)
 
                 km = kconserv[kj,ka,ki]
-                rijabc[ka,kb,kc] += lib.einsum('jima,mcb->ijabc', eris.ooov[kj,ki,km].conj(), r2[km,kc])
+                rijabc[ka,kb] += lib.einsum('jima,mcb->ijabc', eris.ooov[kj,ki,km].conj(), r2[km,kc])
 
                 ke = kconserv[ka,ki,kb]
                 tmp = lib.einsum('ieab,jce->ijabc', eris.ovvv[ki,ke,ka].conj(), r2[kj,kc])
                 ke = kconserv[ka,kj,kb]
                 tmpT = lib.einsum('jeab,ice->ijabc', eris.ovvv[kj,ke,ka].conj(), r2[ki,kc])
-                rijabc[ka,kb,kc] -= (tmp - tmpT)
+                rijabc[ka,kb] -= (tmp - tmpT)
 
-            # P(ijk)
-            lijabc = lijabc + lijabc.transpose(1,2,0,3,4,6,7,5) + lijabc.transpose(2,0,1,3,4,7,5,6)
-            rijabc = rijabc + rijabc.transpose(1,2,0,3,4,6,7,5) + rijabc.transpose(2,0,1,3,4,7,5,6)
+            eabc = np.zeros((nkpts,nkpts,nvir,nvir,nvir), dtype=dtype)
+            Plijabc = np.zeros_like(lijabc)
+            Prijabc = np.zeros_like(rijabc)
+            for ka, kb in itertools.product(range(nkpts), repeat=2):
+                kc = kklist[ka,kb]
+                # P(abc)
+                Plijabc[ka,kb] = (lijabc[ka,kb] + lijabc[kb,kc].transpose(0,1,4,2,3) +
+                                                  lijabc[kc,ka].transpose(0,1,3,4,2))
+
+                Prijabc[ka,kb] = (rijabc[ka,kb] + rijabc[kb,kc].transpose(0,1,4,2,3) +
+                                                  rijabc[kc,ka].transpose(0,1,3,4,2))
+
+
+                eabc[ka,kb] = _get_epqr([0,nvir,ka,mo_e_v,eom.nonzero_vpadding],
+                                        [0,nvir,kb,mo_e_v,eom.nonzero_vpadding],
+                                        [0,nvir,kc,mo_e_v,eom.nonzero_vpadding],
+                                        fac=[-1.,]*3)
 
             # Creating denominator
-            eabc = (mo_e_v[:, None, None, :, None, None] + mo_e_v[None, :, None, None, :, None] +
-                    mo_e_v[None, None, :, None, None, :])
-            eij = mo_e_o[ki][:, None] + mo_e_o[kj][None, :]
-            eijabc = (eij[None, None, None, :, :, None, None, None] -
-                      eabc[:, :, :, None, None, :, :, :])
+            eij = _get_epq([0,nocc,ki,mo_e_o,eom.nonzero_opadding],
+                           [0,nocc,kj,mo_e_o,eom.nonzero_opadding])
+            eijabc = (eij[None, None, :, :, None, None, None] +
+                      eabc[:, :, None, None, :, :, :])
             denom = eijabc + ea_eval
             denom = 1. / denom
 
-            deltaE += lib.einsum('xyzijabc,xyzijabc,xyzijabc', lijabc, rijabc, denom)
+            deltaE += lib.einsum('xyijabc,xyijabc,xyijabc', Plijabc, Prijabc, denom)
 
         deltaE *= 1./12
         deltaE = deltaE.real

--- a/pyscf/pbc/cc/eom_kccsd_rhf.py
+++ b/pyscf/pbc/cc/eom_kccsd_rhf.py
@@ -358,11 +358,17 @@ def ipccsd_star_contract(eom, ipccsd_evals, ipccsd_evecs, lipccsd_evecs, kshift,
                                   2.*lijkab[ki,kk].transpose(0,2,1,3,4) -
                                   2.*lijkab[kk,kj].transpose(2,1,0,3,4) -
                                   2.*lijkab[kj,ki].transpose(1,0,2,3,4))
-                eijk[ki,kj] = eij[ki,kj] + mo_e_o[kk][None,None,None,None,:]
+                eijk[ki,kj] = _get_epqr([0,nocc,ki,mo_e_o,eom.nonzero_opadding],
+                                        [0,nocc,kj,mo_e_o,eom.nonzero_opadding],
+                                        [0,nocc,kk,mo_e_o,eom.nonzero_opadding])
 
             # Creating denominator
-            eab = mo_e_v[ka][:, None] + mo_e_v[kb][None, :]
-            eijkab = (eijk[:, :, :, :, :, None, None] -
+            eab = _get_epq([0,nvir,ka,mo_e_v,eom.nonzero_vpadding],
+                           [0,nvir,kb,mo_e_v,eom.nonzero_vpadding],
+                           fac=[-1.,-1.])
+
+            # Creating denominator
+            eijkab = (eijk[:, :, :, :, :, None, None] +
                       eab[None, None, None, None, None, :, :])
             denom = eijkab + ip_eval
             denom = 1. / denom
@@ -733,7 +739,6 @@ def eaccsd_star_contract(eom, eaccsd_evals, eaccsd_evecs, leaccsd_evecs, kshift,
         l2 /= ldotr
 
         deltaE = 0.0 + 1j*0.0
-        eab = (mo_e_v[:, None, :, None, None] + mo_e_v[None, :, None, :, None])
         for ki, kj in itertools.product(range(nkpts), repeat=2):
             lijabc = np.zeros((nkpts,nkpts,nocc,nocc,nvir,nvir,nvir),dtype=dtype)
             Plijabc = np.zeros((nkpts,nkpts,nocc,nocc,nvir,nvir,nvir),dtype=dtype)
@@ -758,11 +763,15 @@ def eaccsd_star_contract(eom, eaccsd_evals, eaccsd_evecs, leaccsd_evecs, kshift,
                                   2.*lijabc[ka,kc].transpose(0,1,2,4,3) -
                                   2.*lijabc[kc,kb].transpose(0,1,4,3,2) -
                                   2.*lijabc[kb,ka].transpose(0,1,3,2,4))
-                eabc[ka,kb] = eab[ka,kb] + mo_e_v[kc][None,None,None,None,:]
+                eabc[ka,kb] = _get_epqr([0,nvir,ka,mo_e_v,eom.nonzero_vpadding],
+                                        [0,nvir,kb,mo_e_v,eom.nonzero_vpadding],
+                                        [0,nvir,kc,mo_e_v,eom.nonzero_vpadding],
+                                        fac=[-1.,-1.,-1.])
 
             # Creating denominator
-            eij = mo_e_o[ki][:, None] + mo_e_o[kj][None, :]
-            eijabc = (eij[None, None, :, :, None, None, None] -
+            eij = _get_epq([0,nocc,ki,mo_e_o,eom.nonzero_opadding],
+                           [0,nocc,kj,mo_e_o,eom.nonzero_opadding])
+            eijabc = (eij[None, None, :, :, None, None, None] +
                       eabc[:, :, None, None, :, :, :])
             denom = eijabc + ea_eval
             denom = 1. / denom

--- a/pyscf/pbc/cc/eom_kccsd_rhf.py
+++ b/pyscf/pbc/cc/eom_kccsd_rhf.py
@@ -25,6 +25,8 @@ from pyscf.lib.parameters import LOOSE_ZERO_TOL, LARGE_DENOM
 from pyscf.lib import linalg_helper
 from pyscf.pbc.cc import eom_kccsd_ghf as eom_kgccsd
 from pyscf.pbc.cc import kintermediates_rhf as imdk
+from pyscf.pbc.cc.kccsd_rhf import _get_epq
+from pyscf.pbc.cc.kccsd_t_rhf import _get_epqr
 from pyscf.pbc.lib import kpts_helper
 from pyscf.pbc.mp.kmp2 import (get_frozen_mask, get_nocc, get_nmo,
                                padded_mo_coeff, padding_k_idx)

--- a/pyscf/pbc/cc/eom_kccsd_rhf.py
+++ b/pyscf/pbc/cc/eom_kccsd_rhf.py
@@ -911,7 +911,7 @@ class _IMDS:
 
         t1, t2, eris = cc.t1, cc.t2, self.eris
         delta_E_tot, pt1, pt2, Wovoo, Wvvvo = \
-            imd.get_t3p2_imds_slow(cc, t1, t2, eris)
+            imd.get_t3p2_imds(cc, t1, t2, eris)
         self.t1 = pt1
         self.t2 = pt2
 
@@ -958,7 +958,7 @@ class _IMDS:
 
         t1, t2, eris = cc.t1, cc.t2, self.eris
         delta_E_tot, pt1, pt2, Wovoo, Wvvvo = \
-            imd.get_t3p2_imds_slow(cc, t1, t2, eris)
+            imd.get_t3p2_imds(cc, t1, t2, eris)
         self.t1 = pt1
         self.t2 = pt2
 

--- a/pyscf/pbc/cc/eom_kccsd_rhf.py
+++ b/pyscf/pbc/cc/eom_kccsd_rhf.py
@@ -975,7 +975,7 @@ class _IMDS:
 
         t1, t2, eris = cc.t1, cc.t2, self.eris
         delta_E_tot, pt1, pt2, Wovoo, Wvvvo = \
-            imd.get_t3p2_imds_slow(cc, t1, t2, eris)
+            imd.get_t3p2_imds(cc, t1, t2, eris)
         self.t1 = pt1
         self.t2 = pt2
 

--- a/pyscf/pbc/cc/kccsd.py
+++ b/pyscf/pbc/cc/kccsd.py
@@ -231,7 +231,11 @@ def spatial2spin(tx, orbspin, kconserv):
         return spatial2spin((tx,tx), orbspin, kconserv)
     elif isinstance(tx, numpy.ndarray) and tx.ndim == 7:
         # KRCCSD t2 amplitudes
-        t2aa = tx - tx.transpose(0,1,2,4,3,5,6)
+        t2aa = numpy.zeros_like(tx)
+        nkpts = t2aa.shape[2]
+        for ki, kj, ka in kpts_helper.loop_kkk(nkpts):
+            kb = kconserv[ki,ka,kj]
+            t2aa[ki,kj,ka] = tx[ki,kj,ka] - tx[ki,kj,kb].transpose(0,1,3,2)
         return spatial2spin((t2aa,tx,t2aa), orbspin, kconserv)
     elif len(tx) == 2:  # KUCCSD t1
         t1a, t1b = tx

--- a/pyscf/pbc/cc/kccsd_rhf.py
+++ b/pyscf/pbc/cc/kccsd_rhf.py
@@ -209,21 +209,20 @@ def update_amps(cc, t1, t2, eris):
     for ki in range(nkpts):
         ka = ki
         # Remove zero/padded elements from denominator
-        eia = LARGE_DENOM * np.ones((nocc, nvir), dtype=eris.mo_energy[0].dtype)
-        n0_ovp_ia = np.ix_(nonzero_opadding[ki], nonzero_vpadding[ka])
-        eia[n0_ovp_ia] = (mo_e_o[ki][:,None] - mo_e_v[ka])[n0_ovp_ia]
+        eia = _get_epq([0,nocc,ki,mo_e_o,nonzero_opadding],
+                       [0,nvir,ka,mo_e_v,nonzero_vpadding],
+                       fac=[1.0,-1.0])
         t1new[ki] /= eia
 
     for ki, kj, ka in kpts_helper.loop_kkk(nkpts):
         kb = kconserv[ki, ka, kj]
-        # For LARGE_DENOM, see t1new update above
-        eia = LARGE_DENOM * np.ones((nocc, nvir), dtype=eris.mo_energy[0].dtype)
-        n0_ovp_ia = np.ix_(nonzero_opadding[ki], nonzero_vpadding[ka])
-        eia[n0_ovp_ia] = (mo_e_o[ki][:,None] - mo_e_v[ka])[n0_ovp_ia]
+        eia = _get_epq([0,nocc,ki,mo_e_o,nonzero_opadding],
+                       [0,nvir,ka,mo_e_v,nonzero_vpadding],
+                       fac=[1.0,-1.0])
 
-        ejb = LARGE_DENOM * np.ones((nocc, nvir), dtype=eris.mo_energy[0].dtype)
-        n0_ovp_jb = np.ix_(nonzero_opadding[kj], nonzero_vpadding[kb])
-        ejb[n0_ovp_jb] = (mo_e_o[kj][:,None] - mo_e_v[kb])[n0_ovp_jb]
+        ejb = _get_epq([0,nocc,kj,mo_e_o,nonzero_opadding],
+                       [0,nvir,kb,mo_e_v,nonzero_vpadding],
+                       fac=[1.0,-1.0])
         eijab = eia[:, None, :, None] + ejb[:, None, :]
 
         t2new[ki, kj, ka] /= eijab
@@ -231,6 +230,42 @@ def update_amps(cc, t1, t2, eris):
     time0 = log.timer_debug1('update t1 t2', *time0)
 
     return t1new, t2new
+
+
+def _get_epq(pindices,qindices,fac=[1.0,1.0],large_num=LARGE_DENOM):
+    '''Create a denominator
+
+        fac[0]*e[kp,p0:p1] + fac[1]*e[kq,q0:q1]
+
+    where padded elements have been replaced by a large number.
+
+    Args:
+        pindices (5-list of object):
+            A list of p0, p1, kp, orbital values, and non-zero indicess for the first
+            denominator indices.
+        qindices (5-list of object):
+            A list of q0, q1, kq, orbital values, and non-zero indicess for the second
+            denominator element.
+        fac (3-list of float):
+            Factors to multiply the first and second denominator elements.
+        large_num (float):
+            Number to replace the padded elements.
+    '''
+    def get_idx(x0,x1,kx,n0_p):
+        return np.logical_and(n0_p[kx] >= x0, n0_p[kx] < x1)
+
+    assert(all([len(x) == 5 for x in [pindices,qindices]]))
+    p0,p1,kp,mo_e_p,nonzero_p = pindices
+    q0,q1,kq,mo_e_q,nonzero_q = qindices
+    fac_p, fac_q = fac
+
+    epq = large_num * np.ones((p1-p0,q1-q0), dtype=mo_e_p[0].dtype)
+    idxp = get_idx(p0,p1,kp,nonzero_p)
+    idxq = get_idx(q0,q1,kq,nonzero_q)
+    n0_ovp_pq = np.ix_(nonzero_p[kp][idxp], nonzero_q[kq][idxq])
+    epq[n0_ovp_pq] = lib.direct_sum('p,q->pq', fac_p*mo_e_p[kp][p0:p1],
+                                               fac_q*mo_e_q[kq][q0:q1])[n0_ovp_pq]
+    return epq
 
 
 # TODO: pull these 3 methods to pyscf.util and make tests
@@ -553,13 +588,13 @@ class RCCSD(pyscf.cc.ccsd.CCSD):
 
             kb = kconserv[ki, ka, kj]
             # For discussion of LARGE_DENOM, see t1new update above
-            eia = LARGE_DENOM * np.ones((nocc, nvir), dtype=eris.mo_energy[0].dtype)
-            n0_ovp_ia = np.ix_(nonzero_opadding[ki], nonzero_vpadding[ka])
-            eia[n0_ovp_ia] = (mo_e_o[ki][:,None] - mo_e_v[ka])[n0_ovp_ia]
+            eia = _get_epq([0,nocc,ki,mo_e_o,nonzero_opadding],
+                           [0,nvir,ka,mo_e_v,nonzero_vpadding],
+                           fac=[1.0,-1.0])
 
-            ejb = LARGE_DENOM * np.ones((nocc, nvir), dtype=eris.mo_energy[0].dtype)
-            n0_ovp_jb = np.ix_(nonzero_opadding[kj], nonzero_vpadding[kb])
-            ejb[n0_ovp_jb] = (mo_e_o[kj][:,None] - mo_e_v[kb])[n0_ovp_jb]
+            ejb = _get_epq([0,nocc,kj,mo_e_o,nonzero_opadding],
+                           [0,nvir,kb,mo_e_v,nonzero_vpadding],
+                           fac=[1.0,-1.0])
             eijab = eia[:, None, :, None] + ejb[:, None, :]
 
             eris_ijab = eris.oovv[ki, kj, ka]

--- a/pyscf/pbc/cc/kccsd_t.py
+++ b/pyscf/pbc/cc/kccsd_t.py
@@ -16,6 +16,8 @@ from pyscf.pbc.lib import kpts_helper
 from pyscf.lib.misc import flatten
 from pyscf.lib.numpy_helper import cartesian_prod
 from pyscf.lib.parameters import LOOSE_ZERO_TOL, LARGE_DENOM
+from pyscf.pbc.mp.kmp2 import (get_frozen_mask, get_nocc, get_nmo,
+                               padded_mo_coeff, padding_k_idx)
 
 #einsum = np.einsum
 einsum = lib.einsum
@@ -78,13 +80,18 @@ def kernel(mycc, eris, t1=None, t2=None, max_memory=2000, verbose=logger.INFO):
     # Set up class for k-point conservation
     kconserv = kpts_helper.get_kconserv(cell, kpts)
 
+    # Get location of padded elements in occupied and virtual space
+    nonzero_opadding, nonzero_vpadding = padding_k_idx(mycc, kind="split")
+
     energy_t = 0.0
 
     for ki in range(nkpts):
         for kj in range(ki + 1):
             for kk in range(kj + 1):
                 # eigenvalue denominator: e(i) + e(j) + e(k)
-                eijk = lib.direct_sum('i,j,k->ijk', mo_e_o[ki], mo_e_o[kj], mo_e_o[kk])
+                eijk = LARGE_DENOM * np.ones((nocc,)*3, dtype=mo_e_o[0].dtype)
+                n0_ovp_ijk = np.ix_(nonzero_opadding[ki], nonzero_opadding[kj], nonzero_opadding[kk])
+                eijk[n0_ovp_ijk] = lib.direct_sum('i,j,k->ijk', mo_e_o[ki], mo_e_o[kj], mo_e_o[kk])[n0_ovp_ijk]
 
                 # Factors to include for permutational symmetry among k-points for occupied space
                 if ki == kj and kj == kk:
@@ -102,6 +109,10 @@ def kernel(mycc, eris, t1=None, t2=None, max_memory=2000, verbose=logger.INFO):
                         kc = kpts_helper.get_kconserv3(cell, kpts, [ki, kj, kk, ka, kb])
                         if kc not in range(kb + 1):
                             continue
+
+                        eabc = LARGE_DENOM * np.ones((nvir,nvir,nvir), dtype=mo_e_o[0].dtype)
+                        n0_ovp_abc = np.ix_(nonzero_vpadding[ka], nonzero_vpadding[kb], nonzero_vpadding[kc])
+                        eabc[n0_ovp_abc] = lib.direct_sum('a,b,c->abc', mo_e_v[ka], mo_e_v[kb], mo_e_v[kc])[n0_ovp_abc]
 
                         # Factors to include for permutational symmetry among k-points for virtual space
                         if ka == kb and kb == kc:
@@ -147,10 +158,7 @@ def kernel(mycc, eris, t1=None, t2=None, max_memory=2000, verbose=logger.INFO):
                                     symm_abc = 2.
 
                             # Form energy denominator
-                            eijkabc = (eijk - mo_e_v[ka][a] - mo_e_v[kb][b] - mo_e_v[kc][c])
-                            # When padding for non-equal nocc per k-point, some fock elements will be zero
-                            idx = np.where(abs(eijkabc) < LOOSE_ZERO_TOL)[0]
-                            eijkabc[idx] = LARGE_DENOM
+                            eijkabc = (eijk[:,:,:] - eabc[a,b,c])
 
                             # Form connected triple excitation amplitude
                             t3c = np.zeros((nocc, nocc, nocc), dtype=dtype)

--- a/pyscf/pbc/cc/kccsd_t_rhf.py
+++ b/pyscf/pbc/cc/kccsd_t_rhf.py
@@ -308,10 +308,14 @@ def kernel(mycc, eris, t1=None, t2=None, max_memory=2000, verbose=logger.INFO):
                     else:
                         symm_kpt = 6.
 
-                    eijkabc = (eijk[None,None,None,:,:,:] -
-                               mo_e_v[ka][a0:a1][:,None,None,None,None,None] -
-                               mo_e_v[kb][b0:b1][None,:,None,None,None,None] -
-                               mo_e_v[kc][c0:c1][None,None,:,None,None,None])
+                    eabc = LARGE_DENOM * np.ones((a1-a0,b1-b0,c1-c0), dtype=mo_e_o[0].dtype)
+                    idxa = nonzero_vpadding[ka][np.logical_and(nonzero_vpadding[ka] >= a0, nonzero_vpadding[ka] < a1)] - a0
+                    idxb = nonzero_vpadding[kb][np.logical_and(nonzero_vpadding[kb] >= b0, nonzero_vpadding[kb] < b1)] - b0
+                    idxc = nonzero_vpadding[kc][np.logical_and(nonzero_vpadding[kc] >= c0, nonzero_vpadding[kc] < c1)] - c0
+                    n0_ovp_abc = np.ix_(nonzero_vpadding[ka][idxa], nonzero_vpadding[kb][idxb], nonzero_vpadding[kc][idxc])
+                    # The following could be a little slow
+                    eabc[n0_ovp_abc] = lib.direct_sum('a,b,c->abc', mo_e_v[ka][a0:a1], mo_e_v[kb][b0:b1], mo_e_v[kc][c0:c1])[n0_ovp_abc]
+                    eijkabc = (eijk[None,None,None,:,:,:] - eabc[:,:,:,None,None,None])
 
                     pwijk = my_permuted_w[ki,kj,kk] + my_permuted_v[ki,kj,kk]
                     rwijk = (4. * my_permuted_w[ki,kj,kk] +

--- a/pyscf/pbc/cc/kccsd_t_rhf.py
+++ b/pyscf/pbc/cc/kccsd_t_rhf.py
@@ -641,7 +641,7 @@ if __name__ == '__main__':
     eris = myscc.ao2mo()
     sup_ecc, t1, t2 = myscc.kernel(eris=eris)
     sup_energy_t = myscc.ccsd_t(eris=eris)
-    print "Kpoint    CCSD: %20.16f" % ecc
-    print "Supercell CCSD: %20.16f" % (sup_ecc/np.prod(nmp))
-    print "Kpoint    CCSD(T): %20.16f" % energy_t
-    print "Supercell CCSD(T): %20.16f" % (sup_energy_t/np.prod(nmp))
+    print("Kpoint    CCSD: %20.16f" % ecc)
+    print("Supercell CCSD: %20.16f" % (sup_ecc/np.prod(nmp)))
+    print("Kpoint    CCSD(T): %20.16f" % energy_t)
+    print("Supercell CCSD(T): %20.16f" % (sup_energy_t/np.prod(nmp)))

--- a/pyscf/pbc/cc/kccsd_t_rhf.py
+++ b/pyscf/pbc/cc/kccsd_t_rhf.py
@@ -409,7 +409,7 @@ def create_eris_vooo(ooov, nkpts, nocc, nvir, kconserv, out=None):
         out = np.empty((nkpts,nkpts,nkpts,nvir,nocc,nocc,nocc), dtype=ooov.dtype)
 
     for ki, kj, ka in product(range(nkpts), repeat=3):
-        kb = kconserv[ki,ka,kj]
+        kb = kconserv[ki,kj,ka]
         # <bj|ai> -> (ba|ji)    (Physicist->Chemist)
         # (ij|ab) = (ba|ij)*    (Permutational symmetry)
         # out = (ij|ab).transpose(0,1,3,2)
@@ -457,7 +457,7 @@ def create_t3_eris(mycc, kconserv, eris, tmpfile='tmp_t3_eris.h5'):
     if (unit*16 < max_memory):  # Store all in memory
         t2T = t2T[:]
         eris_vvop = eris_vvop[:]
-        eris_vooo_C[:]
+        eris_vooo_C = eris_vooo_C[:]
 
     return feri_tmp, t2T, eris_vvop, eris_vooo_C
 

--- a/pyscf/pbc/cc/kccsd_t_rhf.py
+++ b/pyscf/pbc/cc/kccsd_t_rhf.py
@@ -284,10 +284,10 @@ def kernel(mycc, eris, t1=None, t2=None, max_memory=2000, verbose=logger.INFO):
                     kpt_indices = [ki,kj,kk,ka,kb,kc]
                     data = get_data(kpt_indices)
                     t3Tw, t3Tv = contract_t3Tv(kpt_indices, task, data)
-                    #my_permuted_w[ki,kj,kk] = t3Tw
-                    #my_permuted_v[ki,kj,kk] = t3Tv
-                    my_permuted_w[ki,kj,kk] = get_permuted_w(ki,kj,kk,ka,kb,kc,task)
-                    my_permuted_v[ki,kj,kk] = get_permuted_v(ki,kj,kk,ka,kb,kc,task)
+                    my_permuted_w[ki,kj,kk] = t3Tw
+                    my_permuted_v[ki,kj,kk] = t3Tv
+                    #my_permuted_w[ki,kj,kk] = get_permuted_w(ki,kj,kk,ka,kb,kc,task)
+                    #my_permuted_v[ki,kj,kk] = get_permuted_v(ki,kj,kk,ka,kb,kc,task)
 
                 for ki, kj, kk in product(range(nkpts), repeat=3):
                     # eigenvalue denominator: e(i) + e(j) + e(k)

--- a/pyscf/pbc/cc/kccsd_t_rhf_slow.py
+++ b/pyscf/pbc/cc/kccsd_t_rhf_slow.py
@@ -182,12 +182,12 @@ def kernel(mycc, eris, t1=None, t2=None, max_memory=2000, verbose=logger.INFO):
                 else:
                     symm_kpt = 6.
 
+                eabc = LARGE_DENOM * np.ones((nvir,)*3, dtype=mo_energy_occ[0].dtype)
+                n0_ovp_abc = np.ix_(nonzero_vpadding[ka], nonzero_vpadding[kb], nonzero_vpadding[kc])
+                eabc[n0_ovp_abc] = lib.direct_sum('i,j,k->ijk', mo_energy_vir[ka], mo_energy_vir[kb], mo_energy_vir[kc])[n0_ovp_abc]
                 for task_id, task in enumerate(tasks):
                     orb_indices = a0,a1,b0,b1,c0,c1
-                    eijkabc = (eijk[None,None,None,:,:,:] -
-                               mo_energy_vir[ka][a0:a1][:,None,None,None,None,None] -
-                               mo_energy_vir[kb][b0:b1][None,:,None,None,None,None] -
-                               mo_energy_vir[kc][c0:c1][None,None,:,None,None,None])
+                    eijkabc = (eijk[None,None,None,:,:,:] - eabc[a0:a1,b0:b1,c0:c1,None,None,None])
                     pwijk = (       get_permuted_w(ki,kj,kk,ka,kb,kc,task) +
                               0.5 * get_permuted_v(ki,kj,kk,ka,kb,kc,task) )
                     rwijk = get_rw(ki,kj,kk,ka,kb,kc,task) / eijkabc

--- a/pyscf/pbc/cc/kintermediates.py
+++ b/pyscf/pbc/cc/kintermediates.py
@@ -26,6 +26,8 @@ import numpy
 from pyscf.lib.parameters import LARGE_DENOM
 from pyscf.pbc.mp.kmp2 import (get_frozen_mask, get_nocc, get_nmo,
                                padded_mo_coeff, padding_k_idx)
+from pyscf.pbc.cc.kccsd_rhf import _get_epq
+from pyscf.pbc.cc.kccsd_t_rhf import _get_epqr
 
 #einsum = numpy.einsum
 einsum = lib.einsum
@@ -398,16 +400,17 @@ def get_full_t3p2(mycc, t1, t2, eris):
           t3.transpose(2,0,1,3,4,7,5,6,8,9,10))
 
     for ki, kj, kk in product(range(nkpts), repeat=3):
-        eijk = LARGE_DENOM * numpy.ones((nocc,)*3, dtype=mo_e_o[0].dtype)
-        n0_ovp_ijk = numpy.ix_(nonzero_opadding[ki], nonzero_opadding[kj], nonzero_opadding[kk])
-        eijk[n0_ovp_ijk] = lib.direct_sum('i,j,k->ijk', mo_e_o[ki], mo_e_o[kj], mo_e_o[kk])[n0_ovp_ijk]
+        eijk = _get_epqr([0,nocc,ki,mo_e_o,nonzero_opadding],
+                         [0,nocc,kj,mo_e_o,nonzero_opadding],
+                         [0,nocc,kk,mo_e_o,nonzero_opadding])
         for ka, kb in product(range(nkpts), repeat=2):
             kc = kpts_helper.get_kconserv3(mycc._scf.cell, mycc.kpts,
                                            [ki, kj, kk, ka, kb])
-            eabc = LARGE_DENOM * numpy.ones((nvir,nvir,nvir), dtype=mo_e_o[0].dtype)
-            n0_ovp_abc = numpy.ix_(nonzero_vpadding[ka], nonzero_vpadding[kb], nonzero_vpadding[kc])
-            eabc[n0_ovp_abc] = lib.direct_sum('a,b,c->abc', mo_e_v[ka], mo_e_v[kb], mo_e_v[kc])[n0_ovp_abc]
-            eijkabc = eijk[:, :, :, None, None, None] - eabc[None, None, None, :, :, :]
+            eabc = _get_epqr([0,nvir,ka,mo_e_v,nonzero_vpadding],
+                             [0,nvir,kb,mo_e_v,nonzero_vpadding],
+                             [0,nvir,kc,mo_e_v,nonzero_vpadding],
+                             fac=[-1.,-1.,-1.])
+            eijkabc = eijk[:, :, :, None, None, None] + eabc[None, None, None, :, :, :]
             t3[ki,kj,kk,ka,kb] /= eijkabc
 
     return t3
@@ -481,9 +484,9 @@ def get_t3p2_imds_slow(cc, t1, t2, eris=None, t3p2_ip_out=None, t3p2_ea_out=None
         ka = ki
         for km, kn, ke in product(range(nkpts), repeat=3):
             pt1[ki] += 0.25 * lib.einsum('mnef,imnaef->ia', eris.oovv[km,kn,ke], t3[ki,km,kn,ka,ke])
-        eia = LARGE_DENOM * numpy.ones((nocc, nvir), dtype=eris.mo_energy[0].dtype)
-        n0_ovp_ia = numpy.ix_(nonzero_opadding[ki], nonzero_vpadding[ka])
-        eia[n0_ovp_ia] = (mo_e_o[ki][:,None] - mo_e_v[ka])[n0_ovp_ia]
+        eia = _get_epq([0,nocc,ki,mo_e_o,nonzero_opadding],
+                       [0,nvir,ka,mo_e_v,nonzero_vpadding],
+                       fac=[1.0,-1.0])
         pt1[ki] /= eia
 
     pt2 = numpy.zeros((nkpts, nkpts, nkpts, nocc, nocc, nvir, nvir), dtype=dtype)
@@ -501,15 +504,13 @@ def get_t3p2_imds_slow(cc, t1, t2, eris=None, t3p2_ip_out=None, t3p2_ea_out=None
                 pt2[ki,kj,ka] -= 0.5 * lib.einsum('inmabe,nmje->ijab', t3[ki,kn,km,ka,kb], eris.ooov[kn,km,kj])
                 pt2[ki,kj,ka] += 0.5 * lib.einsum('jnmabe,nmie->ijab', t3[kj,kn,km,ka,kb], eris.ooov[kn,km,ki])
 
-        eia = LARGE_DENOM * numpy.ones((nocc, nvir), dtype=eris.mo_energy[0].dtype)
-        n0_ovp_ia = numpy.ix_(nonzero_opadding[ki], nonzero_vpadding[ka])
-        eia[n0_ovp_ia] = (mo_e_o[ki][:,None] - mo_e_v[ka])[n0_ovp_ia]
-
-        ejb = LARGE_DENOM * numpy.ones((nocc, nvir), dtype=eris.mo_energy[0].dtype)
-        n0_ovp_jb = numpy.ix_(nonzero_opadding[kj], nonzero_vpadding[kb])
-        ejb[n0_ovp_jb] = (mo_e_o[kj][:,None] - mo_e_v[kb])[n0_ovp_jb]
+        eia = _get_epq([0,nocc,ki,mo_e_o,nonzero_opadding],
+                       [0,nvir,ka,mo_e_v,nonzero_vpadding],
+                       fac=[1.0,-1.0])
+        ejb = _get_epq([0,nocc,kj,mo_e_o,nonzero_opadding],
+                       [0,nvir,kb,mo_e_v,nonzero_vpadding],
+                       fac=[1.0,-1.0])
         eijab = eia[:, None, :, None] + ejb[:, None, :]
-
         pt2[ki,kj,ka] /= eijab
 
     pt1 += t1

--- a/pyscf/pbc/cc/kintermediates.py
+++ b/pyscf/pbc/cc/kintermediates.py
@@ -370,6 +370,11 @@ def get_full_t3p2(mycc, t1, t2, eris):
     fov = fock[:, :nocc, nocc:]
     foo = numpy.array([fock[ikpt, :nocc, :nocc].diagonal() for ikpt in range(nkpts)])
     fvv = numpy.array([fock[ikpt, nocc:, nocc:].diagonal() for ikpt in range(nkpts)])
+    mo_energy_occ = numpy.array([eris.mo_energy[ki][:nocc] for ki in range(nkpts)])
+    mo_energy_vir = numpy.array([eris.mo_energy[ki][nocc:] for ki in range(nkpts)])
+
+    mo_e_o = mo_energy_occ
+    mo_e_v = mo_energy_vir
 
     t3 = numpy.empty((nkpts,nkpts,nkpts,nkpts,nkpts,nocc,nocc,nocc,nvir,nvir,nvir),
                       dtype=t2.dtype)
@@ -387,11 +392,11 @@ def get_full_t3p2(mycc, t1, t2, eris):
           t3.transpose(2,0,1,3,4,7,5,6,8,9,10))
 
     for ki, kj, kk in product(range(nkpts), repeat=3):
-        eijk = foo[ki][:, None, None] + foo[kj][None, :, None] + foo[kk][None, None, :]
+        eijk = mo_e_o[ki][:, None, None] + mo_e_o[kj][None, :, None] + mo_e_o[kk][None, None, :]
         for ka, kb in product(range(nkpts), repeat=2):
             kc = kpts_helper.get_kconserv3(mycc._scf.cell, mycc.kpts,
                                            [ki, kj, kk, ka, kb])
-            eabc = fvv[ka][:, None, None] + fvv[kb][None, :, None] + fvv[kc][None, None, :]
+            eabc = mo_e_v[ka][:, None, None] + mo_e_v[kb][None, :, None] + mo_e_v[kc][None, None, :]
             eijkabc = eijk[:, :, :, None, None, None] - eabc[None, None, None, :, :, :]
             t3[ki,kj,kk,ka,kb] /= eijkabc
 

--- a/pyscf/pbc/cc/kintermediates_rhf.py
+++ b/pyscf/pbc/cc/kintermediates_rhf.py
@@ -453,7 +453,7 @@ def get_t3p2_imds_slow(cc, t1, t2, eris=None, t3p2_ip_out=None, t3p2_ea_out=None
     """For a description of arguments, see `get_t3p2_imds_slow` in
     the corresponding `kintermediates.py`.
     """
-    from kccsd_t_rhf import _get_epqr
+    from pyscf.pbc.cc.kccsd_t_rhf import _get_epqr
     if eris is None:
         eris = cc.ao2mo()
     fock = eris.fock
@@ -691,7 +691,7 @@ def get_t3p2_imds(mycc, t1, t2, eris=None, t3p2_ip_out=None, t3p2_ea_out=None):
     """For a description of arguments, see `get_t3p2_imds_slow` in
     the corresponding `kintermediates.py`.
     """
-    from kccsd_t_rhf import _get_epqr
+    from pyscf.pbc.cc.kccsd_t_rhf import _get_epqr
     cpu1 = cpu0 = (time.clock(), time.time())
     if eris is None:
         eris = mycc.ao2mo()
@@ -722,7 +722,7 @@ def get_t3p2_imds(mycc, t1, t2, eris=None, t3p2_ip_out=None, t3p2_ea_out=None):
     Wacek = t3p2_ea_out
 
     # Create necessary temporary eris for fast read
-    from kccsd_t_rhf import create_t3_eris, get_data_slices
+    from pyscf.pbc.cc.kccsd_t_rhf import create_t3_eris, get_data_slices
     feri_tmp, t2T, eris_vvop, eris_vooo_C = create_t3_eris(mycc, kconserv, [eris.vovv, eris.oovv, eris.ooov, t2])
     t1T = np.array([x.T for x in t1], dtype=np.complex, order='C')
     fvo = np.array([x.T for x in fov], dtype=np.complex, order='C')

--- a/pyscf/pbc/cc/kintermediates_rhf.py
+++ b/pyscf/pbc/cc/kintermediates_rhf.py
@@ -789,7 +789,6 @@ def get_t3p2_imds(mycc, t1, t2, eris=None, t3p2_ip_out=None, t3p2_ea_out=None):
 
     pt1 = np.zeros((nkpts,nocc,nvir), dtype=dtype)
     pt2 = np.zeros((nkpts,nkpts,nkpts,nocc,nocc,nvir,nvir), dtype=dtype)
-    print ""
     for ka, kb in product(range(nkpts), repeat=2):
         for task_id, task in enumerate(tasks):
             cput2 = (time.clock(), time.time())

--- a/pyscf/pbc/cc/test/test_eom_krccsd.py
+++ b/pyscf/pbc/cc/test/test_eom_krccsd.py
@@ -263,11 +263,11 @@ class KnownValues(unittest.TestCase):
         rand_cc.t1, rand_cc.t2, rand_cc.eris = t1, t2, eris
 
         e, pt1, pt2, Wmcik, Wacek = kintermediates_rhf.get_t3p2_imds_slow(rand_cc, t1, t2)
-        self.assertAlmostEqual(lib.finger(e),47165803.39384298, 5)
-        self.assertAlmostEqual(lib.finger(pt1),10444.351837617747+20016.35108560657j, 5)
-        self.assertAlmostEqual(lib.finger(pt2),5481819.3905677245929837+-8012159.8432002812623978j, 4)
-        self.assertAlmostEqual(lib.finger(Wmcik),-4401.1631306775143457+-10002.8851650238902948j, 5)
-        self.assertAlmostEqual(lib.finger(Wacek),2057.9135114790879015+1970.9887693509299424j, 5)
+        self.assertAlmostEqual(lib.finger(e),47165803.39384298, 3)
+        self.assertAlmostEqual(lib.finger(pt1),10444.351837617747+20016.35108560657j, 4)
+        self.assertAlmostEqual(lib.finger(pt2),5481819.3905677245929837+-8012159.8432002812623978j, 3)
+        self.assertAlmostEqual(lib.finger(Wmcik),-4401.1631306775143457+-10002.8851650238902948j, 4)
+        self.assertAlmostEqual(lib.finger(Wacek),2057.9135114790879015+1970.9887693509299424j, 4)
 
     def test_t3p2_imds_complex(self):
         '''Test t3p2 implementation.'''
@@ -285,11 +285,11 @@ class KnownValues(unittest.TestCase):
         rand_cc.t1, rand_cc.t2, rand_cc.eris = t1, t2, eris
 
         e, pt1, pt2, Wmcik, Wacek = kintermediates_rhf.get_t3p2_imds(rand_cc, t1, t2)
-        self.assertAlmostEqual(lib.finger(e), 47165803.393840045, 4)
-        self.assertAlmostEqual(lib.finger(pt1),10444.3518376177471509+20016.3510856065695407j, 5)
-        self.assertAlmostEqual(lib.finger(pt2),5481819.3905677245929837+-8012159.8432002812623978j, 4)
-        self.assertAlmostEqual(lib.finger(Wmcik),-4401.1631306775143457+-10002.8851650238902948j, 5)
-        self.assertAlmostEqual(lib.finger(Wacek),2057.9135114790879015+1970.9887693509299424j, 5)
+        self.assertAlmostEqual(lib.finger(e), 47165803.393840045, 3)
+        self.assertAlmostEqual(lib.finger(pt1),10444.3518376177471509+20016.3510856065695407j, 4)
+        self.assertAlmostEqual(lib.finger(pt2),5481819.3905677245929837+-8012159.8432002812623978j, 3)
+        self.assertAlmostEqual(lib.finger(Wmcik),-4401.1631306775143457+-10002.8851650238902948j, 4)
+        self.assertAlmostEqual(lib.finger(Wacek),2057.9135114790879015+1970.9887693509299424j, 4)
 
     def test_t3p2_imds_complex_against_so(self):
         '''Test t3[2] implementation against spin-orbital implmentation.'''

--- a/pyscf/pbc/cc/test/test_eom_krccsd.py
+++ b/pyscf/pbc/cc/test/test_eom_krccsd.py
@@ -243,7 +243,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(eea_gccsd[0][0], eea_rccsd[0][0], 9)
         self.assertAlmostEqual(eip_gccsd[0][0], eip_rccsd[0][0], 9)
 
-    def test_t3p2_intermediates_complex(self):
+    def test_t3p2_intermediates_complex_slow(self):
         rand_cc = pbcc.kccsd_rhf.RCCSD(rand_kmf)
         eris = rand_cc.ao2mo(rand_kmf.mo_coeff)
         eris.mo_energy = [eris.fock[k].diagonal() for k in range(rand_cc.nkpts)]
@@ -251,8 +251,22 @@ class KnownValues(unittest.TestCase):
         rand_cc.t1, rand_cc.t2, rand_cc.eris = t1, t2, eris
 
         e, pt1, pt2, Wmcik, Wacek = kintermediates_rhf.get_t3p2_imds_slow(rand_cc, t1, t2)
-        self.assertAlmostEqual(lib.finger(e),47165803.3938429802656174+  0.0000000000000000j, 5)
+        self.assertAlmostEqual(lib.finger(e),47165803.39384298, 5)
+        self.assertAlmostEqual(lib.finger(pt1),10444.351837617747+20016.35108560657j, 5)
+        self.assertAlmostEqual(lib.finger(pt2),5481819.3905677245929837+-8012159.8432002812623978j, 4)
+        self.assertAlmostEqual(lib.finger(Wmcik),-4401.1631306775143457+-10002.8851650238902948j, 5)
+        self.assertAlmostEqual(lib.finger(Wacek),2057.9135114790879015+1970.9887693509299424j, 5)
+
+    def test_t3p2_intermediates_complex(self):
+        rand_cc = pbcc.kccsd_rhf.RCCSD(rand_kmf)
+        eris = rand_cc.ao2mo(rand_kmf.mo_coeff)
+        eris.mo_energy = [eris.fock[k].diagonal() for k in range(rand_cc.nkpts)]
+        t1, t2 = rand_t1_t2(rand_kmf, rand_cc)
+        rand_cc.t1, rand_cc.t2, rand_cc.eris = t1, t2, eris
+
+        e, pt1, pt2, Wmcik, Wacek = kintermediates_rhf.get_t3p2_imds(rand_cc, t1, t2)
+        self.assertAlmostEqual(lib.finger(e),47165803.39386989, 5)
         self.assertAlmostEqual(lib.finger(pt1),10444.3518376177471509+20016.3510856065695407j, 5)
-        self.assertAlmostEqual(lib.finger(pt2),5481819.3905677245929837+-8012159.8432002812623978j, 5)
+        self.assertAlmostEqual(lib.finger(pt2),5481819.3905677245929837+-8012159.8432002812623978j, 4)
         self.assertAlmostEqual(lib.finger(Wmcik),-4401.1631306775143457+-10002.8851650238902948j, 5)
         self.assertAlmostEqual(lib.finger(Wacek),2057.9135114790879015+1970.9887693509299424j, 5)

--- a/pyscf/pbc/cc/test/test_eom_krccsd.py
+++ b/pyscf/pbc/cc/test/test_eom_krccsd.py
@@ -283,7 +283,7 @@ class KnownValues(unittest.TestCase):
         rand_cc.t1, rand_cc.t2, rand_cc.eris = t1, t2, eris
 
         e, pt1, pt2, Wmcik, Wacek = kintermediates_rhf.get_t3p2_imds(rand_cc, t1, t2)
-        self.assertAlmostEqual(lib.finger(e),47165803.39386989, 5)
+        self.assertAlmostEqual(lib.finger(e), 47165803.393840045, 4)
         self.assertAlmostEqual(lib.finger(pt1),10444.3518376177471509+20016.3510856065695407j, 5)
         self.assertAlmostEqual(lib.finger(pt2),5481819.3905677245929837+-8012159.8432002812623978j, 4)
         self.assertAlmostEqual(lib.finger(Wmcik),-4401.1631306775143457+-10002.8851650238902948j, 5)

--- a/pyscf/pbc/cc/test/test_eom_krccsd.py
+++ b/pyscf/pbc/cc/test/test_eom_krccsd.py
@@ -1,11 +1,15 @@
 import make_test_cell
+import numpy
 from pyscf.pbc.tools.pbc import super_cell
 from pyscf.pbc import gto
 from pyscf.pbc import cc as pbcc
 from pyscf.pbc import scf as pbcscf
 from pyscf.pbc.cc.eom_kccsd_rhf import EOMIP, EOMEA
 from pyscf.pbc.cc.eom_kccsd_rhf import EOMIP_Ta, EOMEA_Ta
+from pyscf.pbc.lib import kpts_helper
 from pyscf.cc import eom_uccsd
+from pyscf.pbc.cc import kintermediates_rhf
+from pyscf import lib
 import unittest
 
 cell_n3d = make_test_cell.test_cell_n3_diffuse()
@@ -13,9 +17,82 @@ kmf = pbcscf.KRHF(cell_n3d, cell_n3d.make_kpts((1,1,2), with_gamma_point=True), 
 kmf.conv_tol = 1e-10
 kmf.scf()
 
+# Helper functions
+def kconserve_pmatrix(nkpts, kconserv):
+    Ps = numpy.zeros((nkpts, nkpts, nkpts, nkpts))
+    for ki in range(nkpts):
+        for kj in range(nkpts):
+            for ka in range(nkpts):
+                # Chemist's notation for momentum conserving t2(ki,kj,ka,kb)
+                kb = kconserv[ki, ka, kj]
+                Ps[ki, kj, ka, kb] = 1
+    return Ps
+
+def rand_t1_t2(kmf, mycc):
+    nkpts = mycc.nkpts
+    nocc = mycc.nocc
+    nmo = mycc.nmo
+    nvir = nmo - nocc
+    numpy.random.seed(1)
+    t1 = (numpy.random.random((nkpts, nocc, nvir)) +
+          numpy.random.random((nkpts, nocc, nvir)) * 1j - .5 - .5j)
+    t2 = (numpy.random.random((nkpts, nkpts, nkpts, nocc, nocc, nvir, nvir)) +
+          numpy.random.random((nkpts, nkpts, nkpts, nocc, nocc, nvir, nvir)) * 1j - .5 - .5j)
+    kconserv = kpts_helper.get_kconserv(kmf.cell, kmf.kpts)
+    Ps = kconserve_pmatrix(nkpts, kconserv)
+    t2 = t2 + numpy.einsum('xyzijab,xyzw->yxwjiba', t2, Ps)
+    return t1, t2
+
+def rand_r1_r2_ip(kmf, mycc):
+    nkpts = mycc.nkpts
+    nocc = mycc.nocc
+    nmo = mycc.nmo
+    nvir = nmo - nocc
+    numpy.random.seed(1)
+    r1 = (numpy.random.random((nocc,)) +
+          numpy.random.random((nocc,)) * 1j - .5 - .5j)
+    r2 = (numpy.random.random((nkpts, nkpts, nocc, nocc, nvir)) +
+          numpy.random.random((nkpts, nkpts, nocc, nocc, nvir)) * 1j - .5 - .5j)
+    return r1, r2
+
+def rand_r1_r2_ea(kmf, mycc):
+    nkpts = mycc.nkpts
+    nocc = mycc.nocc
+    nmo = mycc.nmo
+    nvir = nmo - nocc
+    numpy.random.seed(1)
+    r1 = (numpy.random.random((nvir,)) +
+          numpy.random.random((nvir,)) * 1j - .5 - .5j)
+    r2 = (numpy.random.random((nkpts, nkpts, nocc, nvir, nvir)) +
+          numpy.random.random((nkpts, nkpts, nocc, nvir, nvir)) * 1j - .5 - .5j)
+    return r1, r2
+
+def make_rand_kmf():
+    # Not perfect way to generate a random mf.
+    # CSC = 1 is not satisfied and the fock matrix is neither
+    # diagonal nor sorted.
+    numpy.random.seed(2)
+    kmf = pbcscf.KRHF(cell_n3d, kpts=cell_n3d.make_kpts([1, 1, 3]))
+    kmf.exxdiv = None
+    nmo = cell_n3d.nao_nr()
+    kmf.mo_occ = numpy.zeros((3, nmo))
+    kmf.mo_occ[:, :2] = 2
+    kmf.mo_energy = numpy.arange(nmo) + numpy.random.random((3, nmo)) * .3
+    kmf.mo_energy[kmf.mo_occ == 0] += 2
+    kmf.mo_coeff = (numpy.random.random((3, nmo, nmo)) +
+                    numpy.random.random((3, nmo, nmo)) * 1j - .5 - .5j)
+    # Round to make this insensitive to small changes between PySCF versions
+    mat_veff = kmf.get_veff().round(4)
+    mat_hcore = kmf.get_hcore().round(4)
+    kmf.get_veff = lambda *x: mat_veff
+    kmf.get_hcore = lambda *x: mat_hcore
+    return kmf
+
+rand_kmf = make_rand_kmf()
+
 def tearDownModule():
-    global cell_n3d, kmf
-    del cell_n3d, kmf
+    global cell_n3d, kmf, rand_kmf
+    del cell_n3d, kmf, rand_kmf
 
 class KnownValues(unittest.TestCase):
     def test_n3_diffuse(self):
@@ -165,3 +242,17 @@ class KnownValues(unittest.TestCase):
         # Usually slightly higher agreement when comparing directly against one another
         self.assertAlmostEqual(eea_gccsd[0][0], eea_rccsd[0][0], 9)
         self.assertAlmostEqual(eip_gccsd[0][0], eip_rccsd[0][0], 9)
+
+    def test_t3p2_intermediates_complex(self):
+        rand_cc = pbcc.kccsd_rhf.RCCSD(rand_kmf)
+        eris = rand_cc.ao2mo(rand_kmf.mo_coeff)
+        eris.mo_energy = [eris.fock[k].diagonal() for k in range(rand_cc.nkpts)]
+        t1, t2 = rand_t1_t2(rand_kmf, rand_cc)
+        rand_cc.t1, rand_cc.t2, rand_cc.eris = t1, t2, eris
+
+        e, pt1, pt2, Wmcik, Wacek = kintermediates_rhf.get_t3p2_imds_slow(rand_cc, t1, t2)
+        self.assertAlmostEqual(lib.finger(e),47165803.3938429802656174+  0.0000000000000000j, 5)
+        self.assertAlmostEqual(lib.finger(pt1),10444.3518376177471509+20016.3510856065695407j, 5)
+        self.assertAlmostEqual(lib.finger(pt2),5481819.3905677245929837+-8012159.8432002812623978j, 5)
+        self.assertAlmostEqual(lib.finger(Wmcik),-4401.1631306775143457+-10002.8851650238902948j, 5)
+        self.assertAlmostEqual(lib.finger(Wacek),2057.9135114790879015+1970.9887693509299424j, 5)

--- a/pyscf/pbc/cc/test/test_eom_krccsd.py
+++ b/pyscf/pbc/cc/test/test_eom_krccsd.py
@@ -95,8 +95,8 @@ rand_kmf1 = make_rand_kmf(nkpts=1)
 rand_kmf2 = make_rand_kmf(nkpts=2)
 
 def tearDownModule():
-    global cell_n3d, kmf, rand_kmf
-    del cell_n3d, kmf, rand_kmf
+    global cell_n3d, kmf, rand_kmf, rand_kmf1, rand_kmf2
+    del cell_n3d, kmf, rand_kmf, rand_kmf1, rand_kmf2
 
 class KnownValues(unittest.TestCase):
     def test_n3_diffuse(self):

--- a/pyscf/pbc/cc/test/test_eom_krccsd.py
+++ b/pyscf/pbc/cc/test/test_eom_krccsd.py
@@ -91,6 +91,7 @@ def make_rand_kmf(nkpts=3):
     return kmf
 
 rand_kmf = make_rand_kmf()
+rand_kmf1 = make_rand_kmf(nkpts=1)
 rand_kmf2 = make_rand_kmf(nkpts=2)
 
 def tearDownModule():
@@ -300,7 +301,6 @@ class KnownValues(unittest.TestCase):
 
         rand_cc = pbcc.kccsd_rhf.RCCSD(kmf)
         eris = rand_cc.ao2mo(kmf.mo_coeff)
-        #print eris.oovv[0,0,0]
         eris.mo_energy = [eris.fock[k].diagonal() for k in range(rand_cc.nkpts)]
         t1, t2 = rand_t1_t2(kmf, rand_cc)
         rand_cc.t1, rand_cc.t2, rand_cc.eris = t1, t2, eris

--- a/pyscf/pbc/cc/test/test_kgccsd.py
+++ b/pyscf/pbc/cc/test/test_kgccsd.py
@@ -377,6 +377,15 @@ class KnownValues(unittest.TestCase):
         energy_t_bench = -0.00191440345386
         self.assertAlmostEqual(energy_t, energy_t_bench, 6)
 
+        mycc = pbcc.KGCCSD(kmf, frozen=2)
+        eris = mycc.ao2mo()
+        ecc, t1, t2 = mycc.kernel(eris=eris)
+
+        #eris.mo_energy = [eris.fock[i].diagonal() for i in range(len(kpts))]
+        energy_t = kccsd_t.kernel(mycc, eris=eris)
+        energy_t_bench = -0.0006758542603695721
+        self.assertAlmostEqual(energy_t, energy_t_bench, 6)
+
     def test_rand_ccsd(self):
         '''Single (eom-)ccsd iteration with random t1/t2.'''
         kmf = pbcscf.addons.convert_to_ghf(rand_kmf)

--- a/pyscf/pbc/cc/test/test_krccsd.py
+++ b/pyscf/pbc/cc/test/test_krccsd.py
@@ -633,6 +633,36 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(ekrcc_t, -0.0021709465899365336, 6)
         self.assertAlmostEqual(ekrcc_t, ekgcc_t, 6)
 
+    def test_rccsd_t_non_hf_against_so_frozen(self):
+        '''Tests rccsd_t with gccsd_t with frozen orbitals.'''
+        n = 7
+        cell = make_test_cell.test_cell_n3([n]*3)
+        #import sys
+        #cell.stdout = sys.stdout
+        #cell.verbose = 7
+
+        nk = [2, 1, 1]
+        kpts = cell.make_kpts(nk)
+        kpts -= kpts[0]
+        kks = pbcscf.KRKS(cell, kpts=kpts)
+        ekks = kks.kernel()
+
+        khf = pbcscf.KRHF(cell)
+        khf.__dict__.update(kks.__dict__)
+
+        mycc = pbcc.KGCCSD(khf, frozen=[[],[0,1]])
+        eris = mycc.ao2mo()
+        ekgcc, t1, t2 = mycc.kernel(eris=eris)
+        ekgcc_t = mycc.ccsd_t(eris=eris)
+
+        mycc = pbcc.KRCCSD(khf, frozen=[[],[0]])
+        eris = mycc.ao2mo()
+        ekrcc, t1, t2 = mycc.kernel(eris=eris)
+        ekrcc_t = mycc.ccsd_t(eris=eris)
+
+        self.assertAlmostEqual(ekrcc_t, -0.0018712836246782309, 6)
+        self.assertAlmostEqual(ekrcc_t, ekgcc_t, 6)
+
     def test_ccsd_t_high_cost(self):
         n = 14
         cell = make_test_cell.test_cell_n3([n]*3)

--- a/pyscf/pbc/cc/test/test_krccsd.py
+++ b/pyscf/pbc/cc/test/test_krccsd.py
@@ -17,6 +17,7 @@
 #          Timothy Berkelbach <tim.berkelbach@gmail.com>
 #
 
+import copy
 import unittest
 import numpy as np
 
@@ -683,15 +684,29 @@ class KnownValues(unittest.TestCase):
 
     def test_rccsd_t_vs_gccsd_t(self):
         '''Test rccsd(t) vs gccsd(t) with k-points.'''
-        rand_cc = pbcc.KRCCSD(rand_kmf)
-        eris = rand_cc.ao2mo(rand_kmf.mo_coeff)
+        from pyscf.pbc.scf.addons import convert_to_ghf
+        kmf = copy.copy(rand_kmf)
+        mat_veff = kmf.get_veff().round(4)
+        mat_hcore = kmf.get_hcore().round(4)
+        kmf.get_veff = lambda *x: mat_veff
+        kmf.get_hcore = lambda *x: mat_hcore
+
+        rand_cc = pbcc.KRCCSD(kmf)
+        eris = rand_cc.ao2mo(kmf.mo_coeff)
         eris.mo_energy = [eris.fock[k].diagonal() for k in range(rand_cc.nkpts)]
-        t1, t2 = rand_t1_t2(rand_kmf, rand_cc)
+        t1, t2 = rand_t1_t2(kmf, rand_cc)
         rand_cc.t1, rand_cc.t2, rand_cc.eris = t1, t2, eris
         energy_t = kccsd_t_rhf.kernel(rand_cc, eris=eris)
 
+        gkmf = convert_to_ghf(rand_kmf)
+        # Round to make this insensitive to small changes between PySCF versions
+        mat_veff = gkmf.get_veff().round(4)
+        mat_hcore = gkmf.get_hcore().round(4)
+        gkmf.get_veff = lambda *x: mat_veff
+        gkmf.get_hcore = lambda *x: mat_hcore
+
         from pyscf.pbc.cc import kccsd_t
-        rand_gcc = pbcc.KGCCSD(rand_kmf)
+        rand_gcc = pbcc.KGCCSD(gkmf)
         eris = rand_gcc.ao2mo(rand_gcc.mo_coeff)
         eris.mo_energy = [eris.fock[k].diagonal() for k in range(rand_cc.nkpts)]
         gt1 = rand_gcc.spatial2spin(t1)
@@ -699,77 +714,95 @@ class KnownValues(unittest.TestCase):
         rand_gcc.t1, rand_gcc.t2, rand_gcc.eris = gt1, gt2, eris
         genergy_t = kccsd_t.kernel(rand_gcc, eris=eris)
 
-        self.assertAlmostEqual(energy_t, -62.20775227754235, 6)
-        self.assertAlmostEqual(energy_t, genergy_t, 10)
+        self.assertAlmostEqual(energy_t, -65.5365125645066, 6)
+        self.assertAlmostEqual(energy_t, genergy_t, 8)
 
     def test_rand_ccsd(self):
         '''Single (eom-)ccsd iteration with random t1/t2.'''
-        rand_cc = pbcc.KRCCSD(rand_kmf)
-        eris = rand_cc.ao2mo(rand_kmf.mo_coeff)
+        kmf = copy.copy(rand_kmf)
+        mat_veff = kmf.get_veff().round(4)
+        mat_hcore = kmf.get_hcore().round(4)
+        kmf.get_veff = lambda *x: mat_veff
+        kmf.get_hcore = lambda *x: mat_hcore
+
+        rand_cc = pbcc.KRCCSD(kmf)
+        eris = rand_cc.ao2mo(kmf.mo_coeff)
         eris.mo_energy = [eris.fock[k].diagonal() for k in range(rand_cc.nkpts)]
-        t1, t2 = rand_t1_t2(rand_kmf, rand_cc)
+        t1, t2 = rand_t1_t2(kmf, rand_cc)
         rand_cc.t1, rand_cc.t2, rand_cc.eris = t1, t2, eris
 
         t1, t2 = rand_cc.t1, rand_cc.t2
         Ht1, Ht2 = rand_cc.update_amps(t1, t2, eris)
-        self.assertAlmostEqual(finger(Ht1), (-4.681061461942224+9.496368887816889j), 6)
-        self.assertAlmostEqual(finger(Ht2), (18.596112060562664+114.64086843562939j), 6)
+        self.assertAlmostEqual(finger(Ht1), (-4.6942326686+9.50185397111j), 6)
+        self.assertAlmostEqual(finger(Ht2), (17.1490394799+110.137726574j), 6)
 
         # Excited state results
         kshift = 0
-        r1, r2 = rand_r1_r2_ip(rand_kmf, rand_cc)
+        r1, r2 = rand_r1_r2_ip(kmf, rand_cc)
         Hr1, Hr2 = _run_ip_matvec(rand_cc, r1, r2, kshift)
-        self.assertAlmostEqual(finger(Hr1), (-0.45633804865028355-0.048637849502936675j), 6)
-        self.assertAlmostEqual(finger(Hr2), (0.6159708665361551+2.087978610416984j), 6)
+        self.assertAlmostEqual(finger(Hr1), (-0.456418558025-0.0485067398162j), 6)
+        self.assertAlmostEqual(finger(Hr2), (0.616016341219+2.08777776589j), 6)
 
-        r1, r2 = rand_r1_r2_ea(rand_kmf, rand_cc)
+        r1, r2 = rand_r1_r2_ea(kmf, rand_cc)
         Hr1, Hr2 = _run_ea_matvec(rand_cc, r1, r2, kshift)
-        self.assertAlmostEqual(finger(Hr1), (-0.2348605115213025-0.21832289757435613j), 6)
-        self.assertAlmostEqual(finger(Hr2), (-3.562306992027342+2.120507990816163j), 6)
+        self.assertAlmostEqual(finger(Hr1), (-0.234979092885-0.218401823892j), 6)
+        self.assertAlmostEqual(finger(Hr2), (-3.56244154449+2.12051064183j), 6)
 
     def test_rand_ccsd_frozen0(self):
         '''Single (eom-)ccsd iteration with random t1/t2 and lowest lying orbital
         at multiple k-points frozen.'''
-        rand_cc = pbcc.KRCCSD(rand_kmf, frozen=1)
-        eris = rand_cc.ao2mo(rand_kmf.mo_coeff)
+        kmf = copy.copy(rand_kmf)
+        mat_veff = kmf.get_veff().round(4)
+        mat_hcore = kmf.get_hcore().round(4)
+        kmf.get_veff = lambda *x: mat_veff
+        kmf.get_hcore = lambda *x: mat_hcore
+
+        rand_cc = pbcc.KRCCSD(kmf, frozen=1)
+        eris = rand_cc.ao2mo(kmf.mo_coeff)
         eris.mo_energy = [eris.fock[k].diagonal() for k in range(rand_cc.nkpts)]
 
-        t1, t2 = rand_t1_t2(rand_kmf, rand_cc)
+        t1, t2 = rand_t1_t2(kmf, rand_cc)
         Ht1, Ht2 = rand_cc.update_amps(t1, t2, eris)
-        self.assertAlmostEqual(finger(Ht1), (-8.071714768434164+8.284139832758116j), 6)
-        self.assertAlmostEqual(finger(Ht2), (30.727660436991815-14.347493823633515j), 6)
+        self.assertAlmostEqual(finger(Ht1), (-8.06918006043+8.2779236131j), 6)
+        self.assertAlmostEqual(finger(Ht2), (30.6692903818-14.2701276046j), 6)
 
         frozen = [[0,],[0,],[0,]]
-        rand_cc = pbcc.KRCCSD(rand_kmf, frozen=frozen)
-        eris = rand_cc.ao2mo(rand_kmf.mo_coeff)
+        rand_cc = pbcc.KRCCSD(kmf, frozen=frozen)
+        eris = rand_cc.ao2mo(kmf.mo_coeff)
         eris.mo_energy = [eris.fock[k].diagonal() for k in range(rand_cc.nkpts)]
-        t1, t2 = rand_t1_t2(rand_kmf, rand_cc)
+        t1, t2 = rand_t1_t2(kmf, rand_cc)
         Ht1, Ht2 = rand_cc.update_amps(t1, t2, eris)
-        self.assertAlmostEqual(finger(Ht1), (-8.071714768434164+8.284139832758116j), 6)
-        self.assertAlmostEqual(finger(Ht2), (30.727660436991815-14.347493823633515j), 6)
+        self.assertAlmostEqual(finger(Ht1), (-8.06918006043+8.2779236131j), 6)
+        self.assertAlmostEqual(finger(Ht2), (30.6692903818-14.2701276046j), 6)
 
         # Excited state results
         rand_cc.t1, rand_cc.t2, rand_cc.eris = t1, t2, eris
 
         kshift = 0
-        r1, r2 = rand_r1_r2_ip(rand_kmf, rand_cc)
+        r1, r2 = rand_r1_r2_ip(kmf, rand_cc)
         Hr1, Hr2 = _run_ip_matvec(rand_cc, r1, r2, kshift)
-        self.assertAlmostEqual(finger(Hr1), (0.28941587929738033-0.3940117414961838j), 6)
-        self.assertAlmostEqual(finger(Hr2), (0.05638926343687076+0.1566304977316827j), 6)
+        self.assertAlmostEqual(finger(Hr1), (0.289384011655-0.394002590665j), 6)
+        self.assertAlmostEqual(finger(Hr2), (0.056437476036+0.156522915807j), 6)
 
-        r1, r2 = rand_r1_r2_ea(rand_kmf, rand_cc)
+        r1, r2 = rand_r1_r2_ea(kmf, rand_cc)
         Hr1, Hr2 = _run_ea_matvec(rand_cc, r1, r2, kshift)
-        self.assertAlmostEqual(finger(Hr1), (0.29802527764791387+0.09426803731862107j), 6)
-        self.assertAlmostEqual(finger(Hr2), (-0.2434215819613672+0.8694581227096677j), 6)
+        self.assertAlmostEqual(finger(Hr1), (0.298028415374+0.0944020804565j), 6)
+        self.assertAlmostEqual(finger(Hr2), (-0.243561845158+0.869173612894j), 6)
 
     def test_rand_ccsd_frozen1(self):
         '''Single (eom-)ccsd iteration with random t1/t2 and single frozen occupied
         orbital.'''
+        kmf = copy.copy(rand_kmf)
+        mat_veff = kmf.get_veff().round(4)
+        mat_hcore = kmf.get_hcore().round(4)
+        kmf.get_veff = lambda *x: mat_veff
+        kmf.get_hcore = lambda *x: mat_hcore
+
         frozen = [[0,],[],[]]
-        rand_cc = pbcc.KRCCSD(rand_kmf, frozen=frozen)
-        eris = rand_cc.ao2mo(rand_kmf.mo_coeff)
+        rand_cc = pbcc.KRCCSD(kmf, frozen=frozen)
+        eris = rand_cc.ao2mo(kmf.mo_coeff)
         eris.mo_energy = [eris.fock[k].diagonal() for k in range(rand_cc.nkpts)]
-        t1, t2 = rand_t1_t2(rand_kmf, rand_cc)
+        t1, t2 = rand_t1_t2(kmf, rand_cc)
         # Manually zero'ing out the frozen elements of the t1/t2
         # N.B. the 0'th element frozen means we are freezing the 1'th
         #      element in the current padding scheme
@@ -778,35 +811,41 @@ class KnownValues(unittest.TestCase):
         t2[:, 0, :, :, 1] = 0.0
 
         Ht1, Ht2 = rand_cc.update_amps(t1, t2, eris)
-        self.assertAlmostEqual(finger(Ht1), (-9.3095890633577+16.394056398917446j), 6)
-        self.assertAlmostEqual(finger(Ht2), (-3.7095459835872475+56.25931189248618j), 6)
+        self.assertAlmostEqual(finger(Ht1), (-9.31532552971+16.3972283898j), 6)
+        self.assertAlmostEqual(finger(Ht2), (-4.42939435314+52.147616355j), 6)
 
         # Excited state results
         rand_cc.t1, rand_cc.t2, rand_cc.eris = t1, t2, eris
 
         kshift = 0
-        r1, r2 = rand_r1_r2_ip(rand_kmf, rand_cc)
+        r1, r2 = rand_r1_r2_ip(kmf, rand_cc)
         r1[1] = 0.0
         r2[0, :, 1] = 0.0
         r2[:, 0, :, 1] = 0.0
         Hr1, Hr2 = _run_ip_matvec(rand_cc, r1, r2, kshift)
-        self.assertAlmostEqual(finger(Hr1), (-0.5585807876655065-0.3444926847334551j), 6)
-        self.assertAlmostEqual(finger(Hr2), (0.8831390483845195+0.07528473762808813j), 6)
+        self.assertAlmostEqual(finger(Hr1), (-0.558560718395-0.344470539404j), 6)
+        self.assertAlmostEqual(finger(Hr2), (0.882960101238+0.0752022769822j), 6)
 
-        r1, r2 = rand_r1_r2_ea(rand_kmf, rand_cc)
+        r1, r2 = rand_r1_r2_ea(kmf, rand_cc)
         r2[0, :, 1] = 0.0
         Hr1, Hr2 = _run_ea_matvec(rand_cc, r1, r2, kshift)
-        self.assertAlmostEqual(finger(Hr1), (0.01100476529637437-0.2869863479026128j), 6)
-        self.assertAlmostEqual(finger(Hr2), (-2.5889072159166306+0.6853377118654543j), 6)
+        self.assertAlmostEqual(finger(Hr1), (0.010947007472-0.287095461151j), 6)
+        self.assertAlmostEqual(finger(Hr2), (-2.58907863831+0.685390702884j), 6)
 
     def test_rand_ccsd_frozen2(self):
         '''Single (eom-)ccsd iteration with random t1/t2 and full occupied frozen
         at a single k-point.'''
+        kmf = copy.copy(rand_kmf)
+        mat_veff = kmf.get_veff().round(4)
+        mat_hcore = kmf.get_hcore().round(4)
+        kmf.get_veff = lambda *x: mat_veff
+        kmf.get_hcore = lambda *x: mat_hcore
+
         frozen = [[],[0,1],[]]
-        rand_cc = pbcc.KRCCSD(rand_kmf, frozen=frozen)
-        eris = rand_cc.ao2mo(rand_kmf.mo_coeff)
+        rand_cc = pbcc.KRCCSD(kmf, frozen=frozen)
+        eris = rand_cc.ao2mo(kmf.mo_coeff)
         eris.mo_energy = [eris.fock[k].diagonal() for k in range(rand_cc.nkpts)]
-        t1, t2 = rand_t1_t2(rand_kmf, rand_cc)
+        t1, t2 = rand_t1_t2(kmf, rand_cc)
         # Manually zero'ing out the frozen elements of the t1/t2
         # N.B. the 0'th element frozen means we are freezing the 1'th
         #      element in the current padding scheme
@@ -815,37 +854,43 @@ class KnownValues(unittest.TestCase):
         t2[:, 1, :, :, [0,1]] = 0.0
 
         Ht1, Ht2 = rand_cc.update_amps(t1, t2, eris)
-        self.assertAlmostEqual(finger(Ht1), (-0.9261779272752342+2.1533883595188197j), 6)
-        self.assertAlmostEqual(finger(Ht2), (28.74787140107249-0.6410651293622269j), 6)
+        self.assertAlmostEqual(finger(Ht1), (-0.931278705177+2.16347477318j), 6)
+        self.assertAlmostEqual(finger(Ht2), (29.0079567454-0.114082762172j), 6)
 
         # Excited state results
         rand_cc.t1, rand_cc.t2, rand_cc.eris = t1, t2, eris
 
         kshift = 1
-        r1, r2 = rand_r1_r2_ip(rand_kmf, rand_cc)
+        r1, r2 = rand_r1_r2_ip(kmf, rand_cc)
         r1[[0,1]] = 0.0
         r2[1, :, [0,1]] = 0.0
         r2[:, 1, :, [0,1]] = 0.0
         Hr1, Hr2 = _run_ip_matvec(rand_cc, r1, r2, kshift)
         self.assertAlmostEqual(finger(Hr1), (0.0 + 0.0j), 6)
-        self.assertAlmostEqual(finger(Hr2), (-0.33609168536098066-0.045366758500888754j), 6)
+        self.assertAlmostEqual(finger(Hr2), (-0.336011745573-0.0454220386975j), 6)
 
-        r1, r2 = rand_r1_r2_ea(rand_kmf, rand_cc)
+        r1, r2 = rand_r1_r2_ea(kmf, rand_cc)
         r2[1, :, [0,1]] = 0.0
         Hr1, Hr2 = _run_ea_matvec(rand_cc, r1, r2, kshift)
-        self.assertAlmostEqual(finger(Hr1), (-0.001638748206518631-0.5022363985261444j), 6)
-        self.assertAlmostEqual(finger(Hr2), (-1.5948604719653974+0.8390428852257543j), 6)
+        self.assertAlmostEqual(finger(Hr1), (-0.00152035195068-0.502318229581j), 6)
+        self.assertAlmostEqual(finger(Hr2), (-1.59488320866+0.838903632811j), 6)
 
     def test_rand_ccsd_frozen3(self):
         '''Single (eom-)ccsd iteration with random t1/t2 and single frozen virtual
         orbital.'''
-        kconserv = kpts_helper.get_kconserv(rand_kmf.cell, rand_kmf.kpts)
+        kmf = copy.copy(rand_kmf)
+        mat_veff = kmf.get_veff().round(4)
+        mat_hcore = kmf.get_hcore().round(4)
+        kmf.get_veff = lambda *x: mat_veff
+        kmf.get_hcore = lambda *x: mat_hcore
+
+        kconserv = kpts_helper.get_kconserv(kmf.cell, kmf.kpts)
 
         frozen = [[],[],[3]]  # freezing one virtual
-        rand_cc = pbcc.KRCCSD(rand_kmf, frozen=frozen)
-        eris = rand_cc.ao2mo(rand_kmf.mo_coeff)
+        rand_cc = pbcc.KRCCSD(kmf, frozen=frozen)
+        eris = rand_cc.ao2mo(kmf.mo_coeff)
         eris.mo_energy = [eris.fock[k].diagonal() for k in range(rand_cc.nkpts)]
-        t1, t2 = rand_t1_t2(rand_kmf, rand_cc)
+        t1, t2 = rand_t1_t2(kmf, rand_cc)
         # Manually zero'ing out the frozen elements of the t1/t2
         t1[2, :, 0] = 0.0
         for ki in range(rand_cc.nkpts):
@@ -858,14 +903,14 @@ class KnownValues(unittest.TestCase):
                   t2[ki, kj, ka, :, :, :, 0] = 0.0
 
         Ht1, Ht2 = rand_cc.update_amps(t1, t2, eris)
-        self.assertAlmostEqual(finger(Ht1), (5.330503185540645-7.944707679088895j), 6)
-        self.assertAlmostEqual(finger(Ht2), (-236.78007421641894-360.0131897037422j), 6)
+        self.assertAlmostEqual(finger(Ht1), (5.3320153970710118-7.9402122992688602j), 6)
+        self.assertAlmostEqual(finger(Ht2), (-236.46389414847206-360.1605297160217j), 6)
 
         # Excited state results
         rand_cc.t1, rand_cc.t2, rand_cc.eris = t1, t2, eris
 
         kshift = 2
-        r1, r2 = rand_r1_r2_ip(rand_kmf, rand_cc)
+        r1, r2 = rand_r1_r2_ip(kmf, rand_cc)
         r1[0] = 0.0
         for ki in range(rand_cc.nkpts):
           for kj in range(rand_cc.nkpts):
@@ -874,10 +919,10 @@ class KnownValues(unittest.TestCase):
                 r2[ki, kj, :, :, 0] = 0.0
 
         Hr1, Hr2 = _run_ip_matvec(rand_cc, r1, r2, kshift)
-        self.assertAlmostEqual(finger(Hr1), (0.40669900014295035+0.07683697259574568j), 6)
-        self.assertAlmostEqual(finger(Hr2), (0.09259902378140447-1.0701619457270144j), 6)
+        self.assertAlmostEqual(finger(Hr1), (0.4067595510145880 +  0.0770280877446436j), 6)
+        self.assertAlmostEqual(finger(Hr2), (0.0926714318228812 + -1.0702702421619084j), 6)
 
-        r1, r2 = rand_r1_r2_ea(rand_kmf, rand_cc)
+        r1, r2 = rand_r1_r2_ea(kmf, rand_cc)
         r1[0] = 0.0
         for kj in range(rand_cc.nkpts):
           for ka in range(rand_cc.nkpts):
@@ -888,8 +933,8 @@ class KnownValues(unittest.TestCase):
                 r2[kj, ka, :, :, 0] = 0.0
 
         Hr1, Hr2 = _run_ea_matvec(rand_cc, r1, r2, kshift)
-        self.assertAlmostEqual(finger(Hr1), (0.007072446324766635-0.16466303180382663j), 6)
-        self.assertAlmostEqual(finger(Hr2), (0.45179885273361153-0.5510490106822198j), 6)
+        self.assertAlmostEqual(finger(Hr1), (0.0070404498167285 + -0.1646809321907418j), 6)
+        self.assertAlmostEqual(finger(Hr2), (0.4518315588945250 + -0.5508323185152750j), 6)
 
     def test_h4_fcc_k2(self):
         '''Metallic hydrogen fcc lattice.  Checks versus a corresponding


### PR DESCRIPTION
This corrects a bug in the recently pushed kccsd(t) rhf that wasn't uncovered by doing k-point vs supercell calculations.  

This also corrects a bug in the T2 spatial2spin function when feeding in a T2 amplitude found from kRCCSD.

More rigorous tests checking the restricted k-point closed-shell implementations against their spin-orbital counterparts were made.   This was done for both CCSD(T) and other excited state perturbative methods to make sure everything is in working order.

A faster k-point EOM-CCSD(T)*a method was added.