### PR TITLE
Adding natural orbitals occupations to mc.mo_occ

### DIFF
--- a/pyscf/mcscf/casci.py
+++ b/pyscf/mcscf/casci.py
@@ -422,7 +422,7 @@ def canonicalize(mc, mo_coeff=None, ci=None, eris=None, sort=False,
     nmo = mo_coeff.shape[1]
     fock_ao = mc.get_fock(mo_coeff, ci, eris, casdm1, verbose)
     if cas_natorb:
-        mo_coeff1, ci, occ = mc.cas_natorb(mo_coeff, ci, eris, sort, casdm1,
+        mo_coeff1, ci, mc.mo_occ = mc.cas_natorb(mo_coeff, ci, eris, sort, casdm1,
                                            verbose, with_meta_lowdin)
     else:
         # Keep the active space unchanged by default.  The rotation in active space
@@ -914,9 +914,9 @@ To enable the solvent model for CASCI, the following code needs to be called
     @lib.with_doc(cas_natorb.__doc__)
     def cas_natorb_(self, mo_coeff=None, ci=None, eris=None, sort=False,
                     casdm1=None, verbose=None, with_meta_lowdin=WITH_META_LOWDIN):
-        self.mo_coeff, self.ci, occ = cas_natorb(self, mo_coeff, ci, eris,
+        self.mo_coeff, self.ci, self.mo_occ = cas_natorb(self, mo_coeff, ci, eris,
                                                  sort, casdm1, verbose)
-        return self.mo_coeff, self.ci, occ
+        return self.mo_coeff, self.ci, self.mo_occ
 
     def get_fock(self, mo_coeff=None, ci=None, eris=None, casdm1=None,
                  verbose=None):

--- a/pyscf/mcscf/casci.py
+++ b/pyscf/mcscf/casci.py
@@ -658,6 +658,8 @@ class CASCI(lib.StreamObject):
         mo_energy : ndarray
             Diagonal elements of general Fock matrix (in mo_coeff
             representation).
+        mo_occ : ndarray
+            Occupation numbers of natural orbitals if natorb is specified.
 
     Examples:
 
@@ -712,6 +714,7 @@ class CASCI(lib.StreamObject):
         self.ci = None
         self.mo_coeff = mf.mo_coeff
         self.mo_energy = mf.mo_energy
+        self.mo_occ = None
         self.converged = False
 
         keys = set(('natorb', 'canonicalization', 'sorting_mo_energy'))

--- a/pyscf/mcscf/test/test_casci.py
+++ b/pyscf/mcscf/test/test_casci.py
@@ -96,6 +96,11 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(float(abs(mo1-mo2).max()), 0, 9)
         self.assertAlmostEqual(ci1.ravel().dot(ci2.ravel()), 1, 9)
 
+        # Make sure that mc.mo_occ has been set and that the NOONs add to nelectron
+        mo_occ = getattr(mc1, "mo_occ", numpy.array([]))
+        self.assertNotEqual(mo_occ, numpy.array([]))
+        self.assertAlmostEqual(numpy.sum(mo_occ), mc1.mol.nelectron, 9)
+
     def test_multi_roots(self):
         mc1 = mcscf.CASCI(m, 4, 4)
         mc1.fcisolver.nroots = 2


### PR DESCRIPTION
## Description
This PR resolves #615 and added the natural orbital occupations as an attribute for `mcscf.casci` objects meaning derived classes too, e.g. `mcscf.CASSCF`.

## Code changes
- `mcscf/casci.py`: I changed the `cas_natorb_()` function to automatically set the attribute `mo_occ` of the `mc` object.

- `mcscf/test/test_casci.py`: I added some assertion checks to `test_cas_natorb()` to check that the `mo_occ` attribute was properly set and that the natural orbital occupations sum to an appropriate value.

## Next Steps
If anyone has any comments on this, let me know!