### PR TITLE
Fix 31-cr2_scan example

### DIFF
--- a/examples/dmrg/31-cr2_scan/cr2-scan.py
+++ b/examples/dmrg/31-cr2_scan/cr2-scan.py
@@ -47,7 +47,7 @@ def run(b, dm_guess, mo_guess, ci=None):
 # the initial guess for first calculation
         ncas = {'A1g' : 2, 'E1gx' : 1, 'E1gy' : 1, 'E2gx' : 1, 'E2gy' : 1,
                 'A1u' : 2, 'E1ux' : 1, 'E1uy' : 1, 'E2ux' : 1, 'E2uy' : 1}
-        mo_guess = mcscf.sort_mo_by_irrep(mc, mf.mo_coeff, ncas, ncore)
+        mo_guess = mc.sort_mo_by_irrep(ncas)
     else:
         mo_guess = mcscf.project_init_guess(mc, mo_guess)
 


### PR DESCRIPTION
```ncore``` is not defined so I replaced the call to ```mcscf.sort_mo_by_irrep``` by the class method call. 
Apparently, this example has never been tested? See also https://github.com/pyscf/pyscf/issues/510 
