### PR TITLE
Make code Python 3 compliant.

### DIFF
--- a/pyscf/dmrgscf/p_dmrg.py
+++ b/pyscf/dmrgscf/p_dmrg.py
@@ -106,22 +106,22 @@ class PDMRG(DMRGCI):
                       fout.write(line)
               fout.write('fullrestart')
 
-    import os
-    block_path = os.path.dirname(self.executable)
-    check_call(["%s %s/OH oh.conf wavenum > oh.out"%(self.mpiprefix,block_path)], shell=True)
-    with open('oh.out','r') as f:
+      import os
+      block_path = os.path.dirname(self.executable)
+      check_call(["%s %s/OH oh.conf wavenum > oh.out"%(self.mpiprefix,block_path)], shell=True)
+      with open('oh.out','r') as f:
         H0 = float(f.readlines()[-4])
-    H0 -=self.core_energy
-    E0  = self.E_dmrg*self.H0factor + H0*(1.0-self.H0factor)
+      H0 -=self.core_energy
+      E0  = self.E_dmrg*self.H0factor + H0*(1.0-self.H0factor)
 
-    check_call(["head -n -1 %s > tmpfile"%self.H0_file], shell=True)
-    check_call(["cp tmpfile %s"%self.H0_file], shell=True)
-    with open('%s'%self.H0_file,'a') as f:
+      check_call(["head -n -1 %s > tmpfile"%self.H0_file], shell=True)
+      check_call(["cp tmpfile %s"%self.H0_file], shell=True)
+      with open('%s'%self.H0_file,'a') as f:
         f.write('%s 0 0 0 0\n'%(-E0))
 
-    check_call(["head -n -1 %s > tmpfile"%self.H1_file], shell=True)
-    check_call(["cp tmpfile %s"%self.H1_file], shell=True)
-    with open('%s'%self.H1_file,'a') as f:
+      check_call(["head -n -1 %s > tmpfile"%self.H1_file], shell=True)
+      check_call(["cp tmpfile %s"%self.H1_file], shell=True)
+      with open('%s'%self.H1_file,'a') as f:
         f.write('%s 0 0 0 0\n'%(-self.E_dmrg))
 
   def compress(self):

--- a/pyscf/tools/Molpro2Pyscf/MolproXml.py
+++ b/pyscf/tools/Molpro2Pyscf/MolproXml.py
@@ -30,6 +30,7 @@
 #  This file is adapted with permission from the wmme program of Gerald Knizia.
 #  See http://sites.psu.edu/knizia/software/
 #====================================================
+from __future__ import print_function
 
 
 
@@ -209,7 +210,7 @@ def _ReadOrbitals(OrbitalsNode, Atoms, OrbBasis, SkipVirtual):
    nBf = OrbBasis.nFn
    Orbitals = []
    count =0         #ELVIRA
-   print "# orb       iSym    iOrbInSym"      #ELVIRA 
+   print("# orb       iSym    iOrbInSym")      #ELVIRA 
 
    nOrbInSym = np.array(8*[0])
    for OrbNode in OrbitalsNode.findall("orbital"):
@@ -225,7 +226,7 @@ def _ReadOrbitals(OrbitalsNode, Atoms, OrbBasis, SkipVirtual):
          #raise Exception("Number of orbital coefficients differs from number of basis functions.")
       Orbitals.append(FOrbitalInfo(Coeffs, fEnergy, fOcc, iSym, iOrbInSym, OrbBasis))
       if fOcc != 0.0:
-       print count , "       ", iSym, "          ", iOrbInSym      #ELVIRA 
+       print(count , "       ", iSym, "          ", iOrbInSym)      #ELVIRA 
       count +=1  #ElVIRA
    return Orbitals
 
@@ -484,7 +485,7 @@ def _main():
    FileName = "benzene.xml"
    #FileName = "/home/cgk/dev/xml-molpro/test1.xml"
    XmlData = ReadMolproXml(FileName,SkipVirtual=True)
-   print "Atoms from file [a.u.]:\n%s" % XmlData.Atoms.MakeXyz(NumFmt="%20.15f",Scale=1/wmme.ToAng)
+   print("Atoms from file [a.u.]:\n{}".format(XmlData.Atoms.MakeXyz(NumFmt="%20.15f",Scale=1/wmme.ToAng)))
    OrbBasis = XmlData.OrbBasis
    #BasisLibs = ["def2-nzvpp-jkfit.libmol"]
 
@@ -494,14 +495,14 @@ def _main():
    from wmme import mdot
    C = XmlData.Orbs
    S = ic.MakeOverlap()
-   print "Orbital matrix shape: %s (loaded from '%s')" % (C.shape, FileName)
-   print "Overlap matrix shape: %s (made via WMME)" % (S.shape,)
+   print("Orbital matrix shape: {} (loaded from '{}')".format(C.shape, FileName))
+   print("Overlap matrix shape: {} (made via WMME)".format(S.shape))
    np.set_printoptions(precision=4,linewidth=10000,edgeitems=3,suppress=False)
    SMo = mdot(C.T, S, C)
-   print "Read orbitals:"
+   print("Read orbitals:")
    for OrbInfo in XmlData.Orbitals:
