### PR TITLE
Define long := int when using python3

### DIFF
--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -55,6 +55,7 @@ EXP_DELIMITER = getattr(__config__, 'pbc_gto_cell_split_basis_exp_delimiter',
 # For code compatiblity in python-2 and python-3
 if sys.version_info >= (3,):
     unicode = str
+    long = int
 
 libpbc = _pbcintor.libpbc
 


### PR DESCRIPTION
In [pbc/gto/cell.py](https://github.com/pyscf/pyscf/blob/master/pyscf/pbc/gto/cell.py#L233), there is an `isinstance` check against the type `long`, which is not a built-in type as of Python 3. For compatibility with Python 3, we must define `long = int`. This seems to be the only place in PySCF that currently uses the Python 2.x `long` type, so it's a one-line fix.