### PR TITLE
NEVPT2: fix HDF5 file creation.

### DIFF
--- a/pyscf/mrpt/nevpt2.py
+++ b/pyscf/mrpt/nevpt2.py
@@ -938,7 +938,7 @@ def trans_e1_outcore(mc, mo, max_memory=None, ioblk_size=256, tmpdir=None,
     time1 = [time.clock(), time.time()]
     ao_loc = numpy.array(mol.ao_loc_nr(), dtype=numpy.int32)
     cvcvfile = tempfile.NamedTemporaryFile(dir=tmpdir)
-    with h5py.File(cvcvfile.name, 'r') as f5:
+    with h5py.File(cvcvfile.name, 'w') as f5:
         cvcv = f5.create_dataset('eri_mo', (ncore*nvir,ncore*nvir), 'f8')
         ppaa, papa, pacv = _trans(mo, ncore, ncas, load_buf, cvcv, ao_loc)[:3]
     time0 = logger.timer(mol, 'trans_cvcv', *time0)


### PR DESCRIPTION
PySCF crashed in some NEVPT2 calculations. This appears to fix it.