### PR TITLE
Fixing bug with SHCI.integralFile 

### DIFF
--- a/pyscf/shciscf/examples/01_O2_PT.py
+++ b/pyscf/shciscf/examples/01_O2_PT.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2018 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2019 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,35 +17,27 @@
 #
 # All diatomic bond lengths taken from:
 # http://cccbdb.nist.gov/diatomicexpbondx.asp
-'''
+"""
 All output is deleted after the run to keep the directory neat. Comment out the
 cleanup section to view output files.
-'''
+"""
 import time
-t0 = time.time()
+
 from pyscf import gto, scf, mcscf, dmrgscf
 from pyscf.shciscf import shci
-import struct, os
 
-# Initialize O2 molecule
-b = 1.208
-mol = gto.Mole()
-mol.build(
-    verbose=4,
-    output=None,
-    atom="O 0 0 %f; O 0 0 %f" % (-b / 2, b / 2),
-    basis='ccpvdz',
-    symmetry=True)
+t0 = time.time()
+#
+# Mean Field
+#
+mol = gto.M(verbose=4, atom="O 0 0 0; O 0 0 1.208", basis="ccpvdz")
+mf = scf.RHF(mol).run()
 
-# Create HF molecule
-mf = scf.RHF(mol)
-mf.conv_tol = 1e-9
-mf.scf()
-
-# Number of orbital and electrons
+#
+# Multireference WF
+#
 ncas = 8
 nelecas = 12
-dimer_atom = 'O'
 
 mc = mcscf.CASSCF(mf, ncas, nelecas)
 e_CASSCF = mc.mc1step()[0]
@@ -53,7 +45,7 @@ e_CASSCF = mc.mc1step()[0]
 # Create SHCI molecule for just variational opt.
 # Active spaces chosen to reflect valence active space.
 mc = shci.SHCISCF(mf, ncas, nelecas)
-mc.fcisolver.mpiprefix = 'mpirun -np 2'
+mc.fcisolver.mpiprefix = "mpirun -np 2"
 mc.fcisolver.stochastic = True
 mc.fcisolver.nPTiter = 0  # Turn off perturbative calc.
 mc.fcisolver.sweep_iter = [0]
@@ -66,20 +58,20 @@ mc.fcisolver.stochastic = False  # Turns on deterministic PT calc.
 mc.fcisolver.epsilon2 = 1e-8
 shci.writeSHCIConfFile(mc.fcisolver, [nelecas / 2, nelecas / 2], False)
 shci.executeSHCI(mc.fcisolver)
-e_PT = shci.readEnergy(mc.fcisolver)  #struct.unpack(format, file1.read())
+e_PT = shci.readEnergy(mc.fcisolver)
 
 # Comparison Calculations
 del_PT = e_PT - e_noPT
 del_shci = e_CASSCF - e_PT
 
-print('\n\nEnergies for %s2 give in E_h.' % dimer_atom)
-print('=====================================')
-print('SHCI Variational: %6.12f' % e_noPT)
+print("\n\nEnergies for O2 give in E_h.")
+print("=====================================")
+print("SHCI Variational: %6.12f" % e_noPT)
 # Prints the total energy including the perturbative component.
-print('SHCI Perturbative: %6.12f' % e_PT)
-print('Perturbative Change: %6.12f' % del_PT)
-print('CASSCF Total Energy: %6.12f' % e_CASSCF)
-print('E(CASSCF) - E(SHCI): %6.12f' % del_shci)
+print("SHCI Perturbative: %6.12f" % e_PT)
+print("Perturbative Change: %6.12f" % del_PT)
+print("CASSCF Total Energy: %6.12f" % e_CASSCF)
+print("E(CASSCF) - E(SHCI): %6.12f" % del_shci)
 print("Total Time:    ", time.time() - t0)
 
 # File cleanup

--- a/pyscf/shciscf/examples/02_O2_int_rot.py
+++ b/pyscf/shciscf/examples/02_O2_int_rot.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2018 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2019 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,40 +17,27 @@
 #
 # All diatomic bond lengths taken from:
 # http://cccbdb.nist.gov/diatomicexpbondx.asp
-'''
+"""
 Comparing determining the effect of acitve-active orbital rotations. All output
 is deleted after the run to keep the directory neat. Comment out the cleanup
 section to view output.
