### PR TITLE
Patch libxc interface for compatibility with libxc 5

### DIFF
--- a/pyscf/lib/dft/libxc_itrf.c
+++ b/pyscf/lib/dft/libxc_itrf.c
@@ -157,8 +157,12 @@ static void _eval_xc(xc_func_type *func_x, int spin, int np,
 #if (XC_MAJOR_VERSION == 2 && XC_MINOR_VERSION < 2)
                         xc_gga(func_x, np, rho, sigma, ex,
                                vxc, vsigma, fxc, v2rhosigma, v2sigma2);
-#else
+#elif XC_MAJOR_VERSION < 5
                         xc_gga(func_x, np, rho, sigma, ex,
+                               vxc, vsigma, fxc, v2rhosigma, v2sigma2,
+                               kxc, v3rho2sigma, v3rhosigma2, v3sigma3);
+#else
+                        xc_gga_exc_vxc_fxc(func_x, np, rho, sigma, ex,
                                vxc, vsigma, fxc, v2rhosigma, v2sigma2,
                                kxc, v3rho2sigma, v3rhosigma2, v3sigma3);
 #endif
@@ -188,10 +192,15 @@ static void _eval_xc(xc_func_type *func_x, int spin, int np,
 #if (XC_MAJOR_VERSION == 2 && XC_MINOR_VERSION < 2)
                         xc_gga(func_x, np, rho, sigma, ex,
                                vxc, vsigma, fxc, v2rhosigma, v2sigma2);
-#else
+#elif XC_MAJOR_VERSION < 5
                         xc_gga(func_x, np, rho, sigma, ex,
                                vxc, vsigma, fxc, v2rhosigma, v2sigma2,
                                kxc, v3rho2sigma, v3rhosigma2, v3sigma3);
+#else
+                        xc_gga_exc_fxc_kxc(func_x, np, rho, sigma, ex,
+                               vxc, vsigma, fxc, v2rhosigma, v2sigma2,
+                               kxc, v3rho2sigma, v3rhosigma2, v3sigma3);
+
 #endif
                         free(sigma);
                 }
@@ -242,10 +251,17 @@ static void _eval_xc(xc_func_type *func_x, int spin, int np,
                                 v2sigmalapl = v2lapltau   + np * 4;
                                 v2sigmatau  = v2sigmalapl + np * 6; // np*6
                         }
+#if XC_MAJOR_VERSION >=5
+                        xc_mgga_exc_vxc_fxc(func_x, np, rho, sigma, lapl, tau, ex,
+                                vxc, vsigma, vlapl, vtau,
+                                fxc, v2sigma2, v2lapl2, v2tau2, v2rhosigma, v2rholapl,
+                                v2rhotau, v2sigmalapl, v2sigmatau, v2lapltau);
+#else
                         xc_mgga(func_x, np, rho, sigma, lapl, tau, ex,
                                 vxc, vsigma, vlapl, vtau,
                                 fxc, v2sigma2, v2lapl2, v2tau2, v2rhosigma, v2rholapl,
                                 v2rhotau, v2sigmalapl, v2sigmatau, v2lapltau);
+#endif
                         free(rho);
                         free(sigma);
                         free(lapl);
@@ -277,10 +293,17 @@ static void _eval_xc(xc_func_type *func_x, int spin, int np,
                                 v2sigmalapl = v2lapltau   + np;
                                 v2sigmatau  = v2sigmalapl + np;
                         }
+#if XC_MAJOR_VERSION >= 5
+                        xc_mgga_exc_vxc_fxc(func_x, np, rho, sigma, lapl, tau, ex,
+                                vxc, vsigma, vlapl, vtau,
+                                fxc, v2sigma2, v2lapl2, v2tau2, v2rhosigma, v2rholapl,
+                                v2rhotau, v2sigmalapl, v2sigmatau, v2lapltau);
+#else
                         xc_mgga(func_x, np, rho, sigma, lapl, tau, ex,
                                 vxc, vsigma, vlapl, vtau,
                                 fxc, v2sigma2, v2lapl2, v2tau2, v2rhosigma, v2rholapl,
                                 v2rhotau, v2sigmalapl, v2sigmatau, v2lapltau);
+#endif
                         free(sigma);
                 }
                 break;

--- a/pyscf/lib/dft/libxc_itrf.c
+++ b/pyscf/lib/dft/libxc_itrf.c
@@ -114,11 +114,19 @@ static void _eval_xc(xc_func_type *func_x, int spin, int np,
                                 rho[i*2+0] = rho_u[i];
                                 rho[i*2+1] = rho_d[i];
                         }
+#if XC_MAJOR_VERSION >= 5
+                        xc_lda_exc_vxc_fxc_kxc(func_x, np, rho, ex, vxc, fxc, kxc);
+#else
                         xc_lda(func_x, np, rho, ex, vxc, fxc, kxc);
+#endif
                         free(rho);
                 } else {
                         rho = rho_u;
+#if XC_MAJOR_VERSION >= 5
+                        xc_lda_exc_vxc_fxc_kxc(func_x, np, rho, ex, vxc, fxc, kxc);
+#else
                         xc_lda(func_x, np, rho, ex, vxc, fxc, kxc);
+#endif
                 }
                 break;
         case XC_FAMILY_GGA:
@@ -162,7 +170,7 @@ static void _eval_xc(xc_func_type *func_x, int spin, int np,
                                vxc, vsigma, fxc, v2rhosigma, v2sigma2,
                                kxc, v3rho2sigma, v3rhosigma2, v3sigma3);
 #else
-                        xc_gga_exc_vxc_fxc(func_x, np, rho, sigma, ex,
+                        xc_gga_exc_vxc_fxc_kxc(func_x, np, rho, sigma, ex,
                                vxc, vsigma, fxc, v2rhosigma, v2sigma2,
                                kxc, v3rho2sigma, v3rhosigma2, v3sigma3);
 #endif
@@ -197,7 +205,7 @@ static void _eval_xc(xc_func_type *func_x, int spin, int np,
                                vxc, vsigma, fxc, v2rhosigma, v2sigma2,
                                kxc, v3rho2sigma, v3rhosigma2, v3sigma3);
 #else
-                        xc_gga_exc_fxc_kxc(func_x, np, rho, sigma, ex,
+                        xc_gga_exc_vxc_fxc_kxc(func_x, np, rho, sigma, ex,
                                vxc, vsigma, fxc, v2rhosigma, v2sigma2,
                                kxc, v3rho2sigma, v3rhosigma2, v3sigma3);
 


### PR DESCRIPTION
libxc 5 has 4th derivatives for all classes of functionals. This has also resulted in changes to the worker function APIs. Compatibility wrappers were, however, introduced for easier porting of codes.