### PR TITLE
Set parent class for DFTD3Dispersion to avoid logger crash.

### DIFF
--- a/pyscf/dftd3/itrf.py
+++ b/pyscf/dftd3/itrf.py
@@ -249,7 +249,7 @@ def grad(scf_grad):
     return mfgrad
 
 
-class DFTD3Dispersion(object):
+class DFTD3Dispersion(lib.StreamObject):
     def __init__(self, mol):
         self.mol = mol
         self.verbose = mol.verbose


### PR DESCRIPTION
DFT-D3 crashes in verbose mode. Example:

```
from pyscf import gto, scf, dftd3
from pyscf.lib import logger

mol = gto.Mole()
mol.atom = ''' O    0.00000000    0.00000000   -0.11081188
               H   -0.00000000   -0.84695236    0.59109389
               H   -0.00000000    0.89830571    0.52404783 '''
mol.basis = 'cc-pvdz'
mol.verbose = logger.INFO
mol.build()

mf = dftd3.dftd3(scf.RHF(mol))
print(mf.kernel())
```
leads to the error message:

`AttributeError: 'DFTD3Dispersion' object has no attribute 'stdout'`