### PR TITLE
Easier install for IBM i

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,12 @@ elif sys.platform.startswith('darwin'):
 elif sys.platform.startswith('win'):
     ostype = 'windows'
     so_ext = '.dll'
+elif sys.platform.startswith('aix'):
+    ostype = 'aix'
+    so_ext = '.so'
+    LD_LIBRARY_PATH = 'LIBPATH'
+    if(os.environ.get('PYSCF_INC_DIR') is None):
+        os.environ['PYSCF_INC_DIR'] = '/QOpenSys/pkgs:/QOpenSys/usr:/usr:/usr/local'
 else:
     raise OSError('Unknown platform')
     ostype = None
@@ -272,6 +278,10 @@ def make_ext(pkg_name, relpath, srcs, libraries=[], library_dirs=default_lib_dir
             soname = pkg_name.split('.')[-1]
             extra_link_flags = extra_link_flags + ['-install_name', '@loader_path/'+soname+so_ext]
             runtime_library_dirs = []
+        if sys.platform.startswith('aix'):
+            extra_compile_flags = extra_compile_flags + ['-fopenmp']
+            extra_link_flags = extra_link_flags + ['-lblas', '-lgomp', '-Wl,-brtl']
+            runtime_library_dirs = ['$ORIGIN', '.']
         else:
             extra_compile_flags = extra_compile_flags + ['-fopenmp']
             extra_link_flags = extra_link_flags + ['-fopenmp']


### PR DESCRIPTION
Install reliably fails on the IBM i platform unless the `PYSCF_INC_DIR` environment variable is set. I'd rather if a simple `pip3 install pyscf` would work without knowing about this environment variable. 

I fixed it several ways, but setting this env var in setup.py seemed the least intrusive.