### PR TITLE
allow passing breaksym in arguments for kmf calculations

### DIFF
--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -387,7 +387,7 @@ class KUHF(khf.KSCF, pbcuhf.UHF):
                     'alpha = %d beta = %d', *self.nelec)
         return self
 
-    def get_init_guess(self, cell=None, key='minao'):
+    def get_init_guess(self, cell=None, key='minao', breaksym=False):
         if cell is None:
             cell = self.cell
         dm_kpts = None
@@ -405,9 +405,9 @@ class KUHF(khf.KSCF, pbcuhf.UHF):
             except (IOError, KeyError):
                 logger.warn(self, 'Fail to read %s. Use MINAO initial guess',
                             self.chkfile)
-                dm = self.init_guess_by_minao(cell)
+                dm = self.init_guess_by_minao(cell, breaksym=breaksym)
         else:
-            dm = self.init_guess_by_minao(cell)
+            dm = self.init_guess_by_minao(cell, breaksym=breaksym)
 
         if dm_kpts is None:
             nao = dm[0].shape[-1]

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -119,7 +119,8 @@ Keyword argument "init_dm" is replaced by "dm0"''')
 
     mol = mf.mol
     if dm0 is None:
-        dm = mf.get_init_guess(mol, mf.init_guess)
+        breaksym = kwargs.get("breaksym", None)
+        dm = mf.get_init_guess(mol, mf.init_guess, breaksym=breaksym)
     else:
         dm = dm0
 

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -31,7 +31,7 @@ BREAKSYM = getattr(__config__, 'scf_uhf_init_guess_breaksym', True)
 MO_BASE = getattr(__config__, 'MO_BASE', 1)
 
 
-def init_guess_by_minao(mol, breaksym=BREAKSYM):
+def init_guess_by_minao(mol, breaksym=None):
     '''Generate initial guess density matrix based on ANO basis, then project
     the density matrix to the basis set defined by ``mol``
 
@@ -40,6 +40,8 @@ def init_guess_by_minao(mol, breaksym=BREAKSYM):
     '''
     dm = hf.init_guess_by_minao(mol)
     dma = dmb = dm*.5
+    if breaksym is None:
+        breaksym = BREAKSYM
     if breaksym:
         #remove off-diagonal part of beta DM
         dmb = numpy.zeros_like(dma)


### PR DESCRIPTION
Hi there,

I am using the KUHF function in pbc.scf to do some k-space mean-field calculations. I found that the initial guess of KUHF breaks spin symmetry by default, which causes unphysical results in my calculations. I tried to turn it off but found that breaksym argument is defined as an environment variable, which makes this option very inflexible. Therefore, I added the argument "breaksym" to the get_init_guess() function with the minimal change to the code. I only made changes to the parts that I am using.

Thanks,
Chong