### PR TITLE
PiOS fix

### DIFF
--- a/examples/mcscf/43-PiOS-C8H10.py
+++ b/examples/mcscf/43-PiOS-C8H10.py
@@ -60,8 +60,8 @@ mf.kernel()
 PiAtoms = [1,2,3,4,5,6,7,8]  #list atom numbers for your pi-system, counting from 1
 N_Core,N_Actorb, N_Virt,nelec,coeff=MakePiOS(mol,mf,PiAtoms)  
 #if you don't want the entire pi-space, use MakePiOS(mol,mf,PiAtomsList, nPiOcc,nPiVirt), where nPiOcc and nPiVirt determine how many HOMOs and LUMOs should be picked up
-nalpha=(nelec+mol.spin)/2
-nbeta=(nelec-mol.spin)/2
+nalpha=(nelec+mol.spin)//2
+nbeta=(nelec-mol.spin)//2
 
 #=================================run CASSCF
 mycas = mcscf.CASSCF(mf, N_Actorb, [nalpha,nbeta])

--- a/pyscf/mcscf/PiOS.py
+++ b/pyscf/mcscf/PiOS.py
@@ -515,8 +515,8 @@ def MakePiSystemOrbitals(TargetName, iTargetAtomsForPlane_, iTargetAtomsForBasis
     print("    size of CAomix2       {} ".format(CAoMix.shape[1]))
 
 
-    nOccOrbExpected=nPiElec/2
-    nVirtOrbExpected=nTargetIb - nPiElec/2
+    nOccOrbExpected=nPiElec//2
+    nVirtOrbExpected=nTargetIb - nPiElec//2
     CPiOcc = MakeOverlappingOrbSubspace("Pi", "Occ", COcc, nOccOrbExpected,   CTargetIb, S1, Fock)
     CPiVir = MakeOverlappingOrbSubspace("Pi", "Vir", CVir, nVirtOrbExpected,   CTargetIb, S1, Fock)
     return CPiOcc, CPiVir,nOccOrbExpected,nVirtOrbExpected


### PR DESCRIPTION
Guarantee integer division both in example file and in PiOS code.
Could also be done through a cast to int, I don't know which one you prefer.

Fixes #595 

