### PR TITLE
Update PBC SCF initial guess

### DIFF
--- a/examples/pbc/30-ao_integrals.py
+++ b/examples/pbc/30-ao_integrals.py
@@ -96,7 +96,7 @@ for i, kpti in enumerate(kpts):
         eri_3d = numpy.vstack(eri_3d).reshape(-1,nao,nao)
         eri_3d_kpts[i].append(eri_3d)
 # Test 2-e integrals
-# Note, Coulomb integrals is positive definition in this example. The code
+# Note, Coulomb integrals are positive definition in this example. The code
 # below does not work for 2D pbc system.
 eri = numpy.einsum('Lpq,Lrs->pqrs', eri_3d_kpts[0][3], eri_3d_kpts[3][0])
 print(abs(eri - mydf.get_eri([kpts[0],kpts[3],kpts[3],kpts[0]]).reshape([nao]*4)).max())

--- a/examples/pbc/32-graphene.py
+++ b/examples/pbc/32-graphene.py
@@ -14,13 +14,10 @@ non-periodic direction.
 
 '''
 
-import numpy
 import time
-from pyscf import scf
 from pyscf.pbc import df as pdf
 from pyscf.pbc import gto as pbcgto
 from pyscf.pbc import scf as pbchf
-from pyscf.pbc import tools
 
 nk = 1
 kpts = [nk,nk,1]

--- a/pyscf/fci/direct_spin0.py
+++ b/pyscf/fci/direct_spin0.py
@@ -225,6 +225,8 @@ def kernel_ms0(fci, h1e, eri, norb, nelec, ci0=None, link_index=None,
     if pspace_size is None: pspace_size = fci.pspace_size
 
     assert(fci.spin is None or fci.spin == 0)
+    nelec = direct_spin1._unpack_nelec(nelec, 0)
+    assert(0 < nelec[0] < norb)
 
     link_index = _unpack(norb, nelec, link_index)
     h1e = numpy.ascontiguousarray(h1e)

--- a/pyscf/fci/direct_spin0.py
+++ b/pyscf/fci/direct_spin0.py
@@ -225,8 +225,7 @@ def kernel_ms0(fci, h1e, eri, norb, nelec, ci0=None, link_index=None,
     if pspace_size is None: pspace_size = fci.pspace_size
 
     assert(fci.spin is None or fci.spin == 0)
-    nelec = direct_spin1._unpack_nelec(nelec, 0)
-    assert(0 < nelec[0] < norb)
+    assert(0 <= numpy.sum(nelec) <= norb*2)
 
     link_index = _unpack(norb, nelec, link_index)
     h1e = numpy.ascontiguousarray(h1e)

--- a/pyscf/fci/direct_spin1.py
+++ b/pyscf/fci/direct_spin1.py
@@ -445,7 +445,7 @@ def kernel_ms1(fci, h1e, eri, norb, nelec, ci0=None, link_index=None,
     if pspace_size is None: pspace_size = fci.pspace_size
 
     nelec = _unpack_nelec(nelec, fci.spin)
-    assert(0 < nelec[0] < norb and 0 < nelec[1] < norb)
+    assert(0 <= nelec[0] <= norb and 0 <= nelec[1] <= norb)
     link_indexa, link_indexb = _unpack(norb, nelec, link_index)
     na = link_indexa.shape[0]
     nb = link_indexb.shape[0]

--- a/pyscf/fci/direct_spin1.py
+++ b/pyscf/fci/direct_spin1.py
@@ -445,6 +445,7 @@ def kernel_ms1(fci, h1e, eri, norb, nelec, ci0=None, link_index=None,
     if pspace_size is None: pspace_size = fci.pspace_size
 
     nelec = _unpack_nelec(nelec, fci.spin)
+    assert(0 < nelec[0] < norb and 0 < nelec[1] < norb)
     link_indexa, link_indexb = _unpack(norb, nelec, link_index)
     na = link_indexa.shape[0]
     nb = link_indexb.shape[0]

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2025,10 +2025,17 @@ class Mole(lib.StreamObject):
         if parse_arg:
             _update_from_cmdargs_(self)
 
-        # avoid to open output file twice
-        if (parse_arg and self.output is not None and
-            not (getattr(self.stdout, 'name', None) and  # to handle StringIO().name bug
-                 self.stdout.name == self.output)):
+        # avoid opening output file twice
+        if (self.output is not None
+            # StringIO() does not have attribute 'name'
+            and getattr(self.stdout, 'name', None) != self.output):
+
+            if self.verbose > logger.QUIET:
+                if os.path.isfile(self.output):
+                    print('overwrite output file: %s' % self.output)
+                else:
+                    print('output file: %s' % self.output)
+
             if self.output == '/dev/null':
                 self.stdout = open(os.devnull, 'w')
             else:
@@ -3095,15 +3102,6 @@ def _update_from_cmdargs_(mol):
 
         if opts.output:
             mol.output = opts.output
-
-    if mol.output is not None:
-        if os.path.isfile(mol.output):
-            #os.remove(mol.output)
-            if mol.verbose > logger.QUIET:
-                print('overwrite output file: %s' % mol.output)
-        else:
-            if mol.verbose > logger.QUIET:
-                print('output file: %s' % mol.output)
 
 
 def from_zmatrix(atomstr):

--- a/pyscf/mcscf/addons.py
+++ b/pyscf/mcscf/addons.py
@@ -179,7 +179,7 @@ def caslst_by_irrep(casscf, mo_coeff, cas_irrep_nocc,
             else:
                 irrep_ncore[k] = v
 
-        ncore_rest = casscf.ncore - sum(irrep_ncore.values())
+        ncore_rest = ncore - sum(irrep_ncore.values())
         if ncore_rest > 0:  # guess core configuration
             mask = numpy.ones(len(orbsym), dtype=bool)
             for ir in irrep_ncore:
@@ -188,12 +188,12 @@ def caslst_by_irrep(casscf, mo_coeff, cas_irrep_nocc,
             core_rest = dict([(ir, numpy.count_nonzero(core_rest==ir))
                               for ir in set(core_rest)])
             log.info('Given core space %s < casscf core size %d',
-                     cas_irrep_ncore, casscf.ncore)
+                     cas_irrep_ncore, ncore)
             log.info('Add %s to core configuration', core_rest)
             irrep_ncore.update(core_rest)
         elif ncore_rest < 0:
             raise ValueError('Given core space %s > casscf core size %d'
-                             % (cas_irrep_ncore, casscf.ncore))
+                             % (cas_irrep_ncore, ncore))
     else:
         irrep_ncore = dict([(ir, sum(orbsym[:ncore]==ir)) for ir in irreps])
 

--- a/pyscf/mcscf/casci_symm.py
+++ b/pyscf/mcscf/casci_symm.py
@@ -97,12 +97,12 @@ def label_symmetry_(mc, mo_coeff, ci0=None):
     #irrep_name = mc.mol.irrep_name
     irrep_name = mc.mol.irrep_id
     s = mc._scf.get_ovlp()
+    ncore = mc.ncore
+    nocc = ncore + mc.ncas
     try:
         orbsym = scf.hf_symm.get_orbsym(mc._scf.mol, mo_coeff, s, True)
     except ValueError:
         log.warn('mc1step_symm symmetrizes input orbitals')
-        ncore = mc.ncore
-        nocc = mc.ncore + mc.ncas
         mo_cor = symm.symmetrize_space(mc.mol, mo_coeff[:,    :ncore], s=s, check=False)
         mo_act = symm.symmetrize_space(mc.mol, mo_coeff[:,ncore:nocc], s=s, check=False)
         mo_vir = symm.symmetrize_space(mc.mol, mo_coeff[:,nocc:     ], s=s, check=False)
@@ -113,8 +113,6 @@ def label_symmetry_(mc, mo_coeff, ci0=None):
 
     active_orbsym = getattr(mc.fcisolver, 'orbsym', [])
     if (not getattr(active_orbsym, '__len__', None)) or len(active_orbsym) == 0:
-        ncore = mc.ncore
-        nocc = mc.ncore + mc.ncas
         mc.fcisolver.orbsym = orbsym[ncore:nocc]
     log.debug('Active space irreps %s', str(mc.fcisolver.orbsym))
 
@@ -133,8 +131,6 @@ def label_symmetry_(mc, mo_coeff, ci0=None):
             mc.fcisolver.wfnsym = wfnsym
             log.debug('Set CASCI wfnsym %s based on HF determinant', wfnsym)
         elif getattr(mo_coeff, 'orbsym', None) is not None:  # It may be reordered SCF orbitals
-            ncore = mc.ncore
-            nocc = mc.ncore + mc.ncas
             cas_orb = mo_coeff[:,ncore:nocc]
             s = reduce(numpy.dot, (cas_orb.T, mc._scf.get_ovlp(), mc._scf.mo_coeff))
             if numpy.all(numpy.max(s, axis=1) > 1-1e-9):

--- a/pyscf/mcscf/df.py
+++ b/pyscf/mcscf/df.py
@@ -18,11 +18,9 @@
 
 import sys
 import time
-import tempfile
 import ctypes
 from functools import reduce
 import numpy
-import h5py
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf.ao2mo import _ao2mo
@@ -267,8 +265,7 @@ class _ERIS(object):
         k_cp = numpy.zeros((ncore,nmo))
 
         mo = numpy.asarray(mo, order='F')
-        _tmpfile1 = tempfile.NamedTemporaryFile(dir=lib.param.TMPDIR)
-        fxpp = h5py.File(_tmpfile1.name)
+        fxpp = lib.H5TmpFile()
         bufpa = numpy.empty((naoaux,nmo,ncas))
         bufs1 = numpy.empty((with_df.blockdim,nmo,nmo))
         fmmm = _ao2mo.libao2mo.AO2MOmmm_nr_s2_iltj
@@ -329,7 +326,6 @@ class _ERIS(object):
         bufs1 = bufs2 = buf = None
         t1 = log.timer('density fitting ppaa pass2', *t1)
 
-        fxpp.close()
         self.feri.flush()
 
         dm_core = numpy.dot(mo[:,:ncore], mo[:,:ncore].T)

--- a/pyscf/mcscf/df.py
+++ b/pyscf/mcscf/df.py
@@ -89,10 +89,12 @@ def density_fit(casscf, auxbasis=None, with_df=None):
 
         def get_h2eff(self, mo_coeff=None):  # For CASCI
             if self.with_df:
+                ncore = self.ncore
+                nocc = ncore + self.ncas
                 if mo_coeff is None:
-                    mo_coeff = self.mo_coeff[:,self.ncore:self.ncore+self.ncas]
+                    mo_coeff = self.mo_coeff[:,ncore:nocc]
                 elif mo_coeff.shape[1] != self.ncas:
-                    mo_coeff = mo_coeff[:,self.ncore:self.ncore+self.ncas]
+                    mo_coeff = mo_coeff[:,ncore:nocc]
                 return self.with_df.ao2mo(mo_coeff)
             else:
                 return casscf_class.get_h2eff(self, mo_coeff)

--- a/pyscf/mcscf/mc1step.py
+++ b/pyscf/mcscf/mc1step.py
@@ -341,10 +341,13 @@ def kernel(casscf, mo_coeff, tol=1e-7, conv_tol_grad=None,
 
     mo = mo_coeff
     nmo = mo_coeff.shape[1]
+    ncore = casscf.ncore
+    ncas = casscf.ncas
+    nocc = ncore + ncas
     #TODO: lazy evaluate eris, to leave enough memory for FCI solver
     eris = casscf.ao2mo(mo)
     e_tot, e_cas, fcivec = casscf.casci(mo, ci0, eris, log, locals())
-    if casscf.ncas == nmo and not casscf.internal_rotation:
+    if ncas == nmo and not casscf.internal_rotation:
         if casscf.canonicalization:
             log.debug('CASSCF canonicalization')
             mo, fcivec, mo_energy = casscf.canonicalize(mo, fcivec, eris,
@@ -365,7 +368,7 @@ def kernel(casscf, mo_coeff, tol=1e-7, conv_tol_grad=None,
     r0 = None
 
     t1m = log.timer('Initializing 1-step CASSCF', *cput0)
-    casdm1, casdm2 = casscf.fcisolver.make_rdm12(fcivec, casscf.ncas, casscf.nelecas)
+    casdm1, casdm2 = casscf.fcisolver.make_rdm12(fcivec, ncas, casscf.nelecas)
     norm_ddm = 1e2
     casdm1_prev = casdm1_last = casdm1
     t3m = t2m = log.timer('CAS DM', *t1m)
@@ -429,7 +432,7 @@ def kernel(casscf, mo_coeff, tol=1e-7, conv_tol_grad=None,
         t2m = log.timer('update eri', *t3m)
 
         e_tot, e_cas, fcivec = casscf.casci(mo, fcivec, eris, log, locals())
-        casdm1, casdm2 = casscf.fcisolver.make_rdm12(fcivec, casscf.ncas, casscf.nelecas)
+        casdm1, casdm2 = casscf.fcisolver.make_rdm12(fcivec, ncas, casscf.nelecas)
         norm_ddm = numpy.linalg.norm(casdm1 - casdm1_last)
         casdm1_prev = casdm1_last = casdm1
         log.timer('CASCI solver', *t2m)
@@ -459,8 +462,7 @@ def kernel(casscf, mo_coeff, tol=1e-7, conv_tol_grad=None,
                 casscf.canonicalize(mo, fcivec, eris, casscf.sorting_mo_energy,
                                     casscf.natorb, casdm1, log)
         if casscf.natorb and dump_chk: # dump_chk may save casdm1
-            nocc = casscf.ncore + casscf.ncas
-            occ, ucas = casscf._eig(-casdm1, casscf.ncore, nocc)
+            occ, ucas = casscf._eig(-casdm1, ncore, nocc)
             casdm1 = numpy.diag(-occ)
     else:
         mo_energy = None
@@ -707,10 +709,12 @@ class CASSCF(casci.CASCI):
         log = logger.new_logger(self, verbose)
         log.info('')
         log.info('******** %s ********', self.__class__)
-        nvir = self.mo_coeff.shape[1] - self.ncore - self.ncas
+        ncore = self.ncore
+        ncas = self.ncas
+        nvir = self.mo_coeff.shape[1] - ncore - ncas
         log.info('CAS (%de+%de, %do), ncore = %d, nvir = %d', \
-                 self.nelecas[0], self.nelecas[1], self.ncas, self.ncore, nvir)
-        assert(self.ncas > 0)
+                 self.nelecas[0], self.nelecas[1], ncas, ncore, nvir)
+        assert(nvir >= 0 and ncore >= 0 and ncas >= 0)
         if self.frozen is not None:
             log.info('frozen orbitals %s', str(self.frozen))
         log.info('max_cycle_macro = %d', self.max_cycle_macro)
@@ -1129,7 +1133,7 @@ To enable the solvent model for CASSCF, a decoration to CASSCF object as below n
         else:
             civec = None
         ncore = self.ncore
-        nocc = self.ncore + self.ncas
+        nocc = ncore + self.ncas
         if 'mo' in envs:
             mo_coeff = envs['mo']
         else:
@@ -1147,7 +1151,7 @@ To enable the solvent model for CASSCF, a decoration to CASSCF object as below n
         else:
             mo_energy = 'None'
         chkfile.dump_mcscf(self, self.chkfile, 'mcscf', envs['e_tot'],
-                           mo_coeff, self.ncore, self.ncas, mo_occ,
+                           mo_coeff, ncore, self.ncas, mo_occ,
                            mo_energy, envs['e_cas'], civec, envs['casdm1'],
                            overwrite_mol=False)
         return self
@@ -1257,8 +1261,6 @@ def _fake_h_for_fast_casci(casscf, mo, eris):
     h1eff += eris.vhf_c[ncore:nocc,ncore:nocc]
     mc.get_h1eff = lambda *args: (h1eff, energy_core)
 
-    ncore = casscf.ncore
-    nocc = ncore + casscf.ncas
     eri_cas = eris.ppaa[ncore:nocc,ncore:nocc,:,:].copy()
     mc.get_h2eff = lambda *args: eri_cas
     return mc

--- a/pyscf/mcscf/mc2step.py
+++ b/pyscf/mcscf/mc2step.py
@@ -36,9 +36,12 @@ def kernel(casscf, mo_coeff, tol=1e-7, conv_tol_grad=None,
 
     mo = mo_coeff
     nmo = mo.shape[1]
+    ncore = casscf.ncore
+    ncas = casscf.ncas
+    nocc = ncore + ncas
     eris = casscf.ao2mo(mo)
     e_tot, e_cas, fcivec = casscf.casci(mo, ci0, eris, log, locals())
-    if casscf.ncas == nmo and not casscf.internal_rotation:
+    if ncas == nmo and not casscf.internal_rotation:
         if casscf.canonicalization:
             log.debug('CASSCF canonicalization')
             mo, fcivec, mo_energy = casscf.canonicalize(mo, fcivec, eris,
@@ -65,7 +68,7 @@ def kernel(casscf, mo_coeff, tol=1e-7, conv_tol_grad=None,
         njk = 0
         t3m = t2m
         casdm1_old = casdm1
-        casdm1, casdm2 = casscf.fcisolver.make_rdm12(fcivec, casscf.ncas, casscf.nelecas)
+        casdm1, casdm2 = casscf.fcisolver.make_rdm12(fcivec, ncas, casscf.nelecas)
         norm_ddm = numpy.linalg.norm(casdm1 - casdm1_old)
         t3m = log.timer('update CAS DM', *t3m)
         max_cycle_micro = 1 # casscf.micro_cycle_scheduler(locals())
@@ -133,8 +136,7 @@ def kernel(casscf, mo_coeff, tol=1e-7, conv_tol_grad=None,
                 casscf.canonicalize(mo, fcivec, eris, casscf.sorting_mo_energy,
                                     casscf.natorb, casdm1, log)
         if casscf.natorb and dump_chk: # dump_chk may save casdm1
-            nocc = casscf.ncore + casscf.ncas
-            occ, ucas = casscf._eig(-casdm1, casscf.ncore, nocc)
+            occ, ucas = casscf._eig(-casdm1, ncore, nocc)
             casdm1 = numpy.diag(-occ)
 
     if dump_chk:

--- a/pyscf/mcscf/mc_ao2mo.py
+++ b/pyscf/mcscf/mc_ao2mo.py
@@ -279,7 +279,7 @@ class _ERIS(object):
             if eri is None:
                 eri = mol.intor('int2e', aosym='s8')
             self.j_pc, self.k_pc, self.ppaa, self.papa = \
-                    trans_e1_incore(eri, mo, casscf.ncore, casscf.ncas)
+                    trans_e1_incore(eri, mo, ncore, ncas)
         else:
             import gc
             gc.collect()
@@ -290,8 +290,7 @@ class _ERIS(object):
                 log.warn('Calculation needs %d MB memory, over CASSCF.max_memory (%d MB) limit',
                          (mem_basic+mem_now)/.9, casscf.max_memory)
             self.j_pc, self.k_pc = \
-                    trans_e1_outcore(mol, mo, casscf.ncore, casscf.ncas,
-                                     self.feri,
+                    trans_e1_outcore(mol, mo, ncore, ncas, self.feri,
                                      max_memory=max_memory,
                                      level=level, verbose=log)
             self.ppaa = self.feri['ppaa']

--- a/pyscf/mcscf/mc_ao2mo.py
+++ b/pyscf/mcscf/mc_ao2mo.py
@@ -16,7 +16,6 @@
 import sys
 import ctypes
 import time
-import tempfile
 from functools import reduce
 import numpy
 import h5py
@@ -79,18 +78,17 @@ def trans_e1_incore(eri_ao, mo, ncore, ncas):
 def trans_e1_outcore(mol, mo, ncore, ncas, erifile,
                      max_memory=None, level=1, verbose=logger.WARN):
     time0 = (time.clock(), time.time())
-    if isinstance(verbose, logger.Logger):
-        log = verbose
-    else:
-        log = logger.Logger(mol.stdout, verbose)
+    log = logger.new_logger(mol, verbose)
     log.debug1('trans_e1_outcore level %d  max_memory %d', level, max_memory)
     nao, nmo = mo.shape
     nao_pair = nao*(nao+1)//2
     nocc = ncore + ncas
 
-    _tmpfile1 = tempfile.NamedTemporaryFile(dir=lib.param.TMPDIR)
-    faapp_buf = h5py.File(_tmpfile1.name)
-    feri = h5py.File(erifile, 'w')
+    faapp_buf = lib.H5TmpFile()
+    if isinstance(erifile, h5py.Group):
+        feri = erifile
+    else:
+        feri = lib.H5TmpFile(erifile, 'w')
 
     mo_c = numpy.asarray(mo, order='C')
     mo = numpy.asarray(mo, order='F')
@@ -255,9 +253,6 @@ def trans_e1_outcore(mol, mo, ncore, ncas, erifile,
     tmp = tmp1 = None
     time1 = log.timer('ppaa pass 2', *time1)
 
-    faapp_buf.close()
-    feri.close()
-    _tmpfile1 = None
     time0 = log.timer('mc_ao2mo', *time0)
     return j_pc, k_pc
 
@@ -289,17 +284,16 @@ class _ERIS(object):
             import gc
             gc.collect()
             log = logger.Logger(casscf.stdout, casscf.verbose)
-            self._tmpfile = tempfile.NamedTemporaryFile(dir=lib.param.TMPDIR)
+            self.feri = lib.H5TmpFile()
             max_memory = max(3000, casscf.max_memory*.9-mem_now)
             if max_memory < mem_basic:
                 log.warn('Calculation needs %d MB memory, over CASSCF.max_memory (%d MB) limit',
                          (mem_basic+mem_now)/.9, casscf.max_memory)
             self.j_pc, self.k_pc = \
                     trans_e1_outcore(mol, mo, casscf.ncore, casscf.ncas,
-                                     self._tmpfile.name,
+                                     self.feri,
                                      max_memory=max_memory,
                                      level=level, verbose=log)
-            self.feri = lib.H5TmpFile(self._tmpfile.name, 'r')
             self.ppaa = self.feri['ppaa']
             self.papa = self.feri['papa']
 

--- a/pyscf/mcscf/newton_casscf.py
+++ b/pyscf/mcscf/newton_casscf.py
@@ -645,10 +645,12 @@ class CASSCF(mc1step.CASSCF):
         log = logger.Logger(self.stdout, self.verbose)
         log.info('')
         log.info('******** %s ********', self.__class__)
-        nvir = self.mo_coeff.shape[1] - self.ncore - self.ncas
+        ncore = self.ncore
+        ncas = self.ncas
+        nvir = self.mo_coeff.shape[1] - ncore - ncas
         log.info('CAS (%de+%de, %do), ncore = %d, nvir = %d', \
-                 self.nelecas[0], self.nelecas[1], self.ncas, self.ncore, nvir)
-        assert(nvir > 0 and self.ncore > 0 and self.ncas > 0)
+                 self.nelecas[0], self.nelecas[1], self.ncas, ncore, nvir)
+        assert(nvir > 0 and ncore > 0 and self.ncas > 0)
         if self.frozen is not None:
             log.info('frozen orbitals %s', str(self.frozen))
         log.info('max_cycle_macro = %d', self.max_cycle_macro)

--- a/pyscf/mcscf/ucasci.py
+++ b/pyscf/mcscf/ucasci.py
@@ -133,14 +133,7 @@ class UCASCI(casci.CASCI):
             self.nelecas = (neleca, nelecb)
         else:
             self.nelecas = (nelecas[0], nelecas[1])
-        if ncore is None:
-            ncorelec = mol.nelectron - (self.nelecas[0]+self.nelecas[1])
-            if ncorelec % 2:
-                self.ncore = ((ncorelec+1)//2, (ncorelec-1)//2)
-            else:
-                self.ncore = (ncorelec//2, ncorelec//2)
-        else:
-            self.ncore = (ncore[0], ncore[1])
+        self.ncore = ncore
 
         self.fcisolver = fci.direct_uhf.FCISolver(mol)
         self.fcisolver.lindep = getattr(__config__,
@@ -158,6 +151,26 @@ class UCASCI(casci.CASCI):
         self.e_cas = 0
 
         self._keys = set(self.__dict__.keys())
+
+    @property
+    def ncore(self):
+        if self._ncore is None:
+            ncorelec = self.mol.nelectron - sum(self.nelecas)
+            if ncorelec % 2:
+                ncore = ((ncorelec+1)//2, (ncorelec-1)//2)
+            else:
+                ncore = (ncorelec//2, ncorelec//2)
+            return ncore
+        else:
+            return self._ncore
+    @ncore.setter
+    def ncore(self, x):
+        if x is None:
+            self._ncore = x
+        elif isinstance(x, (int, numpy.integer)):
+            self._ncore = (x, x)
+        else:
+            self._ncore = (x[0], x[1])
 
     def dump_flags(self):
         log = lib.logger.Logger(self.stdout, self.verbose)

--- a/pyscf/mcscf/umc1step.py
+++ b/pyscf/mcscf/umc1step.py
@@ -404,14 +404,16 @@ class UCASSCF(ucasci.UCASCI):
         log.info('')
         log.info('******** UHF-CASSCF flags ********')
         nmo = self.mo_coeff[0].shape[1]
-        nvir_alpha = nmo - self.ncore[0] - self.ncas
-        nvir_beta  = nmo - self.ncore[1]  - self.ncas
+        ncore = self.ncore
+        ncas = self.ncas
+        nvir_alpha = nmo - ncore[0] - ncas
+        nvir_beta  = nmo - ncore[1]  - ncas
         log.info('CAS (%de+%de, %do), ncore = [%d+%d], nvir = [%d+%d]',
-                 self.nelecas[0], self.nelecas[1], self.ncas,
-                 self.ncore[0], self.ncore[1], nvir_alpha, nvir_beta)
-        if self.ncore[0] != self.ncore[1]:
+                 self.nelecas[0], self.nelecas[1], ncas,
+                 ncore[0], ncore[1], nvir_alpha, nvir_beta)
+        if ncore[0] != ncore[1]:
             log.warn('converge might be slow since num alpha core %d != num beta core %d',
-                     self.ncore[0], self.ncore[1])
+                     ncore[0], ncore[1])
         if self.frozen is not None:
             log.info('frozen orbitals %s', str(self.frozen))
         log.info('max. macro cycles = %d', self.max_cycle_macro)
@@ -521,16 +523,20 @@ class UCASSCF(ucasci.UCASCI):
 
     def pack_uniq_var(self, mat):
         nmo = self.mo_coeff[0].shape[1]
-        idxa = self.uniq_var_indices(nmo, self.ncore[0], self.ncas, self.frozen)
-        idxb = self.uniq_var_indices(nmo, self.ncore[1], self.ncas, self.frozen)
+        ncore = self.ncore
+        ncas = self.ncas
+        idxa = self.uniq_var_indices(nmo, ncore[0], ncas, self.frozen)
+        idxb = self.uniq_var_indices(nmo, ncore[1], ncas, self.frozen)
         return numpy.hstack((mat[0][idxa], mat[1][idxb]))
 
     # to anti symmetric matrix
     def unpack_uniq_var(self, v):
         nmo = self.mo_coeff[0].shape[1]
+        ncore = self.ncore
+        ncas = self.ncas
         idx = numpy.empty((2,nmo,nmo), dtype=bool)
-        idx[0] = self.uniq_var_indices(nmo, self.ncore[0], self.ncas, self.frozen)
-        idx[1] = self.uniq_var_indices(nmo, self.ncore[1], self.ncas, self.frozen)
+        idx[0] = self.uniq_var_indices(nmo, ncore[0], ncas, self.frozen)
+        idx[1] = self.uniq_var_indices(nmo, ncore[1], ncas, self.frozen)
         mat = numpy.zeros((2,nmo,nmo))
         mat[idx] = v
         mat[0] = mat[0] - mat[0].T
@@ -745,8 +751,9 @@ class UCASSCF(ucasci.UCASCI):
         else:
             civec = None
         ncore = self.ncore
-        nocca = self.ncore[0] + self.ncas
-        noccb = self.ncore[1] + self.ncas
+        ncas = self.ncas
+        nocca = ncore[0] + ncas
+        noccb = ncore[1] + ncas
         if 'mo' in envs:
             mo_coeff = envs['mo']
         else:
@@ -765,7 +772,7 @@ class UCASSCF(ucasci.UCASCI):
         mo_energy = 'None'
 
         chkfile.dump_mcscf(self, self.chkfile, 'mcscf', envs['e_tot'],
-                           mo_coeff, self.ncore, self.ncas, mo_occ,
+                           mo_coeff, ncore, ncas, mo_occ,
                            mo_energy, envs['e_cas'], civec, envs['casdm1'],
                            overwrite_mol=False)
         return self

--- a/pyscf/mcscf/umc_ao2mo.py
+++ b/pyscf/mcscf/umc_ao2mo.py
@@ -223,11 +223,9 @@ def _trans_cvcv_(mo, ncore, ncas, fload, ao_loc=None):
 class _ERIS(object):
     def __init__(self, casscf, mo, method='incore'):
         mol = casscf.mol
-        self.ncore = casscf.ncore
-        self.ncas = casscf.ncas
+        ncore = self.ncore = casscf.ncore
+        ncas  = self.ncas  = casscf.ncas
         nmo = mo[0].shape[1]
-        ncore = self.ncore
-        ncas = self.ncas
         mem_incore, mem_outcore, mem_basic = _mem_usage(ncore, ncas, nmo)
         mem_now = lib.current_memory()[0]
 
@@ -242,7 +240,7 @@ class _ERIS(object):
             self.appa, self.apPA, self.APPA, \
             self.Iapcv, self.IAPCV, self.apCV, self.APcv, \
             self.Icvcv, self.ICVCV, self.cvCV = \
-                    trans_e1_incore(eri, mo, casscf.ncore, casscf.ncas)
+                    trans_e1_incore(eri, mo, ncore, ncas)
             self.vhf_c = (numpy.einsum('ipq->pq', self.jkcpp) + self.jC_pp,
                           numpy.einsum('ipq->pq', self.jkcPP) + self.jc_PP)
         else:
@@ -259,7 +257,7 @@ class _ERIS(object):
                 self.appa, self.apPA, self.APPA, \
                 self.Iapcv, self.IAPCV, self.apCV, self.APcv, \
                 self.Icvcv, self.ICVCV, self.cvCV = \
-                        trans_e1_outcore(mol, mo, casscf.ncore, casscf.ncas,
+                        trans_e1_outcore(mol, mo, ncore, ncas,
                                          max_memory=max_memory, verbose=log)
                 self.vhf_c = (numpy.einsum('ipq->pq', self.jkcpp) + self.jC_pp,
                               numpy.einsum('ipq->pq', self.jkcPP) + self.jc_PP)

--- a/pyscf/mrpt/nevpt2.py
+++ b/pyscf/mrpt/nevpt2.py
@@ -288,19 +288,21 @@ def Sr(mc,ci,dms, eris=None, verbose=None):
     dm2 = dms['2']
     dm3 = dms['3']
     #dm4 = dms['4']
+    ncore = mo_core.shape[1]
+    nvirt = mo_virt.shape[1]
+    ncas = mo_cas.shape[1]
+    nocc = ncore + ncas
 
     if eris is None:
         h1e = mc.h1e_for_cas()[0]
-        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), mc.ncas).transpose(0,2,1,3)
+        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), ncas).transpose(0,2,1,3)
         h2e_v = ao2mo.incore.general(mc._scf._eri,[mo_virt,mo_cas,mo_cas,mo_cas],compact=False)
-        h2e_v = h2e_v.reshape(mo_virt.shape[1],mc.ncas,mc.ncas,mc.ncas).transpose(0,2,1,3)
+        h2e_v = h2e_v.reshape(mo_virt.shape[1],ncas,ncas,ncas).transpose(0,2,1,3)
         core_dm = numpy.dot(mo_core,mo_core.T) *2
         core_vhf = mc.get_veff(mc.mol,core_dm)
         h1e_v = reduce(numpy.dot, (mo_virt.T, mc.get_hcore()+core_vhf , mo_cas))
         h1e_v -= numpy.einsum('mbbn->mn',h2e_v)
     else:
-        ncore = mc.ncore
-        nocc = mc.ncore + mc.ncas
         h1e = eris['h1eff'][ncore:nocc,ncore:nocc]
         h2e = eris['ppaa'][ncore:nocc,ncore:nocc].transpose(0,2,1,3)
         h2e_v = eris['ppaa'][nocc:,ncore:nocc].transpose(0,2,1,3)
@@ -308,9 +310,9 @@ def Sr(mc,ci,dms, eris=None, verbose=None):
 
 
     if getattr(mc.fcisolver, 'nevpt_intermediate', None):
-        a16 = mc.fcisolver.nevpt_intermediate('A16',mc.ncas,mc.nelecas,ci)
+        a16 = mc.fcisolver.nevpt_intermediate('A16',ncas,mc.nelecas,ci)
     else:
-        a16 = make_a16(h1e,h2e, dms, ci, mc.ncas, mc.nelecas)
+        a16 = make_a16(h1e,h2e, dms, ci, ncas, mc.nelecas)
     a17 = make_a17(h1e,h2e,dm2,dm3)
     a19 = make_a19(h1e,h2e,dm1,dm2)
 
@@ -322,7 +324,7 @@ def Sr(mc,ci,dms, eris=None, verbose=None):
         +  numpy.einsum('ipqr,rpqa,ia->i',h2e_v,dm2,h1e_v)*2.0\
         +  numpy.einsum('ip,pa,ia->i',h1e_v,dm1,h1e_v)
 
-    return _norm_to_energy(norm, ener, mc.mo_energy[mc.ncore+mc.ncas:])
+    return _norm_to_energy(norm, ener, mc.mo_energy[nocc:])
 
 def Si(mc, ci, dms, eris=None, verbose=None):
     #Subspace S_i^{(1)}
@@ -331,31 +333,32 @@ def Si(mc, ci, dms, eris=None, verbose=None):
     dm2 = dms['2']
     dm3 = dms['3']
     #dm4 = dms['4']
+    ncore = mo_core.shape[1]
+    ncas = mo_cas.shape[1]
+    nocc = ncore + ncas
 
     if eris is None:
         h1e = mc.h1e_for_cas()[0]
-        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), mc.ncas).transpose(0,2,1,3)
+        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), ncas).transpose(0,2,1,3)
         h2e_v = ao2mo.incore.general(mc._scf._eri,[mo_cas,mo_core,mo_cas,mo_cas],compact=False)
-        h2e_v = h2e_v.reshape(mc.ncas,mc.ncore,mc.ncas,mc.ncas).transpose(0,2,1,3)
+        h2e_v = h2e_v.reshape(ncas,ncore,ncas,ncas).transpose(0,2,1,3)
         core_dm = numpy.dot(mo_core,mo_core.T) *2
         core_vhf = mc.get_veff(mc.mol,core_dm)
         h1e_v = reduce(numpy.dot, (mo_cas.T, mc.get_hcore()+core_vhf , mo_core))
     else:
-        ncore = mc.ncore
-        nocc = mc.ncore + mc.ncas
         h1e = eris['h1eff'][ncore:nocc,ncore:nocc]
         h2e = eris['ppaa'][ncore:nocc,ncore:nocc].transpose(0,2,1,3)
         h2e_v = eris['ppaa'][ncore:nocc,:ncore].transpose(0,2,1,3)
         h1e_v = eris['h1eff'][ncore:nocc,:ncore]
 
     if getattr(mc.fcisolver, 'nevpt_intermediate', None):
-        #mc.fcisolver.make_a22(mc.ncas, state)
-        a22 = mc.fcisolver.nevpt_intermediate('A22',mc.ncas,mc.nelecas,ci)
+        #mc.fcisolver.make_a22(ncas, state)
+        a22 = mc.fcisolver.nevpt_intermediate('A22',ncas,mc.nelecas,ci)
     else:
-        a22 = make_a22(h1e,h2e, dms, ci, mc.ncas, mc.nelecas)
+        a22 = make_a22(h1e,h2e, dms, ci, ncas, mc.nelecas)
     a23 = make_a23(h1e,h2e,dm1,dm2,dm3)
     a25 = make_a25(h1e,h2e,dm1,dm2)
-    delta = numpy.eye(mc.ncas)
+    delta = numpy.eye(ncas)
     dm3_h = numpy.einsum('abef,cd->abcdef',dm2,delta)*2\
             - dm3.transpose(0,1,3,2,4,5)
     dm2_h = numpy.einsum('ab,cd->abcd',dm1,delta)*2\
@@ -370,14 +373,15 @@ def Si(mc, ci, dms, eris=None, verbose=None):
         +  numpy.einsum('qpir,rpqa,ai->i',h2e_v,dm2_h,h1e_v)*2.0\
         +  numpy.einsum('pi,pa,ai->i',h1e_v,dm1_h,h1e_v)
 
-    return _norm_to_energy(norm, ener, -mc.mo_energy[:mc.ncore])
+    return _norm_to_energy(norm, ener, -mc.mo_energy[:ncore])
 
 
 def Sijrs(mc, eris, verbose=None):
     mo_core, mo_cas, mo_virt = _extract_orbs(mc, mc.mo_coeff)
     ncore = mo_core.shape[1]
     nvirt = mo_virt.shape[1]
-    nocc = ncore + mc.ncas
+    ncas = mo_cas.shape[1]
+    nocc = ncore + ncas
     if eris is None:
         erifile = tempfile.NamedTemporaryFile(dir=lib.param.TMPDIR)
         feri = ao2mo.outcore.general(mc.mol, (mo_core,mo_virt,mo_core,mo_virt),
@@ -405,14 +409,15 @@ def Sijr(mc, dms, eris, verbose=None):
     mo_core, mo_cas, mo_virt = _extract_orbs(mc, mc.mo_coeff)
     dm1 = dms['1']
     dm2 = dms['2']
+    ncore = mo_core.shape[1]
+    ncas = mo_cas.shape[1]
+    nocc = ncore + ncas
     if eris is None:
         h1e = mc.h1e_for_cas()[0]
-        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), mc.ncas).transpose(0,2,1,3)
+        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), ncas).transpose(0,2,1,3)
         h2e_v = ao2mo.incore.general(mc._scf._eri,[mo_virt,mo_core,mo_cas,mo_core],compact=False)
-        h2e_v = h2e_v.reshape(mo_virt.shape[1],mc.ncore,mc.ncas,mc.ncore).transpose(0,2,1,3)
+        h2e_v = h2e_v.reshape(mo_virt.shape[1],ncore,ncas,ncore).transpose(0,2,1,3)
     else:
-        ncore = mc.ncore
-        nocc = mc.ncore + mc.ncas
         h1e = eris['h1eff'][ncore:nocc,ncore:nocc]
         h2e = eris['ppaa'][ncore:nocc,ncore:nocc].transpose(0,2,1,3)
         h2e_v = eris['pacv'][:ncore].transpose(3,1,2,0)
@@ -427,7 +432,7 @@ def Sijr(mc, dms, eris, verbose=None):
     h = 2.0*numpy.einsum('rpji,raji,pa->rji',h2e_v,h2e_v,a3)\
          - 1.0*numpy.einsum('rpji,raij,pa->rji',h2e_v,h2e_v,a3)
 
-    diff = mc.mo_energy[mc.ncore+mc.ncas:,None,None] - mc.mo_energy[None,:mc.ncore,None] - mc.mo_energy[None,None,:mc.ncore]
+    diff = mc.mo_energy[nocc:,None,None] - mc.mo_energy[None,:ncore,None] - mc.mo_energy[None,None,:ncore]
 
     return _norm_to_energy(norm, h, diff)
 
@@ -436,14 +441,15 @@ def Srsi(mc, dms, eris, verbose=None):
     mo_core, mo_cas, mo_virt = _extract_orbs(mc, mc.mo_coeff)
     dm1 = dms['1']
     dm2 = dms['2']
+    ncore = mo_core.shape[1]
+    ncas = mo_cas.shape[1]
+    nocc = ncore + ncas
     if eris is None:
         h1e = mc.h1e_for_cas()[0]
-        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), mc.ncas).transpose(0,2,1,3)
+        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), ncas).transpose(0,2,1,3)
         h2e_v = ao2mo.incore.general(mc._scf._eri,[mo_virt,mo_core,mo_virt,mo_cas],compact=False)
-        h2e_v = h2e_v.reshape(mo_virt.shape[1],mc.ncore,mo_virt.shape[1],mc.ncas).transpose(0,2,1,3)
+        h2e_v = h2e_v.reshape(mo_virt.shape[1],ncore,mo_virt.shape[1],ncas).transpose(0,2,1,3)
     else:
-        ncore = mc.ncore
-        nocc = mc.ncore + mc.ncas
         h1e = eris['h1eff'][ncore:nocc,ncore:nocc]
         h2e = eris['ppaa'][ncore:nocc,ncore:nocc].transpose(0,2,1,3)
         h2e_v = eris['pacv'][nocc:].transpose(3,0,2,1)
@@ -453,7 +459,7 @@ def Srsi(mc, dms, eris, verbose=None):
          - 1.0*numpy.einsum('rsip,sria,pa->rsi',h2e_v,h2e_v,dm1)
     h = 2.0*numpy.einsum('rsip,rsia,pa->rsi',h2e_v,h2e_v,k27)\
          - 1.0*numpy.einsum('rsip,sria,pa->rsi',h2e_v,h2e_v,k27)
-    diff = mc.mo_energy[mc.ncore+mc.ncas:,None,None] + mc.mo_energy[None,mc.ncore+mc.ncas:,None] - mc.mo_energy[None,None,:mc.ncore]
+    diff = mc.mo_energy[nocc:,None,None] + mc.mo_energy[None,nocc:,None] - mc.mo_energy[None,None,:ncore]
     return _norm_to_energy(norm, h, diff)
 
 def Srs(mc, dms, eris=None, verbose=None):
@@ -462,16 +468,17 @@ def Srs(mc, dms, eris=None, verbose=None):
     dm1 = dms['1']
     dm2 = dms['2']
     dm3 = dms['3']
+    ncore = mo_core.shape[1]
+    ncas = mo_cas.shape[1]
+    nocc = ncore + ncas
     if mo_virt.shape[1] ==0:
         return 0, 0
     if eris is None:
         h1e = mc.h1e_for_cas()[0]
-        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), mc.ncas).transpose(0,2,1,3)
+        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), ncas).transpose(0,2,1,3)
         h2e_v = ao2mo.incore.general(mc._scf._eri,[mo_virt,mo_cas,mo_virt,mo_cas],compact=False)
-        h2e_v = h2e_v.reshape(mo_virt.shape[1],mc.ncas,mo_virt.shape[1],mc.ncas).transpose(0,2,1,3)
+        h2e_v = h2e_v.reshape(mo_virt.shape[1],ncas,mo_virt.shape[1],ncas).transpose(0,2,1,3)
     else:
-        ncore = mc.ncore
-        nocc = mc.ncore + mc.ncas
         h1e = eris['h1eff'][ncore:nocc,ncore:nocc]
         h2e = eris['ppaa'][ncore:nocc,ncore:nocc].transpose(0,2,1,3)
         h2e_v = eris['papa'][nocc:,:,nocc:].transpose(0,2,1,3)
@@ -480,7 +487,7 @@ def Srs(mc, dms, eris=None, verbose=None):
     rm2, a7 = make_a7(h1e,h2e,dm1,dm2,dm3)
     norm = 0.5*numpy.einsum('rsqp,rsba,pqba->rs',h2e_v,h2e_v,rm2)
     h = 0.5*numpy.einsum('rsqp,rsba,pqab->rs',h2e_v,h2e_v,a7)
-    diff = mc.mo_energy[mc.ncore+mc.ncas:,None] + mc.mo_energy[None,mc.ncore+mc.ncas:]
+    diff = mc.mo_energy[nocc:,None] + mc.mo_energy[None,nocc:]
     return _norm_to_energy(norm, h, diff)
 
 def Sij(mc, dms, eris, verbose=None):
@@ -489,16 +496,17 @@ def Sij(mc, dms, eris, verbose=None):
     dm1 = dms['1']
     dm2 = dms['2']
     dm3 = dms['3']
+    ncore = mo_core.shape[1]
+    ncas = mo_cas.shape[1]
+    nocc = ncore + ncas
     if mo_core.size ==0 :
         return 0.0, 0
     if eris is None:
         h1e = mc.h1e_for_cas()[0]
-        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), mc.ncas).transpose(0,2,1,3)
+        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), ncas).transpose(0,2,1,3)
         h2e_v = ao2mo.incore.general(mc._scf._eri,[mo_cas,mo_core,mo_cas,mo_core],compact=False)
-        h2e_v = h2e_v.reshape(mc.ncas,mc.ncore,mc.ncas,mc.ncore).transpose(0,2,1,3)
+        h2e_v = h2e_v.reshape(ncas,ncore,ncas,ncore).transpose(0,2,1,3)
     else:
-        ncore = mc.ncore
-        nocc = mc.ncore + mc.ncas
         h1e = eris['h1eff'][ncore:nocc,ncore:nocc]
         h2e = eris['ppaa'][ncore:nocc,ncore:nocc].transpose(0,2,1,3)
         h2e_v = eris['papa'][:ncore,:,:ncore].transpose(1,3,0,2)
@@ -520,7 +528,7 @@ def Sij(mc, dms, eris, verbose=None):
     a9 = make_a9(h1e,h2e,hdm1,hdm2,hdm3)
     norm = 0.5*numpy.einsum('qpij,baij,pqab->ij',h2e_v,h2e_v,hdm2)
     h = 0.5*numpy.einsum('qpij,baij,pqab->ij',h2e_v,h2e_v,a9)
-    diff = mc.mo_energy[:mc.ncore,None] + mc.mo_energy[None,:mc.ncore]
+    diff = mc.mo_energy[:ncore,None] + mc.mo_energy[None,:ncore]
     return _norm_to_energy(norm, h, -diff)
 
 
@@ -530,17 +538,18 @@ def Sir(mc, dms, eris, verbose=None):
     dm1 = dms['1']
     dm2 = dms['2']
     dm3 = dms['3']
+    ncore = mo_core.shape[1]
+    ncas = mo_cas.shape[1]
+    nocc = ncore + ncas
     if eris is None:
         h1e = mc.h1e_for_cas()[0]
-        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), mc.ncas).transpose(0,2,1,3)
+        h2e = ao2mo.restore(1, mc.ao2mo(mo_cas), ncas).transpose(0,2,1,3)
         h2e_v1 = ao2mo.incore.general(mc._scf._eri,[mo_virt,mo_core,mo_cas,mo_cas],compact=False)
-        h2e_v1 = h2e_v1.reshape(mo_virt.shape[1],mc.ncore,mc.ncas,mc.ncas).transpose(0,2,1,3)
+        h2e_v1 = h2e_v1.reshape(mo_virt.shape[1],ncore,ncas,ncas).transpose(0,2,1,3)
         h2e_v2 = ao2mo.incore.general(mc._scf._eri,[mo_virt,mo_cas,mo_cas,mo_core],compact=False)
-        h2e_v2 = h2e_v2.reshape(mo_virt.shape[1],mc.ncas,mc.ncas,mc.ncore).transpose(0,2,1,3)
+        h2e_v2 = h2e_v2.reshape(mo_virt.shape[1],ncas,ncas,ncore).transpose(0,2,1,3)
         core_dm = numpy.dot(mo_core,mo_core.T)*2
     else:
-        ncore = mc.ncore
-        nocc = mc.ncore + mc.ncas
         h1e = eris['h1eff'][ncore:nocc,ncore:nocc]
         h2e = eris['ppaa'][ncore:nocc,ncore:nocc].transpose(0,2,1,3)
         h2e_v1 = eris['ppaa'][nocc:,:ncore].transpose(0,2,1,3)
@@ -564,7 +573,7 @@ def Sir(mc, dms, eris, verbose=None):
          - numpy.einsum('rpiq,rabi,pqab->ir',h2e_v1,h2e_v2,a12)\
          - numpy.einsum('rpqi,raib,pqab->ir',h2e_v2,h2e_v1,a12)\
          + numpy.einsum('rpqi,rabi,pqab->ir',h2e_v2,h2e_v2,a13)
-    diff = mc.mo_energy[:mc.ncore,None] - mc.mo_energy[None,mc.ncore+mc.ncas:]
+    diff = mc.mo_energy[:ncore,None] - mc.mo_energy[None,nocc:]
     return _norm_to_energy(norm, h, -diff)
 
 
@@ -587,6 +596,7 @@ class NEVPT(lib.StreamObject):
     '''
     def __init__(self, mc, root=0):
         self.__dict__.update(mc.__dict__)
