### PR TITLE
Batching of integrals for PE and PE(ECP) repulsive potentials

### DIFF
--- a/.github/workflows/ci_linux/python_deps.sh
+++ b/.github/workflows/ci_linux/python_deps.sh
@@ -6,5 +6,5 @@ pip install pyberny geometric
 #cppe
 version=$(python -c 'import sys; version=sys.version_info[:2]; print("{0}.{1}".format(*version))')
 if [ $version != '2.7' ] && [ $version != '3.5' ]; then
-    pip install git+https://github.com/maxscheurer/cppe.git
+    pip install cppe
 fi

--- a/.github/workflows/ci_macos/python_deps.sh
+++ b/.github/workflows/ci_macos/python_deps.sh
@@ -6,5 +6,5 @@ pip install pyberny geometric
 #cppe
 version=$(python -c 'import sys; version=sys.version_info[:2]; print("{0}.{1}".format(*version))')
 if [ $version != '2.7' ] && [ $version != '3.5' ]; then
-    pip install git+https://github.com/maxscheurer/cppe.git
+    pip install cppe
 fi

--- a/pyscf/solvent/pol_embed.py
+++ b/pyscf/solvent/pol_embed.py
@@ -24,7 +24,7 @@ Code:        10.5281/zenodo.3345696
 Publication: https://doi.org/10.1021/acs.jctc.9b00758
 
 The CPPE library can be installed via:
-pip install git+https://github.com/maxscheurer/cppe.git
+pip install cppe
 
 The potential file required by CPPE library needs to be generated from the
 PyFraME library  https://gitlab.com/FraME-projects/PyFraME
@@ -159,7 +159,7 @@ class PolEmbed(lib.StreamObject):
         else:
             options = options_or_potfile
 
-        min_version = "0.2.0"
+        min_version = "0.3.1"
         if parse_version(cppe.__version__) < parse_version(min_version):
             raise ModuleNotFoundError("cppe version {} is required at least. "
                                       "Version {}"
@@ -301,7 +301,7 @@ class PolEmbed(lib.StreamObject):
         self.cppe_state.energies["Electrostatic"]["Electronic"] = (
             e_static[0]
         )
-        
+
         e_ecp = 0.0
         if self.do_ecp:
             e_ecp = numpy.einsum('ij,xij->x', self.V_ecp, dms)[0]


### PR DESCRIPTION
For large environments, `pyscf` can run into memory issues in PE calculations. This PR splits up the integral computations into individual batches, depending on how much memory is available.

Furthermore, this PR adds the feature to use repulsive potentials on the environment sites to avoid electron spill-out (https://doi.org/10.1021/acs.jctc.9b01162).