### PR TITLE
Bug fix in FFTDF and molecular DFMP2

### DIFF
--- a/pyscf/pbc/df/fft.py
+++ b/pyscf/pbc/df/fft.py
@@ -324,7 +324,7 @@ class FFTDF(lib.StreamObject):
         ao_pairs_G = self.get_ao_pairs_G(kpts0, compact=True)
         ao_pairs_G *= numpy.sqrt(coulG*(self.cell.vol/ngrids**2)).reshape(-1,1)
 
-        Lpq = numpy.empty((self.blockdim, ao_pairs_G.shape[1]))
+        Lpq = numpy.empty((blksize, ao_pairs_G.shape[1]))
         for p0, p1 in lib.prange(0, ngrids, blksize):
             Lpq[:p1-p0] = ao_pairs_G[p0:p1].real
             yield Lpq[:p1-p0]


### PR DESCRIPTION
This pullreq fixes two bugs:

1. `loop()` in `class 'pbc.df.fft.FFTDF'` raises a shape mismatch issue when `self.blockdim` is smaller than the block size defined by `blksize` (or `ngrids`). Fixed by consistently using `blksize`.

2. The molecular DFMP2 kernel gives incorrect energy when `loop_ao2mo()` yields more than one chunk of `qov`, e.g. when `FFTDF` is used as the DF type or when a small blksize is fed into [`with_df.loop(blksize=blksize)`.](https://github.com/pyscf/pyscf/blob/master/pyscf/mp/dfmp2.py#L91) The MP2 energy requires products of 4-center integrals, like `<ij|ab>* <ij|ab>`, which means we need **double** sum of auxiliary index over each integral. This can't be accomplished by a single-layer loop over chunks of Q (as in b^Q_{ia}). So a simple solution is to build the full `Lov` tensor first.