### PR TITLE
Fix off-by-one error in Huckel guess.

### DIFF
--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -573,7 +573,7 @@ def _init_guess_huckel_orbitals(mol):
     for io in range(nocc):
         # Diagonal is just the orbital energies
         orb_H[io,io] = orb_E[io]
-        for jo in range(io-1):
+        for jo in range(io):
             # Off-diagonal is given by GWH approximation
             orb_H[io,jo] = 0.5*Kgwh*orb_S[io,jo]*(orb_E[io]+orb_E[jo])
             orb_H[jo,io] = orb_H[io,jo]


### PR DESCRIPTION
This PR fixes an off-by-one error in the Huckel guess, improves the documentation - orbitals, not density matrices - and splits the implementation into one step that builds the Huckel basis and another that assembles the core matrices.

The minimal atomic basis produced by the routine could be used to replace the `minao` guess as soon as the SAD algorithm supports ECPs.