### PR TITLE
added URLs to libxc releases on gitlab.com since tddft.org is longer …

### DIFF
--- a/pyscf/lib/CMakeLists.txt
+++ b/pyscf/lib/CMakeLists.txt
@@ -147,19 +147,26 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/deps/include/xc.h" AND
     # Stick to libxc-3.0.1 because libxc-4.2.3 does not support M05X, M06X. They
     # are defined in libxc-3.0.1 and agree very well to xcfun.
     #URL http://www.tddft.org/programs/octopus/down.php?file=libxc/4.2.3/libxc-4.2.3.tar.gz
-    URL http://www.tddft.org/programs/octopus/down.php?file=libxc/3.0.1/libxc-3.0.1.tar.gz
+    #URL http://www.tddft.org/programs/octopus/down.php?file=libxc/3.0.1/libxc-3.0.1.tar.gz
     #URL http://www.sunqm.net/pyscf/files/src/libxc-3.0.1.tar.gz
+    # URLs to get libxc versions from gitlab in case tddft.org in not avilable
+    # libxc Version 3.0.1 
+    URL https://gitlab.com/libxc/libxc/-/archive/3.0.1/libxc-3.0.1.tar.gz
+    # libxc Version 4.2.3 
+    #URL https://gitlab.com/libxc/libxc/-/archive/4.2.3/libxc-4.2.3.tar.gz
+    # libxc Version 4.3.4 newest version 
+    #URL https://gitlab.com/libxc/libxc/-/archive/4.3.4/libxc-4.3.4.tar.gz
     PREFIX ${PROJECT_BINARY_DIR}/deps
     INSTALL_DIR ${PROJECT_SOURCE_DIR}/deps
     BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --libdir=<INSTALL_DIR>/lib
-          --enable-shared --disable-static --disable-fortran ${LIBM}
-          CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
-
-## For git checkout
-#    CONFIGURE_COMMAND autoreconf -i || autoreconf && ./configure --prefix=<INSTALL_DIR> --libdir=<INSTALL_DIR>/lib
-#          --enable-shared --disable-static --disable-fortran LIBS=-lm
+#    CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --libdir=<INSTALL_DIR>/lib
+#          --enable-shared --disable-static --disable-fortran ${LIBM}
 #          CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
+
+## For git checkout or tar.gz versions from gitlab.com 
+    CONFIGURE_COMMAND autoreconf -i || autoreconf && ./configure --prefix=<INSTALL_DIR> --libdir=<INSTALL_DIR>/lib
+          --enable-shared --disable-static --disable-fortran LIBS=-lm
+          CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER}
   )
 endif() # ENABLE_LIBXC
 


### PR DESCRIPTION
since tddft.org is longer unavalable and corresponding configuration.
Fixes issue #417 