### PR TITLE
State average inheritance fix

### DIFF
--- a/pyscf/mcscf/addons.py
+++ b/pyscf/mcscf/addons.py
@@ -710,7 +710,7 @@ def state_average(casscf, weights=(0.5,0.5)):
             self._keys = self._keys.union (keys)
         @property
         def _base_class (self):
-            ''' for convenience; this is equal to fcibase_class '''
+            ''' for convenience; this is equal to mcscfbase_class '''
             return self.__class__.__bases__[0]
         @property
         def weights (self):

--- a/pyscf/mcscf/casci.py
+++ b/pyscf/mcscf/casci.py
@@ -884,7 +884,7 @@ To enable the solvent model for CASSCF, a decoration to CASSCF object as below n
 
     @lib.with_doc(addons.state_average_.__doc__)
     def state_average_(self, weights=(0.5,0.5)):
-        addons.state_average(self, weights)
+        addons.state_average_(self, weights)
         return self
 
     @lib.with_doc(addons.state_specific_.__doc__)

--- a/pyscf/mcscf/casci.py
+++ b/pyscf/mcscf/casci.py
@@ -882,10 +882,13 @@ To enable the solvent model for CASSCF, a decoration to CASSCF object as below n
         if mo_coeff is None: mo_coeff = self.mo_coeff
         return addons.sort_mo(self, mo_coeff, caslst, base)
 
-    @lib.with_doc(addons.state_average_.__doc__)
+    @lib.with_doc(addons.state_average.__doc__)
     def state_average_(self, weights=(0.5,0.5)):
         addons.state_average_(self, weights)
         return self
+    @lib.with_doc(addons.state_average.__doc__)
+    def state_average(self, weights=(0.5,0.5)):
+        return addons.state_average(self, weights)
 
     @lib.with_doc(addons.state_specific_.__doc__)
     def state_specific_(self, state=1):

--- a/pyscf/mcscf/mc1step.py
+++ b/pyscf/mcscf/mc1step.py
@@ -1245,7 +1245,7 @@ To enable the solvent model for CASSCF, a decoration to CASSCF object as below n
         # MRH, 04/08/2019: enable state-average CASSCF second-order algorithm
         from pyscf.mcscf.addons import StateAverageMCSCFSolver
         if isinstance (self, StateAverageMCSCFSolver):
-            mc1 = mc1.state_average_()
+            mc1 = mc1.state_average_(self.weights)
         return mc1
 
 from pyscf import scf

--- a/pyscf/mcscf/mc1step.py
+++ b/pyscf/mcscf/mc1step.py
@@ -1242,6 +1242,10 @@ To enable the solvent model for CASSCF, a decoration to CASSCF object as below n
         mc1 = newton_casscf.CASSCF(self._scf, self.ncas, self.nelecas)
         mc1.__dict__.update(self.__dict__)
         mc1.max_cycle_micro = 10
+        # MRH, 04/08/2019: enable state-average CASSCF second-order algorithm
+        from pyscf.mcscf.addons import StateAverageMCSCFSolver
+        if isinstance (self, StateAverageMCSCFSolver):
+            mc1 = mc1.state_average_()
         return mc1
 
 from pyscf import scf

--- a/pyscf/mcscf/mc1step_symm.py
+++ b/pyscf/mcscf/mc1step_symm.py
@@ -115,6 +115,10 @@ class SymAdaptedCASSCF(mc1step.CASSCF):
         mc1 = newton_casscf_symm.CASSCF(self._scf, self.ncas, self.nelecas)
         mc1.__dict__.update(self.__dict__)
         mc1.max_cycle_micro = 10
+        # MRH, 04/08/2019: enable state-average CASSCF second-order algorithm
+        from pyscf.mcscf.addons import StateAverageMCSCFSolver
+        if isinstance (self, StateAverageMCSCFSolver):
+            mc1 = mc1.state_average_()
         return mc1
 
 CASSCF = SymAdaptedCASSCF