-      print "%30s" % OrbInfo.Desc
-   print "MO deviation from orthogonality: %.2e" % rmsd(SMo - np.eye(SMo.shape[0]))
+      print("{:30s}".format(OrbInfo.Desc))
+   print("MO deviation from orthogonality: {:.2e}".format(rmsd(SMo - np.eye(SMo.shape[0]))))
 
    pass
 

--- a/pyscf/tools/Molpro2Pyscf/example_Pd_atom.py
+++ b/pyscf/tools/Molpro2Pyscf/example_Pd_atom.py
@@ -28,6 +28,7 @@
 # Note, that right now the default value is  SkipVirtual =True, that means that Orbitals COrb include only those,
 # which have non-zero occupation numbers in XML file. If you want virtual orbitals too, change SkipVirtual to False.
 
+from __future__ import print_function
 
 import numpy as np
 from wmme import mdot
@@ -47,20 +48,20 @@ def rmsd(X):
 
 
 def PrintMatrix(Caption, M):
-   print "Matrix %s [%i x %i]:\n" % (Caption, M.shape[0], M.shape[1])
-   ColsFmt = M.shape[1] * " %11.5f"
+   print("Matrix {} [{} x {}]:\n".format(Caption, M.shape[0], M.shape[1]))
+   ColsFmt = M.shape[1] * " {:11.5f}"
    for iRow in range(M.shape[0]):
-      print "  %s" % (ColsFmt % tuple(M[iRow,:]))
+      print(ColsFmt.format(tuple(M[iRow,:])))
 
 
 def _run_with_pyscf(FileNameXml):
    # read Molpro XML file exported via {put,xml,filename}
-   print "\n* Reading: '%s'" % FileNameXml
+   print("\n* Reading: '{}'".format(FileNameXml))
    XmlData = MolproXml.ReadMolproXml(FileNameXml, SkipVirtual=True)
 # Note, that right now the default value is  SkipVirtual =True, that means that Orbitals COrb include only those,
 # which have non-zero occupation numbers in XML file. If you want virtual orbitals too, change SkipVirtual to False.
  
-   print "Atoms from file [a.u.]:\n%s" % XmlData.Atoms.MakeXyz(NumFmt="%20.15f",Scale=1/wmme.ToAng)
+   print("Atoms from file [a.u.]:\n{}".format(XmlData.Atoms.MakeXyz(NumFmt="%20.15f",Scale=1/wmme.ToAng)))
 
    # convert data from XML file (atom positions, basis sets, MO coeffs) into format compatible
    # with PySCF.
@@ -82,14 +83,14 @@ def _run_with_pyscf(FileNameXml):
    # and the overlap matrix computed with PySCF to check that MO were imported properly.
    SMo = mdot(COrb.T, S, COrb)
    PrintMatrix("MO-Basis overlap (should be unity!)", SMo)
-   print "RMSD(SMo-id): %8.2e" % rmsd(SMo - np.eye(SMo.shape[0]))
+   print("RMSD(SMo-id): {:8.2e}".format(rmsd(SMo - np.eye(SMo.shape[0]))))
    print
 
 def get_1e_integrals_in_MOs_from_Molpro_for_SOC(FileNameXml):
    # read Molpro XML file exported via {put,xml,filename}
-   print "\n* Reading: '%s'" % FileNameXml
+   print("\n* Reading: '{}'".format(FileNameXml))
    XmlData = MolproXml.ReadMolproXml(FileNameXml, SkipVirtual=True)
-   print "Atoms from file [a.u.]:\n%s" % XmlData.Atoms.MakeXyz(NumFmt="%20.15f",Scale=1/wmme.ToAng)
+   print("Atoms from file [a.u.]:\n{}".format(XmlData.Atoms.MakeXyz(NumFmt="%20.15f",Scale=1/wmme.ToAng)))
 
    # convert data from XML file (atom positions, basis sets, MO coeffs) into format compatible    # with PySCF.
    Atoms, Basis, COrb = MolproXmlToPyscf.ConvertMolproXmlToPyscfInput(XmlData)
@@ -122,8 +123,8 @@ def get_1e_integrals_in_MOs_from_Molpro_for_SOC(FileNameXml):
      for o2 in range(norb):
        ActOrb[o1,o2]= COrb[o1, Orblist[o2]]
 
-   print "================================================="
-   print " Now print So1e integrals" 
+   print("=================================================")
+   print(" Now print So1e integrals")
    for id in range(natoms):
      chg = mol.atom_charge(id)
      mol.set_rinv_origin_(mol.atom_coord(id)) # set the gauge origin to first atom
@@ -134,7 +135,7 @@ def get_1e_integrals_in_MOs_from_Molpro_for_SOC(FileNameXml):
      for i in range(3):
       for j in range(h1[i].shape[0]):
        for k in range(h1[i].shape[1]):
-        print id, i+1, j+1, k+1, h1[i][j,k]
+        print(id, i+1, j+1, k+1, h1[i][j,k])
 
 
 


### PR DESCRIPTION
The PR has straightforward print syntax changes to pyscf/tools/Molpro2Pyscf/MolproXml.py and pyscf/tools/Molpro2Pyscf/example_Pd_atom.py, which should not cause any problems.

The PR also fixes incorrect indentation in pyscf/dmrgscf/p_dmrg.py, for which Python throws an error.