### PR TITLE
Changes according to issue #349: Error in mpicc

### DIFF
--- a/pyscf/pbc/mpicc/kccsd_rhf.py
+++ b/pyscf/pbc/mpicc/kccsd_rhf.py
@@ -1022,7 +1022,7 @@ class RCCSD(pyscf.pbc.cc.kccsd_rhf.RCCSD):
         nvir = self.nmo - nocc
         nkpts = self.nkpts
         t1 = numpy.zeros((nkpts,nocc,nvir), dtype=numpy.complex128)
-        tril_shape = ((nkpts)*(nkpts+1))/2
+        tril_shape = ((nkpts)*(nkpts+1))//2
         t2_tril = numpy.zeros((tril_shape,nkpts,nocc,nocc,nvir,nvir),dtype=numpy.complex128)
         local_mp2 = numpy.array(0.0,dtype=numpy.complex128)
         self.emp2 = 0

--- a/pyscf/pbc/mpitools/mpi_helper.py
+++ b/pyscf/pbc/mpitools/mpi_helper.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mpi_blksize import get_max_blocksize_from_mem
+from .mpi_blksize import get_max_blocksize_from_mem
 from pyscf.lib.numpy_helper import cartesian_prod
 import numpy
 from mpi4py import MPI

--- a/pyscf/pbc/tools/tril.py
+++ b/pyscf/pbc/tools/tril.py
@@ -17,7 +17,7 @@ import pyscf.lib
 
 def tril_index(ki,kj):
     assert (numpy.array([ki<=kj])).all()
-    return (kj*(kj+1))/2 + ki
+    return (kj*(kj+1))//2 + ki
 
 # TODO: fairly messy and slow
 def unpack_tril(in_array,nkpts,kp,kq,kr,ks):


### PR DESCRIPTION
We accepted all three of @hungpham2017 's changes mentioned in [Issue #349](https://github.com/pyscf/pyscf/issues/349).

- Changes in [kccsd_rhf.py](https://github.com/pyscf/pyscf/blob/master/pyscf/pbc/mpicc/kccsd_rhf.py#L1025) and [tril.py](https://github.com/pyscf/pyscf/blob/master/pyscf/pbc/tools/tril.py#L20) simply add stability for int operations.
- Changes in in [mpi_helper.py](https://github.com/pyscf/pyscf/blob/master/pyscf/pbc/mpitools/mpi_helper.py#L15) is also okay because Python3 does require relative imports to be explicit.   