-'''
-
+"""
 from pyscf import gto, scf, mcscf, dmrgscf
 from pyscf.shciscf import shci
-import os
 
-# O2 molecule Parameters
-b = 1.208  # Bond length.
-dimer_atom = 'O'
+#
+# Mean Field
+#
+mol = gto.M(verbose=4, atom="O 0 0 0; O 0 0 1.208", basis="ccpvdz")
+mf = scf.RHF(mol).run()
+
+
+#
+# Multireference WF
+#
 ncas = 12  # Number of orbitals included in the active space.
 nelecas = 12  # Number of electrons included in the active space.
 nfrozen = 2  # Number of orbitals that won't be rotated/optimized.
-
-mol = gto.Mole()
-mol.build(
-    verbose=4,
-    output=None,
-    atom=[
-        [dimer_atom, (0.000000, 0.000000, -b / 2)],
-        [dimer_atom, (0.000000, 0.000000, b / 2)],
-    ],
-    basis={
-        dimer_atom: 'ccpvdz',
-    },
-    symmetry=True)
-
-# Create HF molecule
-mf = scf.RHF(mol)
-mf.conv_tol = 1e-9
-mf.scf()
 
 # Calculate energy of the molecules with frozen core.
 mc = shci.SHCISCF(mf, ncas, nelecas)
@@ -73,11 +60,11 @@ e_aa = mc.mc1step()[0]
 # Comparison Calculations
 del_aa = e_aa - e_noaa
 
-print('\n\nEnergies for %s2 give in E_h.' % dimer_atom)
-print('=====================================')
-print('SHCI w/o Act.-Act. Rotations: %6.12f' % e_noaa)
-print('SHCI w/ Act.-Act. Rotations: %6.12f' % e_aa)
-print('Change w/ Act.-Act. Rotations: %6.12f' % del_aa)
+print("\n\nEnergies for O2 give in E_h.")
+print("=====================================")
+print("SHCI w/o Act.-Act. Rotations: %6.12f" % e_noaa)
+print("SHCI w/ Act.-Act. Rotations: %6.12f" % e_aa)
+print("Change w/ Act.-Act. Rotations: %6.12f" % del_aa)
 
 # File cleanup. Comment out to help debugging.
 mc.fcisolver.cleanup_dice_files()

--- a/pyscf/shciscf/examples/04_c2_state_avg.py
+++ b/pyscf/shciscf/examples/04_c2_state_avg.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2018 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2019 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,33 +16,22 @@
 # Authors:  Sandeep Sharma <sanshar@gmail.com>
 #           James Smith <james.smith9113@gmail.com>
 #
-'''
+"""
 All output is deleted after the run to keep the directory neat. Comment out the
 cleanup section to view output.
-'''
+"""
 import os, time
-t0 = time.time()
+
 from pyscf import gto, scf, mcscf, dmrgscf
 from pyscf.shciscf import shci
 
-# C2 molecule Parameters
-b = 1.3119  # Bond length.
-dimer_atom = 'C'
-norb = 8  # Number of orbitals in active space.
-nelec = 8  # Number of electrons in active space.
+t0 = time.time()
 
-mol = gto.Mole()
-mol.build(
-    verbose=4,
-    output=None,
-    atom=[
-        [dimer_atom, (0.000000, 0.000000, -b / 2)],
-        [dimer_atom, (0.000000, 0.000000, b / 2)],
-    ],
-    basis={
-        dimer_atom: 'ccpvdz',
-    },
-    symmetry=1)
+#
+# Mean Field
+#
+mol = gto.M(verbose=4, atom="C 0 0 0; C 0 0 1.3119", basis="ccpvdz")
+mf = scf.RHF(mol).run()
 
 # Create HF molecule
 mf = scf.RHF(mol)
@@ -51,10 +40,13 @@ mf.scf()
 
 # Calculate energy of the molecules with frozen core.
 # Active spaces chosen to reflect valence active space.
-#mc = shci.SHCISCF( mf, norb, nelec ).state_average_([0.333333, 0.33333, 0.33333])
-mc = shci.SHCISCF(mf, norb, nelec).state_average_([0.5, 0.5])
+# mc = shci.SHCISCF( mf, norb, nelec ).state_average_([0.333333, 0.33333, 0.33333])
+ncas = 8
+nelecas = 8
+mc = shci.SHCISCF(mf, ncas, nelecas).state_average_([0.5, 0.5])
+mc.frozen = mc.ncore
 mc.fcisolver.sweep_iter = [0, 3]
-mc.fcisolver.sweep_epsilon = [1.e-3, 1.e-4]
+mc.fcisolver.sweep_epsilon = [1.0e-3, 1.0e-4]
 mc.kernel()
 
 print("Total Time:    ", time.time() - t0)

--- a/pyscf/shciscf/shci.py
+++ b/pyscf/shciscf/shci.py
@@ -874,9 +874,10 @@ class SHCI(pyscf.lib.StreamObject):
         """
         Remove the files used for Dice communication.
         """
-        os.remove("input.dat")
-        os.remove("output.dat")
-        os.remove("FCIDUMP")
+        
+        os.remove(os.path.join(self.runtimeDir, self.configFile))
+        os.remove(os.path.join(self.runtimeDir, self.outputFile))
+        os.remove(os.path.join(self.runtimeDir, self.integralFile))
 
 
 def print1Int(h1, name):
@@ -995,6 +996,10 @@ def writeSHCIConfFile(SHCI, nelec, Restart):
                         "number of irreps %s beta  electrons = %d" % (k, v[1]))
                     exit(1)
     f.write('\nend\n')
+
+    # Handle different cases for FCIDUMP file names/paths
+    f.write("orbitals {}\n".format(os.path.join(SHCI.runtimeDir, SHCI.integralFile)))
+
     f.write('nroots %r\n' % SHCI.nroots)
 
     # Variational Keyword Section


### PR DESCRIPTION
This PR addresses a small bug I found in `shci.py`. Basically, if you specified a custom output folder for Dice, it would put the integral, input, and output files there, but not add the path of the integral file to the input file. 

There are also some updates to the formatting in `shciscf/examples` to make them clearer and easier to understand. In addition, I've added a new example demonstrating how to set the `SHCI.runtimeDir` for any interested users.