### PR TITLE
Fix compilation with GCC 9.

### DIFF
--- a/pyscf/lib/cc/ccsd_grad.c
+++ b/pyscf/lib/cc/ccsd_grad.c
@@ -81,9 +81,7 @@ void CCvhfs2kl(double *eri, double *dm, double *vj, double *vk, int ni, int nj)
         memset(vj, 0, sizeof(double)*ni*nj);
         memset(vk, 0, sizeof(double)*ni*nj);
 
-#pragma omp parallel default(none) \
-        shared(eri, dm, vj, vk, ni, nj) \
-        private(ij, i, j, off)
+#pragma omp parallel private(ij, i, j, off)
         {
                 double *vj_priv = malloc(sizeof(double)*ni*nj);
                 double *vk_priv = malloc(sizeof(double)*ni*nj);

--- a/pyscf/lib/dft/grid_basis.c
+++ b/pyscf/lib/dft/grid_basis.c
@@ -94,9 +94,7 @@ void VXCgen_grid(double *out, double *coords, double *atm_coords,
                 }
         }
 
-#pragma omp parallel default(none) \
-        shared(out, coords, atm_coords, atom_dist, radii_table, natm) \
-        private(i, j, dx, dy, dz)
+#pragma omp parallel private(i, j, dx, dy, dz)
 {
         double *grid_dist = malloc(sizeof(double) * natm*GRIDS_BLOCK);
         double *buf = malloc(sizeof(double) * natm*GRIDS_BLOCK);

--- a/pyscf/lib/dft/nr_numint.c
+++ b/pyscf/lib/dft/nr_numint.c
@@ -106,9 +106,7 @@ void VXCdot_ao_dm(double *vm, double *ao, double *dm,
 {
         const int nblk = (ngrids+BLKSIZE-1) / BLKSIZE;
 
-#pragma omp parallel default(none) \
-        shared(vm, ao, dm, nao, nocc, ngrids, nbas, \
-               non0table, shls_slice, ao_loc)
+#pragma omp parallel
 {
         int ip, ib;
 #pragma omp for nowait schedule(static)
@@ -171,9 +169,7 @@ void VXCdot_ao_ao(double *vv, double *ao1, double *ao2,
         const int nblk = (ngrids+BLKSIZE-1) / BLKSIZE;
         memset(vv, 0, sizeof(double) * nao * nao);
 
-#pragma omp parallel default(none) \
-        shared(vv, ao1, ao2, nao, ngrids, nbas, hermi, \
-               non0table, shls_slice, ao_loc)
+#pragma omp parallel
 {
         int ip, ib;
         double *v_priv = calloc(nao*nao+2, sizeof(double));
@@ -201,8 +197,7 @@ void VXCdot_ao_ao(double *vv, double *ao1, double *ao2,
 void VXC_dscale_ao(double *aow, double *ao, double *wv,
                    int comp, int nao, int ngrids)
 {
-#pragma omp parallel default(none) \
-        shared(aow, ao, wv, comp, nao, ngrids)
+#pragma omp parallel
 {
         size_t Ngrids = ngrids;
         size_t ao_size = nao * Ngrids;
@@ -226,8 +221,7 @@ void VXC_dscale_ao(double *aow, double *ao, double *wv,
 void VXC_dcontract_rho(double *rho, double *bra, double *ket,
                        int nao, int ngrids)
 {
-#pragma omp parallel default(none) \
-        shared(rho, bra, ket, nao, ngrids)
+#pragma omp parallel
 {
         size_t Ngrids = ngrids;
         int nthread = omp_get_num_threads();

--- a/pyscf/lib/dft/numint_uniform_grid.c
+++ b/pyscf/lib/dft/numint_uniform_grid.c
@@ -1604,10 +1604,7 @@ void NUMINT_fill2c(int (*eval_ints)(), double *weights, double *F_mat,
         if (dimension == 0) {
                 nimgs = 1;
         }
-#pragma omp parallel default(none) \
-        shared(eval_ints, weights, F_mat, comp, hermi, ao_loc, \
-               log_prec, dimension, nimgs, Ls, a, b, offset, submesh, mesh, \
-               atm, natm, bas, nbas, env, nenv)
+#pragma omp parallel
 {
         int ncij = comp * naoi * naoj;
         int nijsh = nish * njsh;
@@ -2642,10 +2639,7 @@ void NUMINT_rho_drv(void (*eval_rho)(), double *rho, double *F_dm,
                 nimgs = 1;
         }
         double *rhobufs[MAX_THREADS];
-#pragma omp parallel default(none) \
-        shared(eval_rho, rho, F_dm, comp, hermi, ao_loc, \
-               log_prec, dimension, a, b, offset, submesh, mesh, rhobufs, nimgs, Ls, \
-               atm, natm, bas, nbas, env, nenv)
+#pragma omp parallel
 {
         int ncij = naoi * naoj;
         int nijsh = nish * njsh;

--- a/pyscf/lib/dft/r_numint.c
+++ b/pyscf/lib/dft/r_numint.c
@@ -78,9 +78,7 @@ void VXCzdot_ao_dm(double complex *vm, double complex *ao, double complex *dm,
 {
         const int nblk = (ngrids+BLKSIZE-1) / BLKSIZE;
 
-#pragma omp parallel default(none) \
-        shared(vm, ao, dm, nao, nocc, ngrids, nbas, \
-               non0table, shls_slice, ao_loc)
+#pragma omp parallel
 {
         int ip, ib;
 #pragma omp for nowait schedule(static)
@@ -143,9 +141,7 @@ void VXCzdot_ao_ao(double complex *vv, double complex *ao1, double complex *ao2,
         const int nblk = (ngrids+BLKSIZE-1) / BLKSIZE;
         memset(vv, 0, sizeof(double complex) * nao * nao);
 
-#pragma omp parallel default(none) \
-        shared(vv, ao1, ao2, nao, ngrids, nbas, hermi, \
-               non0table, shls_slice, ao_loc)
+#pragma omp parallel
 {
         int ip, ib;
         double complex *v_priv = calloc(nao*nao+2, sizeof(double complex));
@@ -172,8 +168,7 @@ void VXCzdot_ao_ao(double complex *vv, double complex *ao1, double complex *ao2,
 void VXC_zscale_ao(double complex *aow, double complex *ao, double *wv,
                    int comp, int nao, int ngrids)
 {
-#pragma omp parallel default(none) \
-        shared(aow, ao, wv, comp, nao, ngrids)
+#pragma omp parallel
 {
         size_t Ngrids = ngrids;
         size_t ao_size = nao * Ngrids;
@@ -197,8 +192,7 @@ void VXC_zscale_ao(double complex *aow, double complex *ao, double *wv,
 void VXC_zcontract_rho(double *rho, double complex *bra, double complex *ket,
                        int nao, int ngrids)
 {
-#pragma omp parallel default(none) \
-        shared(rho, bra, ket, nao, ngrids)
+#pragma omp parallel
 {
         size_t Ngrids = ngrids;
         int nthread = omp_get_num_threads();

--- a/pyscf/lib/gto/fill_int2c.c
+++ b/pyscf/lib/gto/fill_int2c.c
@@ -47,8 +47,7 @@ void GTOint2c(int (*intor)(), double *mat, int comp, int hermi,
         const size_t naoj = ao_loc[jsh1] - ao_loc[jsh0];
         const int cache_size = GTOmax_cache_size(intor, shls_slice, 2,
                                                  atm, natm, bas, nbas, env);
-#pragma omp parallel default(none) \
-        shared(intor, mat, comp, hermi, ao_loc, opt, atm, natm, bas, nbas, env)
+#pragma omp parallel
 {
         int dims[] = {naoi, naoj};
         int ish, jsh, ij, i0, j0;
@@ -97,8 +96,7 @@ void GTOint2c_spinor(int (*intor)(), double complex *mat, int comp, int hermi,
         const int cache_size = GTOmax_cache_size(intor, shls_slice, 2,
                                                  atm, natm, bas, nbas, env);
 
-#pragma omp parallel default(none) \
-        shared(intor, mat, comp, hermi, ao_loc, opt, atm, natm, bas, nbas, env)
+#pragma omp parallel
 {
         int dims[] = {naoi, naoj};
         int ish, jsh, ij, i0, j0;

--- a/pyscf/lib/gto/fill_int2e.c
+++ b/pyscf/lib/gto/fill_int2e.c
@@ -553,9 +553,7 @@ void GTOnr2e_fill_drv(int (*intor)(), void (*fill)(), int (*fprescreen)(),
         const int cache_size = GTOmax_cache_size(intor, shls_slice, 4,
                                                  atm, natm, bas, nbas, env);
 
-#pragma omp parallel default(none) \
-        shared(fill, fprescreen, eri, intor, comp, \
-               shls_slice, ao_loc, cintopt, atm, natm, bas, nbas, env)
+#pragma omp parallel
 {
         int ij, i, j;
         double *buf = malloc(sizeof(double) * (di*di*di*di*comp + cache_size));

--- a/pyscf/lib/gto/fill_nr_3c.c
+++ b/pyscf/lib/gto/fill_nr_3c.c
@@ -214,9 +214,7 @@ void GTOnr3c_drv(int (*intor)(), void (*fill)(), double *eri, int comp,
                                                  atm, natm, bas, nbas, env);
         const int njobs = (MAX(nish,njsh) / BLKSIZE + 1) * nksh;
 
-#pragma omp parallel default(none) \
-        shared(intor, fill, eri, comp, shls_slice, ao_loc, cintopt, \
-               atm, natm, bas, nbas, env)
+#pragma omp parallel
 {
         int jobid;
         double *buf = malloc(sizeof(double) * (di*di*di*comp + cache_size));

--- a/pyscf/lib/gto/fill_r_3c.c
+++ b/pyscf/lib/gto/fill_r_3c.c
@@ -191,9 +191,7 @@ void GTOr3c_drv(int (*intor)(), void (*fill)(), double complex *eri, int comp,
         const int di = GTOmax_shell_dim(ao_loc, shls_slice, 3);
         const int cache_size = GTOmax_cache_size(intor, shls_slice, 3,
                                                  atm, natm, bas, nbas, env);
-#pragma omp parallel default(none) \
-        shared(intor, fill, eri, comp, shls_slice, ao_loc, cintopt, \
-               atm, natm, bas, nbas, env)
+#pragma omp parallel
 {
         int ish, jsh, ij;
         double complex *buf = malloc(sizeof(double complex) *

--- a/pyscf/lib/gto/fill_r_4c.c
+++ b/pyscf/lib/gto/fill_r_4c.c
@@ -85,9 +85,7 @@ void GTOr4c_drv(int (*intor)(), void (*fill)(), int (*prescreen)(),
         const int njsh = jsh1 - jsh0;
         const int cache_size = GTOmax_cache_size(intor, shls_slice, 4,
                                                  atm, natm, bas, nbas, env);
-#pragma omp parallel default(none) \
-        shared(intor, fill, eri, comp, shls_slice, ao_loc, cintopt, \
-               atm, natm, bas, nbas, env)
+#pragma omp parallel
 {
         int ish, jsh, ij;
         double *buf = malloc(sizeof(double) * cache_size);

--- a/pyscf/lib/gto/ft_ao.c
+++ b/pyscf/lib/gto/ft_ao.c
@@ -1593,9 +1593,7 @@ void GTO_ft_fill_drv(int (*intor)(), FPtr_eval_gz eval_gz, void (*fill)(),
                 eval_aopair = &GTO_aopair_lazy_contract;
         }
 
-#pragma omp parallel default(none) \
-        shared(intor, eval_gz, eval_aopair, fill, mat, comp, shls_slice, \
-               ao_loc, Gv, b, gxyz, gs, nGv, atm, natm, bas, nbas, env)
+#pragma omp parallel
 {
         int i, j, ij;
         double complex *buf = malloc(sizeof(double complex)
@@ -1641,11 +1639,7 @@ void GTO_ft_fill_shls_drv(int (*intor)(), FPtr_eval_gz eval_gz,
                 eval_aopair = &GTO_aopair_lazy_contract;
         }
 
-#pragma omp parallel default(none) \
-        shared(intor, eval_gz, eval_aopair, out, comp, Gv, b, gxyz, gs, \
-               nGv, npair, shls_lst, ao_loc, \
-               atm, natm, bas, nbas, env, ijloc) \
-        private(n)
+#pragma omp parallel private(n)
 {
         int ish, jsh;
         int dims[2];

--- a/pyscf/lib/gto/grid_ao_drv.c
+++ b/pyscf/lib/gto/grid_ao_drv.c
@@ -344,9 +344,7 @@ void GTOeval_loop(void (*fiter)(), FPtr_eval feval, FPtr_exp fexp, double fac,
         const int nblk = (ngrids+BLKSIZE-1) / BLKSIZE;
         const size_t Ngrids = ngrids;
 
-#pragma omp parallel default(none) \
-        shared(fiter, feval, fexp, fac, param, ao_loc, shls_slice, ngrids, \
-               ao, coord, non0table, atm, natm, bas, nbas, env, shloc)
+#pragma omp parallel
 {
         const int sh0 = shls_slice[0];
         const int sh1 = shls_slice[1];
@@ -402,9 +400,7 @@ void GTOeval_spinor_drv(FPtr_eval feval, FPtr_exp fexp, void (*c2s)(), double fa
         const int nblk = (ngrids+BLKSIZE-1) / BLKSIZE;
         const size_t Ngrids = ngrids;
 
-#pragma omp parallel default(none) \
-        shared(feval, fexp, c2s, fac, ngrids, param, ao_loc, shls_slice, \
-               ao, coord, non0table, atm, natm, bas, nbas, env, shloc)
+#pragma omp parallel
 {
         const int sh0 = shls_slice[0];
         const int sh1 = shls_slice[1];

--- a/pyscf/lib/hci/hci.c
+++ b/pyscf/lib/hci/hci.c
@@ -33,7 +33,7 @@ void contract_h_c(double *h1, double *eri, int norb, int neleca, int nelecb, uin
 
     int *ts = malloc(sizeof(int) * ndet);
 
-    #pragma omp parallel default(none) shared(h1, eri, norb, neleca, nelecb, strs, civec, hdiag, ndet, ci1, ts)
+    #pragma omp parallel
     {
 
     size_t ip, jp, p;
@@ -810,7 +810,7 @@ void contract_ss_c(int norb, int neleca, int nelecb, uint64_t *strs, double *civ
 
     int *ts = malloc(sizeof(int) * ndet);
 
-    #pragma omp parallel default(none) shared(norb, neleca, nelecb, strs, civec, ndet, ci1, ts)
+    #pragma omp parallel
     {
 
     size_t ip, jp, p, q;
@@ -888,7 +888,7 @@ void contract_h_c_ss_c(double *h1, double *eri, int norb, int neleca, int nelecb
 
     int *ts = malloc(sizeof(int) * ndet);
 
-    #pragma omp parallel default(none) shared(h1, eri, norb, neleca, nelecb, strs, civec, hdiag, ndet, ci1, ci2, ts)
+    #pragma omp parallel
     {
 
     size_t ip, jp, p, q;
@@ -1062,7 +1062,7 @@ void contract_h_c_ss_c(double *h1, double *eri, int norb, int neleca, int nelecb
 // 2-RDM is sorted in physicists notation: gamma_pqsr=<\Phi|a_p^dag a_q^dag a_r a_s|\Phi>
 void compute_rdm12s(int norb, int neleca, int nelecb, uint64_t *strs, double *civec, uint64_t ndet, double *rdm1a, double *rdm1b, double *rdm2aa, double *rdm2ab, double *rdm2bb) {
 
-    #pragma omp parallel default(none) shared(norb, neleca, nelecb, strs, civec, ndet, rdm1a, rdm1b, rdm2aa, rdm2ab, rdm2bb)
+    #pragma omp parallel
     {
 
     size_t ip, jp, p, q, r, s;

--- a/pyscf/lib/mcscf/fci_4pdm.c
+++ b/pyscf/lib/mcscf/fci_4pdm.c
@@ -51,9 +51,7 @@ static void rdm4_0b_t2(double *ci0, double *t2,
         FCI_t1ci_sf(ci0, t1, nb, stra_id, 0,
                     norb, na, nb, nlinka, nlinkb, clink_indexa, clink_indexb);
 
-#pragma omp parallel default(none) \
-        shared(t1, t2, bcount, strb_id, norb, nlinkb, clink_indexb), \
-        private(i, j, k, l, a, str1, sign, pt1, pt2, tab)
+#pragma omp parallel private(i, j, k, l, a, str1, sign, pt1, pt2, tab)
 {
 #pragma omp for schedule(static, 1) nowait
         for (k = 0; k < bcount; k++) {
@@ -95,10 +93,7 @@ static void rdm4_a_t2(double *ci0, double *t2,
         double *pt1, *pt2;
         _LinkT *tab = clink_indexa + stra_id * nlinka;
 
-#pragma omp parallel default(none) \
-        shared(ci0, t2, bcount, strb_id, norb, na, nb, nlinka, nlinkb, \
-               clink_indexa, clink_indexb, tab), \
-        private(i, j, k, l, a, str1, sign, pt1, pt2)
+#pragma omp parallel private(i, j, k, l, a, str1, sign, pt1, pt2)
 {
         double *t1 = malloc(sizeof(double) * bcount * nnorb);
 #pragma omp for schedule(static, 40)
@@ -314,9 +309,7 @@ void FCI4pdm_kern_sf(double *rdm1, double *rdm2, double *rdm3, double *rdm4,
                             norb, na, nb, nlinka, nlinkb, clink_indexa, clink_indexb);
         }
 
-#pragma omp parallel default(none) \
-        shared(rdm3, rdm4, t1ket, t2bra, t2ket, norb, bcount), \
-        private(ij, i, j, k, l, n, tbra, pbra, pt2)
+#pragma omp parallel private(ij, i, j, k, l, n, tbra, pbra, pt2)
 {
         tbra = malloc(sizeof(double) * nnorb * bcount);
 #pragma omp for schedule(static, 1) nowait
@@ -395,9 +388,7 @@ void FCI4pdm_kern_spin0(double *rdm1, double *rdm2, double *rdm3, double *rdm4,
                             norb, na, nb, nlinka, nlinkb, clink_indexa, clink_indexb);
         }
 
-#pragma omp parallel default(none) \
-        shared(rdm3, rdm4, t1ket, t2bra, t2ket, norb, stra_id, strb_id, fill1), \
-        private(ij, i, j, k, l, n, tbra, pbra, pt2, factor)
+#pragma omp parallel private(ij, i, j, k, l, n, tbra, pbra, pt2, factor)
 {
         tbra = malloc(sizeof(double) * nnorb * fill1);
 #pragma omp for schedule(dynamic, 4)
@@ -498,9 +489,7 @@ void FCI3pdm_kern_sf(double *rdm1, double *rdm2, double *rdm3,
         FCI_t1ci_sf(ket, t1ket, bcount, stra_id, strb_id,
                     norb, na, nb, nlinka, nlinkb, clink_indexa, clink_indexb);
 
-#pragma omp parallel default(none) \
-        shared(rdm3, t1ket, t2bra, norb, bcount), \
-        private(ij, i, j, k, l, n, tbra, pbra, pt2)
+#pragma omp parallel private(ij, i, j, k, l, n, tbra, pbra, pt2)
 {
         tbra = malloc(sizeof(double) * nnorb * bcount);
 #pragma omp for schedule(dynamic, 4)
@@ -568,9 +557,7 @@ void FCI3pdm_kern_spin0(double *rdm1, double *rdm2, double *rdm3,
         FCI_t1ci_sf(ket, t1ket, fill1, stra_id, strb_id,
                     norb, na, nb, nlinka, nlinkb, clink_indexa, clink_indexb);
 
-#pragma omp parallel default(none) \
-        shared(rdm3, t1ket, t2bra, norb, stra_id, strb_id, fill1), \
-        private(ij, i, j, k, l, n, tbra, pbra, pt2, factor)
+#pragma omp parallel private(ij, i, j, k, l, n, tbra, pbra, pt2, factor)
 {
         tbra = malloc(sizeof(double) * nnorb * fill1);
 #pragma omp for schedule(dynamic, 4)

--- a/pyscf/lib/mcscf/fci_contract.c
+++ b/pyscf/lib/mcscf/fci_contract.c
@@ -347,8 +347,7 @@ void FCIcontract_2e_spin0(double *eri, double *ci0, double *ci1,
 
         memset(ci1, 0, sizeof(double)*na*na);
         double *ci1bufs[MAX_THREADS];
-#pragma omp parallel default(none) \
-                shared(eri, ci0, ci1, norb, na, nlink, clink, ci1bufs)
+#pragma omp parallel
 {
         int strk, ib;
         size_t blen;
@@ -392,9 +391,7 @@ void FCIcontract_2e_spin1(double *eri, double *ci0, double *ci1,
 
         memset(ci1, 0, sizeof(double)*na*nb);
         double *ci1bufs[MAX_THREADS];
-#pragma omp parallel default(none) \
-        shared(eri, ci0, ci1, norb, na, nb, nlinka, nlinkb, \
-               clinka, clinkb, ci1bufs)
+#pragma omp parallel
 {
         int strk, ib;
         size_t blen;
@@ -478,9 +475,7 @@ void FCIcontract_uhf2e(double *eri_aa, double *eri_ab, double *eri_bb,
 
         memset(ci1, 0, sizeof(double)*na*nb);
         double *ci1bufs[MAX_THREADS];
-#pragma omp parallel default(none) \
-        shared(eri_aa, eri_ab, eri_bb, ci0, ci1, norb, na, nb, nlinka, nlinkb,\
-               clinka, clinkb, ci1bufs)
+#pragma omp parallel
 {
         int strk, ib;
         size_t blen;
@@ -523,10 +518,7 @@ void FCImake_hdiag_uhf(double *hdiag, double *h1e_a, double *h1e_b,
                        int norb, int nstra, int nstrb, int nocca, int noccb,
                        int *occslista, int *occslistb)
 {
-#pragma omp parallel default(none) \
-                shared(hdiag, h1e_a, h1e_b, \
-                       jdiag_aa, jdiag_ab, jdiag_bb, kdiag_aa, kdiag_bb, \
-                       norb, nstra, nstrb, nocca, noccb, occslista, occslistb)
+#pragma omp parallel
 {
         int j, j0, k0, jk, jk0;
         size_t ia, ib;
@@ -605,9 +597,7 @@ void FCIpspace_h0tril_uhf(double *h0, double *h1e_a, double *h1e_b,
 {
         const int d2 = norb * norb;
         const int d3 = norb * norb * norb;
-#pragma omp parallel default(none) \
-                shared(h0, h1e_a, h1e_b, g2e_aa, g2e_ab, g2e_bb, \
-                       stra, strb, norb, np)
+#pragma omp parallel
 {
         int i, j, k, pi, pj, pk, pl;
         int n1da, n1db;
@@ -780,9 +770,7 @@ static void loop_c2e_symm1(double *eri, double *ci0, double *ci1aa, double *ci1a
                            _LinkTrilT *clinka, _LinkTrilT *clinkb)
 {
         double *ci1bufs[MAX_THREADS];
-#pragma omp parallel default(none) \
-                shared(eri, ci0, ci1aa, ci1ab, nnorb, na, nb, nlinka, nlinkb, \
-                       na_intermediate, nb_intermediate, clinka, clinkb, ci1bufs)
+#pragma omp parallel
 {
         int strk, ib;
         size_t blen;

--- a/pyscf/lib/mcscf/fci_rdm.c
+++ b/pyscf/lib/mcscf/fci_rdm.c
@@ -227,10 +227,7 @@ void FCIrdm12_drv(void (*dm12kernel)(),
         FCIcompress_link(clinka, link_indexa, norb, na, nlinka);
         FCIcompress_link(clinkb, link_indexb, norb, nb, nlinkb);
 
-#pragma omp parallel default(none) \
-        shared(dm12kernel, bra, ket, norb, na, nb, nlinka, \
-               nlinkb, clinka, clinkb, rdm1, rdm2, symm), \
-        private(strk, i, ib, blen, pdm1, pdm2)
+#pragma omp parallel private(strk, i, ib, blen, pdm1, pdm2)
 {
         pdm1 = calloc(nnorb+2, sizeof(double));
         pdm2 = calloc(nnorb*nnorb+2, sizeof(double));

--- a/pyscf/lib/mcscf/nevpt_contract.c
+++ b/pyscf/lib/mcscf/nevpt_contract.c
@@ -66,9 +66,7 @@ void NEVPTkern_dfec_dfae(double *gt2, double *eri, double *t2ket,
         double *cp0, *cp1;
         double *t2t; // E^d_fE^a_e with ae transposed
 
-#pragma omp parallel default(none) \
-        shared(gt2, eri, t2ket, bcount, norb, na, nb) \
-        private(cp0, cp1, t2t, m, n, i, k)
+#pragma omp parallel private(cp0, cp1, t2t, m, n, i, k)
 {
         t2t = malloc(sizeof(double) * n4);
 #pragma omp for schedule(dynamic, 4)
@@ -106,9 +104,7 @@ void NEVPTkern_aedf_ecdf(double *gt2, double *eri, double *t2ket,
         double *cp0, *cp1;
         double *t2t;
 
-#pragma omp parallel default(none) \
-        shared(gt2, eri, t2ket, bcount, norb, na, nb) \
-        private(cp0, cp1, t2t, m, n, i, k)
+#pragma omp parallel private(cp0, cp1, t2t, m, n, i, k)
 {
         t2t = malloc(sizeof(double) * n4);
 #pragma omp for schedule(dynamic, 4)
@@ -144,9 +140,7 @@ void NEVPTkern_cedf_aedf(double *gt2, double *eri, double *t2ket,
         size_t k;
         int blen;
 
-#pragma omp parallel default(none) \
-        shared(gt2, eri, t2ket, bcount, norb, na, nb) \
-        private(k, blen)
+#pragma omp parallel private(k, blen)
 #pragma omp for schedule(dynamic, 1)
         for (k = 0; k < bcount; k+=8) {
                 blen = MIN(bcount-k, 8) * norb;
@@ -169,9 +163,7 @@ void NEVPTkern_dfea_dfec(double *gt2, double *eri, double *t2ket,
         const int n3 = nnorb * norb;
         size_t k;
 
-#pragma omp parallel default(none) \
-        shared(gt2, eri, t2ket, bcount, norb, na, nb) \
-        private(k)
+#pragma omp parallel private(k)
 #pragma omp for schedule(dynamic, 4)
         for (k = 0; k < bcount; k++) {
                 dgemm_(&TRANS_N, &TRANS_T, &norb, &norb, &n3,
@@ -206,9 +198,7 @@ void NEVPTkern_sf(void (*contract_kernel)(),
 
         (*contract_kernel)(gt2, eri, t2ket, bcount, norb, na, nb);
 
-#pragma omp parallel default(none) \
-        shared(rdm2, rdm3, t1ket, t2ket, gt2, norb, bcount), \
-        private(ij, i, j, k, l, n, tbra, pbra, pt2)
+#pragma omp parallel private(ij, i, j, k, l, n, tbra, pbra, pt2)
 {
         tbra = malloc(sizeof(double) * nnorb * bcount);
 #pragma omp for schedule(dynamic, 4)

--- a/pyscf/lib/mcscf/select_ci.c
+++ b/pyscf/lib/mcscf/select_ci.c
@@ -356,9 +356,7 @@ void SCIcontract_2e_bbaa(double *eri, double *ci0, double *ci1,
         FCIcompress_link_tril(clinka, link_indexa, na, nlinka);
         FCIcompress_link_tril(clinkb, link_indexb, nb, nlinkb);
 
-#pragma omp parallel default(none) \
-        shared(eri, ci0, ci1, norb, na, nb, nlinka, nlinkb, \
-               clinka, clinkb)
+#pragma omp parallel
 {
         int strk, ib, blen;
         double *t1buf = malloc(sizeof(double) * (STRB_BLKSIZE*norb*(norb+1)+2));
@@ -409,9 +407,7 @@ void SCIcontract_2e_aaaa(double *eri, double *ci0, double *ci1,
         _LinkTrilT *clinkb = NULL;
 
         double *ci1bufs[MAX_THREADS];
-#pragma omp parallel default(none) \
-        shared(eri, ci0, ci1, norb, na, nb, inter_na, nlinka, clinka, clinkb, \
-               ci1bufs)
+#pragma omp parallel
 {
         int strk, ib, blen;
         double *t1buf = malloc(sizeof(double) * (STRB_BLKSIZE*norb*norb+2));
@@ -503,9 +499,7 @@ void SCIrdm2_aaaa(void (*dm2kernel)(), double *rdm2, double *bra, double *ket,
         _LinkT *clinka = malloc(sizeof(_LinkT) * nlinka * inter_na);
         FCIcompress_link(clinka, link_indexa, norb, inter_na, nlinka);
 
-#pragma omp parallel default(none) \
-        shared(dm2kernel, bra, ket, norb, na, nb, inter_na, nlinka, clinka, rdm2), \
-        private(pdm2)
+#pragma omp parallel private(pdm2)
 {
         int strk, i, ib, blen;
         double *buf = malloc(sizeof(double) * (nnorb*BUFBASE*2+2));
@@ -580,9 +574,7 @@ void SCIcontract_2e_bbaa_symm(double *eri, double *ci0, double *ci1,
         FCIcompress_link_tril(clinka, link_indexa, na, nlinka);
         FCIcompress_link_tril(clinkb, link_indexb, nb, nlinkb);
 
-#pragma omp parallel default(none) \
-        shared(eri, ci0, ci1, norb, na, nb, nlinka, nlinkb, \
-               clinka, clinkb, dimirrep, totirrep)
+#pragma omp parallel
 {
         int strk, ib, blen;
         double *t1buf = malloc(sizeof(double) * (STRB_BLKSIZE*norb*(norb+1)+2));
@@ -641,9 +633,7 @@ void SCIcontract_2e_aaaa_symm(double *eri, double *ci0, double *ci1,
         _LinkTrilT *clinkb = NULL;
 
         double *ci1bufs[MAX_THREADS];
-#pragma omp parallel default(none) \
-        shared(eri, ci0, ci1, norb, na, nb, inter_na, nlinka, clinka, clinkb, \
-               dimirrep, totirrep, ci1bufs)
+#pragma omp parallel
 {
         int strk, ib, blen;
         double *t1buf = malloc(sizeof(double) * (STRB_BLKSIZE*norb*norb+2));

--- a/pyscf/lib/np_helper/npdot.c
+++ b/pyscf/lib/np_helper/npdot.c
@@ -67,8 +67,7 @@ void NPdgemm(const char trans_a, const char trans_b,
                         }
                 }
 
-#pragma omp parallel default(none) shared(a, b, c) \
-        private(i, j)
+#pragma omp parallel private(i, j)
 {
                 int nthread = omp_get_num_threads();
                 int nblk = MAX((k+nthread-1) / nthread, 1);
@@ -107,7 +106,7 @@ void NPdgemm(const char trans_a, const char trans_b,
 
         } else if (m > n*2) { // parallelize m
 
-#pragma omp parallel default(none) shared(a, b, c)
+#pragma omp parallel
 {
                 int nthread = omp_get_num_threads();
                 int nblk = MAX((m+nthread-1) / nthread, 1);
@@ -130,7 +129,7 @@ void NPdgemm(const char trans_a, const char trans_b,
 
         } else { // parallelize n
 
-#pragma omp parallel default(none) shared(a, b, c)
+#pragma omp parallel
 {
                 int nthread = omp_get_num_threads();
                 int nblk = MAX((n+nthread-1) / nthread, 1);
@@ -193,8 +192,7 @@ void NPzgemm(const char trans_a, const char trans_b,
                         }
                 }
 
-#pragma omp parallel default(none) shared(a, b, c, alpha) \
-        private(i, j)
+#pragma omp parallel private(i, j)
 {
                 int nthread = omp_get_num_threads();
                 int nblk = MAX((k+nthread-1) / nthread, 1);
@@ -233,7 +231,7 @@ void NPzgemm(const char trans_a, const char trans_b,
 
         } else if (m > n*2) { // parallelize m
 
-#pragma omp parallel default(none) shared(a, b, c, alpha, beta)
+#pragma omp parallel
 {
                 int nthread = omp_get_num_threads();
                 int nblk = MAX((m+nthread-1) / nthread, 1);
@@ -256,7 +254,7 @@ void NPzgemm(const char trans_a, const char trans_b,
 
         } else { // parallelize n
 
-#pragma omp parallel default(none) shared(a, b, c, alpha, beta)
+#pragma omp parallel
 {
                 int nthread = omp_get_num_threads();
                 int nblk = MAX((n+nthread-1) / nthread, 1);

--- a/pyscf/lib/pbc/fill_ints.c
+++ b/pyscf/lib/pbc/fill_ints.c
@@ -933,10 +933,7 @@ void PBCnr3c_drv(int (*intor)(), void (*fill)(), double complex *eri,
         const int cache_size = GTOmax_cache_size(intor, shls_slice, 3,
                                                  atm, natm, bas, nbas, env);
 
-#pragma omp parallel default(none) \
-        shared(intor, fill, eri, nkpts_ij, nkpts, comp, nimgs, \
-               Ls, expkL_r, expkL_i, kptij_idx, shls_slice, ao_loc, cintopt, pbcopt, \
-               atm, natm, bas, nbas, env, nenv, count)
+#pragma omp parallel
 {
         int ish, jsh, ij;
         double *env_loc = malloc(sizeof(double)*nenv);
@@ -1109,10 +1106,7 @@ void PBCnr2c_drv(int (*intor)(), void (*fill)(), double complex *out,
         const int cache_size = GTOmax_cache_size(intor, shls_slice, 2,
                                                  atm, natm, bas, nbas, env);
 
-#pragma omp parallel default(none) \
-        shared(intor, fill, out, nkpts, comp, nimgs, \
-               Ls, expkL_r, expkL_i, shls_slice, ao_loc, cintopt, pbcopt, \
-               atm, natm, bas, nbas, env, nenv)
+#pragma omp parallel
 {
         int jsh;
         double *env_loc = malloc(sizeof(double)*nenv);

--- a/pyscf/lib/pbc/ft_ao.c
+++ b/pyscf/lib/pbc/ft_ao.c
@@ -448,10 +448,7 @@ void PBC_ft_latsum_drv(int (*intor)(), void (*eval_gz)(), void (*fill)(),
                 eval_aopair = &GTO_aopair_lazy_contract;
         }
 
-#pragma omp parallel default(none) \
-        shared(intor, eval_aopair, eval_gz, fill, out, nkpts, comp, nimgs, \
-               Ls, expkL, shls_slice, ao_loc, sGv, b, sgxyz, gs, nGv,\
-               atm, natm, bas, nbas, env, blksize)
+#pragma omp parallel
 {
         int i, j, ij;
         int nenv = PBCsizeof_env(shls_slice, atm, natm, bas, nbas, env);

--- a/pyscf/lib/pbc/grid_ao.c
+++ b/pyscf/lib/pbc/grid_ao.c
@@ -67,8 +67,7 @@ void PBCnr_ao_screen(unsigned char *non0table, double *coords, int ngrids,
 {
         const int nblk = (ngrids+BLKSIZE-1) / BLKSIZE;
 
-#pragma omp parallel default(none) \
-        shared(Ls, nimgs, coords, ngrids, non0table, atm, natm, bas, nbas, env)
+#pragma omp parallel
 {
         int i, j, m;
         int np, nc, atm_id;
@@ -428,10 +427,7 @@ void PBCeval_loop(void (*fiter)(), FPtr_eval feval, FPtr_exp fexp,
                 di_max = MAX(di_max, ao_loc[i+1] - ao_loc[i]);
         }
 
-#pragma omp parallel default(none) \
-        shared(fiter, feval, fexp, param, ngrids, \
-               Ls, nimgs, di_max, expLk, nkpts, shls_slice, ao_loc, \
-               ao, coord, rcut, non0table, atm, natm, bas, nbas, env, shloc)
+#pragma omp parallel
 {
         const int sh0 = shls_slice[0];
         const int sh1 = shls_slice[1];

--- a/pyscf/lib/vhf/fill_nr_s8.c
+++ b/pyscf/lib/vhf/fill_nr_s8.c
@@ -124,8 +124,7 @@ void GTO2e_cart_or_sph(int (*intor)(), CINTOpt *cintopt, double *eri, int *ao_lo
         const int cache_size = GTOmax_cache_size(intor, shls_slice, 1,
                                                  atm, natm, bas, nbas, env);
 
-#pragma omp parallel default(none) \
-        shared(intor, eri, ao_loc, nbas, envs, vhfopt)
+#pragma omp parallel
 {
         int i, j, ij;
         double *buf = malloc(sizeof(double) * (di*di*nao*nao + cache_size));

--- a/pyscf/lib/vhf/nr_direct.c
+++ b/pyscf/lib/vhf/nr_direct.c
@@ -255,9 +255,7 @@ void CVHFnr_direct_drv(int (*intor)(), void (*fdot)(), JKOperator **jkop,
         const int cache_size = GTOmax_cache_size(intor, shls_slice, 4,
                                                  atm, natm, bas, nbas, env);
 
-#pragma omp parallel default(none) \
-        shared(intor, fdot, jkop, ao_loc, shls_slice, \
-               dms, vjk, n_dm, ncomp, nbas, vhfopt, envs)
+#pragma omp parallel
 {
         int i, j, ij, ij1;
         JKArray *v_priv[n_dm];

--- a/pyscf/lib/vhf/nr_incore.c
+++ b/pyscf/lib/vhf/nr_incore.c
@@ -621,8 +621,7 @@ void CVHFnrs8_incore_drv(double *eri, double *dmj, double *vj,
         memset(vj, 0, sizeof(double)*n*n);
         memset(vk, 0, sizeof(double)*n*n);
 
-#pragma omp parallel default(none) \
-        shared(eri, dmj, dmk, vj, vk, n)
+#pragma omp parallel
         {
                 int i, j;
                 size_t ij, off;
@@ -656,8 +655,7 @@ void CVHFnrs4_incore_drv(double *eri, double *dmj, double *vj,
         memset(vj, 0, sizeof(double)*n*n);
         memset(vk, 0, sizeof(double)*n*n);
 
-#pragma omp parallel default(none) \
-        shared(eri, dmj, dmk, vj, vk, n)
+#pragma omp parallel
         {
                 int i, j;
                 size_t ij, off;
@@ -691,8 +689,7 @@ void CVHFnrs2ij_incore_drv(double *eri, double *dmj, double *vj,
         memset(vj, 0, sizeof(double)*n*n);
         memset(vk, 0, sizeof(double)*n*n);
 
-#pragma omp parallel default(none) \
-        shared(eri, dmj, dmk, vj, vk, n)
+#pragma omp parallel
         {
                 int i, j;
                 size_t ij, off;
@@ -726,8 +723,7 @@ void CVHFnrs2kl_incore_drv(double *eri, double *dmj, double *vj,
         memset(vj, 0, sizeof(double)*n*n);
         memset(vk, 0, sizeof(double)*n*n);
 
-#pragma omp parallel default(none) \
-        shared(eri, dmj, dmk, vj, vk, n)
+#pragma omp parallel
         {
                 int i, j;
                 size_t ij, off;
@@ -760,8 +756,7 @@ void CVHFnrs1_incore_drv(double *eri, double *dmj, double *vj,
         memset(vj, 0, sizeof(double)*n*n);
         memset(vk, 0, sizeof(double)*n*n);
 
-#pragma omp parallel default(none) \
-        shared(eri, dmj, dmk, vj, vk, n)
+#pragma omp parallel
         {
                 int i, j;
                 size_t ij, off;

--- a/pyscf/lib/vhf/optimizer.c
+++ b/pyscf/lib/vhf/optimizer.c
@@ -205,8 +205,7 @@ void CVHFsetnr_direct_scf(CVHFOpt *opt, int (*intor)(), CINTOpt *cintopt,
         int shls_slice[] = {0, nbas};
         const int cache_size = GTOmax_cache_size(intor, shls_slice, 1,
                                                  atm, natm, bas, nbas, env);
-#pragma omp parallel default(none) \
-        shared(opt, intor, cintopt, ao_loc, atm, natm, bas, nbas, env)
+#pragma omp parallel
 {
         double qtmp, tmp;
         int ij, i, j, di, dj, ish, jsh;

--- a/pyscf/lib/vhf/r_direct_o1.c
+++ b/pyscf/lib/vhf/r_direct_o1.c
@@ -294,9 +294,7 @@ void CVHFr_direct_drv(int (*intor)(), void (*fdot)(), void (**fjk)(),
         const int di = GTOmax_shell_dim(ao_loc, shls_slice, 4);
         const int cache_size = GTOmax_cache_size(intor, shls_slice, 4,
                                                  atm, natm, bas, nbas, env);
-#pragma omp parallel default(none) \
-        shared(intor, fdot, fjk, \
-               dms, vjk, n_dm, ncomp, nbas, cintopt, vhfopt, envs)
+#pragma omp parallel
 {
         int i, j, ij;
         double complex *v_priv = malloc(sizeof(double complex)*nao*nao*n_dm*ncomp);

--- a/pyscf/lib/vhf/rkb_screen.c
+++ b/pyscf/lib/vhf/rkb_screen.c
@@ -152,8 +152,7 @@ static void set_qcond(int (*intor)(), CINTOpt *cintopt, double *qcond,
         int shls_slice[] = {0, nbas};
         const int cache_size = GTOmax_cache_size(intor, shls_slice, 1,
                                                  atm, natm, bas, nbas, env);
-#pragma omp parallel default(none) \
-        shared(intor, cintopt, qcond, ao_loc, atm, natm, bas, nbas, env)
+#pragma omp parallel
 {
         double qtmp, tmp;
         int i, j, ij, di, dj, ish, jsh;


### PR DESCRIPTION
This addresses issue #329 by removing the unnecessary OpenMP pragmas.

Instead of manually defining the roles of all the parameters, it suffices to specify the private ones, since by default everything is shared.

The code should work exactly as before, since I've left in all the `private` statements.