### PR TITLE
VVO and LIVVO

### DIFF
--- a/examples/local_orb/04-ibo_benzene_cubegen.py
+++ b/examples/local_orb/04-ibo_benzene_cubegen.py
@@ -41,7 +41,7 @@ a = lo.vec_lowdin(a, mf.get_ovlp())
 Generate IBOS from orthogonal IAOs
 '''
 
-ibo = lo.ibo.ibo(mol, mo_occ, a)
+ibo = lo.ibo.ibo(mol, mo_occ, iaos=a)
 
 '''
 Print the IBOS into Gausian Cube files
@@ -70,7 +70,7 @@ mf.mulliken_pop(iao_mol, dm, s=numpy.eye(iao_mol.nao_nr()))
 #
 mo_occ = mf.mo_coeff[:,mf.mo_occ>0]
 iaos = lo.iao.iao(mol, mo_occ)
-ibo = lo.ibo.PM(mol, mo_occ, iaos).kernel()
+ibo = lo.ibo.ibo(mol, mo_occ, locmethod='PM', iaos=iaos).kernel()
 for i in range(ibo.shape[1]):
     tools.cubegen.orbital(mol, 'benzene_ibo2_{:02d}.cube'.format(i+1), ibo[:,i])
 

--- a/examples/local_orb/05-ibo_periodic_diamond_cubegen.py
+++ b/examples/local_orb/05-ibo_periodic_diamond_cubegen.py
@@ -42,7 +42,7 @@ a = lo.iao.iao(cell, mo_occ)
 # Orthogonalize IAO
 a = lo.vec_lowdin(a, mf.get_ovlp())
 #ibo must take the orthonormalized IAOs
-ibo = lo.ibo.ibo(cell, mo_occ, a)
+ibo = lo.ibo.ibo(cell, mo_occ, iaos=a)
 
 
 '''

--- a/examples/local_orb/06-vvo_livvo_water_cubegen.py
+++ b/examples/local_orb/06-vvo_livvo_water_cubegen.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+#
+# Author: Shiv Upadhyay <shivnupadhyay@gmail.com>
+#
+
+'''
+VVO and LIVVO generation for a water molecule
+'''
+
+from pyscf import gto, lo, tools, dft
+from pyscf.lo import iao, orth
+
+
+mol = gto.Mole()
+mol.verbose = 1
+mol.atom = '''
+O	 0.0000000	 0.0000000	 0.0000000
+H	 0.7569685	 0.0000000	-0.5858752
+H	-0.7569685	 0.0000000	-0.5858752'''
+mol.unit = 'Angstrom'
+mol.basis = 'aug-cc-pvtz'
+mol.symmetry = 1
+mol.build()
+
+mf = dft.RKS(mol)
+mf.xc = 'HF*0.2 + .08*LDA + .72*B88, .81*LYP + .19*VWN5'
+mf.kernel()
+
+orbocc = mf.mo_coeff[:,0:mol.nelec[0]]
+orbvirt = mf.mo_coeff[:,mol.nelec[0]:]
+mocoeff = mf.mo_coeff
+
+ovlpS = mol.intor_symmetric('int1e_ovlp')
+
+# plot canonical mos
+iaos = iao.iao(mol, orbocc)
+iaos = orth.vec_lowdin(iaos, ovlpS)
+for i in range(iaos.shape[1]):
+    tools.cubegen.orbital(mol, 'h2o_cmo_{:02d}.cube'.format(i+1), mocoeff[:,i])
+
+# plot intrinsic atomic orbitals
+for i in range(iaos.shape[1]):
+    tools.cubegen.orbital(mol, 'h2o_iao_{:02d}.cube'.format(i+1), iaos[:,i])
+
+# plot intrinsic bonding orbitals
+count = 0
+ibos = lo.ibo.ibo(mol, orbocc, locmethod='IBO')
+for i in range(ibos.shape[1]):
+    count += 1
+    tools.cubegen.orbital(mol, 'h2o_ibo_{:02d}.cube'.format(count), ibos[:,i])
+
+# plot valence virtual orbitals and localized valence virtual orbitals
+vvo = lo.vvo.vvo(mol, orbocc, orbvirt)
+livvo = lo.vvo.livvo(mol, orbocc, orbvirt)
+for i in range(vvo.shape[1]):
+    count += 1
+    tools.cubegen.orbital(mol, 'h2o_vvo_{:02d}.cube'.format(count), vvo[:,i])
+    tools.cubegen.orbital(mol, 'h2o_livvo_{:02d}.cube'.format(count), livvo[:,i])
+

--- a/pyscf/lo/__init__.py
+++ b/pyscf/lo/__init__.py
@@ -17,6 +17,7 @@ from pyscf.lo import orth
 from pyscf.lo.orth import lowdin, schmidt, vec_lowdin, vec_schmidt, orth_ao
 from pyscf.lo import iao
 from pyscf.lo import ibo
+from pyscf.lo import vvo
 from pyscf.lo.nao import set_atom_conf
 from pyscf.lo.boys import Boys, BF
 from pyscf.lo.edmiston import EdmistonRuedenberg, ER

--- a/pyscf/lo/ibo.py
+++ b/pyscf/lo/ibo.py
@@ -35,8 +35,53 @@ from pyscf.lo import iao
 from pyscf.lo import orth, pipek
 from pyscf import __config__
 
+def ibo(mol, orbocc, locmethod='IBO', iaos=None, s=None, exponent=4, grad_tol=1e-8, max_iter=200, verbose=logger.NOTE):
+    '''Intrinsic Bonding Orbitals
+    
+    This function serves as a wrapper to the underlying localization functions
+    ibo_loc and PipekMezey to create IBOs.
 
