### PR TITLE
Fixing Issue #443 and getting rid of some NumPy warnings

### DIFF
--- a/pyscf/dmrgscf/dmrgci.py
+++ b/pyscf/dmrgscf/dmrgci.py
@@ -443,7 +443,7 @@ class DMRGCI(lib.StreamObject):
 
         return onepdm, twopdm, threepdm
 
-    def make_rdm3(self, state, norb, nelec, dt=numpy.dtype('Float64'), filetype = "binary", link_index=None, **kwargs):
+    def make_rdm3(self, state, norb, nelec, dt=numpy.float64, filetype = "binary", link_index=None, **kwargs):
         import os
 
         if self.has_threepdm == False:
@@ -488,7 +488,7 @@ class DMRGCI(lib.StreamObject):
             fname = os.path.join(self.scratchDirectory,"node0", "spatial_threepdm.%d.%d.bin" %(state, state))
             fnameout = os.path.join(self.scratchDirectory,"node0", "spatial_threepdm.%d.%d.bin.unpack" %(state, state))
             libunpack.unpackE3(ctypes.c_char_p(fname.encode()), ctypes.c_char_p(fnameout.encode()), ctypes.c_int(norb))
-            E3 = numpy.fromfile(fnameout, dtype=numpy.dtype('Float64'))
+            E3 = numpy.fromfile(fnameout, dtype=numpy.float64)
             E3 = numpy.reshape(E3, (norb, norb, norb, norb, norb, norb), order='F')
           else:
             print('Reading binary 3RDM from BLOCK')
@@ -518,7 +518,7 @@ class DMRGCI(lib.StreamObject):
         print('')
         return E3
 
-    def make_rdm4(self, state, norb, nelec, dt=numpy.dtype('Float64'), filetype = "binary", link_index=None, **kwargs):
+    def make_rdm4(self, state, norb, nelec, dt=numpy.float64, filetype = "binary", link_index=None, **kwargs):
         import os
 
         if self.has_fourpdm == False:
@@ -567,7 +567,7 @@ class DMRGCI(lib.StreamObject):
             fname = os.path.join(self.scratchDirectory,"node0", "spatial_fourpdm.%d.%d.bin" %(state, state))
             fnameout = os.path.join(self.scratchDirectory,"node0", "spatial_fourpdm.%d.%d.bin.unpack" %(state, state))
             libunpack.unpackE4(ctypes.c_char_p(fname.encode()), ctypes.c_char_p(fnameout.encode()), ctypes.c_int(norb))
-            E4 = numpy.fromfile(fnameout, dtype=numpy.dtype('Float64'))
+            E4 = numpy.fromfile(fnameout, dtype=numpy.float64)
             E4 = numpy.reshape(E4, (norb, norb, norb, norb, norb, norb, norb, norb), order='F')
           else:
             print('Reading binary 4RDM from BLOCK')

--- a/pyscf/shciscf/test/test_shci.py
+++ b/pyscf/shciscf/test/test_shci.py
@@ -176,7 +176,6 @@ class KnownValues(unittest.TestCase):
         # Number of orbital and electrons
         ncas = 8
         nelecas = 12
-        dimer_atom = 'O'
 
         mc = mcscf.CASCI(mf, ncas, nelecas)
         e_casscf = mc.kernel()[0]
@@ -199,8 +198,7 @@ class KnownValues(unittest.TestCase):
         # Number of orbital and electrons
         ncas = 8
         nelecas = 12
-        dimer_atom = 'O'
-
+        
         mc = mcscf.CASSCF(mf, ncas, nelecas)
         e_casscf = mc.kernel()[0]
 


### PR DESCRIPTION
This pull request does three things:

1) Fixes #443 by modifying the `shci.dryrun()` (`SHCI.orbsym` was previously not being initialized here)
2) Slightly modifies the way the Dice input file is written
3) Changes numpy.dtype("Float64") -> numpy.float64 in `shci.py` and `dmrgci.py` since this was throwing warning.

I changed the behavior of `shci.dryrun()` slightly because the documentation for it said that it was just intended to generate the `input.dat` and `FCIDUMP` files while in reality it performed an iteration of `mc.casci(mo_coeff)` (which is equivalent to `mc.kernel(mo_coeff)`). In my changes, I modified `shci.dryrun()` so that in never actually calls Dice, it only generates the inputs a Dice run. 

@sanshar if this isn't the behavior you're looking for here let me know and I'll have dryrun execute a Dice run.  