--- a/pyscf/mcscf/mc1step_symm.py
+++ b/pyscf/mcscf/mc1step_symm.py
@@ -118,7 +118,7 @@ class SymAdaptedCASSCF(mc1step.CASSCF):
         # MRH, 04/08/2019: enable state-average CASSCF second-order algorithm
         from pyscf.mcscf.addons import StateAverageMCSCFSolver
         if isinstance (self, StateAverageMCSCFSolver):
-            mc1 = mc1.state_average_()
+            mc1 = mc1.state_average_(self.weights)
         return mc1
 
 CASSCF = SymAdaptedCASSCF

--- a/pyscf/mcscf/newton_casscf.py
+++ b/pyscf/mcscf/newton_casscf.py
@@ -326,7 +326,8 @@ def _sa_gen_g_hop(casscf, mo, ci0, eris, verbose=None):
 # MRH, 04/08/2019: enable multiple roots
 def extract_rotation(casscf, dr, u, ci0):
     nroots = casscf.fcisolver.nroots
-    ngorb = numpy.count_nonzero (casscf.uniq_var_indices (u.shape[1], casscf.ncore, casscf.ncas, casscf.frozen))
+    nmo = casscf.mo_coeff.shape[1]
+    ngorb = numpy.count_nonzero (casscf.uniq_var_indices (nmo, casscf.ncore, casscf.ncas, casscf.frozen))
     u = numpy.dot(u, casscf.update_rotate_matrix(dr[:ngorb]))
     ci1 = (numpy.asarray (ci0).ravel() + dr[ngorb:]).reshape (nroots, -1)
     ci1 *= 1./numpy.linalg.norm(ci1, axis=1)[:,None]

--- a/pyscf/mcscf/newton_casscf.py
+++ b/pyscf/mcscf/newton_casscf.py
@@ -28,7 +28,7 @@ import numpy
 import scipy.linalg
 from pyscf import lib
 from pyscf.lib import logger
-from pyscf.mcscf import casci, mc1step
+from pyscf.mcscf import casci, mc1step, addons
 from pyscf.mcscf.casci import get_fock, cas_natorb, canonicalize
 from pyscf.mcscf import chkfile
 from pyscf import ao2mo
@@ -39,6 +39,9 @@ from pyscf import fci
 
 # gradients, hessian operator and hessian diagonal
 def gen_g_hop(casscf, mo, ci0, eris, verbose=None):
+    # MRH 04/08/2019: punt to state-average wrapper if necessary
+    if isinstance (casscf, addons.StateAverageMCSCFSolver):
+        return _sa_gen_g_hop (casscf, mo, ci0, eris, verbose)
     ncas = casscf.ncas
     ncore = casscf.ncore
     nocc = ncas + ncore
@@ -290,11 +293,45 @@ def gen_g_hop(casscf, mo, ci0, eris, verbose=None):
 
     return g_all, g_update, h_op, hdiag_all
 
+def _sa_gen_g_hop(casscf, mo, ci0, eris, verbose=None):
+    ''' MRH, 04/08/2019: This is a thin wrapper around the original gen_g_hop to weight and average the derivatives
+        in the second-order algorithm for a SA-CASSCF calculation. '''
+    ngorb = numpy.count_nonzero (casscf.uniq_var_indices (mo.shape[1], casscf.ncore, casscf.ncas, casscf.frozen))
+    nroots = casscf.fcisolver.nroots
+    fcasscf = casscf._base_class (casscf._scf, casscf.ncas, casscf.nelecas)
+    fcasscf.fcisolver = casscf.fcisolver._base_class (casscf.mol)
+
+    # Warning: do not call gen_g_hop from here with casscf: infinite recursion danger
+    gh_roots = [gen_g_hop (fcasscf, mo, ci0_i, eris, verbose=verbose) for ci0_i in ci0]
+    def avg_orb_wgt_ci (x_roots):
+        x_orb = sum ([x_iroot[:ngorb] * w for x_iroot, w in zip (x_roots, casscf.weights)])
+        x_ci = numpy.stack ([x_iroot[ngorb:] * w for x_iroot, w in zip (x_roots, casscf.weights)], axis=0)
+        x_all = numpy.append (x_orb, x_ci.ravel ()).ravel ()
+        return x_all
+
+    g_all = avg_orb_wgt_ci ([gh_iroot[0] for gh_iroot in gh_roots])
+    hdiag_all = avg_orb_wgt_ci ([gh_iroot[3] for gh_iroot in gh_roots])
+
+    def g_update (u, fcivec):
+        return avg_orb_wgt_ci ([gh_iroot[1] (u, ci) for gh_iroot, ci in zip (gh_roots, fcivec)])
+
+    def h_op (x):
+        x_orb = x[:ngorb]
+        x_ci = x[ngorb:].reshape (nroots, -1)
+        return avg_orb_wgt_ci ([gh_iroot[2] (numpy.append (x_orb, x_ci_iroot))
+            for gh_iroot, x_ci_iroot in zip (gh_roots, x_ci)])
+
+    return g_all, g_update, h_op, hdiag_all
+
+# MRH, 04/08/2019: enable multiple roots
 def extract_rotation(casscf, dr, u, ci0):
