### PR TITLE
MAINT: Reduce code duplication and fix missing ECPscalar contribution in FCIDUMP interface

### DIFF
--- a/pyscf/tools/fcidump.py
+++ b/pyscf/tools/fcidump.py
@@ -121,7 +121,7 @@ def write_hcore(fout, h, nmo, tol=TOL, float_format=DEFAULT_FLOAT_FORMAT):
 
 
 def from_chkfile(filename, chkfile, tol=TOL, float_format=DEFAULT_FLOAT_FORMAT,
-                 molpro_orbsym=MOLPRO_ORBSYM):
+                 molpro_orbsym=MOLPRO_ORBSYM, orbsym=None):
     '''Read SCF results from PySCF chkfile and transform 1-electron,
     2-electron integrals using the SCF orbitals.  The transformed integrals is
     written to FCIDUMP
@@ -140,25 +140,12 @@ def from_chkfile(filename, chkfile, tol=TOL, float_format=DEFAULT_FLOAT_FORMAT,
         # Not support the chkfile from pbc calculation
         raise RuntimeError('Non-orthogonal orbitals found in chkfile')
 
-    with open(filename, 'w') as fout:
-        if mol.symmetry:
-            orbsym = symm.label_orb_symm(mol, mol.irrep_id,
-                                         mol.symm_orb, mo_coeff, check=False)
-            if molpro_orbsym:
-                orbsym = [ORBSYM_MAP[mol.groupname][i] for i in orbsym]
-            write_head(fout, nmo, mol.nelectron, mol.spin, orbsym)
-        else:
-            write_head(fout, nmo, mol.nelectron, mol.spin)
-
-        eri = ao2mo.full(mol, mo_coeff, verbose=0)
-        write_eri(fout, ao2mo.restore(8, eri, nmo), nmo, tol, float_format)
-
-        t = mol.intor_symmetric('int1e_kin')
-        v = mol.intor_symmetric('int1e_nuc')
-        h = reduce(numpy.dot, (mo_coeff.T, t+v, mo_coeff))
-        write_hcore(fout, h, nmo, tol, float_format)
-        output_format = ' ' + float_format + '  0  0  0  0\n'
-        fout.write(output_format % mol.energy_nuc())
+    if mol.symmetry:
+        orbsym = symm.label_orb_symm(mol, mol.irrep_id,
+                                     mol.symm_orb, mo_coeff, check=False)
+    from_mo(mol, filename, mo_coeff, orbsym=orbsym, tol=tol,
+            float_format=float_format, molpro_orbsym=molpro_orbsym,
+            ms=mol.spin)
 
 def from_integrals(filename, h1e, h2e, nmo, nelec, nuc=0, ms=0, orbsym=None,
                    tol=TOL, float_format=DEFAULT_FLOAT_FORMAT):
@@ -172,7 +159,7 @@ def from_integrals(filename, h1e, h2e, nmo, nelec, nuc=0, ms=0, orbsym=None,
 
 def from_mo(mol, filename, mo_coeff, orbsym=None,
             tol=TOL, float_format=DEFAULT_FLOAT_FORMAT,
-            molpro_orbsym=MOLPRO_ORBSYM):
+            molpro_orbsym=MOLPRO_ORBSYM, ms=0):
     '''Use the given MOs to transfrom the 1-electron and 2-electron integrals
     then dump them to FCIDUMP.
 
@@ -188,12 +175,11 @@ def from_mo(mol, filename, mo_coeff, orbsym=None,
         orbsym = getattr(mo_coeff, 'orbsym', None)
         if molpro_orbsym and orbsym is not None:
             orbsym = [ORBSYM_MAP[mol.groupname][i] for i in orbsym]
-    t = mol.intor_symmetric('int1e_kin')
-    v = mol.intor_symmetric('int1e_nuc')
-    h1e = reduce(numpy.dot, (mo_coeff.T, t+v, mo_coeff))
+    h1ao = scf.hf.get_hcore(mol)
+    h1e = reduce(numpy.dot, (mo_coeff.T, h1ao, mo_coeff))
     eri = ao2mo.full(mol, mo_coeff, verbose=0)
     nuc = mol.energy_nuc()
-    from_integrals(filename, h1e, eri, h1e.shape[0], mol.nelec, nuc, 0, orbsym,
+    from_integrals(filename, h1e, eri, h1e.shape[0], mol.nelec, nuc, ms, orbsym,
                    tol, float_format)
 
 def from_scf(mf, filename, tol=TOL, float_format=DEFAULT_FLOAT_FORMAT,


### PR DESCRIPTION
Use of `scf.hf.get_hcore(mol)` instead of manual computation of hcore in the fcidump interface fixes the missing ECPscalar contribution, see also a911d5bd.
`fcidump.from_chkfile` now calls `fcidump.from_mo` instead of repeating its code.