### PR TITLE
Update geometric_solver.py

### DIFF
--- a/pyscf/geomopt/geometric_solver.py
+++ b/pyscf/geomopt/geometric_solver.py
@@ -75,7 +75,7 @@ class PySCFEngine(geometric.engine.Engine):
 
         if self.assert_convergence and not g_scanner.converged:
             raise RuntimeError('Nuclear gradients of %s not converged' % g_scanner.base)
-        return energy, gradients.ravel()
+        return {"energy": energy, "gradient": gradients.ravel()}
 
 def kernel(method, assert_convergence=ASSERT_CONV,
            include_ghost=INCLUDE_GHOST, constraints=None, callback=None,


### PR DESCRIPTION
This one-line change should accommodate the recent geomeTRIC API change for the `geometric.Engine.calc_new()` function.  The basic idea is that previously a 2-tuple containing the energy and gradient were returned.  Now a dictionary is returned as `{'energy':energy, 'gradient':gradient}`.