### PR TITLE
Fix python3 incompatibility issues and add missing methods

### DIFF
--- a/pyscf/pbc/mpicc/kccsd_rhf.py
+++ b/pyscf/pbc/mpicc/kccsd_rhf.py
@@ -3010,7 +3010,7 @@ class _ERIS:
 
             mem = 0.5e9
             pre = 1.*nvir*nvir*nvir*nvir*16
-            unique_klist = khelper.symm_map.keys()
+            unique_klist = list(khelper.symm_map.keys())
             nUnique_klist = len(unique_klist)
             nkpts_blksize = min(max(int(numpy.floor(mem/pre)),1),nUnique_klist)
 

--- a/pyscf/pbc/mpicc/kccsd_rhf.py
+++ b/pyscf/pbc/mpicc/kccsd_rhf.py
@@ -295,7 +295,7 @@ def update_amps(cc, t1, t2, eris, max_memory=2000):
     log = logger.Logger(cc.stdout, cc.verbose)
     nkpts, nocc, nvir = t1.shape
     fock = eris.fock
-    tril_shape = ((nkpts)*(nkpts+1))/2
+    tril_shape = ((nkpts)*(nkpts+1))//2
 
     mo_e_o = [e[:nocc] for e in eris.mo_energy]
     mo_e_v = [e[nocc:] + cc.level_shift for e in eris.mo_energy]
@@ -2662,7 +2662,7 @@ class RCCSD(pyscf.pbc.cc.kccsd_rhf.RCCSD):
         nkpts = self.nkpts
         nov = nkpts*nocc*nvir
         t1 = vec[:nov].reshape(nkpts,nocc,nvir)
-        t2 = vec[nov:].reshape(nkpts*(nkpts+1)/2,nkpts,nocc,nocc,nvir,nvir)
+        t2 = vec[nov:].reshape(nkpts*(nkpts+1)//2,nkpts,nocc,nocc,nvir,nvir)
         return t1, t2
 
 class _ERIS:

--- a/pyscf/pbc/tools/tril.py
+++ b/pyscf/pbc/tools/tril.py
@@ -25,10 +25,10 @@ def unpack_tril(in_array,nkpts,kp,kq,kr,ks):
     #
     if in_array.shape[0] == nkpts:
         return in_array[kp,kq,kr].copy()
-    nints = sum([isinstance(x,int) for x in (kp,kq,kr)])
+    nints = sum([isinstance(x, (int, numpy.integer)) for x in (kp,kq,kr)])
     assert(nints>=2)
 
-    kp,kq,kr,ks = [[x] if isinstance(x,int) else x for x in (kp,kq,kr,ks)]
+    kp,kq,kr,ks = [[x] if isinstance(x, (int, numpy.integer)) else x for x in (kp,kq,kr,ks)]
     kp,kq,kr,ks = [numpy.array(x) for x in (kp,kq,kr,ks)]
     indices = numpy.array(pyscf.lib.cartesian_prod((kp,kq,kr)))
 


### PR DESCRIPTION
This pull request fixed a few issues caused by Python3/2 incompatibility (I have only tested 3.7 vs 2.7), including
- single slash `/` in `int(m)/int(n)` returns `float` in Python3 while it returns `int` in Python2. Thus, use `//` to make sure you get integers. 
- `dict.keys()` does not support indexing in Python3 because it returns dictionary views (instead of `list`).
- `isinstance(a, int)` returns `False` if `a` is `numpy.int64` in Python3 (`True` in Python2)

Besides, several methods needed by `mpicc.RCCSD` (such as `mask_frozen_ea`, `mask_frozen_ip`, `vector_size_ea`, `vector_size_ip`) are missing from `pbc/cc/kccsd_rhf.py`, due to recent merge. I imported/added them to `mpicc/kccsd_rhf.py` to make parallel KCCSD (with IP/EA) work. 