### PR TITLE
Update cppe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ install:
   - cd $TRAVIS_BUILD_DIR/pyscf/lib &&
     curl http://www.sunqm.net/pyscf/files/bin/pyscf-1.7-deps.tar.gz | tar xzf -
   - pip install pyberny geometric
+  - if [[ $TRAVIS_PYTHON_VERSION != 2.7 && $TRAVIS_PYTHON_VERSION != 3.5 ]]; then pip install git+https://github.com/maxscheurer/cppe.git; fi
   - cd $TRAVIS_BUILD_DIR/pyscf/lib &&
     mkdir build &&
     cd build &&

--- a/examples/solvent/04-pe_potfile_from_pyframe.py
+++ b/examples/solvent/04-pe_potfile_from_pyframe.py
@@ -7,7 +7,7 @@
 This example shows how to call the PyFraME library to generate the potential
 file for the CPPE library used by pyscf polarizable embedding method
 
-More details of PyFraME usage can be found in CPPE paper arXiv:1804.03598
+More details of PyFraME usage can be found in PE tutorial paper arXiv:1804.03598
 '''
 
 import pyframe

--- a/examples/solvent/04-scf_with_pe.py
+++ b/examples/solvent/04-scf_with_pe.py
@@ -7,15 +7,12 @@
 A simple example of using polarizable embedding model in the mean-field
 calculations. This example requires the cppe library
 
-https://github.com/maxscheurer/cppe
-arXiv:1804.03598
+GitHub:      https://github.com/maxscheurer/cppe
+Code:        10.5281/zenodo.3345696
+Publication: https://doi.org/10.1021/acs.jctc.9b00758
 
-The CPPE library needs to be built from sources (according to the CPPE document):
-
-mkdir build && cd build && cmake -DENABLE_PYTHON_INTERFACE=ON .. && make
-
-If successfully built, find the directory where the file cppe.*.so locates
-then put the directory in PYTHONPATH.
+The CPPE library can be installed via:
+pip install git+https://github.com/maxscheurer/cppe.git
 
 The potfile required by this example can be generated with the script
 04-pe_potfile_from_pyframe.py

--- a/pyscf/solvent/__init__.py
+++ b/pyscf/solvent/__init__.py
@@ -82,17 +82,16 @@ def PE(method_or_mol, solvent_obj, dm=None):
         method_or_mol (pyscf method object or gto.Mole object)
             If method_or_mol is gto.Mole object, this function returns a
             PolEmbed object constructed with this Mole object.
-        solvent_obj (PolEmbed object or cppe.PeOptions object or str)
+        solvent_obj (PolEmbed object or dictionary with options or str)
             If solvent_obj is an object of PolEmbed class, the PE-enabled
             method will be created using solvent_obj.
-            If solvent_obj is cppe.PeOptions or str, an PolEmbed object will
+            If solvent_obj is dict or str, a PolEmbed object will
             be created first with the solvent_obj, on top of which PE-enabled
             method will be created.
 
     Examples:
 
-    >>> pe_options = cppe.PeOptions()
-    >>> pe_options.potfile = "pyframe.pot"
+    >>> pe_options = {"potfile": "pyframe.pot"}
     >>> mf = PE(scf.RHF(mol), pe_options)
     >>> mf.kernel()
     '''

