### PR TITLE
Gaussian'94 format defines l=7 function as J, not K.

### DIFF
--- a/pyscf/gto/basis/parse_gaussian.py
+++ b/pyscf/gto/basis/parse_gaussian.py
@@ -37,7 +37,8 @@ MAPSPDF = {'S': 0,
            'G': 4,
            'H': 5,
            'I': 6,
-           'K': 7}
+           'J': 7,
+           'K': 8}
 
 DELIMETER = '****'
 
@@ -100,6 +101,9 @@ def _parse(raw_basis, optimize=True):
             elif key[0] == 'SP':
                 basis_add.append([0])
                 basis_add.append([1])
+            elif len(key)>2 and key[0][:2] in ['l=', 'L=']:
+                # Angular momentum defined explicitly
+                basis_add.append([int(key[0][2:])])
             else:
                 basis_add.append([MAPSPDF[key[0]]])
         else:


### PR DESCRIPTION
This PR fixes a bug in the Gaussian'94 basis set parser, since in the Gaussian standard the l=7 function is J, not K. (Unfortunately, at least the old basis set exchange had a similar bug, too.)

This PR also adds support for the l= format, with which the issue can be circumvented altogether.