### PR TITLE
Fix dmrg-nevpt2 example; slow version of NEVPT2 is no longer supported in StackBlock 1.5.3

### DIFF
--- a/examples/dmrg/30-dmrg_casscf_nevpt2_for_Cr2.py
+++ b/examples/dmrg/30-dmrg_casscf_nevpt2_for_Cr2.py
@@ -48,11 +48,12 @@ mo = mc.sort_mo_by_irrep(cas_occ)
 mc.kernel(mo)
 
 #
-# DMRG-NEVPT2
+# DMRG-NEVPT2 (slow version)
+# not available since StackBlock 1.5.3
 #
-mrpt.NEVPT(mc).kernel()
+# mrpt.NEVPT(mc).kernel()
 
 #
 # The compressed-MPS-perturber DMRG-NEVPT2 is more efficient.
 #
-mrpt.NEVPT(mc).compress_approx()
+mrpt.NEVPT(mc).compress_approx().kernel()


### PR DESCRIPTION
Latest StackBlock 1.5.3 does not support the calculation type "RESTART_NEVPT2PDM" (https://github.com/sanshar/StackBlock/blob/master/dmrg.C#L557) (slow version of NEVPT2 DMRG). This causes an error in pyscf Cr2 NEVPT2-DMRG example when StackBlock 1.5.3 is used.
One can use the more efficient `mrpt.NEVPT(mc).compress_approx().kernel()` instead of the default `mrpt.NEVPT(mc).kernel()`.

Fixes #547 