### PR TITLE
Missing import in IAO population example

### DIFF
--- a/examples/local_orb/02-pop_with_iao.py
+++ b/examples/local_orb/02-pop_with_iao.py
@@ -4,6 +4,7 @@
 Mulliken population analysis with IAO orbitals
 '''
 import numpy
+from functools import reduce
 from pyscf import gto, scf, lo
 
 x = .63


### PR DESCRIPTION
This PR fixes the error I got trying to run the IAO population analysis example
```
Traceback (most recent call last):
  File "02-pop_with_iao.py", line 25, in <module>
    mo_occ = reduce(numpy.dot, (a.T, mf.get_ovlp(), mo_occ))
NameError: name 'reduce' is not defined
```