--- a/pyscf/solvent/pol_embed.py
+++ b/pyscf/solvent/pol_embed.py
@@ -19,15 +19,12 @@
 '''
 This interface requires the cppe library
 
-https://github.com/maxscheurer/cppe
-arXiv:1804.03598
+GitHub:      https://github.com/maxscheurer/cppe
+Code:        10.5281/zenodo.3345696
+Publication: https://doi.org/10.1021/acs.jctc.9b00758
 
-The CPPE library needs to be built from sources (according to the CPPE document):
-
-mkdir build && cd build && cmake -DENABLE_PYTHON_INTERFACE=ON .. && make
-
-If successfully built, find the directory where the file cppe.*.so locates
-then put the directory in PYTHONPATH.
+The CPPE library can be installed via:
+pip install git+https://github.com/maxscheurer/cppe.git
 
 The potential file required by CPPE library needs to be generated from the
 PyFraME library  https://gitlab.com/FraME-projects/PyFraME
@@ -35,10 +32,11 @@ PyFraME library  https://gitlab.com/FraME-projects/PyFraME
 
 import sys
 import numpy
+from pkg_resources import parse_version
 
 try:
     import cppe
-except:
+except ModuleNotFoundError:
     sys.stderr.write('cppe library was not found\n')
     sys.stderr.write(__doc__)
     raise
@@ -98,20 +96,27 @@ class PolEmbed(lib.StreamObject):
 ##################################################
 # don't modify the following attributes, they are not input options
         if isinstance(options_or_potfile, str):
-            options = cppe.PeOptions()
-            options.potfile = options_or_potfile
+            options = {"potfile": options_or_potfile}
         else:
             options = options_or_potfile
 
-        if not isinstance(options, cppe.PeOptions):
-            raise TypeError("Invalid type for options.")
+        min_version = "0.2.0"
+        if parse_version(cppe.__version__) < parse_version(min_version):
+            raise ModuleNotFoundError("cppe version {} is required at least. "
+                                      "Version {}"
+                                      " was found.".format(min_version,
+                                                           cppe.__version__))
+
+        if not isinstance(options, dict):
+            raise TypeError("Options should be a dictionary.")
 
         self.options = options
         self.cppe_state = self._create_cppe_state(mol)
         self.potentials = self.cppe_state.potentials
         self.V_es = None
 
-        # e (the dielectric correction) and v (the additional potential) are
+        # e (the electrostatic and induction energy)
+        # and v (the additional potential) are
         # updated during the SCF iterations
         self.e = None
         self.v = None
@@ -121,20 +126,12 @@ class PolEmbed(lib.StreamObject):
 
     def dump_flags(self, verbose=None):
         logger.info(self, '******** %s flags ********', self.__class__)
-        options = self.options
+        options = self.cppe_state.options
+        option_keys = cppe.valid_option_keys
         logger.info(self, 'frozen = %s'       , self.frozen)
         logger.info(self, 'equilibrium_solvation = %s', self.equilibrium_solvation)
-        logger.info(self, "cppe.potfile                  = %s", options.potfile)
-        logger.info(self, "cppe.iso_pol                  = %s", options.iso_pol)
-        logger.info(self, "cppe.induced_thresh           = %s", options.induced_thresh)
-        logger.info(self, "cppe.do_diis                  = %s", options.do_diis)
-        logger.info(self, "cppe.diis_start_norm          = %s", options.diis_start_norm)
-        logger.info(self, "cppe.maxiter                  = %s", options.maxiter)
-        logger.info(self, "cppe.damp_induced             = %s", options.damp_induced)
-        logger.info(self, "cppe.damping_factor_induced   = %s", options.damping_factor_induced)
-        logger.info(self, "cppe.damp_multipole           = %s", options.damp_multipole)
-        logger.info(self, "cppe.damping_factor_multipole = %s", options.damping_factor_multipole)
-        logger.info(self, "cppe.pe_border                = %s", options.pe_border)
+        for key in option_keys:
+            logger.info(self, "cppe.%s = %s", key, options[key])
         return self
 
     def _create_cppe_state(self, mol):
@@ -344,9 +341,8 @@ EXCLISTS
 2   1  3
 3   1  2''')
         f.flush()
-        pe_options = cppe.PeOptions()
-        pe_options.potfile = f.name
-        #pe = pol_embed.PolEmbed(mol, pe_options)
+        pe_options = {"potfile": f.name}
+        # pe = pol_embed.PolEmbed(mol, pe_options)
         #mf = PE(mf, pe).run()
         mf = PE(mf, pe_options).run()
         print(mf.e_tot - -112.35232445743728)

--- a/pyscf/solvent/test/test_pol_embed.py
+++ b/pyscf/solvent/test/test_pol_embed.py
@@ -201,9 +201,7 @@ class TestPolEmbed(unittest.TestCase):
         '''
         mol.basis = "STO-3G"
         mol.build()
-        pe_options = cppe.PeOptions()
-        pe_options.potfile = os.path.join(dname, "pna_6w.potential")
-        print(pe_options.potfile)
+        pe_options = {"potfile": os.path.join(dname, "pna_6w.potential")}
         pe = pol_embed.PolEmbed(mol, pe_options)
         mf = solvent.PE(scf.RHF(mol), pe)
         mf.conv_tol = 1e-10


### PR DESCRIPTION
This PR updates the code to the newest version of `cppe` for polarizable embedding calculations.

- options are now handled as `dict` on the Python side
- updated examples and code comments
- require a minimal version (`v0.2.0`)
- test with `cppe` on Travis