+        self.ncore = mc.ncore
         self._mc = mc
         self.root = root
         self.compressed_mps = False
@@ -677,6 +687,9 @@ class NEVPT(lib.StreamObject):
         else:
             log = logger.Logger(self.stdout, self.verbose)
         time0 = (time.clock(), time.time())
+        ncore = self.ncore
+        ncas = self.ncas
+        nocc = ncore + ncas
 
         #By defaut, _mc is canonicalized for the first root.
         #For SC-NEVPT based on compressed MPS perturber functions, the _mc was already canonicalized.
@@ -685,10 +698,10 @@ class NEVPT(lib.StreamObject):
 
         if getattr(self.fcisolver, 'nevpt_intermediate', None):
             logger.info(self, 'DMRG-NEVPT')
-            dm1, dm2, dm3 = self.fcisolver._make_dm123(self.load_ci(),self.ncas,self.nelecas,None)
+            dm1, dm2, dm3 = self.fcisolver._make_dm123(self.load_ci(),ncas,self.nelecas,None)
         else:
             dm1, dm2, dm3 = fci.rdm.make_dm123('FCI3pdm_kern_sf',
-                                               self.load_ci(), self.load_ci(), self.ncas, self.nelecas)
+                                               self.load_ci(), self.load_ci(), ncas, self.nelecas)
         dm4 = None
 
         dms = {'1': dm1, '2': dm2, '3': dm3, '4': dm4,
@@ -698,15 +711,14 @@ class NEVPT(lib.StreamObject):
 
         eris = _ERIS(self, self.mo_coeff)
         time1 = log.timer('integral transformation', *time1)
-        nocc = self.ncore + self.ncas
 
         if not getattr(self.fcisolver, 'nevpt_intermediate', None):  # regular FCI solver
-            link_indexa = fci.cistring.gen_linkstr_index(range(self.ncas), self.nelecas[0])
-            link_indexb = fci.cistring.gen_linkstr_index(range(self.ncas), self.nelecas[1])
-            aaaa = eris['ppaa'][self.ncore:nocc,self.ncore:nocc].copy()
-            f3ca = _contract4pdm('NEVPTkern_cedf_aedf', aaaa, self.load_ci(), self.ncas,
+            link_indexa = fci.cistring.gen_linkstr_index(range(ncas), self.nelecas[0])
+            link_indexb = fci.cistring.gen_linkstr_index(range(ncas), self.nelecas[1])
+            aaaa = eris['ppaa'][ncore:nocc,ncore:nocc].copy()
+            f3ca = _contract4pdm('NEVPTkern_cedf_aedf', aaaa, self.load_ci(), ncas,
                                  self.nelecas, (link_indexa,link_indexb))
-            f3ac = _contract4pdm('NEVPTkern_aedf_ecdf', aaaa, self.load_ci(), self.ncas,
+            f3ac = _contract4pdm('NEVPTkern_aedf_ecdf', aaaa, self.load_ci(), ncas,
                                  self.nelecas, (link_indexa,link_indexb))
             dms['f3ca'] = f3ca
             dms['f3ac'] = f3ac

--- a/pyscf/pbc/cc/eom_kccsd_ghf.py
+++ b/pyscf/pbc/cc/eom_kccsd_ghf.py
@@ -115,11 +115,11 @@ def kernel(eom, nroots=1, koopmans=False, guess=None, left=False,
                 return lib.linalg_helper._eigs_cmplx2real(w, v, idx)
             conv_k, evals_k, evecs_k = eig(matvec, guess, precond, pick=pickeig,
                                            tol=eom.conv_tol, max_cycle=eom.max_cycle,
-                                           max_space=eom.max_space, nroots=nroots, verbose=eom.verbose)
+                                           max_space=eom.max_space, nroots=nroots, verbose=log)
         else:
             conv_k, evals_k, evecs_k = eig(matvec, guess, precond,
                                            tol=eom.conv_tol, max_cycle=eom.max_cycle,
-                                           max_space=eom.max_space, nroots=nroots, verbose=eom.verbose)
+                                           max_space=eom.max_space, nroots=nroots, verbose=log)
 
         evals_k = evals_k.real
         evals[k] = evals_k

--- a/pyscf/pbc/cc/kintermediates_rhf.py
+++ b/pyscf/pbc/cc/kintermediates_rhf.py
@@ -17,9 +17,7 @@
 #          Timothy Berkelbach <tim.berkelbach@gmail.com>
 #
 
-import tempfile
 import numpy as np
-import h5py
 from pyscf import lib
 
 #einsum = np.einsum

--- a/pyscf/pbc/cc/test/test_kpoint_rhf.py
+++ b/pyscf/pbc/cc/test/test_kpoint_rhf.py
@@ -233,7 +233,7 @@ class KnownValues(unittest.TestCase):
         cc.diis_start_cycle = 1
         ecc, t1, t2 = cc.kernel()
         self.assertAlmostEqual(ehf, ehf_bench, 9)
-        self.assertAlmostEqual(ecc, ecc_bench, 8)
+        self.assertAlmostEqual(ecc, ecc_bench, 7)
 
     def test_ao2mo(self):
         kmf = make_rand_kmf()
@@ -287,7 +287,7 @@ class KnownValues(unittest.TestCase):
         eris.mo_energy = [f.diagonal() for f in eris.fock]
         ecc1, t1, t2 = mycc.kernel(eris=eris)
 
-        self.assertAlmostEqual(ecc1, ecc1_bench, 6)
+        self.assertAlmostEqual(ecc1, ecc1_bench, 5)
 
     def _test_cu_metallic_frozen_occ(self, kmf, cell):
         assert cell.mesh == [7, 7, 7]

--- a/pyscf/pbc/df/test/test_aft_jk.py
+++ b/pyscf/pbc/df/test/test_aft_jk.py
@@ -41,8 +41,8 @@ class KnowValues(unittest.TestCase):
         vj, vk = mydf.get_jk(dm, exxdiv='ewald')
         ej1 = numpy.einsum('ij,ji->', vj, dm)
         ek1 = numpy.einsum('ij,ji->', vk, dm)
-        self.assertAlmostEqual(ej1, 3.0455881073561235*4./3.66768353356587, 9)
-        self.assertAlmostEqual(ek1, 7.7905480251964629*4./3.66768353356587, 9)
+        self.assertAlmostEqual(ej1, 3.0455881073561235*(4./3.66768353356587)**2, 9)
+        self.assertAlmostEqual(ek1, 7.7905480251964629*(4./3.66768353356587)**2, 9)
 
         numpy.random.seed(12)
         nao = cell.nao_nr()

--- a/pyscf/pbc/df/test/test_aft_jk.py
+++ b/pyscf/pbc/df/test/test_aft_jk.py
@@ -41,8 +41,8 @@ class KnowValues(unittest.TestCase):
         vj, vk = mydf.get_jk(dm, exxdiv='ewald')
         ej1 = numpy.einsum('ij,ji->', vj, dm)
         ek1 = numpy.einsum('ij,ji->', vk, dm)
-        self.assertAlmostEqual(ej1, 3.0455881073561235, 9)
-        self.assertAlmostEqual(ek1, 7.7905480251964629, 9)
+        self.assertAlmostEqual(ej1, 3.0455881073561235*4./3.66768353356587, 9)
+        self.assertAlmostEqual(ek1, 7.7905480251964629*4./3.66768353356587, 9)
 
         numpy.random.seed(12)
         nao = cell.nao_nr()

--- a/pyscf/pbc/df/test/test_band.py
+++ b/pyscf/pbc/df/test/test_band.py
@@ -29,13 +29,13 @@ class KnowValues(unittest.TestCase):
     def test_fft_band(self):
         mf = scf.RHF(cell)
         mf.kernel()
-        self.assertAlmostEqual(finger(mf.get_bands(kband[0])[0]), 1.9966435479483238, 8)
+        self.assertAlmostEqual(finger(mf.get_bands(kband[0])[0]), 1.9966435479483238, 7)
 
     def test_aft_band(self):
         mf = scf.RHF(cell)
         mf.with_df = df.AFTDF(cell)
         mf.kernel()
-        self.assertAlmostEqual(finger(mf.get_bands(kband[0])[0]), 1.9966027703000777, 8)
+        self.assertAlmostEqual(finger(mf.get_bands(kband[0])[0]), 1.9966027703000777, 7)
 
     def test_df_band(self):
         mf = scf.RHF(cell)
@@ -43,7 +43,7 @@ class KnowValues(unittest.TestCase):
         mf.with_df.exp_to_discard = mf.with_df.eta
         mf.with_df.kpts_band = kband[0]
         mf.kernel()
-        self.assertAlmostEqual(finger(mf.get_bands(kband[0])[0]), 1.992205011752425, 8)
+        self.assertAlmostEqual(finger(mf.get_bands(kband[0])[0]), 1.992205011752425, 7)
 
     def test_mdf_band(self):
         mf = scf.RHF(cell)
@@ -57,7 +57,7 @@ class KnowValues(unittest.TestCase):
         mf.kpts = cell.make_kpts([2]*3)
         mf.kernel()
         self.assertAlmostEqual(finger(mf.get_bands(kband[0])[0]), 1.758544475679261, 8)
-        self.assertAlmostEqual(finger(mf.get_bands(kband)[0]), 0.76562781841701533, 8)
+        self.assertAlmostEqual(finger(mf.get_bands(kband)[0]), 0.76562781841701533, 7)
 
     def test_aft_bands(self):
         mf = scf.KRHF(cell)
@@ -65,7 +65,7 @@ class KnowValues(unittest.TestCase):
         mf.kpts = cell.make_kpts([2,1,1])
         mf.kernel()
         self.assertAlmostEqual(finger(mf.get_bands(kband[0])[0]), 1.968506055533682, 8)
-        self.assertAlmostEqual(finger(mf.get_bands(kband)[0]), 1.0538585525613609, 8)
+        self.assertAlmostEqual(finger(mf.get_bands(kband)[0]), 1.0538585525613609, 7)
 
     def test_df_bands(self):
         mf = scf.KRHF(cell)
@@ -75,7 +75,7 @@ class KnowValues(unittest.TestCase):
         mf.kpts = cell.make_kpts([2,1,1])
         mf.kernel()
         self.assertAlmostEqual(finger(mf.get_bands(kband[0])[0]), 1.9648945030342437, 8)
-        self.assertAlmostEqual(finger(mf.get_bands(kband)[0]), 1.0455025876245683, 8)
+        self.assertAlmostEqual(finger(mf.get_bands(kband)[0]), 1.0455025876245683, 7)
 
     def test_mdf_bands_high_cost(self):
         mf = scf.KRHF(cell)

--- a/pyscf/pbc/df/test/test_fft.py
+++ b/pyscf/pbc/df/test/test_fft.py
@@ -632,8 +632,8 @@ class KnownValues(unittest.TestCase):
 
         ej1 = numpy.einsum('ij,ji->', vj1, dm)
         ek1 = numpy.einsum('ij,ji->', vk1, dm)
-        self.assertAlmostEqual(ej1, 2.3002596914518700, 9)
-        self.assertAlmostEqual(ek1, 3.3165691757797346, 9)
+        self.assertAlmostEqual(ej1, 2.3002596914518700*(6/6.82991739766009)**2, 9)
+        self.assertAlmostEqual(ek1, 3.3165691757797346*(6/6.82991739766009)**2, 9)
 
         dm = mf0.get_init_guess()
         vj0, vk0 = get_jk(mf0, cell, dm)
@@ -645,8 +645,8 @@ class KnownValues(unittest.TestCase):
 
         ej1 = numpy.einsum('ij,ji->', vj1, dm)
         ek1 = numpy.einsum('ij,ji->', vk1, dm)
-        self.assertAlmostEqual(ej1, 2.4673139106639925, 9)
-        self.assertAlmostEqual(ek1, 3.6886674521354221, 9)
+        self.assertAlmostEqual(ej1, 2.4673139106639925*(6/6.82991739766009)**2, 9)
+        self.assertAlmostEqual(ek1, 3.6886674521354221*(6/6.82991739766009)**2, 9)
 
     def test_get_jk_kpts(self):
         df = fft.FFTDF(cell)
@@ -662,14 +662,14 @@ class KnownValues(unittest.TestCase):
 
         ej1 = numpy.einsum('xij,xji->', vj1, dms) / len(kpts)
         ek1 = numpy.einsum('xij,xji->', vk1, dms) / len(kpts)
-        self.assertAlmostEqual(ej1, 2.3163352969873445, 9)
-        self.assertAlmostEqual(ek1, 7.7311228144548600, 9)
+        self.assertAlmostEqual(ej1, 2.3163352969873445*(6/6.82991739766009)**2, 9)
+        self.assertAlmostEqual(ek1, 7.7311228144548600*(6/6.82991739766009)**2, 9)
 
         numpy.random.seed(1)
         kpts_band = numpy.random.random((2,3))
         vj1, vk1 = df.get_jk(dms, kpts=kpts, kpts_band=kpts_band, exxdiv=None)
-        self.assertAlmostEqual(lib.finger(vj1), 3.437188138446714+0.1360466492092307j, 9)
-        self.assertAlmostEqual(lib.finger(vk1), 7.479986541097368+1.1980593415201204j, 9)
+        self.assertAlmostEqual(lib.finger(vj1), 6/6.82991739766009*(3.437188138446714+0.1360466492092307j), 9)
+        self.assertAlmostEqual(lib.finger(vk1), 6/6.82991739766009*(7.479986541097368+1.1980593415201204j), 9)
 
         nao = dm.shape[0]
         mo_coeff = numpy.random.random((nkpts,nao,nao))
@@ -869,3 +869,46 @@ if __name__ == '__main__':
     unittest.main()
 
 
+#|| ======================================================================
+#|| FAIL: test_get_jk (__main__.KnownValues)
+#|| ----------------------------------------------------------------------
+#|| Traceback (most recent call last):
+#||   File "df/test/test_fft.py", line 635, in test_get_jk
+#||     self.assertAlmostEqual(ej1, 2.3002596914518700*6./6.82991739766009, 9)
+#|| AssertionError: (1.7752048157393747-2.5392293537889846e-19j) != 2.0207503759034617 within 9 places
+#|| 
+#|| ======================================================================
+#|| FAIL: test_get_jk_kpts (__main__.KnownValues)
+#|| ----------------------------------------------------------------------
+#|| Traceback (most recent call last):
+#||   File "df/test/test_fft.py", line 665, in test_get_jk_kpts
+#||     self.assertAlmostEqual(ej1, 2.3163352969873445*6./6.82991739766009, 9)
+#|| AssertionError: (1.7876110203371138+9.959029383250026e-19j) != 2.0348726013414873 within 9 places
+#|| 
+#|| ======================================================================
+#|| FAIL: test_get_jk_with_casscf (__main__.KnownValues)
+#|| ----------------------------------------------------------------------
+#|| Traceback (most recent call last):
+#||   File "df/test/test_fft.py", line 861, in test_get_jk_with_casscf
+#||     mc = mcscf.CASSCF(mf, 1, 2).run()
+#||   File "/home/sunqm/workspace/program/pyscf/pyscf/lib/misc.py", line 472, in run
+#||     self.kernel(*args)
+#||   File "/home/sunqm/workspace/program/pyscf/pyscf/mcscf/mc1step.py", line 796, in kernel
+#||     ci0=ci0, callback=callback, verbose=self.verbose)
+#||   File "/home/sunqm/workspace/program/pyscf/pyscf/mcscf/mc1step.py", line 346, in kernel
+#||     e_tot, e_cas, fcivec = casscf.casci(mo, ci0, eris, log, locals())
+#||   File "/home/sunqm/workspace/program/pyscf/pyscf/mcscf/mc1step.py", line 816, in casci
+#||     e_tot, e_cas, fcivec = casci.kernel(fcasci, mo_coeff, ci0, log)
+#||   File "/home/sunqm/workspace/program/pyscf/pyscf/mcscf/casci.py", line 493, in kernel
+#||     ecore=energy_core)
+#||   File "/home/sunqm/workspace/program/pyscf/pyscf/fci/direct_spin1.py", line 738, in kernel
+#||     davidson_only, pspace_size, ecore=ecore, **kwargs)
+#||   File "/home/sunqm/workspace/program/pyscf/pyscf/fci/direct_spin1.py", line 448, in kernel_ms1
+#||     assert(0 < nelec[0] < norb and 0 < nelec[1] < norb)
+#|| AssertionError
+#|| 
+#|| ----------------------------------------------------------------------
+#|| Ran 14 tests in 9.418s
+#|| 
+#|| FAILED (failures=3)
+#|| [Finished in 10 seconds with code 1]

--- a/pyscf/pbc/mp/__init__.py
+++ b/pyscf/pbc/mp/__init__.py
@@ -31,6 +31,7 @@ def GMP2(mf, frozen=0, mo_coeff=None, mo_occ=None):
     mf = scf.addons.convert_to_ghf(mf)
     return mp2.GMP2(mf, frozen, mo_coeff, mo_occ)
 
-def KMP2(mf, frozen=0, mo_coeff=None, mo_occ=None):
-    return kmp2.KMP2(mf, frozen, mo_coeff, mo_occ)
+def KRMP2(mf, frozen=0, mo_coeff=None, mo_occ=None):
+    return kmp2.KRMP2(mf, frozen, mo_coeff, mo_occ)
 
+KMP2 = KRMP2

--- a/pyscf/pbc/scf/ghf.py
+++ b/pyscf/pbc/scf/ghf.py
@@ -110,19 +110,7 @@ class GHF(pbchf.SCF, mol_ghf.GHF):
     def get_init_guess(self, cell=None, key='minao'):
         if cell is None: cell = self.cell
         dm = mol_ghf.GHF.get_init_guess(self, cell, key)
-        if cell.dimension < 3:
-            if isinstance(dm, np.ndarray) and dm.ndim == 2:
-                ne = np.einsum('ij,ji', dm, self.get_ovlp(cell))
-            else:
-                ne = np.einsum('xij,ji', dm, self.get_ovlp(cell))
-            if abs(ne - cell.nelectron).sum() > 1e-7:
-                logger.warn(self, 'Big error detected in the electron number '
-                            'of initial guess density matrix (Ne/cell = %g)!\n'
-                            '  This can cause huge error in Fock matrix and '
-                            'lead to instability in SCF for low-dimensional '
-                            'systems.\n  DM is normalized to correct number '
-                            'of electrons', ne)
-                dm *= cell.nelectron / ne
+        dm = pbchf.normalize_dm_(self, dm)
         return dm
 
     def convert_from_(self, mf):

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -775,7 +775,7 @@ def normalize_dm_(mf, dm):
     else:
         ne = np.einsum('xij,ji->', dm, mf.get_ovlp(cell))
     if abs(ne - cell.nelectron).sum() > 1e-7:
-        logger.warn(mf, 'Big error detected in the electron number '
+        logger.debug(mf, 'Big error detected in the electron number '
                     'of initial guess density matrix (Ne/cell = %g)!\n'
                     '  This can cause huge error in Fock matrix and '
                     'lead to instability in SCF for low-dimensional '

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -771,9 +771,9 @@ def normalize_dm_(mf, dm):
     '''
     cell = mf.cell
     if isinstance(dm, np.ndarray) and dm.ndim == 2:
-        ne = np.einsum('ij,ji->', dm, mf.get_ovlp(cell))
+        ne = np.einsum('ij,ji->', dm, mf.get_ovlp(cell)).real
     else:
-        ne = np.einsum('xij,ji->', dm, mf.get_ovlp(cell))
+        ne = np.einsum('xij,ji->', dm, mf.get_ovlp(cell)).real
     if abs(ne - cell.nelectron).sum() > 1e-7:
         logger.debug(mf, 'Big error detected in the electron number '
                     'of initial guess density matrix (Ne/cell = %g)!\n'

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -696,16 +696,7 @@ class SCF(mol_hf.SCF):
     def get_init_guess(self, cell=None, key='minao'):
         if cell is None: cell = self.cell
         dm = mol_hf.SCF.get_init_guess(self, cell, key)
-        if cell.dimension < 3:
-            ne = np.einsum('ij,ji', dm, self.get_ovlp(cell))
-            if abs(ne - cell.nelectron).sum() > 1e-7:
-                logger.warn(self, 'Big error detected in the electron number '
-                            'of initial guess density matrix (Ne/cell = %g)!\n'
-                            '  This can cause huge error in Fock matrix and '
-                            'lead to instability in SCF for low-dimensional '
-                            'systems.\n  DM is normalized to the number '
-                            'of electrons', ne)
-                dm *= cell.nelectron / ne
+        dm = normalize_dm_(self, dm)
         return dm
 
     def init_guess_by_1e(self, cell=None):
@@ -773,3 +764,22 @@ def _format_jks(vj, dm, kpts_band):
     elif getattr(dm, "ndim", 0) == 2:
         vj = vj[0]
     return vj
+
+def normalize_dm_(mf, dm):
+    '''
+    Scale density matrix to make it produce the correct number of electrons.
+    '''
+    cell = mf.cell
+    if isinstance(dm, np.ndarray) and dm.ndim == 2:
+        ne = np.einsum('ij,ji->', dm, mf.get_ovlp(cell))
+    else:
+        ne = np.einsum('xij,ji->', dm, mf.get_ovlp(cell))
+    if abs(ne - cell.nelectron).sum() > 1e-7:
+        logger.warn(mf, 'Big error detected in the electron number '
+                    'of initial guess density matrix (Ne/cell = %g)!\n'
+                    '  This can cause huge error in Fock matrix and '
+                    'lead to instability in SCF for low-dimensional '
+                    'systems.\n  DM is normalized wrt the number '
+                    'of electrons %s', ne, cell.nelectron)
+        dm *= cell.nelectron / ne
+    return dm

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -506,20 +506,19 @@ class KSCF(pbchf.SCF):
         if dm_kpts is None:
             dm_kpts = lib.asarray([dm]*len(self.kpts))
 
-        if cell.dimension < 3:
-            ne = np.einsum('kij,kji->', dm_kpts, self.get_ovlp(cell)).real
-            # FIXME: consider the fractional num_electron or not? This maybe
-            # relates to the charged system.
-            nkpts = len(self.kpts)
-            nelectron = self.cell.tot_electrons(nkpts)
-            if abs(ne - nelectron) > 1e-7*nkpts:
-                logger.warn(self, 'Big error detected in the electron number '
-                            'of initial guess density matrix (Ne/cell = %g)!\n'
-                            '  This can cause huge error in Fock matrix and '
-                            'lead to instability in SCF for low-dimensional '
-                            'systems.\n  DM is normalized to the number '
-                            'of electrons', ne.mean()/nkpts)
-                dm_kpts *= (nelectron / ne).reshape(-1,1,1)
+        ne = np.einsum('kij,kji->', dm_kpts, self.get_ovlp(cell)).real
+        # FIXME: consider the fractional num_electron or not? This maybe
+        # relate to the charged system.
+        nkpts = len(self.kpts)
+        nelectron = float(self.cell.tot_electrons(nkpts))
+        if abs(ne - nelectron) > 1e-7*nkpts:
+            logger.warn(self, 'Big error detected in the electron number '
+                        'of initial guess density matrix (Ne/cell = %g)!\n'
+                        '  This can cause huge error in Fock matrix and '
+                        'lead to instability in SCF for low-dimensional '
+                        'systems.\n  DM is normalized wrt the number '
+                        'of electrons %s', ne/nkpts, nelectron/nkpts)
+            dm_kpts *= (nelectron / ne).reshape(-1,1,1)
         return dm_kpts
 
     def init_guess_by_1e(self, cell=None):

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -512,7 +512,7 @@ class KSCF(pbchf.SCF):
         nkpts = len(self.kpts)
         nelectron = float(self.cell.tot_electrons(nkpts))
         if abs(ne - nelectron) > 1e-7*nkpts:
-            logger.warn(self, 'Big error detected in the electron number '
+            logger.debug(self, 'Big error detected in the electron number '
                         'of initial guess density matrix (Ne/cell = %g)!\n'
                         '  This can cause huge error in Fock matrix and '
                         'lead to instability in SCF for low-dimensional '

--- a/pyscf/pbc/scf/krohf.py
+++ b/pyscf/pbc/scf/krohf.py
@@ -334,7 +334,7 @@ class KROHF(pbcrohf.ROHF, khf.KRHF):
         nkpts = len(self.kpts)
         nelec = float(sum(self.nelec))
         if np.any(abs(ne - nelec) > 1e-7*nkpts):
-            logger.warn(self, 'Big error detected in the electron number '
+            logger.debug(self, 'Big error detected in the electron number '
                         'of initial guess density matrix (Ne/cell = %g)!\n'
                         '  This can cause huge error in Fock matrix and '
                         'lead to instability in SCF for low-dimensional '

--- a/pyscf/pbc/scf/krohf.py
+++ b/pyscf/pbc/scf/krohf.py
@@ -328,20 +328,19 @@ class KROHF(pbcrohf.ROHF, khf.KRHF):
             # dm[spin,nao,nao] at gamma point -> dm_kpts[spin,nkpts,nao,nao]
             dm_kpts = np.repeat(dm[:,None,:,:], nkpts, axis=1)
 
-        if cell.dimension < 3:
-            ne = np.einsum('xkij,kji->', dm_kpts, self.get_ovlp(cell)).real
-            # FIXME: consider the fractional num_electron or not? This maybe
-            # relates to the charged system.
-            nkpts = len(self.kpts)
-            nelec = sum(self.nelec)
-            if np.any(abs(ne - nelec) > 1e-7*nkpts):
-                logger.warn(self, 'Big error detected in the electron number '
-                            'of initial guess density matrix (Ne/cell = %g)!\n'
-                            '  This can cause huge error in Fock matrix and '
-                            'lead to instability in SCF for low-dimensional '
-                            'systems.\n  DM is normalized to the number '
-                            'of electrons', ne/nkpts)
-                dm_kpts *= nelec / ne
+        ne = np.einsum('xkij,kji->', dm_kpts, self.get_ovlp(cell)).real
+        # FIXME: consider the fractional num_electron or not? This maybe
+        # relates to the charged system.
+        nkpts = len(self.kpts)
+        nelec = float(sum(self.nelec))
+        if np.any(abs(ne - nelec) > 1e-7*nkpts):
+            logger.warn(self, 'Big error detected in the electron number '
+                        'of initial guess density matrix (Ne/cell = %g)!\n'
+                        '  This can cause huge error in Fock matrix and '
+                        'lead to instability in SCF for low-dimensional '
+                        'systems.\n  DM is normalized wrt the number '
+                        'of electrons %g', ne/nkpts, nelec/nkpts)
+            dm_kpts *= nelec / ne
         return dm_kpts
 
     get_hcore = khf.KSCF.get_hcore

--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -419,20 +419,19 @@ class KUHF(pbcuhf.UHF, khf.KSCF):
             dm_kpts[1,:] *= 0.99  # To slightly break spin symmetry
             assert dm_kpts.shape[0]==2
 
-        if cell.dimension < 3:
-            ne = np.einsum('xkij,kji->x', dm_kpts, self.get_ovlp(cell)).real
-            # FIXME: consider the fractional num_electron or not? This maybe
-            # relates to the charged system.
-            nkpts = len(self.kpts)
-            nelec = np.asarray(self.nelec)
-            if np.any(abs(ne - nelec) > 1e-7*nkpts):
-                logger.warn(self, 'Big error detected in the electron number '
-                            'of initial guess density matrix (Ne/cell = %g)!\n'
-                            '  This can cause huge error in Fock matrix and '
-                            'lead to instability in SCF for low-dimensional '
-                            'systems.\n  DM is normalized to the number '
-                            'of electrons', ne.sum()/nkpts)
-                dm_kpts *= (nelec / ne).reshape(2,-1,1,1)
+        ne = np.einsum('xkij,kji->x', dm_kpts, self.get_ovlp(cell)).real
+        # FIXME: consider the fractional num_electron or not? This maybe
+        # relates to the charged system.
+        nkpts = len(self.kpts)
+        nelec = np.asarray(self.nelec)
+        if np.any(abs(ne - nelec) > 1e-7*nkpts):
+            logger.warn(self, 'Big error detected in the electron number '
+                        'of initial guess density matrix (Ne/cell = %g)!\n'
+                        '  This can cause huge error in Fock matrix and '
+                        'lead to instability in SCF for low-dimensional '
+                        'systems.\n  DM is normalized wrt the number '
+                        'of electrons %s', ne.mean()/nkpts, nelec/nkpts)
+            dm_kpts *= (nelec / ne).reshape(2,-1,1,1)
         return dm_kpts
 
     get_hcore = khf.KSCF.get_hcore

--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -425,7 +425,7 @@ class KUHF(pbcuhf.UHF, khf.KSCF):
         nkpts = len(self.kpts)
         nelec = np.asarray(self.nelec)
         if np.any(abs(ne - nelec) > 1e-7*nkpts):
-            logger.warn(self, 'Big error detected in the electron number '
+            logger.debug(self, 'Big error detected in the electron number '
                         'of initial guess density matrix (Ne/cell = %g)!\n'
                         '  This can cause huge error in Fock matrix and '
                         'lead to instability in SCF for low-dimensional '

--- a/pyscf/pbc/scf/rohf.py
+++ b/pyscf/pbc/scf/rohf.py
@@ -129,19 +129,7 @@ class ROHF(mol_rohf.ROHF, pbchf.RHF):
     def get_init_guess(self, cell=None, key='minao'):
         if cell is None: cell = self.cell
         dm = mol_rohf.ROHF.get_init_guess(self, cell, key)
-        if cell.dimension < 3:
-            if isinstance(dm, np.ndarray) and dm.ndim == 2:
-                ne = np.einsum('ij,ji->', dm, self.get_ovlp(cell))
-            else:
-                ne = np.einsum('xij,ji->', dm, self.get_ovlp(cell))
-            if abs(ne - cell.nelectron).max() > 1e-7:
-                logger.warn(self, 'Big error detected in the electron number '
-                            'of initial guess density matrix (Ne/cell = %g)!\n'
-                            '  This can cause huge error in Fock matrix and '
-                            'lead to instability in SCF for low-dimensional '
-                            'systems.\n  DM is normalized to the number '
-                            'of electrons', ne)
-                dm *= cell.nelectron / ne
+        dm = pbchf.normalize_dm_(self, dm)
         return dm
 
     def init_guess_by_1e(self, cell=None):

--- a/pyscf/pbc/scf/test/test_hf.py
+++ b/pyscf/pbc/scf/test/test_hf.py
@@ -152,7 +152,7 @@ class KnownValues(unittest.TestCase):
         mf.max_cycle = 1
         mf.diis = None
         e1 = mf.kernel()
-        self.assertAlmostEqual(e1, -4.132914531737784, 9)
+        self.assertAlmostEqual(e1, -4.132445328608581, 9)
 
         mf1 = pbchf.RHF(cell, exxdiv='vcut_sph')
         mf1.chkfile = mf.chkfile
@@ -160,7 +160,7 @@ class KnownValues(unittest.TestCase):
         mf1.diis = None
         mf1.max_cycle = 1
         e1 = mf1.kernel()
-        self.assertAlmostEqual(e1, -4.291691793916943, 9)
+        self.assertAlmostEqual(e1, -4.291854736401251, 9)
         self.assertTrue(mf1.mo_coeff.dtype == numpy.double)
 
     def test_uhf_exx_ewald(self):
@@ -468,7 +468,7 @@ class KnownValues(unittest.TestCase):
 
     def test_dipole_moment(self):
         dip = mf.dip_moment()
-        self.assertAlmostEqual(lib.finger(dip), 0.03847620192010277, 9)
+        self.assertAlmostEqual(lib.finger(dip), 0.03847620192010277, 8)
 
         # For test cover only. Results for low-dimesion system are not
         # implemented.

--- a/pyscf/pbc/scf/test/test_khf.py
+++ b/pyscf/pbc/scf/test/test_khf.py
@@ -64,7 +64,7 @@ class KnownValues(unittest.TestCase):
         upop, uchg = kumf.analyze()
         self.assertTrue(isinstance(rpop, np.ndarray) and rpop.ndim == 1)
         self.assertAlmostEqual(abs(upop[0]+upop[1]-rpop).max(), 0, 7)
-        self.assertAlmostEqual(lib.finger(rpop), 1.6974490052755433, 6)
+        self.assertAlmostEqual(lib.finger(rpop), 1.697446, 5)
 
     def test_kpt_vs_supercell_high_cost(self):
         # For large n, agreement is always achieved
@@ -270,7 +270,7 @@ class KnownValues(unittest.TestCase):
         kmf.diis = None
         e2 = kmf.kernel()
         self.assertAlmostEqual(e1, e2, 9)
-        self.assertAlmostEqual(e1, -11.451354250609718, 9)
+        self.assertAlmostEqual(e1, -11.451118801956275, 9)
 
 
 if __name__ == '__main__':

--- a/pyscf/pbc/scf/test/test_khf.py
+++ b/pyscf/pbc/scf/test/test_khf.py
@@ -64,7 +64,7 @@ class KnownValues(unittest.TestCase):
         upop, uchg = kumf.analyze()
         self.assertTrue(isinstance(rpop, np.ndarray) and rpop.ndim == 1)
         self.assertAlmostEqual(abs(upop[0]+upop[1]-rpop).max(), 0, 7)
-        self.assertAlmostEqual(lib.finger(rpop), 1.6974490052755433, 7)
+        self.assertAlmostEqual(lib.finger(rpop), 1.6974490052755433, 6)
 
     def test_kpt_vs_supercell_high_cost(self):
         # For large n, agreement is always achieved
@@ -121,7 +121,7 @@ class KnownValues(unittest.TestCase):
         kmf1.max_cycle = 2
         ekpt = kmf1.scf()
         kmf1.conv_check = False
-        self.assertAlmostEqual(ekpt, -11.215218432275057, 8)
+        self.assertAlmostEqual(ekpt, -11.215259853108822, 8)
 
     def test_krhf(self):
         self.assertAlmostEqual(kmf.e_tot, -11.218735269838586, 8)
@@ -132,7 +132,7 @@ class KnownValues(unittest.TestCase):
         np.random.seed(1)
         kpts_bands = np.random.random((2,3))
         e = kumf.get_bands(kpts_bands)[0]
-        self.assertAlmostEqual(finger(np.array(e)), -0.045547555445877741, 6)
+        self.assertAlmostEqual(finger(np.array(e)), -0.0455444, 6)
 
     def test_krhf_1d(self):
         L = 4
@@ -223,7 +223,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e1, -3.5112358424228809, 4)
 
     def test_get_fermi(self):
-        self.assertAlmostEqual(kmf.get_fermi(), 0.33154831914017424, 8)
+        self.assertAlmostEqual(kmf.get_fermi(), 0.33154831914017424, 6)
 
         def occ_vir(nocc, nvir):
             occ = np.zeros(nocc+nvir)
@@ -255,7 +255,7 @@ class KnownValues(unittest.TestCase):
 
     def test_dipole_moment(self):
         dip = kmf.dip_moment()
-        self.assertAlmostEqual(lib.finger(dip), 0.729751581497479, 9)
+        self.assertAlmostEqual(lib.finger(dip), 0.729751581497479, 5)
 
     def test_krhf_vs_rhf(self):
         np.random.seed(1)

--- a/pyscf/pbc/scf/test/test_rohf.py
+++ b/pyscf/pbc/scf/test/test_rohf.py
@@ -88,10 +88,10 @@ class KnownValues(unittest.TestCase):
 
     def test_dipole_moment(self):
         dip = mf.dip_moment()
-        self.assertAlmostEqual(lib.finger(dip), 1.6424482249196493, 9)
+        self.assertAlmostEqual(lib.finger(dip), 1.6424482249196493, 7)
 
         dip = kmf.dip_moment()
-        self.assertAlmostEqual(lib.finger(dip), 0.7361493256233677, 9)
+        self.assertAlmostEqual(lib.finger(dip), 0.7361493256233677, 7)
 
     def test_get_init_guess(self):
         cell1 = cell.copy()

--- a/pyscf/pbc/scf/test/test_rohf.py
+++ b/pyscf/pbc/scf/test/test_rohf.py
@@ -65,7 +65,7 @@ class KnownValues(unittest.TestCase):
         kmf.diis = None
         e2 = kmf.kernel()
         self.assertAlmostEqual(e1, e2, 9)
-        self.assertAlmostEqual(e1, -3.3035461870274085, 9)
+        self.assertAlmostEqual(e1, -3.3046228601655607, 9)
 
     def test_init_guess_by_chkfile(self):
         np.random.seed(1)

--- a/pyscf/pbc/scf/test/test_uhf.py
+++ b/pyscf/pbc/scf/test/test_uhf.py
@@ -75,7 +75,7 @@ class KnownValues(unittest.TestCase):
         mf.max_cycle = 1
         mf.diis = None
         e1 = mf.kernel()
-        self.assertAlmostEqual(e1, -3.3058403617753886, 9)
+        self.assertAlmostEqual(e1, -3.4070772194665477, 9)
 
         mf1 = pscf.UHF(cell, exxdiv='vcut_sph')
         mf1.chkfile = mf.chkfile
@@ -83,19 +83,19 @@ class KnownValues(unittest.TestCase):
         mf1.diis = None
         mf1.max_cycle = 1
         e1 = mf1.kernel()
-        self.assertAlmostEqual(e1, -3.4204798298887615, 9)
+        self.assertAlmostEqual(e1, -3.4272925247351256, 9)
         self.assertTrue(mf1.mo_coeff[0].dtype == np.double)
 
     def test_dipole_moment(self):
         dip = mf.dip_moment()
-        self.assertAlmostEqual(lib.finger(dip), 1.644379056097664, 9)
+        self.assertAlmostEqual(lib.finger(dip), 1.644379056097664, 7)
 
         dip = kmf.dip_moment()
-        self.assertAlmostEqual(lib.finger(dip), 0.6934374246768265, 9)
+        self.assertAlmostEqual(lib.finger(dip), 0.6934317735537686, 6)
 
     def test_spin_square(self):
         ss = kmf.spin_square()[0]
-        self.assertAlmostEqual(ss, 2.077383024287556, 9)
+        self.assertAlmostEqual(ss, 2.077383024287556, 4)
 
     def test_bands(self):
         np.random.seed(1)
@@ -105,7 +105,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(lib.finger(e), 0.9038555558945438, 6)
 
         e = kmf.get_bands(kpts_bands)[0]
-        self.assertAlmostEqual(lib.finger(e), -0.30205862019368834, 6)
+        self.assertAlmostEqual(lib.finger(e), -0.3020614, 6)
 
 
 if __name__ == '__main__':

--- a/pyscf/pbc/scf/uhf.py
+++ b/pyscf/pbc/scf/uhf.py
@@ -216,19 +216,7 @@ class UHF(mol_uhf.UHF, pbchf.SCF):
     def get_init_guess(self, cell=None, key='minao'):
         if cell is None: cell = self.cell
         dm = mol_uhf.UHF.get_init_guess(self, cell, key)
-        if cell.dimension < 3:
-            if isinstance(dm, np.ndarray) and dm.ndim == 2:
-                ne = np.einsum('ij,ji->', dm, self.get_ovlp(cell))
-            else:
-                ne = np.einsum('xij,ji->', dm, self.get_ovlp(cell))
-            if abs(ne - cell.nelectron).sum() > 1e-7:
-                logger.warn(self, 'Big error detected in the electron number '
-                            'of initial guess density matrix (Ne/cell = %g)!\n'
-                            '  This can cause huge error in Fock matrix and '
-                            'lead to instability in SCF for low-dimensional '
-                            'systems.\n  DM is normalized to the number '
-                            'of electrons', ne)
-                dm *= cell.nelectron / ne
+        dm = pbchf.normalize_dm_(self, dm)
         return dm
 
     def init_guess_by_1e(self, cell=None):

--- a/pyscf/pbc/x2c/test/test_x2c.py
+++ b/pyscf/pbc/x2c/test/test_x2c.py
@@ -41,10 +41,10 @@ class KnownValues(unittest.TestCase):
             mf.with_df = df.AFTDF(cell)
             dm = mf.get_init_guess()
             h1 = mf.get_hcore()
-            self.assertAlmostEqual(numpy.einsum('ij,ji', dm, h1), -0.47578184212352159+0j, 8)
+            self.assertAlmostEqual(numpy.einsum('ij,ji', dm, h1), 2/3.7865300454631*-0.47578184212352159+0j, 8)
             kpts = cell.make_kpts([3,1,1])
             h1 = mf.get_hcore(kpt=kpts[1])
-            self.assertAlmostEqual(numpy.einsum('ij,ji', dm, h1), -0.09637799091491725+0j, 8)
+            self.assertAlmostEqual(numpy.einsum('ij,ji', dm, h1), 2/3.7865300454631*-0.09637799091491725+0j, 8)
 
     def test_khf(self):
         with lib.light_speed(2) as c:
@@ -53,9 +53,9 @@ class KnownValues(unittest.TestCase):
             mf.kpts = cell.make_kpts([3,1,1])
             dm = mf.get_init_guess()
             h1 = mf.get_hcore()
-            self.assertAlmostEqual(numpy.einsum('ij,ji', dm[0], h1[0]),-0.47578184212352159+0j, 8)
-            self.assertAlmostEqual(numpy.einsum('ij,ji', dm[1], h1[1]),-0.09637799091491725+0j, 8)
-            self.assertAlmostEqual(numpy.einsum('ij,ji', dm[2], h1[2]),-0.09637799091491725+0j, 8)
+            self.assertAlmostEqual(numpy.einsum('ij,ji', dm[0], h1[0]),6/8.98384358326*-0.47578184212352159+0j, 8)
+            self.assertAlmostEqual(numpy.einsum('ij,ji', dm[1], h1[1]),6/8.98384358326*-0.09637799091491725+0j, 8)
+            self.assertAlmostEqual(numpy.einsum('ij,ji', dm[2], h1[2]),6/8.98384358326*-0.09637799091491725+0j, 8)
 
     def test_pnucp(self):
         cell1 = gto.Cell()

--- a/pyscf/scf/ghf.py
+++ b/pyscf/scf/ghf.py
@@ -110,7 +110,7 @@ def get_jk(mol, dm, hermi=0,
     n_dm = dms.shape[0]
 
     dmaa = dms[:,:nao,:nao]
-    dmab = dms[:,nao:,:nao]
+    dmab = dms[:,:nao,nao:]
     dmbb = dms[:,nao:,nao:]
     dms = numpy.vstack((dmaa, dmbb, dmab))
     if dm.dtype == numpy.complex128:

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -602,7 +602,7 @@ def dot_eri_dm(eri, dm, hermi=0):
     >>> print(j.shape)
     (3, 2, 2)
     '''
-    dm = numpy.asarray(dm)
+    dm = numpy.asarray(dm,order='C')
     nao = dm.shape[-1]
     dms = dm.reshape(-1,nao,nao)
     if eri.dtype == numpy.complex128 or eri.size == nao**4:

--- a/pyscf/scf/test/test_ghf.py
+++ b/pyscf/scf/test/test_ghf.py
@@ -150,7 +150,7 @@ class KnownValues(unittest.TestCase):
         self.assertEqual(vj.shape, (2,nao,nao))
         self.assertEqual(vk.shape, (2,nao,nao))
         self.assertAlmostEqual(lib.finger(vj), 246.24944977538354, 9)
-        self.assertAlmostEqual(lib.finger(vk), 37.840557968925779, 9)
+        self.assertAlmostEqual(lib.finger(vk), 53.22954677121744, 9)
 
         numpy.random.seed(1)
         d1 = numpy.random.random((nao,nao)) + 1j*numpy.random.random((nao,nao))
@@ -160,7 +160,7 @@ class KnownValues(unittest.TestCase):
         self.assertEqual(vj.shape, (2,nao,nao))
         self.assertEqual(vk.shape, (2,nao,nao))
         self.assertAlmostEqual(lib.finger(vj), 254.68614111766146+0j, 9)
-        self.assertAlmostEqual(lib.finger(vk), 53.629159066971539-2.1298002812909353j, 9)
+        self.assertAlmostEqual(lib.finger(vk), 62.08832587927003-8.640597547171135j, 9)
 
         nao = mol.nao_nr()
         numpy.random.seed(1)
@@ -290,7 +290,7 @@ H     0    0.757    0.587'''
         vhf4 = mf1.get_veff(pmol, dm, hermi=0)
         self.assertEqual(vhf4.ndim, 4)
         self.assertAlmostEqual(lib.finger(vhf4),
-                               -5.1441200982786057-5.5331447834480718j, 12)
+                               17.264430281812047-5.533144783448073j, 12)
         self.assertAlmostEqual(abs(vhf4[0]-vhf3).max(), 0, 12)
 
         vj = mf1.get_j(pmol, dm[0,0], hermi=0)


### PR DESCRIPTION
* Scale the PBC SCF initial density matrix to get the correct number of electrons. Without this normalization, the initial SCF energy may be far off to the results.
* Update command line parser
* Fix issue #289. Lazy initialization for the number of core electrons in CASCI/CASSCF.
* Fix GHF. The alpha-beta coupling density matrix was incorrect.