### PR TITLE
Fix broken code in fciqmc

### DIFF
--- a/pyscf/fciqmcscf/fciqmc.py
+++ b/pyscf/fciqmcscf/fciqmc.py
@@ -534,7 +534,7 @@ def execute_fciqmc(fciqmcci):
         logger.info(fciqmcci, 'Waiting for density matrices and output file '
                               'to be returned.')
         try:
-            if sys.version_info >= (3,)
+            if sys.version_info[0] >= 3:
                 raw_input = input
             raw_input("Press Enter to continue with calculation...")
         except:


### PR DESCRIPTION
Fixes the error
```
*** Error compiling '/builddir/build/BUILDROOT/python-pyscf-1.7.2-1.fc33.x86_64/usr/lib64/python3.8/site-packages/pyscf/fciqmcscf/fciqmc.py'...
  File "/usr/lib64/python3.8/site-packages/pyscf/fciqmcscf/fciqmc.py", line 536
    if sys.version_info >= (3,)
                              ^
SyntaxError: invalid syntax
```