### PR TITLE
Spin density analysis for UHF

### DIFF
--- a/pyscf/scf/test/test_uhf.py
+++ b/pyscf/scf/test/test_uhf.py
@@ -121,6 +121,13 @@ class KnownValues(unittest.TestCase):
         pop, chg = mf.mulliken_pop_meta_lowdin_ao(mol, dm, pre_orth_method='ano')
         self.assertAlmostEqual(numpy.linalg.norm(pop), 12.322626374896178, 9)
 
+    def test_mulliken_spin_pop(self):
+        Ms_true = [0.990027, 0.504987, 0.504987]
+        _, Ms = mf2.mulliken_spin_pop()
+        self.assertAlmostEqual(Ms[0], Ms_true[0],5)
+        self.assertAlmostEqual(Ms[1], Ms_true[1],5)
+        self.assertAlmostEqual(Ms[2], Ms_true[2],5)
+
     def test_scf(self):
         self.assertAlmostEqual(mf.e_tot, -76.026765673119627, 9)
 

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -478,9 +478,13 @@ def analyze(mf, verbose=logger.DEBUG, with_meta_lowdin=WITH_META_LOWDIN,
 
     dm = mf.make_rdm1(mo_coeff, mo_occ)
     if with_meta_lowdin:
+        log.note("\nTo work with the spin densities directly, `use mulliken_meta_spin()` only printing them here.\n")
+        mulliken_meta_spin(mf.mol, dm, s=ovlp_ao, verbose=log)
         return (mf.mulliken_meta(mf.mol, dm, s=ovlp_ao, verbose=log),
                 mf.dip_moment(mf.mol, dm, verbose=log))
     else:
+        log.note("\nTo work with the spin densities directly, `use mulliken_spin_pop()` only printing them here.\n")
+        mulliken_spin_pop(mf.mol, dm, s=ovlp_ao, verbose=log)
         return (mf.mulliken_pop(mf.mol, dm, s=ovlp_ao, verbose=log),
                 mf.dip_moment(mf.mol, dm, verbose=log))
 

--- a/pyscf/shciscf/shci.py
+++ b/pyscf/shciscf/shci.py
@@ -1000,6 +1000,10 @@ def writeSHCIConfFile(SHCI, nelec, Restart):
     f.write("orbitals {}\n".format(os.path.join(SHCI.runtimeDir, SHCI.integralFile)))
 
     f.write('nroots %r\n' % SHCI.nroots)
+    if SHCI.mol.symmetry and SHCI.mol.groupname:
+        f.write(f"pointGroup {SHCI.mol.groupname.lower()}\n")
+    if hasattr(SHCI, "wfnsym"):
+        f.write(f"irrep {SHCI.wfnsym}\n")
 
     # Variational Keyword Section
     f.write('\n#variational\n')


### PR DESCRIPTION
I added two new functions in `uhf.py`: `mulliken_spin_pop()` and `mulliken_meta_spin()` (aliased as `mulliken_spin_pop_meta_lowdin_ao()`). I've also added a test to `test_uhf.py` comparing the results from the new functionality to results from another package.

Let me know if there are other features/documentation/testing I should add. I've chosen to keep this function separate from `mf.analyze()` since calling it and returning the spin density would break the previous behaviour of `analyze()` in several scripts in PySCF. 

Thanks to @linusjoonho for pointing out the need for this and writing the `mulliken_spin_pop()` function.