-def ibo(mol, orbocc, iaos=None, exponent=4, grad_tol=1e-8, max_iter=200,
+    Args:
+        mol : the molecule or cell object
+
+        orbocc : occupied molecular orbital coefficients
+
+    Kwargs:
+        locmethod : string
+            the localization method 'PM' for Pipek Mezey localization or 'IBO' for the IBO localization
+
+        iaos : 2D array
+            the array of IAOs
+
+        s : 2D array
+            the overlap array in the ao basis
+
+    Returns:
+        IBOs in the basis defined in mol object.
+    '''
+    
+    if s is None:
+        if getattr(mol, 'pbc_intor', None):  # whether mol object is a cell
+            if isinstance(orbocc, numpy.ndarray) and orbocc.ndim == 2:
+                s = mol.pbc_intor('int1e_ovlp', hermi=1)
+            else:
+                raise NotImplementedError('k-points crystal orbitals')
+        else:
+            s = mol.intor_symmetric('int1e_ovlp')
+
+    if iaos is None:
+        iaos = iao.iao(mol, orbocc)
+
+    locmethod = locmethod.strip().upper()
+    if locmethod == 'PM':
+        EXPONENT = getattr(__config__, 'lo_ibo_PipekMezey_exponent', 4)
+        ibos = PipekMezey(mol, orbocc, iaos, s, exponent=EXPONENT)
+        del(EXPONENT)
+    else:
+        ibos = ibo_loc(mol, orbocc, iaos, s, exponent=exponent, grad_tol=grad_tol, max_iter=max_iter, verbose=verbose)
+    return ibos
+
+def ibo_loc(mol, orbocc, iaos, s, exponent, grad_tol, max_iter,
         verbose=logger.NOTE):
     '''Intrinsic Bonding Orbitals. [Ref. JCTC, 9, 4834]
 
@@ -68,20 +113,9 @@ def ibo(mol, orbocc, iaos=None, exponent=4, grad_tol=1e-8, max_iter=200,
     log = logger.new_logger(mol, verbose)
     assert(exponent in (2, 4))
 
-    if getattr(mol, 'pbc_intor', None):  # whether mol object is a cell
-        if isinstance(orbocc, numpy.ndarray) and orbocc.ndim == 2:
-            ovlpS = mol.pbc_intor('int1e_ovlp', hermi=1)
-        else:
-            raise NotImplementedError('k-points crystal orbitals')
-    else:
-        ovlpS = mol.intor_symmetric('int1e_ovlp')
-
-    if iaos is None:
-        iaos = iao.iao(mol, orbocc)
-
     # Symmetrically orthogonalization of the IAO orbitals as Knizia's
     # implementation.  The IAO returned by iao.iao function is not orthogonal.
-    iaos = orth.vec_lowdin(iaos, ovlpS)
+    iaos = orth.vec_lowdin(iaos, s)
 
     #static variables
     StartTime = time()
@@ -100,7 +134,7 @@ def ibo(mol, orbocc, iaos=None, exponent=4, grad_tol=1e-8, max_iter=200,
     AtomOffsets = MakeAtomIbOffsets(Atoms)[0]
     iAtSl = [slice(AtomOffsets[A],AtomOffsets[A+1]) for A in range(nAtoms)]
     #converts the occupied MOs to the IAO basis
-    CIb = reduce(numpy.dot, (iaos.T, ovlpS , orbocc))
+    CIb = reduce(numpy.dot, (iaos.T, s , orbocc))
     numOccOrbitals = CIb.shape[1]
 
     log.debug("   {0:^5s} {1:^14s} {2:^11s} {3:^8s}"
@@ -175,9 +209,7 @@ def ibo(mol, orbocc, iaos=None, exponent=4, grad_tol=1e-8, max_iter=200,
     return numpy.dot(iaos, (orth.vec_lowdin(CIb)))
 
 
-EXPONENT = getattr(__config__, 'lo_ibo_PipekMezey_exponent', 4)
-
-def PipekMezey(mol, orbocc, iaos=None, s=None, exponent=EXPONENT):
+def PipekMezey(mol, orbocc, iaos, s, exponent):
     '''
     Note this localization is slightly different to Knizia's implementation.
     The localization here reserves orthogonormality during optimization.
@@ -196,20 +228,6 @@ def PipekMezey(mol, orbocc, iaos=None, s=None, exponent=EXPONENT):
     >>> pm = ibo.PM(mol, mf.mo_coeff[:,mf.mo_occ>0])
     >>> loc_orb = pm.kernel()
     '''
-    if getattr(mol, 'pbc_intor', None):  # whether mol object is a cell
-        if isinstance(orbocc, numpy.ndarray) and orbocc.ndim == 2:
-            s = mol.pbc_intor('int1e_ovlp', hermi=1)
-        else:
-            raise NotImplementedError('k-points crystal orbitals')
-    else:
-        s = mol.intor_symmetric('int1e_ovlp')
-
-    if iaos is None:
-        iaos = iao.iao(mol, orbocc)
-
-    # Different to Knizia's code, the reference IAOs are not neccessary
-    # orthogonal.
-    #iaos = orth.vec_lowdin(iaos, s)
 
     cs = numpy.dot(iaos.T.conj(), s)
     s_iao = numpy.dot(cs, iaos)
@@ -231,9 +249,6 @@ def PipekMezey(mol, orbocc, iaos=None, s=None, exponent=EXPONENT):
     pm.exponent = exponent
     return pm
 PM = Pipek = PipekMezey
-
-del(EXPONENT)
-
 
 '''
 These are parameters for selecting the valence space correctly.

--- a/pyscf/lo/ibo.py
+++ b/pyscf/lo/ibo.py
@@ -74,7 +74,7 @@ def ibo(mol, orbocc, locmethod='IBO', iaos=None, s=None, exponent=4, grad_tol=1e
 
     locmethod = locmethod.strip().upper()
     if locmethod == 'PM':
-        EXPONENT = getattr(__config__, 'lo_ibo_PipekMezey_exponent', 4)
+        EXPONENT = getattr(__config__, 'lo_ibo_PipekMezey_exponent', exponent)
         ibos = PipekMezey(mol, orbocc, iaos, s, exponent=EXPONENT)
         del(EXPONENT)
     else:

--- a/pyscf/lo/vvo.py
+++ b/pyscf/lo/vvo.py
@@ -129,7 +129,7 @@ def livvo(mol, orbocc, orbvirt, locmethod='IBO', iaos=None, s=None, exponent=4, 
     vvos = vvo(mol, orbocc, orbvirt, iaos=iaos, s=s)
     locmethod = locmethod.strip().upper()
     if locmethod == 'PM':
-        EXPONENT = getattr(__config__, 'lo_ibo_PipekMezey_exponent', 4)
+        EXPONENT = getattr(__config__, 'lo_ibo_PipekMezey_exponent', exponent)
         livvos = ibo.PipekMezey(mol, vvos, iaos, s, exponent=EXPONENT)
         del(EXPONENT)
     else:

--- a/pyscf/lo/vvo.py
+++ b/pyscf/lo/vvo.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# Copyright 2014-2019 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: Shiv Upadhyay <shivnupadhyay@gmail.com>
+#
+
+'''
+Valence Virtual Orbitals
+ref. 10.1021/acs.jctc.7b00493
+'''
+
+from time import time
+from functools import reduce
+import numpy
+import scipy.linalg
+from pyscf.lib import logger
+from pyscf.lo import iao
+from pyscf.lo import orth, pipek
+from pyscf.lo import ibo
+from pyscf import __config__
+
+
+def vvo(mol, orbocc, orbvirt, iaos=None, s=None, verbose=logger.NOTE):
+    '''Valence Virtual Orbitals ref. 10.1021/acs.jctc.7b00493
+
+    Valence virtual orbitals can be formed from the singular value 
+    decomposition of the overlap between the canonical molecular orbitals
+    and an accurate underlying atomic basis set. This implementation uses
+    the intrinsic atomic orbital as this underlying set. VVOs can also be 
+    formed from the null space of the overlap of the canonical molecular 
+    orbitals and the underlying atomic basis sets (IAOs). This is not 
+    implemented here.
+
+    Args:
+        mol : the molecule or cell object
+
+        orbocc : occupied molecular orbital coefficients
+
+        orbvirt : virtual molecular orbital coefficients
+
+    Kwargs:
+        iaos : 2D array
+            the array of IAOs
+
+        s : 2D array
+            the overlap array in the ao basis
+
+    Returns:
+        VVOs in the basis defined in mol object.
+    '''
+    log = logger.new_logger(mol, verbose)
+    if s is None:
+        if getattr(mol, 'pbc_intor', None):  # whether mol object is a cell
+            if isinstance(orbocc, numpy.ndarray) and orbocc.ndim == 2:
+                s = mol.pbc_intor('int1e_ovlp', hermi=1)
+            else:
+                raise NotImplementedError('k-points crystal orbitals')
+        else:
+            s = mol.intor_symmetric('int1e_ovlp')
+
+    if iaos is None:
+        iaos = iao.iao(mol, orbocc)
+    
+    nvvo = iaos.shape[1] - orbocc.shape[1]
+
+    # Symmetrically orthogonalization of the IAO orbitals as Knizia's
+    # implementation.  The IAO returned by iao.iao function is not orthogonal.
+    iaos = orth.vec_lowdin(iaos, s)
+
+    #S = reduce(np.dot, (orbvirt.T, s, iaos))
+    S = numpy.einsum('ji,jk,kl->il', orbvirt, s, iaos, optimize=True)
+    U, sigma, Vh = scipy.linalg.svd(S)
+    U = U[:, 0:nvvo]
+    vvo = numpy.einsum('ik,ji->jk', U, orbvirt, optimize=True)
+    return vvo
+
+def livvo(mol, orbocc, orbvirt, locmethod='IBO', iaos=None, s=None, exponent=4, grad_tol=1e-8, max_iter=200, verbose=logger.NOTE):
+    '''Localized Intrinsic Valence Virtual Orbitals ref. 10.1021/acs.jctc.7b00493
+
+    Localized Intrinsic valence virtual orbitals are formed when the valence
+    virtual orbitals are localized using an IBO-type of localization. Here
+    the VVOs are created in the IAO basis then the IBO localization functions
+    are called to localize the VVOs.
+
+    Args:
+        mol : the molecule or cell object
+
+        orbocc : occupied molecular orbital coefficients
+
+        orbvirt : virtual molecular orbital coefficients
+
+    Kwargs:
+        locmethod : string
+            the localization method 'PM' for Pipek Mezey localization or 'IBO' for the IBO localization
+
+        iaos : 2D array
+            the array of IAOs
+
+        s : 2D array
+            the overlap array in the ao basis
+
+    Returns:
+        LIVVOs in the basis defined in mol object.
+    '''
+    if s is None:
+        if getattr(mol, 'pbc_intor', None):  # whether mol object is a cell
+            if isinstance(orbocc, numpy.ndarray) and orbocc.ndim == 2:
+                s = mol.pbc_intor('int1e_ovlp', hermi=1)
+            else:
+                raise NotImplementedError('k-points crystal orbitals')
+        else:
+            s = mol.intor_symmetric('int1e_ovlp')
+
+    if iaos is None:
+        iaos = iao.iao(mol, orbocc)
+
+    vvos = vvo(mol, orbocc, orbvirt, iaos=iaos, s=s)
+    locmethod = locmethod.strip().upper()
+    if locmethod == 'PM':
+        EXPONENT = getattr(__config__, 'lo_ibo_PipekMezey_exponent', 4)
+        livvos = ibo.PipekMezey(mol, vvos, iaos, s, exponent=EXPONENT)
+        del(EXPONENT)
+    else:
+        livvos = ibo.ibo_loc(mol, vvos, iaos, s, exponent=exponent, grad_tol=grad_tol, max_iter=max_iter, verbose=verbose)
+    return livvos


### PR DESCRIPTION
This PR allows for the construction of VVO and LIVVO [from this paper.](https://pubs.acs.org/doi/10.1021/acs.jctc.7b00493)

The IBO part of the code had to be touched to expose the localization functions.

The image below allows for comparison to figure 1 in the linked paper.
![vvo_livvo](https://user-images.githubusercontent.com/16597884/70395882-74672f00-19d1-11ea-8a38-43707fe4d19c.png)

Let me know if anything needs changed.
