### PR TITLE
Implement partial Cholesky orthogonalization.

### DIFF
--- a/examples/scf/42-remove_linear_dep.py
+++ b/examples/scf/42-remove_linear_dep.py
@@ -7,7 +7,8 @@ This example shows how to remove basis linear dependency by modifying the SCF
 eig method.
 
 The pyscf.scf.addons module provides a function remove_linear_dep_ to remove
-basis linear dependency in a similar manner.
+basis linear dependency in a similar manner, but it also can handle
+pathological linear dependencies via the partial Cholesky procedure.
 '''
 
 
@@ -27,9 +28,11 @@ mol = gto.M(atom=['H 0 0 %f'%i for i in range(10)], unit='Bohr',
 # answer. This example shows how to remove linear dependency from overlap
 # matrix and use the linearly independent basis in the HF, MCSCF calculations.
 #
-# There is a shortcut function to remove linear-dependency, eg
+# There is a shortcut function to remove linear-dependency, e.g.
 #
 #       mf = scf.RHF(mol).apply(scf.addons.remove_linear_dep_)
+#
+# which also implements the partial Cholesky ortogonalization method.
 #
 # This example demonstrated how the linear dependency is removed in our
 # implementation.

--- a/pyscf/scf/addons.py
+++ b/pyscf/scf/addons.py
@@ -28,7 +28,7 @@ from pyscf.scf import hf
 from pyscf import __config__
 
 LINEAR_DEP_THRESHOLD = getattr(__config__, 'scf_addons_remove_linear_dep_threshold', 1e-8)
-CHOLESKY_THRESHOLD = getattr(__config__, 'scf_addons_cholesky_threshold', 1e-10)
+CHOLESKY_THRESHOLD = getattr(__config__, 'scf_addons_cholesky_threshold', 1e-8)
 LINEAR_DEP_TRIGGER = getattr(__config__, 'scf_addons_remove_linear_dep_trigger', 1e-10)
 
 def frac_occ_(mf, tol=1e-3):

--- a/pyscf/scf/addons.py
+++ b/pyscf/scf/addons.py
@@ -28,7 +28,7 @@ from pyscf.scf import hf
 from pyscf import __config__
 
 LINEAR_DEP_THRESHOLD = getattr(__config__, 'scf_addons_remove_linear_dep_threshold', 1e-8)
-CHOLESKY_THRESHOLD = getattr(__config__, 'scf_addons_cholesky_threshold', 1e-8)
+CHOLESKY_THRESHOLD = getattr(__config__, 'scf_addons_cholesky_threshold', 1e-9)
 LINEAR_DEP_TRIGGER = getattr(__config__, 'scf_addons_remove_linear_dep_trigger', 1e-10)
 
 def frac_occ_(mf, tol=1e-3):


### PR DESCRIPTION
This PR implements the partial Cholesky orthogonalization procedure I suggested last fall in

Curing basis set overcompleteness with pivoted Cholesky decompositions
J. Chem. Phys. 151, 241102 (2019); https://doi.org/10.1063/1.5139948

and for which I realized an easier implementation with the Gershgorin theorem in

Accurate reproduction of strongly repulsive interatomic potentials
Phys. Rev. A 101, 032504 (2020); https://doi.org/10.1103/PhysRevA.101.032504