### PR TITLE
Make breaksym behave the same way in atom and huckel guess.

### DIFF
--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -54,10 +54,10 @@ def init_guess_by_atom(mol, breaksym=BREAKSYM):
     dm = hf.init_guess_by_atom(mol)
     dma = dmb = dm*.5
     if breaksym:
-        #Add off-diagonal part for alpha DM
-        dma = mol.intor('int1e_ovlp') * 1e-2
+        #remove off-diagonal part of beta DM
+        dmb = numpy.zeros_like(dma)
         for b0, b1, p0, p1 in mol.aoslice_by_atom():
-            dma[p0:p1,p0:p1] = dmb[p0:p1,p0:p1]
+            dmb[p0:p1,p0:p1] = dma[p0:p1,p0:p1]
     return numpy.array((dma,dmb))
 
 def init_guess_by_huckel(mol, breaksym=BREAKSYM):
@@ -735,7 +735,13 @@ class UHF(hf.SCF):
         mo_energy = (mo_energy, mo_energy)
         mo_coeff = (mo_coeff, mo_coeff)
         mo_occ = self.get_occ(mo_energy, mo_coeff)
-        return self.make_rdm1(mo_coeff, mo_occ)
+        dma, dmb = self.make_rdm1(mo_coeff, mo_occ)
+        if mol.spin == 0 and breaksym:
+            #remove off-diagonal part of beta DM
+            dmb = numpy.zeros_like(dma)
+            for b0, b1, p0, p1 in mol.aoslice_by_atom():
+                dmb[p0:p1,p0:p1] = dma[p0:p1,p0:p1]
+        return numpy.array((dma,dmb))
 
     def init_guess_by_1e(self, mol=None, breaksym=BREAKSYM):
         if mol is None: mol = self.mol


### PR DESCRIPTION
This PR adds `breaksym` to the `huckel` guess, as well as fixes `breaksym` for the `atom` guess that used to

1. set the alpha density matrix to 1e-2 times the overlap and
2. set the block diagonal of the beta density matrix to that of the alpha matrix

i.e. the `atom` guess was not used at all with `breaksym`!