### PR TITLE
Fix mindo3_grad import

### DIFF
--- a/pyscf/semiempirical/mindo3.py
+++ b/pyscf/semiempirical/mindo3.py
@@ -216,7 +216,7 @@ class RMINDO3(scf.hf.RHF):
     x2c = x2c1e = sfx2c1e = None
 
     def nuc_grad_method(self):
-        import rmindo3_grad
+        from . import rmindo3_grad
         return rmindo3_grad.Gradients(self)
 
 
@@ -279,7 +279,7 @@ class UMINDO3(scf.uhf.UHF):
     x2c = x2c1e = sfx2c1e = None
 
     def nuc_grad_method(self):
-        import umindo3_grad
+        from . import umindo3_grad
         return umindo3_grad.Gradients(self)
 
 


### PR DESCRIPTION
Currently, the import statements in the {R,U}MINDO3 `nuc_grad_method` methods do not work correctly when running as a library (though the tests at the bottom in `if __name__ == '__main__'` do run correctly). This PR changes the absolute imports into relative imports, fixing the problem.