-    ngorb = dr.size - ci0.size
+    nroots = casscf.fcisolver.nroots
+    ngorb = numpy.count_nonzero (casscf.uniq_var_indices (u.shape[1], casscf.ncore, casscf.ncas, casscf.frozen))
     u = numpy.dot(u, casscf.update_rotate_matrix(dr[:ngorb]))
-    ci1 = ci0.ravel() + dr[ngorb:]
-    ci1 *= 1./numpy.linalg.norm(ci1)
+    ci1 = (numpy.asarray (ci0).ravel() + dr[ngorb:]).reshape (nroots, -1)
+    ci1 *= 1./numpy.linalg.norm(ci1, axis=1)[:,None]
+    ci1 = [ci1[iroot].ravel () for iroot in range (nroots)]
+    if nroots == 1: ci1 = ci1[0]
     return u, ci1
 
 def update_orb_ci(casscf, mo, ci0, eris, x0_guess=None,
@@ -304,9 +341,13 @@ def update_orb_ci(casscf, mo, ci0, eris, x0_guess=None,
         max_stepsize = casscf.max_stepsize
 
     nmo = mo.shape[1]
-    ci0 = ci0.ravel()
+    # MRH, 04/08/2019: enable multiple roots
+    if casscf.fcisolver.nroots == 1:
+        ci0 = ci0.ravel ()
+    else:
+        ci0 = [c.ravel () for c in ci0]
     g_all, g_update, h_op, h_diag = gen_g_hop(casscf, mo, ci0, eris)
-    ngorb = g_all.size - ci0.size
+    ngorb = numpy.count_nonzero (casscf.uniq_var_indices (nmo, casscf.ncore, casscf.ncas, casscf.frozen))
     g_kf = g_all
     norm_gkf = norm_gall = numpy.linalg.norm(g_all)
     log.debug('    |g|=%5.3g (%4.3g %4.3g) (keyframe)', norm_gall,
@@ -423,7 +464,7 @@ def update_orb_ci(casscf, mo, ci0, eris, x0_guess=None,
     log.debug('    tot inner=%d  |g|= %4.3g (%4.3g %4.3g) |u-1|= %4.3g  |dci|= %4.3g',
               stat.imic, norm_gall, norm_gorb, norm_gci,
               numpy.linalg.norm(u-numpy.eye(nmo)),
-              numpy.linalg.norm(ci_kf-ci0))
+              numpy.linalg.norm(numpy.asarray(ci_kf)-numpy.asarray(ci0)))
     return u, ci_kf, norm_gkf, stat, dxi
 
 


### PR DESCRIPTION
The mcscf.addons.state_average function now creates a child class of the
casscf function argument as well as the casscf.fcisolver attribute. This
allows the creation of children metaclasses for state-averaged CASCI and
MCSCF calculation objects. The values of the weights are now attributes
of the children objects and can be addressed after object creation (they
are no longer "lost" in the local scope of the addons.state_average_
function). The second-order CASSCF algorithm is extended to state-
averaged CASSCF calculations based on these metaclasses, with a view
towards implementing the Lagrange-multiplier method of SACASSCF
single-root nuclear gradients as described in Mol. Phys. 99, 103 (2001).