### PR TITLE
Add AGF2 module

### DIFF
--- a/FEATURES
+++ b/FEATURES
@@ -106,6 +106,13 @@
   - CI wavefunction overlap
 
 
+* AGF2
+
+  - Canonical RAGF2, UAGF2
+  - Density-fitting RAGF2, UAGF2 with optional MPI support
+  - General moment self-consistent RAGF2 and UAGF2 via _slow methods
+
+
 * Analytical Nuclear Gradients
 
   - Non-relativistic HF nuclear gradients

--- a/examples/agf2/00-simple_agf2.py
+++ b/examples/agf2/00-simple_agf2.py
@@ -18,7 +18,7 @@ mf.run()
 # Run an AGF2 calculation
 gf2 = agf2.AGF2(mf)
 gf2.conv_tol = 1e-7
-gf2.run()
+gf2.run(verbose=4)
 
 # Print the first 3 ionization potentials
 gf2.ipagf2(nroots=3)

--- a/examples/agf2/00-simple_agf2.py
+++ b/examples/agf2/00-simple_agf2.py
@@ -6,9 +6,9 @@
 '''
 A simple example of restricted AGF2.
 
-AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
-  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
-  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
+Default AGF2 corresponds to the AGF2(1,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 1090 (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
 '''
 
 from pyscf import gto, scf, agf2

--- a/examples/agf2/00-simple_agf2.py
+++ b/examples/agf2/00-simple_agf2.py
@@ -5,7 +5,9 @@
 #
 
 '''
-A simple example of restricted AGF2.
+A simple example of restricted AGF2. AGF2 will compute correlation energies, one-particle
+properties and charged excitations / energy levels via an iterated, renormalized perturbation
+theory.
 
 Default AGF2 corresponds to the AGF2(1,0) method outlined in the papers:
   - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 1090 (2020).
@@ -26,6 +28,7 @@ gf2.conv_tol = 1e-7
 gf2.run(verbose=4)
 
 # Print the first 3 ionization potentials
+# Note that there is no additional cost to write out larger numbers of excitations.
 gf2.ipagf2(nroots=3)
 
 # Print the first 3 electron affinities

--- a/examples/agf2/00-simple_agf2.py
+++ b/examples/agf2/00-simple_agf2.py
@@ -14,7 +14,7 @@ Default AGF2 corresponds to the AGF2(1,0) method outlined in the papers:
 
 from pyscf import gto, scf, agf2
 
-mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='cc-pvdz', verbose=5)
+mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='cc-pvdz')
 
 mf = scf.RHF(mol)
 mf.conv_tol = 1e-12

--- a/examples/agf2/00-simple_agf2.py
+++ b/examples/agf2/00-simple_agf2.py
@@ -5,6 +5,10 @@
 
 '''
 A simple example of restricted AGF2.
+
+AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
 '''
 
 from pyscf import gto, scf, agf2

--- a/examples/agf2/01-simple_uagf2.py
+++ b/examples/agf2/01-simple_uagf2.py
@@ -18,7 +18,7 @@ mf.run()
 # Run an AGF2 calculation
 gf2 = agf2.AGF2(mf)
 gf2.conv_tol = 1e-7
-gf2.run()
+gf2.run(verbose=4)
 
 # Print the first 3 ionization potentials
 gf2.ipagf2(nroots=3)

--- a/examples/agf2/01-simple_uagf2.py
+++ b/examples/agf2/01-simple_uagf2.py
@@ -5,6 +5,10 @@
 
 '''
 A simple example of unrestricted AGF2.
+
+AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
 '''
 
 from pyscf import gto, scf, agf2

--- a/examples/agf2/01-simple_uagf2.py
+++ b/examples/agf2/01-simple_uagf2.py
@@ -6,9 +6,9 @@
 '''
 A simple example of unrestricted AGF2.
 
-AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
-  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
-  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
+Default AGF2 corresponds to the AGF2(1,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 1090 (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
 '''
 
 from pyscf import gto, scf, agf2

--- a/examples/agf2/01-simple_uagf2.py
+++ b/examples/agf2/01-simple_uagf2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+#         George H. Booth <george.booth@kcl.ac.uk>
 #
 
 '''

--- a/examples/agf2/02-dfagf2.py
+++ b/examples/agf2/02-dfagf2.py
@@ -18,7 +18,7 @@ mf.run()
 # Run an AGF2 calculation
 gf2 = agf2.AGF2(mf)
 gf2.conv_tol = 1e-7
-gf2.run()
+gf2.run(verbose=4)
 
 # Print the first 3 ionization potentials
 gf2.ipagf2(nroots=3)

--- a/examples/agf2/02-dfagf2.py
+++ b/examples/agf2/02-dfagf2.py
@@ -4,10 +4,11 @@
 #
 
 '''
-An example of restricted AGF2 with density fitting.
+An example of restricted AGF2 with density fitting and get the 1RDM
 '''
 
 from pyscf import gto, scf, agf2
+import numpy as np
 
 mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='cc-pvdz')
 
@@ -25,3 +26,8 @@ gf2.ipagf2(nroots=3)
 
 # Print the first 3 electron affinities
 gf2.eaagf2(nroots=3)
+
+# Get the density matrix and calculate dipole moments:
+dm = gf2.make_rdm1()
+mol.set_common_origin([0,0,0])
+dipole = np.einsum('xij,ji->x', mol.intor('int1e_r'), dm)

--- a/examples/agf2/02-dfagf2.py
+++ b/examples/agf2/02-dfagf2.py
@@ -5,6 +5,10 @@
 
 '''
 An example of restricted AGF2 with density fitting and get the 1RDM
+
+AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
 '''
 
 from pyscf import gto, scf, agf2

--- a/examples/agf2/02-dfagf2.py
+++ b/examples/agf2/02-dfagf2.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+#         George H. Booth <george.booth@kcl.ac.uk>
 #
 
 '''

--- a/examples/agf2/03-photoemission_spectra.py
+++ b/examples/agf2/03-photoemission_spectra.py
@@ -6,6 +6,10 @@
 '''
 Use the converged Green's function to build a photoemission spectrum
 following an AGF2 calculation.
+
+AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
 '''
 
 import numpy

--- a/examples/agf2/03-photoemission_spectra.py
+++ b/examples/agf2/03-photoemission_spectra.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+#         George H. Booth <george.booth@kcl.ac.uk>
 #
 
 '''
@@ -32,6 +33,9 @@ eta = 0.02
 spectrum = gf.real_freq_spectrum(grid, eta=eta)
 # The array `spectrum` is now a length nfreq array of the
 # spectral function -1/pi * Tr[Im[G(\omega + i\eta)]].
+# Note that for UHF AGF2 calculations, the individual gf 
+# elements can be passed to real_freq_spectrum in order 
+# to obtain the spin-resolved spectra.
 
 # We can also build the self-energy on the real-frequency axis
 # by accessing the renormalized auxiliary states:

--- a/examples/agf2/03-photoemission_spectra.py
+++ b/examples/agf2/03-photoemission_spectra.py
@@ -32,5 +32,12 @@ grid = numpy.arange(-10.0, 10.0, 1000)
 eta = 0.02
 spectrum = gf.real_freq_spectrum(grid, eta=eta)
 
-# The array `spectrum` is now a (nfreq x nmo x nmo) array of the
-# spectral function -1/pi * G(\omega + i\eta).
+# The array `spectrum` is now a length nfreq array of the
+# spectral function -1/pi * Tr[Im[G(\omega + i\eta)]].
+
+# We can also build the self-energy on the real-frequency axis
+# by accessing the poles:
+e = gf2.se.energy - gf2.se.chempot
+v = gf2.se.coupling
+denom = grid[:,None] - (e + np.sign(e)*eta*1.0j)[None]
+se = numpy.einsum('xk,yk,wk->wxy', v, v.conj(), 1./denom)

--- a/examples/agf2/03-photoemission_spectra.py
+++ b/examples/agf2/03-photoemission_spectra.py
@@ -4,12 +4,11 @@
 #
 
 '''
-Use the converged Green's function to build a photoemission spectrum
-following an AGF2 calculation.
+Use a converged AGF2 calculation to build the full photoemission (quasiparticle) spectrum
 
-AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
-  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
-  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
+Default AGF2 corresponds to the AGF2(1,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 1090 (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
 '''
 
 import numpy
@@ -31,12 +30,11 @@ gf = gf2.gf
 grid = numpy.linspace(-10.0, 10.0, 1000)
 eta = 0.02
 spectrum = gf.real_freq_spectrum(grid, eta=eta)
-
 # The array `spectrum` is now a length nfreq array of the
 # spectral function -1/pi * Tr[Im[G(\omega + i\eta)]].
 
 # We can also build the self-energy on the real-frequency axis
-# by accessing the poles:
+# by accessing the renormalized auxiliary states:
 e = gf2.se.energy - gf2.se.chempot
 v = gf2.se.coupling
 denom = grid[:,None] - (e + numpy.sign(e)*eta*1.0j)[None]

--- a/examples/agf2/03-photoemission_spectra.py
+++ b/examples/agf2/03-photoemission_spectra.py
@@ -28,7 +28,7 @@ gf2.run()
 
 # Access the GreensFunction object and compute the spectrum
 gf = gf2.gf
-grid = numpy.arange(-10.0, 10.0, 1000)
+grid = numpy.linspace(-10.0, 10.0, 1000)
 eta = 0.02
 spectrum = gf.real_freq_spectrum(grid, eta=eta)
 
@@ -39,5 +39,5 @@ spectrum = gf.real_freq_spectrum(grid, eta=eta)
 # by accessing the poles:
 e = gf2.se.energy - gf2.se.chempot
 v = gf2.se.coupling
-denom = grid[:,None] - (e + np.sign(e)*eta*1.0j)[None]
+denom = grid[:,None] - (e + numpy.sign(e)*eta*1.0j)[None]
 se = numpy.einsum('xk,yk,wk->wxy', v, v.conj(), 1./denom)

--- a/examples/agf2/04-restart.py
+++ b/examples/agf2/04-restart.py
@@ -4,7 +4,7 @@
 #
 
 '''
-An example of ways to restart an AGF2 calculation.
+An example of restarting an AGF2 calculation.
 
 The agf2.chkfile module provides similar functionality to the existing
 chkfile utilities in pyscf, but prevents failure during MPI runs.

--- a/examples/agf2/04-restart.py
+++ b/examples/agf2/04-restart.py
@@ -10,19 +10,18 @@ An example of ways to restart an AGF2 calculation.
 import numpy
 from pyscf import gto, scf, agf2, lib
 
-mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='cc-pvdz', verbose=3)
+mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='cc-pvdz', verbose=5)
 
 mf = scf.RHF(mol)
 mf.conv_tol = 1e-12
 mf.chkfile = 'agf2.chk'
 mf.run()
 
-# Run an AGF2 calculation which does not converge fully
+# Run an AGF2 calculation:
 gf2 = agf2.AGF2(mf)
 gf2.conv_tol = 1e-7
 gf2.max_cycle = 3
 gf2.run()
-gf2.dump_chk()
 
 # Restore the Mole and SCF first
 mol = lib.chkfile.load_mol('agf2.chk')

--- a/examples/agf2/04-restart.py
+++ b/examples/agf2/04-restart.py
@@ -35,7 +35,6 @@ mf = scf.RHF(mol)
 mf.__dict__.update(agf2.chkfile.load('agf2.chk', 'scf'))
 
 # Restore the AGF2 calculation
-dic = agf2.chkfile.load_agf2('agf2.chk')
 gf2a = agf2.AGF2(mf)
 gf2a.__dict__.update(agf2.chkfile.load_agf2('agf2.chk')[1])
 gf2a.max_cycle = 50

--- a/examples/agf2/04-restart.py
+++ b/examples/agf2/04-restart.py
@@ -5,6 +5,9 @@
 
 '''
 An example of ways to restart an AGF2 calculation.
+
+The agf2.chkfile module provides similar functionality to the existing
+chkfile utilities in pyscf, but prevents failure during MPI runs.
 '''
 
 import numpy
@@ -14,7 +17,9 @@ mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='cc-pvdz', verbose=5)
 
 mf = scf.RHF(mol)
 mf.conv_tol = 1e-12
-mf.chkfile = 'agf2.chk'
+# if we are using MPI, we only want pyscf to save a chkfile on the root process:
+if agf2.mpi_helper.rank == 0:
+    mf.chkfile = 'agf2.chk'
 mf.run()
 
 # Run an AGF2 calculation:
@@ -24,9 +29,9 @@ gf2.max_cycle = 3
 gf2.run()
 
 # Restore the Mole and SCF first
-mol = lib.chkfile.load_mol('agf2.chk')
+mol = agf2.chkfile.load_mol('agf2.chk')
 mf = scf.RHF(mol)
-mf.__dict__.update(lib.chkfile.load('agf2.chk', 'scf'))
+mf.__dict__.update(agf2.chkfile.load('agf2.chk', 'scf'))
 
 # Restore the AGF2 calculation
 dic = agf2.chkfile.load_agf2('agf2.chk')

--- a/examples/agf2/04-restart.py
+++ b/examples/agf2/04-restart.py
@@ -29,7 +29,8 @@ mf = scf.RHF(mol)
 mf.__dict__.update(lib.chkfile.load('agf2.chk', 'scf'))
 
 # Restore the AGF2 calculation
+dic = agf2.chkfile.load_agf2('agf2.chk')
 gf2a = agf2.AGF2(mf)
-gf2a.__dict__.update(lib.chkfile.load('agf2.chk', 'agf2'))
+gf2a.__dict__.update(agf2.chkfile.load_agf2('agf2.chk')[1])
 gf2a.max_cycle = 50
 gf2a.run()

--- a/examples/agf2/04-restart.py
+++ b/examples/agf2/04-restart.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+#         George H. Booth <george.booth@kcl.ac.uk>
 #
 
 '''

--- a/examples/agf2/05-agf2_moments.py
+++ b/examples/agf2/05-agf2_moments.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 # Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+#         George H. Booth <george.booth@kcl.ac.uk>
 #
 
 '''
@@ -18,7 +19,7 @@ Default AGF2 corresponds to the AGF2(1,0) method outlined in the papers:
 from __future__ import print_function
 from pyscf import gto, scf, agf2, mp
 
-mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='6-31g', verbose=0)
+mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='6-31g')
 
 mf = scf.RHF(mol)
 mf.conv_tol = 1e-12
@@ -42,7 +43,7 @@ print('Error: ', abs(mp2.e_corr - e_mp2))
 # Run a high moment AGF2(5,6) calculation and compare to AGF2 (AGF2 as
 # default in pyscf is technically AGF2(None,0)). See
 # second reference for more details.
-gf2_56.run(verbose=3)
+gf2_56.run()
 
 gf2 = agf2.AGF2(mf)
 gf2.run()

--- a/examples/agf2/05-agf2_moments.py
+++ b/examples/agf2/05-agf2_moments.py
@@ -5,6 +5,10 @@
 
 '''
 An example of AGF2 for higher moment consistency
+
+AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
 '''
 
 from __future__ import print_function

--- a/examples/agf2/05-agf2_moments.py
+++ b/examples/agf2/05-agf2_moments.py
@@ -4,11 +4,15 @@
 #
 
 '''
-An example of AGF2 for higher moment consistency
+An example of higher moment self-consistency in renormalization of self-energy in AGF2.
 
-AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
-  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
-  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
+Note that only the default AGF2 is efficiently implemented (corresponding to AGF2(1,0) in 
+the literature, and equivalent to AGF2(None,0)). Higher moments do not support density-fitting 
+or parallelism.
+
+Default AGF2 corresponds to the AGF2(1,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 1090 (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
 '''
 
 from __future__ import print_function
@@ -24,29 +28,29 @@ mf.run()
 mp2 = mp.MP2(mf)
 mp2.run()
 
-# We can use very high moment calculations to approximate GF2 - this
-# is computationally unfeasible but we can use the zeroth iteration
-# to verify that we match the MP2 energy.
-gf2 = agf2.AGF2(mf, nmom=(8,8))
-gf2.build_se()
-e_mp2 = gf2.energy_mp2()
+# We can use very high moment calculations to converge to traditional GF2 limit.
+# We can also use the zeroth iteration to quantify the AGF2 error by comparison
+# to the MP2 energy.
+gf2_56 = agf2.AGF2(mf, nmom=(5,6))
+gf2_56.build_se()
+e_mp2 = gf2_56.energy_mp2()
 
-print('Canonical MP2: ', mp2.e_corr)
-print('AGF2(%s,%s) MP2: '%gf2.nmom, e_mp2)
+print('Canonical MP2 Ecorr: ', mp2.e_corr)
+print('AGF2(%s,%s) MP2 Ecorr: '%gf2_56.nmom, e_mp2)
 print('Error: ', abs(mp2.e_corr - e_mp2))
 
-# Run an AGF2(3,4) calculation and compare to AGF2 (AGF2 as
-# implemented in pyscf is technically AGF2(None,0)):
-gf2_3_4 = agf2.AGF2(mf, nmom=(3,4))
-gf2_3_4.run()
+# Run a high moment AGF2(5,6) calculation and compare to AGF2 (AGF2 as
+# default in pyscf is technically AGF2(None,0)). See
+# second reference for more details.
+gf2_56.run(verbose=3)
 
 gf2 = agf2.AGF2(mf)
 gf2.run()
 
 print('E(corr):')
-print('AGF2(%s,%s): '%gf2_3_4.nmom, gf2_3_4.e_corr)
-print('AGF2: ', gf2.e_corr)
+print('AGF2(%s,%s): '%gf2_56.nmom, gf2_56.e_corr)
+print('AGF2(1,0): ', gf2.e_corr)
 
 print('IP:')
-print('AGF2(%s,%s): '%gf2_3_4.nmom, gf2_3_4.ipagf2(nroots=1)[0])
-print('AGF2: ', gf2.ipagf2(nroots=1)[0])
+print('AGF2(%s,%s): '%gf2_56.nmom, gf2_56.ipagf2(nroots=1)[0])
+print('AGF2(1,0): ', gf2.ipagf2(nroots=1)[0])

--- a/examples/agf2/05-agf2_moments.py
+++ b/examples/agf2/05-agf2_moments.py
@@ -7,6 +7,7 @@
 An example of AGF2 for higher moment consistency
 '''
 
+from __future__ import print_function
 from pyscf import gto, scf, agf2, mp
 
 mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='6-31g', verbose=0)

--- a/examples/agf2/06-adc2_solver.py
+++ b/examples/agf2/06-adc2_solver.py
@@ -56,6 +56,6 @@ gf2 = agf2.AGF2(mf, nmom=(None, None))
 se = gf2.build_se()
 se = se.get_occupied() # 2p1h/1p2h -> 2p1h
 se.coupling = se.coupling[:gf2.nocc] # 1p/1h -> 1p
-e_ip = agf2.aux.davidson(se, h_1p, nroots=1)[0]
+e_ip = agf2.aux.davidson(se, h_1p, nroots=1)[1]
 print('IP-ADC(2) using the AGF2_slow solver:')
 print(-e_ip[-1])

--- a/examples/agf2/06-adc2_solver.py
+++ b/examples/agf2/06-adc2_solver.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python
 #
 # Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+#         George H. Booth <george.booth@kcl.ac.uk>
 #
 
 '''
 An example of the connection between AGF2 and ADC(2)
 
-AGF2 in the zeroth iteration with no compression is equivalent
-to ADC(2). AGF2 is not recommended as a practical solver for
-ADC(2), this is mostly to demonstrate the link between the
-methods.
+AGF2 without self-consistency, with no renormalization of the auxiliary space, 
+and with occupied/virtual separation, is equivalent to ADC(2). AGF2 is not 
+recommended as a practical solver for ADC(2), but this example numerically 
+demonstrates this correspondance between the methods.
 
-AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
-  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
+The AGF2 method is outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 1090 (2020).
   - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
 '''
 
@@ -32,30 +33,32 @@ se = gf2.build_se()
 se = se.get_occupied() # 2p1h/1p2h -> 2p1h
 se.coupling = se.coupling[:gf2.nocc] # 1p/1h -> 1p
 
-# Use the adc module to get the 1p space from ADC(2):
+# Use the adc module to get the 1p space from ADC(2). In AGF2, this is the
+# bare Fock matrix, and is relaxed through the self-consistency. We can use
+# the ADC 1p space instead.
 adc2 = adc.radc.RADCIP(adc.ADC(mf).run())
 h_1p = adc2.get_imds()
 
 # Find the eigenvalues of the self-energy in the 'extended Fock matrix'
 # format, which are the ionization potentials:
 e_ip = se.eig(h_1p)[0]
-print('IP-ADC(2) using the AGF2 solver:')
+print('IP-ADC(2) using the AGF2 solver (with renormalization):')
 print(-e_ip[-1])
 
 # Compare to ADC(2) values - note that these will not be the same, since
-# AGF2 performs a compression to allow full diagonalisation of the 
-# Hamiltonian instead of using an iterative solver:
+# AGF2 performs a compression/renormalization of the 2p1h space to allow 
+# full diagonalisation of the Hamiltonian instead of using an iterative solver:
 e_ip = adc2.kernel(nroots=1)[0]
 print('IP-ADC(2) using the pyscf solver:')
 print(e_ip[-1])
 
-# One may calculate the uncompressed self-energy using RAGF2_slow, and
-# then use the Davidson solver in pyscf.agf2.aux to get the full ADC(2)
+# One may instead calculate the uncompressed self-energy (slow code), and
+# then use the Davidson solver in pyscf.agf2.aux to get the exact ADC(2)
 # values:
 gf2 = agf2.AGF2(mf, nmom=(None, None))
 se = gf2.build_se()
 se = se.get_occupied() # 2p1h/1p2h -> 2p1h
 se.coupling = se.coupling[:gf2.nocc] # 1p/1h -> 1p
 e_ip = agf2.aux.davidson(se, h_1p, nroots=1)[1]
-print('IP-ADC(2) using the AGF2_slow solver:')
+print('IP-ADC(2) via AGF2 without self-consistency or auxiliary renormalization:')
 print(-e_ip[-1])

--- a/examples/agf2/06-adc2_solver.py
+++ b/examples/agf2/06-adc2_solver.py
@@ -10,6 +10,10 @@ AGF2 in the zeroth iteration with no compression is equivalent
 to ADC(2). AGF2 is not recommended as a practical solver for
 ADC(2), this is mostly to demonstrate the link between the
 methods.
+
+AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
 '''
 
 import numpy

--- a/examples/agf2/06-adc2_solver.py
+++ b/examples/agf2/06-adc2_solver.py
@@ -13,7 +13,7 @@ methods.
 
 AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
   - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
-  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
 '''
 
 import numpy

--- a/examples/agf2/07-scs_agf2.py
+++ b/examples/agf2/07-scs_agf2.py
@@ -8,7 +8,7 @@ An example of SCS-AGF2 calculation.
 
 AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
   - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
-  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
 '''
 
 from pyscf import gto, scf, agf2

--- a/examples/agf2/07-scs_agf2.py
+++ b/examples/agf2/07-scs_agf2.py
@@ -1,14 +1,11 @@
 #!/usr/bin/env python
 #
 # Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+#         George H. Booth <george.booth@kcl.ac.uk>
 #
 
 '''
-An example of SCS-AGF2 calculation.
-
-AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
-  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
-  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
+An example of Spin-Component-Scaled-AGF2 calculation.
 '''
 
 from pyscf import gto, scf, agf2

--- a/examples/agf2/07-scs_agf2.py
+++ b/examples/agf2/07-scs_agf2.py
@@ -5,6 +5,10 @@
 
 '''
 An example of SCS-AGF2 calculation.
+
+AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
 '''
 
 from pyscf import gto, scf, agf2

--- a/examples/agf2/08-frozen_core.py
+++ b/examples/agf2/08-frozen_core.py
@@ -11,11 +11,11 @@ AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
   - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
 '''
 
-from pyscf import gto, scf, agf2
+from pyscf import gto, scf, agf2, mp
 
 mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='cc-pvdz')
 
-mf = scf.UHF(mol)
+mf = scf.RHF(mol)
 mf.conv_tol = 1e-12
 mf.run()
 
@@ -30,3 +30,20 @@ gf2.ipagf2(nroots=3)
 
 # Print the first 3 electron affinities
 gf2.eaagf2(nroots=3)
+
+
+# Check that a high-moment calculation is equal to MP2 in the first iteration
+mol = gto.M(atom='H 0 0 0; Li 0 0 1', basis='cc-pvdz')
+
+mf = scf.RHF(mol)
+mf.run()
+
+mp2 = mp.MP2(mf)
+mp2.run()
+
+gf2 = agf2.AGF2(mf, nmom=(5,6))
+gf2.frozen = mp2.frozen
+gf2.run(max_cycle=1)
+
+print(mp2.e_corr)
+print(gf2.e_init)

--- a/examples/agf2/08-frozen_core.py
+++ b/examples/agf2/08-frozen_core.py
@@ -8,7 +8,7 @@ An example of AGF2 within the frozen core approximation.
 
 AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
   - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
-  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
 '''
 
 from pyscf import gto, scf, agf2, mp

--- a/examples/agf2/08-frozen_core.py
+++ b/examples/agf2/08-frozen_core.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 #
 # Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+#         George H. Booth <george.booth@kcl.ac.uk>
 #
 
 '''
 An example of AGF2 within the frozen core approximation.
 
-AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
-  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
+Default AGF2 corresponds to the AGF2(1,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 1090 (2020).
   - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
 '''
 
@@ -22,6 +23,7 @@ mf.run()
 # Run an AGF2 calculation
 gf2 = agf2.AGF2(mf)
 gf2.conv_tol = 1e-7
+# Freeze two orbitals (four electrons)
 gf2.frozen = 2
 gf2.run()
 
@@ -32,7 +34,7 @@ gf2.ipagf2(nroots=3)
 gf2.eaagf2(nroots=3)
 
 
-# Check that a high-moment calculation is equal to MP2 in the first iteration
+# Check that a high-moment calculation is equal to MP2 in the first iteration for frozen core example
 mol = gto.M(atom='H 0 0 0; Li 0 0 1', basis='cc-pvdz')
 
 mf = scf.RHF(mol)
@@ -42,9 +44,9 @@ mp2 = mp.MP2(mf)
 mp2.frozen = 1
 mp2.run()
 
-gf2 = agf2.AGF2(mf, nmom=(5,6))
+gf2 = agf2.AGF2(mf, nmom=(6,7))
 gf2.frozen = mp2.frozen
-gf2.run(max_cycle=1)
+gf2.run(max_cycle=0)
 
 print(mp2.e_corr)
 print(gf2.e_init)

--- a/examples/agf2/08-frozen_core.py
+++ b/examples/agf2/08-frozen_core.py
@@ -39,6 +39,7 @@ mf = scf.RHF(mol)
 mf.run()
 
 mp2 = mp.MP2(mf)
+mp2.frozen = 1
 mp2.run()
 
 gf2 = agf2.AGF2(mf, nmom=(5,6))

--- a/examples/agf2/08-frozen_core.py
+++ b/examples/agf2/08-frozen_core.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+#
+# Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+#
+
+'''
+An example of AGF2 within the frozen core approximation.
+
+AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
+'''
+
+from pyscf import gto, scf, agf2
+
+mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='cc-pvdz')
+
+mf = scf.UHF(mol)
+mf.conv_tol = 1e-12
+mf.run()
+
+# Run an AGF2 calculation
+gf2 = agf2.AGF2(mf)
+gf2.conv_tol = 1e-7
+gf2.frozen = 2
+gf2.run()
+
+# Print the first 3 ionization potentials
+gf2.ipagf2(nroots=3)
+
+# Print the first 3 electron affinities
+gf2.eaagf2(nroots=3)

--- a/examples/agf2/09-mpi_dfragf2.py
+++ b/examples/agf2/09-mpi_dfragf2.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+#
+# Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+#
+
+'''
+An example of DFRAGF2 with MPI (the MPI support is very transparent,
+so this example is almost identical to 02-dfagf2.py).
+
+AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
+'''
+
+from pyscf import gto, scf, agf2
+
+mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='cc-pvdz', verbose=3 if agf2.mpi_helper.rank == 0 else 0)
+
+mf = scf.RHF(mol).density_fit(auxbasis='cc-pv5z-ri')
+mf.conv_tol = 1e-12
+mf.run()
+
+# Run an AGF2 calculation
+gf2 = agf2.AGF2(mf)
+gf2.conv_tol = 1e-7
+gf2.run(verbose=4 if agf2.mpi_helper.rank == 0 else 0)
+
+# Print the first 3 ionization potentials
+gf2.ipagf2(nroots=3)
+
+# Print the first 3 electron affinities
+gf2.eaagf2(nroots=3)

--- a/examples/agf2/09-mpi_dfragf2.py
+++ b/examples/agf2/09-mpi_dfragf2.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python
 #
 # Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+#         George H. Booth <george.booth@kcl.ac.uk>
 #
 
 '''
-An example of DFRAGF2 with MPI (the MPI support is very transparent,
-so this example is almost identical to 02-dfagf2.py).
+An example of Density-fitted AGF2 with MPI (the MPI support is very transparent,
+so this example is almost identical to 02-dfagf2.py). 
 
-AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
-  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
+MPI support is provided by mpi4py module. The implementation is also hybrid 
+parallelized, and therefore may benefit from a combination of OMP threads 
+and MPI processes. OMP threads will automatically be used if OMP_NUM_THREADS
+is appropriately set.
+
+Default AGF2 corresponds to the AGF2(1,0) method outlined in the papers:
+  - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 1090 (2020).
   - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
 '''
 

--- a/examples/agf2/09-mpi_dfragf2.py
+++ b/examples/agf2/09-mpi_dfragf2.py
@@ -9,7 +9,7 @@ so this example is almost identical to 02-dfagf2.py).
 
 AGF2 corresponds to the AGF2(None,0) method outlined in the papers:
   - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
-  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
+  - O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
 '''
 
 from pyscf import gto, scf, agf2

--- a/examples/agf2/10-dyson_orbitals.py
+++ b/examples/agf2/10-dyson_orbitals.py
@@ -14,7 +14,7 @@ Default AGF2 corresponds to the AGF2(1,0) method outlined in the papers:
 
 from pyscf import gto, scf, agf2
 
-mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='cc-pvdz', verbose=5)
+mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='cc-pvdz')
 
 mf = scf.RHF(mol)
 mf.conv_tol = 1e-12

--- a/examples/agf2/10-dyson_orbitals.py
+++ b/examples/agf2/10-dyson_orbitals.py
@@ -5,7 +5,7 @@
 #
 
 '''
-A simple example of restricted AGF2.
+An example of generating Dyson orbitals from an AGF2 calculation.
 
 Default AGF2 corresponds to the AGF2(1,0) method outlined in the papers:
   - O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 1090 (2020).
@@ -25,8 +25,9 @@ gf2 = agf2.AGF2(mf)
 gf2.conv_tol = 1e-7
 gf2.run(verbose=4)
 
-# Print the first 3 ionization potentials
-gf2.ipagf2(nroots=3)
+# Access the Dyson orbitals (vectors in AO basis):
+dyson_orbitals = gf2.qmo_coeff
 
-# Print the first 3 electron affinities
-gf2.eaagf2(nroots=3)
+# Find the Dyson orbital corresponding to the HOMO and LUMO:
+dyson_homo = gf2.qmo_coeff[:,gf2.qmo_occ > 0][:,-1]
+dyson_lumo = gf2.qmo_coeff[:,gf2.qmo_occ == 0][:,0]

--- a/pyscf/agf2/__init__.py
+++ b/pyscf/agf2/__init__.py
@@ -17,7 +17,6 @@
 #
 
 #TODO: volume/issue for second paper
-#NOTE: I don't like using nmom as a variable in all of these methods
 
 '''
 Auxiliary second-order Green's function perturbation therory

--- a/pyscf/agf2/__init__.py
+++ b/pyscf/agf2/__init__.py
@@ -25,7 +25,7 @@ ground-state properties at the AGF2(None,0) level.
 
 When using results of this code for publications, please cite the follow papers:
 "Wave function perspective and efficient truncation of renormalized second-order perturbation theory", O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
-"Efficient excitations and spectra within a perturbative renormalization approach", O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., X, X (2020).
+"Efficient excitations and spectra within a perturbative renormalization approach", O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
 
 
 Simple usage::

--- a/pyscf/agf2/__init__.py
+++ b/pyscf/agf2/__init__.py
@@ -24,7 +24,7 @@ The AGF2 method permits the computation of quasiparticle excitations and
 ground-state properties at the AGF2(None,0) level. 
 
 When using results of this code for publications, please cite the follow papers:
-"Wave function perspective and efficient truncation of renormalized second-order perturbation theory", O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).
+"Wave function perspective and efficient truncation of renormalized second-order perturbation theory", O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 1090 (2020).
 "Efficient excitations and spectra within a perturbative renormalization approach", O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).
 
 

--- a/pyscf/agf2/__init__.py
+++ b/pyscf/agf2/__init__.py
@@ -77,8 +77,8 @@ Saved result
         One-body part of :attr:`e_tot`
     e_2b : float
         Two-body part of :attr:`e_tot`
-    e_mp2 : float
-        MP2 correlation energy
+    e_init : float
+        Initial correlation energy (truncated MP2)
     converged : bool
         Whether convergence was successful
     se : SelfEnergy

--- a/pyscf/agf2/__init__.py
+++ b/pyscf/agf2/__init__.py
@@ -112,6 +112,10 @@ AGF2.__doc__ = ragf2.RAGF2.__doc__
 
 
 def RAGF2(mf, nmom=(None,0), frozen=None, mo_energy=None, mo_coeff=None, mo_occ=None):
+    if nmom != (None,0): # redundant
+        if nmom[1] == 0 and nmom[0] != 0:
+            nmom = (None,0)
+    
     if nmom != (None,0) and getattr(mf, 'with_df', None) is not None:
         raise RuntimeError('AGF2 with custom moment orders does not '
                            'density fitting.')
@@ -131,6 +135,10 @@ RAGF2.__doc__ = ragf2.RAGF2.__doc__
 
 
 def UAGF2(mf, nmom=(None,0), frozen=None, mo_energy=None, mo_coeff=None, mo_occ=None):
+    if nmom != (None,0): # redundant
+        if nmom[1] == 0 and nmom[0] != 0:
+            nmom = (None,0)
+    
     if nmom != (None,0) and getattr(mf, 'with_df', None) is not None:
         raise RuntimeError('AGF2 with custom moment orders does not '
                            'density fitting.')

--- a/pyscf/agf2/__init__.py
+++ b/pyscf/agf2/__init__.py
@@ -16,11 +16,12 @@
 #         George Booth <george.booth@kcl.ac.uk>
 #
 
-#TODO: volume/issue for second paper
-
 '''
 Auxiliary second-order Green's function perturbation therory
 ============================================================
+
+The AGF2 method permits the computation of quasiparticle excitations and 
+ground-state properties at the AGF2(None,0) level. 
 
 When using results of this code for publications, please cite the follow papers:
 "Wave function perspective and efficient truncation of renormalized second-order perturbation theory", O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 2 (2020).

--- a/pyscf/agf2/__init__.py
+++ b/pyscf/agf2/__init__.py
@@ -92,17 +92,17 @@ from pyscf.agf2.aux import AuxiliarySpace, GreensFunction, SelfEnergy
 
 
 def AGF2(mf, nmom=(None,0), frozen=None, mo_energy=None, mo_coeff=None, mo_occ=None):
-    if isinstance(mf, scf.rhf.RHF):
-        return RAGF2(mf, nmom, frozen, mo_energy, mo_coeff, mo_occ)
-
-    elif isinstance(mf, scf.uhf.UHF):
+    if isinstance(mf, scf.uhf.UHF):
         return UAGF2(mf, nmom, frozen, mo_energy, mo_coeff, mo_occ)
 
-    elif isinstance(mf, scf.rhf.ROHF):
+    elif isinstance(mf, scf.rohf.ROHF):
         lib.logger.warn(mf, 'RAGF2 method does not support ROHF reference. '
                             'Converting to UHF and using UAGF2.')
         mf = scf.addons.convert_to_uhf(mf)
         return UAGF2(mf, nmom, frozen, mo_energy, mo_coeff, mo_occ)
+
+    elif isinstance(mf, scf.rhf.RHF):
+        return RAGF2(mf, nmom, frozen, mo_energy, mo_coeff, mo_occ)
 
     else:
         raise RuntimeError('AGF2 code only supports RHF, ROHF and UHF references')

--- a/pyscf/agf2/_agf2.py
+++ b/pyscf/agf2/_agf2.py
@@ -21,8 +21,6 @@ import ctypes
 from pyscf import lib
 from pyscf.agf2 import mpi_helper
 
-#TODO: move _get_blksize etc. here
-
 libagf2 = lib.load_library('libagf2')
 
 
@@ -66,10 +64,10 @@ def cholesky_build(vv, vev, gf_occ, gf_vir, eps=1e-20):
     e, c = np.linalg.eigh(m)
     c = np.dot(b.T, c[:gf_occ.nphys])
 
-    if c.shape[0] < gf_occ.nphys:
-        c_full = np.zeros((gf_occ.nphys, c.shape[1]), dtype=c.dtype)
-        c_full[~null_space] = c
-        c = c_full
+    #if c.shape[0] < gf_occ.nphys:
+    #    c_full = np.zeros((gf_occ.nphys, c.shape[1]), dtype=c.dtype)
+    #    c_full[~null_space] = c
+    #    c = c_full
 
     return e, c
 

--- a/pyscf/agf2/_agf2.py
+++ b/pyscf/agf2/_agf2.py
@@ -36,20 +36,6 @@ def cholesky_build(vv, vev, gf_occ, gf_vir, eps=1e-20):
         for the virtual self-energy.
     '''
 
-    ##NOTE: test this
-    ##FIXME: doesn't seem to work when situation arises due to frozen core - might have to rethink this
-    ##FIXME: won't work for UAGF2 if we use this solution (need to change naux)
-    #if gf_occ.nphys >= (gf_occ.naux**2 * gf_vir.naux):
-    #    # remove the null space from vv and vev
-    #    zero_rows = np.all(np.absolute(vv) < eps, axis=1)
-    #    zero_cols = np.all(np.absolute(vv) < eps, axis=0)
-    #    null_space = np.logical_and(zero_rows, zero_cols)
-
-    #    vv = vv[~null_space][:,~null_space]
-    #    vev = vev[~null_space][:,~null_space]
-    #    np.set_printoptions(precision=4, linewidth=150)
-
-    #NOTE: this seems like an unscientific solution... rescue the above?
     try:
         b = np.linalg.cholesky(vv).T
     except np.linalg.LinAlgError:
@@ -63,11 +49,6 @@ def cholesky_build(vv, vev, gf_occ, gf_vir, eps=1e-20):
     m = np.dot(np.dot(b_inv.T, vev), b_inv)
     e, c = np.linalg.eigh(m)
     c = np.dot(b.T, c[:gf_occ.nphys])
-
-    #if c.shape[0] < gf_occ.nphys:
-    #    c_full = np.zeros((gf_occ.nphys, c.shape[1]), dtype=c.dtype)
-    #    c_full[~null_space] = c
-    #    c = c_full
 
     return e, c
 

--- a/pyscf/agf2/_agf2.py
+++ b/pyscf/agf2/_agf2.py
@@ -24,7 +24,7 @@ from pyscf.agf2 import mpi_helper
 libagf2 = lib.load_library('libagf2')
 
 
-def cholesky_build(vv, vev, gf_occ, gf_vir, eps=1e-20):
+def cholesky_build(vv, vev, eps=1e-20):
     ''' Constructs the truncated auxiliaries from :attr:`vv` and :attr:`vev`.
         Performs a Cholesky decomposition via :func:`numpy.linalg.cholesky`,
         for a positive-definite or positive-semidefinite matrix. For the
@@ -35,6 +35,8 @@ def cholesky_build(vv, vev, gf_occ, gf_vir, eps=1e-20):
         the occupied self-energy, or :attr:`gf_vir.naux` < :attr:`gf_vir.nphys`
         for the virtual self-energy.
     '''
+
+    nmo = vv.shape[0]
 
     try:
         b = np.linalg.cholesky(vv).T
@@ -48,7 +50,7 @@ def cholesky_build(vv, vev, gf_occ, gf_vir, eps=1e-20):
 
     m = np.dot(np.dot(b_inv.T, vev), b_inv)
     e, c = np.linalg.eigh(m)
-    c = np.dot(b.T, c[:gf_occ.nphys])
+    c = np.dot(b.T, c[:nmo])
 
     return e, c
 

--- a/pyscf/agf2/_agf2.py
+++ b/pyscf/agf2/_agf2.py
@@ -108,11 +108,12 @@ def build_mats_ragf2_incore(qeri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
          vv.ctypes.data_as(ctypes.c_void_p),
          vev.ctypes.data_as(ctypes.c_void_p))
 
-    vv = mpi_helper.reduce(vv)
-    vev = mpi_helper.reduce(vev)
-
     vv = vv.reshape(nmo, nmo)
     vev = vev.reshape(nmo, nmo)
+
+    mpi_helper.barrier()
+    mpi_helper.allreduce_safe_inplace(vv)
+    mpi_helper.allreduce_safe_inplace(vev)
 
     return vv, vev
 
@@ -150,8 +151,12 @@ def build_mats_ragf2_outcore(qeri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0)
         vev = lib.dot(exija, xija.T, alpha=fpos, beta=1, c=vev)
         vev = lib.dot(exija, xjia.T, alpha=fneg, beta=1, c=vev)
 
-    vv = mpi_helper.reduce(vv)
-    vev = mpi_helper.reduce(vev)
+    vv = vv.reshape(nmo, nmo)
+    vev = vev.reshape(nmo, nmo)
+
+    mpi_helper.barrier()
+    mpi_helper.allreduce_safe_inplace(vv)
+    mpi_helper.allreduce_safe_inplace(vev)
 
     return vv, vev
 
@@ -197,8 +202,12 @@ def build_mats_dfragf2_incore(qxi, qja, gf_occ, gf_vir, os_factor=1.0, ss_factor
          vv.ctypes.data_as(ctypes.c_void_p),
          vev.ctypes.data_as(ctypes.c_void_p))
 
-    vv = mpi_helper.reduce(vv)
-    vev = mpi_helper.reduce(vev)
+    vv = vv.reshape(nmo, nmo)
+    vev = vev.reshape(nmo, nmo)
+
+    mpi_helper.barrier()
+    mpi_helper.allreduce_safe_inplace(vv)
+    mpi_helper.allreduce_safe_inplace(vev)
 
     vv = vv.reshape(nmo, nmo)
     vev = vev.reshape(nmo, nmo)
@@ -245,8 +254,12 @@ def build_mats_dfragf2_outcore(qxi, qja, gf_occ, gf_vir, os_factor=1.0, ss_facto
         vev = lib.dot(exija, xija.T, alpha=fpos, beta=1, c=vev)
         vev = lib.dot(exija, xjia.T, alpha=fneg, beta=1, c=vev)
 
-    vv = mpi_helper.reduce(vv)
-    vev = mpi_helper.reduce(vev)
+    vv = vv.reshape(nmo, nmo)
+    vev = vev.reshape(nmo, nmo)
+
+    mpi_helper.barrier()
+    mpi_helper.allreduce_safe_inplace(vv)
+    mpi_helper.allreduce_safe_inplace(vev)
 
     return vv, vev
 
@@ -296,8 +309,12 @@ def build_mats_uagf2_incore(qeri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
          vv.ctypes.data_as(ctypes.c_void_p),
          vev.ctypes.data_as(ctypes.c_void_p))
 
-    vv = mpi_helper.reduce(vv)
-    vev = mpi_helper.reduce(vev)
+    vv = vv.reshape(nmo, nmo)
+    vev = vev.reshape(nmo, nmo)
+
+    mpi_helper.barrier()
+    mpi_helper.allreduce_safe_inplace(vv)
+    mpi_helper.allreduce_safe_inplace(vev)
 
     vv = vv.reshape(nmo, nmo)
     vev = vev.reshape(nmo, nmo)
@@ -345,8 +362,12 @@ def build_mats_uagf2_outcore(qeri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0)
         vev = lib.dot(exija_aa, xjia_aa.T, alpha=fnega, beta=1, c=vev)
         vev = lib.dot(exija_ab, xija_ab.T, alpha=fposb, beta=1, c=vev)
 
-    vv = mpi_helper.reduce(vv)
-    vev = mpi_helper.reduce(vev)
+    vv = vv.reshape(nmo, nmo)
+    vev = vev.reshape(nmo, nmo)
+
+    mpi_helper.barrier()
+    mpi_helper.allreduce_safe_inplace(vv)
+    mpi_helper.allreduce_safe_inplace(vev)
 
     return vv, vev
 
@@ -404,8 +425,12 @@ def build_mats_dfuagf2_incore(qxi, qja, gf_occ, gf_vir, os_factor=1.0, ss_factor
          vv.ctypes.data_as(ctypes.c_void_p),
          vev.ctypes.data_as(ctypes.c_void_p))
 
-    vv = mpi_helper.reduce(vv)
-    vev = mpi_helper.reduce(vev)
+    vv = vv.reshape(nmo, nmo)
+    vev = vev.reshape(nmo, nmo)
+
+    mpi_helper.barrier()
+    mpi_helper.allreduce_safe_inplace(vv)
+    mpi_helper.allreduce_safe_inplace(vev)
 
     vv = vv.reshape(nmo, nmo)
     vev = vev.reshape(nmo, nmo)
@@ -460,8 +485,12 @@ def build_mats_dfuagf2_outcore(qxi, qja, gf_occ, gf_vir, os_factor=1.0, ss_facto
         vev = lib.dot(exija_aa, xjia_aa.T, alpha=fnega, beta=1, c=vev)
         vev = lib.dot(exija_ab, xija_ab.T, alpha=fposb, beta=1, c=vev)
 
-    vv = mpi_helper.reduce(vv)
-    vev = mpi_helper.reduce(vev)
+    vv = vv.reshape(nmo, nmo)
+    vev = vev.reshape(nmo, nmo)
+
+    mpi_helper.barrier()
+    mpi_helper.allreduce_safe_inplace(vv)
+    mpi_helper.allreduce_safe_inplace(vev)
 
     return vv, vev
 

--- a/pyscf/agf2/_agf2.py
+++ b/pyscf/agf2/_agf2.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 #
 # Author: Oliver J. Backhouse <olbackhouse@gmail.com>
-#         George H. Booth <george.booth@kcl.ac.uk>
 #         Alejandro Santana-Bonilla <alejandro.santana_bonilla@kcl.ac.uk>
+#         George H. Booth <george.booth@kcl.ac.uk>
 #
 
 import numpy as np
@@ -25,7 +25,7 @@ from pyscf.agf2 import mpi_helper
 libagf2 = lib.load_library('libagf2')
 
 
-def cholesky_build(vv, vev, eps=1e-20):
+def cholesky_build(vv, vev, eps=1e-16):
     ''' Constructs the truncated auxiliaries from :attr:`vv` and :attr:`vev`.
         Performs a Cholesky decomposition via :func:`numpy.linalg.cholesky`,
         for a positive-definite or positive-semidefinite matrix. For the

--- a/pyscf/agf2/_agf2.py
+++ b/pyscf/agf2/_agf2.py
@@ -364,9 +364,6 @@ def build_mats_uagf2_incore(qeri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     mpi_helper.allreduce_safe_inplace(vv)
     mpi_helper.allreduce_safe_inplace(vev)
 
-    vv = vv.reshape(nmo, nmo)
-    vev = vev.reshape(nmo, nmo)
-
     return vv, vev
 
 
@@ -480,9 +477,6 @@ def build_mats_dfuagf2_incore(qxi, qja, gf_occ, gf_vir, os_factor=1.0, ss_factor
     mpi_helper.allreduce_safe_inplace(vv)
     mpi_helper.allreduce_safe_inplace(vev)
 
-    vv = vv.reshape(nmo, nmo)
-    vev = vev.reshape(nmo, nmo)
-
     return vv, vev
 
     
@@ -546,9 +540,6 @@ def build_mats_dfuagf2_lowmem(qxi, qja, gf_occ, gf_vir, os_factor=1.0, ss_factor
     mpi_helper.barrier()
     mpi_helper.allreduce_safe_inplace(vv)
     mpi_helper.allreduce_safe_inplace(vev)
-
-    vv = vv.reshape(nmo, nmo)
-    vev = vev.reshape(nmo, nmo)
 
     return vv, vev
 

--- a/pyscf/agf2/_agf2.py
+++ b/pyscf/agf2/_agf2.py
@@ -14,6 +14,7 @@
 #
 # Author: Oliver J. Backhouse <olbackhouse@gmail.com>
 #         George H. Booth <george.booth@kcl.ac.uk>
+#         Alejandro Santana-Bonilla <alejandro.santana_bonilla@kcl.ac.uk>
 #
 
 import numpy as np

--- a/pyscf/agf2/aux.py
+++ b/pyscf/agf2/aux.py
@@ -29,7 +29,7 @@ from pyscf import __config__
 from pyscf.lib.parameters import MAX_MEMORY, LARGE_DENOM
 
 
-class AuxiliarySpace:
+class AuxiliarySpace(object):
     ''' Simple container to hold the energies, couplings and chemical
         potential associated with an auxiliary space.
 
@@ -487,10 +487,10 @@ def davidson(auxspc, phys, chempot=None, nroots=1, which='SM', tol=1e-14, maxite
             Number of roots to solve for. Default 1.
         which : str
             Which eigenvalues to solve for. Options are:
-             ‘LM’ : Largest (in magnitude) eigenvalues.
-             ‘SM’ : Smallest (in magnitude) eigenvalues.
-             ‘LA’ : Largest (algebraic) eigenvalues.
-             ‘SA’ : Smallest (algebraic) eigenvalues.
+             `LM` : Largest (in magnitude) eigenvalues.
+             `SM` : Smallest (in magnitude) eigenvalues.
+             `LA` : Largest (algebraic) eigenvalues.
+             `SA` : Smallest (algebraic) eigenvalues.
             Default 'SM'.
         tol : float
             Convergence threshold
@@ -545,7 +545,7 @@ def davidson(auxspc, phys, chempot=None, nroots=1, which='SM', tol=1e-14, maxite
                                max_space=ntrial, max_cycle=maxiter, pick=pick)
 
     if not np.all(conv):
-        log.warn('Davidson did not converge')
+        logger.warn('Davidson did not converge')
 
     return w, v
 

--- a/pyscf/agf2/aux.py
+++ b/pyscf/agf2/aux.py
@@ -26,7 +26,7 @@ import scipy.linalg.blas
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf import __config__
-from pyscf.lib.parameters import MAX_MEMORY, LARGE_DENOM
+from pyscf.lib.parameters import LARGE_DENOM
 
 
 class AuxiliarySpace(object):
@@ -544,10 +544,7 @@ def davidson(auxspc, phys, chempot=None, nroots=1, which='SM', tol=1e-14, maxite
     conv, w, v = lib.davidson1(matvec, guess, diag, tol=tol, nroots=nroots,
                                max_space=ntrial, max_cycle=maxiter, pick=pick)
 
-    if not np.all(conv):
-        logger.warn('Davidson did not converge')
-
-    return w, v
+    return conv, w, v
 
 
 def _band_lanczos(se_occ, n=0, max_memory=None):

--- a/pyscf/agf2/aux.py
+++ b/pyscf/agf2/aux.py
@@ -113,8 +113,10 @@ class AuxiliarySpace(object):
 
         _check_phys_shape(self, phys)
 
+        dtype = np.result_type(phys.dtype, self.energy.dtype, self.coupling.dtype)
+
         if out is None:
-            out = np.zeros((self.nphys+self.naux,)*2)
+            out = np.zeros((self.nphys+self.naux,)*2, dtype=dtype)
 
         sp = slice(None, self.nphys)
         sa = slice(self.nphys, None)

--- a/pyscf/agf2/aux.py
+++ b/pyscf/agf2/aux.py
@@ -411,7 +411,7 @@ class GreensFunction(AuxiliarySpace):
             denom = grid[p0:p1,None] - (e_shifted + eta*1.0j)[None]
             spectrum[p0:p1] = lib.einsum('xk,yk,wk->wxy', v, v.conj(), 1./denom)
 
-        return -spectrum.imag / np.pi
+        return -1/np.pi * np.trace(spectrum.imag, axis1=1, axis2=2)
 
     def make_rdm1(self, chempot=None, occupancy=2):
         ''' Returns the first-order reduced density matrix associated

--- a/pyscf/agf2/chempot.py
+++ b/pyscf/agf2/chempot.py
@@ -149,11 +149,10 @@ def minimize_chempot(se, fock, nelec, occupancy=2, x0=0.0, tol=1e-6, maxiter=200
         AuxiliarySpace object with altered :attr:`energy` and 
         :attr:`chempot`, and the SciPy :attr:`OptimizeResult` object.
     '''
-    #TODO: initialise buf and pass with fargs?
-    #TODO: add some more minimization algorithms
 
     tol = tol**2  # we minimize the squared error
-    fargs = (se, fock, nelec, occupancy)
+    buf = np.zeros((se.nphys+se.naux, se.nphys+se.naux))
+    fargs = (se, fock, nelec, occupancy, buf)
 
     options = dict(maxiter=maxiter, ftol=tol, xtol=tol, gtol=tol)
     kwargs = dict(x0=x0, method='TNC', jac=jac, options=options)

--- a/pyscf/agf2/chempot.py
+++ b/pyscf/agf2/chempot.py
@@ -56,10 +56,10 @@ def _gradient(x, se, fock, nelec, occupancy=2, buf=None):
     zai = -h1 / lib.direct_sum('i,a->ai', w[:nocc], -w[nocc:])
 
     c_occ = np.dot(v[:nphys,nocc:], zai)
-    d_rdm1 = np.dot(v[:nphys,:nocc], c_occ.conj().T) * 4 #FIXME: should this be *2*occupancy instead of *4?
+    d_rdm1 = np.dot(v[:nphys,:nocc], c_occ.conj().T) * 4
 
     ne = np.trace(d_rdm1).real
-    d = 2 * error * ne
+    d = occupancy * error * ne
 
     return error**2, d
 

--- a/pyscf/agf2/chempot.py
+++ b/pyscf/agf2/chempot.py
@@ -151,7 +151,8 @@ def minimize_chempot(se, fock, nelec, occupancy=2, x0=0.0, tol=1e-6, maxiter=200
     '''
 
     tol = tol**2  # we minimize the squared error
-    buf = np.zeros((se.nphys+se.naux, se.nphys+se.naux))
+    dtype = np.result_type(se.energy.dtype, se.coupling.dtype, fock.dtype)
+    buf = np.zeros((se.nphys+se.naux, se.nphys+se.naux), dtype=dtype)
     fargs = (se, fock, nelec, occupancy, buf)
 
     options = dict(maxiter=maxiter, ftol=tol, xtol=tol, gtol=tol)

--- a/pyscf/agf2/chkfile.py
+++ b/pyscf/agf2/chkfile.py
@@ -43,7 +43,8 @@ def load(chkfile, key):
     else:
         vals = None
 
-    vals = mpi_helper.broadcast(vals)
+    mpi_helper.barrier()
+    vals = mpi_helper.bcast_dict(vals)
 
     return vals
 
@@ -60,7 +61,8 @@ def load_mol(chkfile):
     else:
         dumps = None
 
-    dumps = mpi_helper.broadcast(dumps)
+    mpi_helper.barrier()
+    dumps = mpi_helper.bcast_dict(dumps)
     mol = gto.loads(dumps)
 
     return mol
@@ -75,7 +77,8 @@ def load_agf2(chkfile):
     else:
         dic = None
 
-    dic = mpi_helper.broadcast(dic)
+    mpi_helper.barrier()
+    dic = mpi_helper.bcast_dict(dic)
 
     if 'gf' in dic:
         gf = dic['gf']

--- a/pyscf/agf2/chkfile.py
+++ b/pyscf/agf2/chkfile.py
@@ -83,7 +83,6 @@ def load_agf2(chkfile):
     if 'gf' in dic:
         gf = dic['gf']
         dic['gf'] = GreensFunction(gf['energy'], gf['coupling'], chempot=gf['chempot'])
-        del(dic['gf'])
     elif 'gfa' in dic:
         gfa, gfb = dic['gfa'], dic['gfb']
         dic['gf'] = (GreensFunction(gfa['energy'], gfa['coupling'], chempot=gfa['chempot']),
@@ -93,7 +92,6 @@ def load_agf2(chkfile):
     if 'se' in dic:
         se = dic['se']
         dic['se'] = SelfEnergy(se['energy'], se['coupling'], chempot=se['chempot'])
-        del(dic['se'])
     elif 'sea' in dic:
         sea, seb = dic['sea'], dic['seb']
         dic['se'] = (SelfEnergy(sea['energy'], sea['coupling'], chempot=sea['chempot']),

--- a/pyscf/agf2/chkfile.py
+++ b/pyscf/agf2/chkfile.py
@@ -1,0 +1,135 @@
+# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+#         George H. Booth <george.booth@kcl.ac.uk>
+#
+
+import time
+import numpy as np
+import h5py
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf import __config__
+from pyscf.lib.chkfile import load_mol, load
+from pyscf.agf2.aux import GreensFunction, SelfEnergy
+
+
+def load_agf2(chkfile):
+    ''' Load the AGF2 data from the chkfile.
+    '''
+
+    dic = load(chkfile, 'agf2')
+
+    if 'gf' in dic:
+        gf = dic['gf']
+        dic['gf'] = GreensFunction(gf['energy'], gf['coupling'], chempot=gf['chempot'])
+        del(dic['gf'])
+    elif 'gfa' in dic:
+        gfa, gfb = dic['gfa'], dic['gfb']
+        dic['gf'] = (GreensFunction(gfa['energy'], gfa['coupling'], chempot=gfa['chempot']),
+                     GreensFunction(gfb['energy'], gfb['coupling'], chempot=gfb['chempot']))
+        del(dic['gfa'], dic['gfb'])
+
+    if 'se' in dic:
+        se = dic['se']
+        dic['se'] = SelfEnergy(se['energy'], se['coupling'], chempot=se['chempot'])
+        del(dic['se'])
+    elif 'sea' in dic:
+        sea, seb = dic['sea'], dic['seb']
+        dic['se'] = (SelfEnergy(sea['energy'], sea['coupling'], chempot=sea['chempot']),
+                     SelfEnergy(seb['energy'], seb['coupling'], chempot=seb['chempot']))
+        del(dic['sea'], dic['seb'])
+
+    if 'ngf' in dic:
+        dic['nmom'] = (dic.get('ngf', None), dic.get('nse', None))
+        del(dic['ngf'], dic['nse'])
+
+    return load_mol(chkfile), dic
+
+
+def dump_agf2(agf2, chkfile=None, key='agf2', 
+              gf=None, se=None, frozen=None, nmom=None,
+              mo_energy=None, mo_coeff=None, mo_occ=None):
+    ''' Save the AGF2 calculatuion to a chkfile.
+    '''
+
+    if chkfile is None: chkfile = agf2.chkfile
+
+    if gf is None: gf = agf2.gf
+    if se is None: se = agf2.se
+    if frozen is None: frozen = agf2.frozen
+    if mo_energy is None: mo_energy = agf2.mo_energy
+    if mo_coeff is None: mo_coeff = agf2.mo_coeff
+    if mo_occ is None: mo_occ = agf2.mo_occ
+
+    if h5py.is_hdf5(chkfile):
+        fh5 = h5py.File(chkfile, 'a')
+        if key in fh5:
+            del(fh5[key])
+    else:
+        fh5 = h5py.File(chkfile, 'w')
+
+    if 'mol' not in fh5:
+        fh5['mol'] = agf2.mol.dumps()
+
+    def store(subkey, val):
+        if val is not None:
+            fh5[key+'/'+subkey] = val
+
+    store('e_1b', agf2.e_1b)
+    store('e_2b', agf2.e_2b)
+    store('e_mp2', agf2.e_mp2)
+    store('converged', agf2.converged)
+    store('mo_energy', mo_energy)
+    store('mo_coeff', mo_coeff)
+    store('mo_occ', mo_occ)
+    store('_nmo', agf2._nmo)
+    store('_nocc', agf2._nocc)
+    store('frozen', frozen)
+
+    if gf is not None:
+        if isinstance(gf, (tuple, list)):
+            store('gfa/energy', gf[0].energy)
+            store('gfa/coupling', gf[0].coupling)
+            store('gfa/chempot', gf[0].chempot)
+            store('gfb/energy', gf[1].energy)
+            store('gfb/coupling', gf[1].coupling)
+            store('gfb/chempot', gf[1].chempot)
+        else:
+            store('gf/energy', gf.energy)
+            store('gf/coupling', gf.coupling)
+            store('gf/chempot', gf.chempot)
+
+    if se is not None:
+        if isinstance(se, (tuple, list)):
+            store('sea/energy', se[0].energy)
+            store('sea/coupling', se[0].coupling)
+            store('sea/chempot', se[0].chempot)
+            store('seb/energy', se[1].energy)
+            store('seb/coupling', se[1].coupling)
+            store('seb/chempot', se[1].chempot)
+        else:
+            store('se/energy', se.energy)
+            store('se/coupling', se.coupling)
+            store('se/chempot', se.chempot)
+
+    if getattr(agf2, 'nmom', None) is not None:
+        if nmom is None:
+            nmom = agf2.nmom
+        ngf, nse = nmom
+        store('ngf', ngf)
+        store('nse', nse)
+
+    fh5.close()

--- a/pyscf/agf2/chkfile.py
+++ b/pyscf/agf2/chkfile.py
@@ -142,7 +142,7 @@ def dump_agf2(agf2, chkfile=None, key='agf2',
 
     store('e_1b', agf2.e_1b)
     store('e_2b', agf2.e_2b)
-    store('e_mp2', agf2.e_mp2)
+    store('e_init', agf2.e_init)
     store('converged', agf2.converged)
     store('mo_energy', mo_energy)
     store('mo_coeff', mo_coeff)

--- a/pyscf/agf2/dfragf2.py
+++ b/pyscf/agf2/dfragf2.py
@@ -78,7 +78,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     if (himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory \
             and agf2.allow_lowmem_build:
         log.debug('Thread-private memory overhead %.3f exceeds max_memory, using '
-                  'low-memory version.')
+                  'low-memory version.', himem_required)
         vv, vev = _agf2.build_mats_dfragf2_lowmem(qxi, qja, gf_occ, gf_vir, **facs)
     else:
         vv, vev = _agf2.build_mats_dfragf2_incore(qxi, qja, gf_occ, gf_vir, **facs)

--- a/pyscf/agf2/dfragf2.py
+++ b/pyscf/agf2/dfragf2.py
@@ -79,8 +79,8 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     himem_required *= 8e-6
     himem_required *= lib.num_threads()
 
-    if (himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory \
-            and agf2.allow_lowmem_build:
+    if ((himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory
+            and agf2.allow_lowmem_build) or agf2.allow_lowmem_build == 'force':
         log.debug('Thread-private memory overhead %.3f exceeds max_memory, using '
                   'low-memory version.', himem_required)
         vv, vev = _agf2.build_mats_dfragf2_lowmem(qxi, qja, ei, ea, **facs)
@@ -197,9 +197,10 @@ class DFRAGF2(ragf2.RAGF2):
             Allowed memory in MB. Default value equals to :class:`Mole.max_memory`
         incore_complete : bool
             Avoid all I/O. Default is False.
-        allow_lowmem_build : bool
+        allow_lowmem_build : bool or str
             Allow the self-energy build to switch to a serially slower
-            code with loweer thread-private memory overhead if needed.
+            code with lower thread-private memory overhead if needed. One
+            of True, False or 'force'. Default value is True.
         conv_tol : float
             Convergence threshold for AGF2 energy. Default value is 1e-7
         conv_tol_rdm1 : float

--- a/pyscf/agf2/dfragf2.py
+++ b/pyscf/agf2/dfragf2.py
@@ -218,9 +218,16 @@ class DFRAGF2(ragf2.RAGF2):
         weight_tol : float
             Threshold in spectral weight of auxiliaries to be considered
             zero. Default 1e-11.
+        diis : bool or lib.diis.DIIS
+            Whether to use DIIS, can also be a lib.diis.DIIS object. Default
+            value is True.
         diis_space : int
+            DIIS space size. Default value is 8.
+        diis_min_space : int
+            Minimum space of DIIS. Default value is 1.
+        fock_diis_space : int
             DIIS space size for Fock loop iterations. Default value is 6.
-        diis_min_space : 
+        fock_diis_min_space : 
             Minimum space of DIIS. Default value is 1.
         os_factor : float
             Opposite-spin factor for spin-component-scaled (SCS)

--- a/pyscf/agf2/dfragf2.py
+++ b/pyscf/agf2/dfragf2.py
@@ -69,6 +69,9 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     tol = agf2.weight_tol
     facs = dict(os_factor=os_factor, ss_factor=ss_factor)
 
+    ei, ci = gf_occ.energy, gf_occ.coupling
+    ea, ca = gf_vir.energy, gf_vir.coupling
+
     qxi, qja = _make_qmo_eris_incore(agf2, eri, gf_occ, gf_vir)
 
     himem_required = naux*(nvir+nmo) + (nocc*nvir)*(2*nmo+1) + (2*nmo**2)
@@ -79,9 +82,9 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
             and agf2.allow_lowmem_build:
         log.debug('Thread-private memory overhead %.3f exceeds max_memory, using '
                   'low-memory version.', himem_required)
-        vv, vev = _agf2.build_mats_dfragf2_lowmem(qxi, qja, gf_occ, gf_vir, **facs)
+        vv, vev = _agf2.build_mats_dfragf2_lowmem(qxi, qja, ei, ea, **facs)
     else:
-        vv, vev = _agf2.build_mats_dfragf2_incore(qxi, qja, gf_occ, gf_vir, **facs)
+        vv, vev = _agf2.build_mats_dfragf2_incore(qxi, qja, ei, ea, **facs)
 
     e, c = _agf2.cholesky_build(vv, vev)
     se = aux.SelfEnergy(e, c, chempot=gf_occ.chempot)

--- a/pyscf/agf2/dfragf2.py
+++ b/pyscf/agf2/dfragf2.py
@@ -229,6 +229,8 @@ class DFRAGF2(ragf2.RAGF2):
         ss_factor : float
             Same-spin factor for spin-component-scaled (SCS)
             calculations. Default 1.0
+        damping : float
+            Damping factor for the self-energy. Default value is 0.0
 
     Saved results
 

--- a/pyscf/agf2/dfragf2.py
+++ b/pyscf/agf2/dfragf2.py
@@ -231,7 +231,6 @@ class DFRAGF2(ragf2.RAGF2):
             self.with_df = mf.with_df
         else:
             self.with_df = df.DF(mf.mol)
-            #NOTE: how do we want to build this by default? this will also be the result of RAGF2.density_fit()
             self.with_df.auxbasis = df.make_auxbasis(mf.mol, mp2fit=True)
 
         self._keys.update(['_with_df'])

--- a/pyscf/agf2/dfragf2.py
+++ b/pyscf/agf2/dfragf2.py
@@ -63,7 +63,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     assert type(gf_occ) is aux.GreensFunction
     assert type(gf_vir) is aux.GreensFunction
 
-    nmo = agf2.nmo
+    nmo = eri.nmo
     nocc, nvir = gf_occ.naux, gf_vir.naux
     naux = agf2.with_df.get_naoaux()
     tol = agf2.weight_tol

--- a/pyscf/agf2/dfragf2.py
+++ b/pyscf/agf2/dfragf2.py
@@ -223,8 +223,8 @@ class DFRAGF2(ragf2.RAGF2):
             One-body part of :attr:`e_tot`
         e_2b : float
             Two-body part of :attr:`e_tot`
-        e_mp2 : float
-            MP2 correlation energy
+        e_init : float
+            Initial correlation energy (truncated MP2)
         converged : bool
             Whether convergence was successful
         se : SelfEnergy

--- a/pyscf/agf2/dfragf2.py
+++ b/pyscf/agf2/dfragf2.py
@@ -72,7 +72,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     ei, ci = gf_occ.energy, gf_occ.coupling
     ea, ca = gf_vir.energy, gf_vir.coupling
 
-    qxi, qja = _make_qmo_eris_incore(agf2, eri, gf_occ, gf_vir)
+    qxi, qja = _make_qmo_eris_incore(agf2, eri, (ci, ci, ca))
 
     himem_required = naux*(nvir+nmo) + (nocc*nvir)*(2*nmo+1) + (2*nmo**2)
     himem_required *= 8e-6
@@ -336,7 +336,7 @@ def _make_mo_eris_incore(agf2, mo_coeff=None):
 
     return eris
 
-def _make_qmo_eris_incore(agf2, eri, gf_occ, gf_vir):
+def _make_qmo_eris_incore(agf2, eri, coeffs):
     ''' Returns tuple of ndarray
     '''
     
@@ -349,8 +349,7 @@ def _make_qmo_eris_incore(agf2, eri, gf_occ, gf_vir):
     naux = with_df.get_naoaux()
 
     cx = np.eye(nmo)
-    ci = cj = gf_occ.coupling
-    ca = gf_vir.coupling
+    ci, cj, ca = coeffs
 
     xisym, nxi, cxi, sxi = ao2mo.incore._conc_mos(cx, ci, compact=False)
     jasym, nja, cja, sja = ao2mo.incore._conc_mos(cj, ca, compact=False)

--- a/pyscf/agf2/dfragf2.py
+++ b/pyscf/agf2/dfragf2.py
@@ -273,7 +273,7 @@ class DFRAGF2(ragf2.RAGF2):
             MO basis.
         '''
 
-        eri = _make_mo_eris_incore(self)
+        eri = _make_mo_eris_incore(self, mo_coeff)
 
         return eri
 

--- a/pyscf/agf2/dfragf2.py
+++ b/pyscf/agf2/dfragf2.py
@@ -77,7 +77,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     se = aux.SelfEnergy(e, c, chempot=gf_occ.chempot)
     se.remove_uncoupled(tol=tol)
 
-    log.timer_debug1('se part', *cput0)
+    log.timer('se part', *cput0)
 
     return se
 

--- a/pyscf/agf2/dfragf2.py
+++ b/pyscf/agf2/dfragf2.py
@@ -75,7 +75,8 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     himem_required *= 8e-6
     himem_required *= lib.num_threads()
 
-    if (himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory:
+    if (himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory \
+            and agf2.allow_lowmem_build:
         log.debug('Thread-private memory overhead %.3f exceeds max_memory, using '
                   'low-memory version.')
         vv, vev = _agf2.build_mats_dfragf2_lowmem(qxi, qja, gf_occ, gf_vir, **facs)
@@ -183,6 +184,11 @@ class DFRAGF2(ragf2.RAGF2):
             Print level. Default value equals to :class:`Mole.verbose`
         max_memory : float or int
             Allowed memory in MB. Default value equals to :class:`Mole.max_memory`
+        incore_complete : bool
+            Avoid all I/O. Default is False.
+        allow_lowmem_build : bool
+            Allow the self-energy build to switch to a serially slower
+            code with loweer thread-private memory overhead if needed.
         conv_tol : float
             Convergence threshold for AGF2 energy. Default value is 1e-7
         conv_tol_rdm1 : float
@@ -243,7 +249,9 @@ class DFRAGF2(ragf2.RAGF2):
             self.with_df = df.DF(mf.mol)
             self.with_df.auxbasis = df.make_auxbasis(mf.mol, mp2fit=True)
 
-        self._keys.update(['_with_df'])
+        self.allow_lowmem_build = True
+
+        self._keys.update(['_with_df', 'allow_lowmem_build'])
 
     build_se_part = build_se_part
     get_jk = get_jk

--- a/pyscf/agf2/dfragf2.py
+++ b/pyscf/agf2/dfragf2.py
@@ -83,7 +83,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     else:
         vv, vev = _agf2.build_mats_dfragf2_incore(qxi, qja, gf_occ, gf_vir, **facs)
 
-    e, c = _agf2.cholesky_build(vv, vev, gf_occ, gf_vir)
+    e, c = _agf2.cholesky_build(vv, vev)
     se = aux.SelfEnergy(e, c, chempot=gf_occ.chempot)
     se.remove_uncoupled(tol=tol)
 

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -90,7 +90,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     se_b = aux.SelfEnergy(e, c, chempot=gf_occ[1].chempot)
     se_b.remove_uncoupled(tol=tol)
 
-    cput0 = log.timer_debug1('se part (beta)', *cput0)
+    cput0 = log.timer('se part (beta)', *cput0)
 
     return (se_a, se_b)
 

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -90,7 +90,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
         build_mats_dfuagf2 = _agf2.build_mats_dfuagf2_incore
 
     vv, vev = build_mats_dfuagf2(qxi, qja, gf_occ, gf_vir, **facs)
-    e, c = _agf2.cholesky_build(vv, vev, gf_occ[0], gf_vir[0])
+    e, c = _agf2.cholesky_build(vv, vev)
     se_a = aux.SelfEnergy(e, c, chempot=gf_occ[0].chempot)
     se_a.remove_uncoupled(tol=tol)
 
@@ -110,7 +110,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
 
     rv = np.s_[::-1]
     vv, vev = build_mats_dfuagf2(qxi[rv], qja[rv], gf_occ[rv], gf_vir[rv], **facs)
-    e, c = _agf2.cholesky_build(vv, vev, gf_occ[1], gf_vir[1])
+    e, c = _agf2.cholesky_build(vv, vev)
     se_b = aux.SelfEnergy(e, c, chempot=gf_occ[1].chempot)
     se_b.remove_uncoupled(tol=tol)
 

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -181,6 +181,8 @@ class DFUAGF2(uagf2.UAGF2):
         ss_factor : float
             Same-spin factor for spin-component-scaled (SCS)
             calculations. Default 1.0
+        damping : float
+            Damping factor for the self-energy. Default value is 0.0
 
     Saved results
 

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -165,8 +165,8 @@ class DFUAGF2(uagf2.UAGF2):
             One-body part of :attr:`e_tot`
         e_2b : float
             Two-body part of :attr:`e_tot`
-        e_mp2 : float
-            MP2 correlation energy
+        e_init : float
+            Initial correlation energy (truncated MP2)
         converged : bool
             Whether convergence was successful
         se : tuple of SelfEnergy

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -65,7 +65,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     assert type(gf_vir[0]) is aux.GreensFunction
     assert type(gf_vir[1]) is aux.GreensFunction
 
-    nmoa, nmob = agf2.nmo
+    nmoa, nmob = eri.nmo
     nocca, nvira = gf_occ[0].naux, gf_vir[0].naux
     noccb, nvirb = gf_occ[1].naux, gf_vir[1].naux
     naux = agf2.with_df.get_naoaux()

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -81,7 +81,8 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     himem_required *= 8e-6
     himem_required *= lib.num_threads()
 
-    if (himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory:
+    if (himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory \
+            and agf2.allow_lowmem_build:
         log.debug('Thread-private memory overhead %.3f exceeds max_memory, using '
                   'low-memory version.')
         build_mats_dfuagf2 = _agf2.build_mats_dfuagf2_lowmem
@@ -99,7 +100,8 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     himem_required *= 8e-6
     himem_required *= lib.num_threads()
 
-    if (himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory:
+    if (himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory \
+            and agf2.allow_lowmem_build:
         log.debug('Thread-private memory overhead %.3f exceeds max_memory, using '
                   'low-memory version.')
         build_mats_dfuagf2 = _agf2.build_mats_dfuagf2_lowmem
@@ -125,6 +127,11 @@ class DFUAGF2(uagf2.UAGF2):
             Print level. Default value equals to :class:`Mole.verbose`
         max_memory : float or int
             Allowed memory in MB. Default value equals to :class:`Mole.max_memory`
+        incore_complete : bool
+            Avoid all I/O. Default is False.
+        allow_lowmem_build : bool
+            Allow the self-energy build to switch to a serially slower
+            code with loweer thread-private memory overhead if needed.
         conv_tol : float
             Convergence threshold for AGF2 energy. Default value is 1e-7
         conv_tol_rdm1 : float
@@ -185,7 +192,9 @@ class DFUAGF2(uagf2.UAGF2):
             self.with_df = df.DF(mf.mol)
             self.with_df.auxbasis = df.make_auxbasis(mf.mol, mp2fit=True)
 
-        self._keys.update(['_with_df'])
+        self.allow_lowmem_build = True
+
+        self._keys.update(['_with_df', 'allow_lowmem_build'])
 
     build_se_part = build_se_part
     get_jk = dfragf2.get_jk

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -84,7 +84,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     if (himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory \
             and agf2.allow_lowmem_build:
         log.debug('Thread-private memory overhead %.3f exceeds max_memory, using '
-                  'low-memory version.')
+                  'low-memory version.', himem_required)
         build_mats_dfuagf2 = _agf2.build_mats_dfuagf2_lowmem
     else:
         build_mats_dfuagf2 = _agf2.build_mats_dfuagf2_incore
@@ -103,7 +103,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     if (himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory \
             and agf2.allow_lowmem_build:
         log.debug('Thread-private memory overhead %.3f exceeds max_memory, using '
-                  'low-memory version.')
+                  'low-memory version.', himem_required)
         build_mats_dfuagf2 = _agf2.build_mats_dfuagf2_lowmem
     else:
         build_mats_dfuagf2 = _agf2.build_mats_dfuagf2_incore

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -169,9 +169,16 @@ class DFUAGF2(uagf2.UAGF2):
         weight_tol : float
             Threshold in spectral weight of auxiliaries to be considered
             zero. Default 1e-11.
+        diis : bool or lib.diis.DIIS
+            Whether to use DIIS, can also be a lib.diis.DIIS object. Default
+            value is True.
         diis_space : int
+            DIIS space size. Default value is 8.
+        diis_min_space : int
+            Minimum space of DIIS. Default value is 1.
+        fock_diis_space : int
             DIIS space size for Fock loop iterations. Default value is 6.
-        diis_min_space : 
+        fock_diis_min_space : 
             Minimum space of DIIS. Default value is 1.
         os_factor : float
             Opposite-spin factor for spin-component-scaled (SCS)

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -77,7 +77,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     ca_a, ea_a = gf_vir[0].coupling, gf_vir[0].energy
     ca_b, ea_b = gf_vir[1].coupling, gf_vir[1].energy
 
-    qeri = _make_qmo_eris_incore(agf2, eri, gf_occ, gf_vir)
+    qeri = _make_qmo_eris_incore(agf2, eri, (ci_a, ci_a, ca_a), (ci_b, ci_b, ca_b))
     (qxi_a, qja_a), (qxi_b, qja_b) = qeri
     qxi = (qxi_a, qxi_b)
     qja = (qja_a, qja_b)
@@ -278,7 +278,7 @@ def _make_mo_eris_incore(agf2, mo_coeff=None):
 
     return eris
 
-def _make_qmo_eris_incore(agf2, eri, gf_occ, gf_vir):
+def _make_qmo_eris_incore(agf2, eri, coeffs_a, coeffs_b):
     ''' Returns nested tuple of ndarray
     '''
 
@@ -290,9 +290,8 @@ def _make_qmo_eris_incore(agf2, eri, gf_occ, gf_vir):
     with_df = agf2.with_df
     naux = with_df.get_naoaux()
     cxa, cxb = np.eye(nmoa), np.eye(nmob)
-    cia = cja = gf_occ[0].coupling
-    cib = cjb = gf_occ[1].coupling
-    caa, cab = gf_vir[0].coupling, gf_vir[1].coupling
+    cia, cja, caa = coeffs_a
+    cib, cjb, cab = coeffs_b
 
     xisym_a, nxi_a, cxi_a, sxi_a = ao2mo.incore._conc_mos(cxa, cia, compact=False)
     jasym_a, nja_a, cja_a, sja_a = ao2mo.incore._conc_mos(cja, caa, compact=False)

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -226,8 +226,9 @@ def _make_mo_eris_incore(agf2, mo_coeff=None):
         qxy_a[p0:p1] = ao2mo._ao2mo.nr_e2(eri0, moa, sija, out=qxy_a[p0:p1], **sym)
         qxy_b[p0:p1] = ao2mo._ao2mo.nr_e2(eri0, mob, sijb, out=qxy_b[p0:p1], **sym)
 
-    qxy_a = mpi_helper.reduce(qxy_a)
-    qxy_b = mpi_helper.reduce(qxy_b)
+    mpi_helper.barrier()
+    mpi_helper.allreduce_safe_inplace(qxy_a)
+    mpi_helper.allreduce_safe_inplace(qxy_b)
 
     eris.eri_a = qxy_a
     eris.eri_b = qxy_b
@@ -281,10 +282,11 @@ def _make_qmo_eris_incore(agf2, eri, gf_occ, gf_vir):
         qja_a[p0:p1] = ao2mo._ao2mo.nr_e2(bufa0, cja_a, sja_a, out=qja_a[p0:p1], **sym)
         qja_b[p0:p1] = ao2mo._ao2mo.nr_e2(bufb0, cja_b, sja_b, out=qja_b[p0:p1], **sym)
 
-    qxi_a = mpi_helper.reduce(qxi_a)
-    qxi_b = mpi_helper.reduce(qxi_b)
-    qja_a = mpi_helper.reduce(qja_a)
-    qja_b = mpi_helper.reduce(qja_b)
+    mpi_helper.barrier()
+    mpi_helper.allreduce_safe_inplace(qxi_a)
+    mpi_helper.allreduce_safe_inplace(qxi_b)
+    mpi_helper.allreduce_safe_inplace(qja_a)
+    mpi_helper.allreduce_safe_inplace(qja_b)
 
     qxi_a = qxi_a.reshape(naux, -1)
     qxi_b = qxi_b.reshape(naux, -1)

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -224,7 +224,7 @@ class DFUAGF2(uagf2.UAGF2):
             MO basis.
         '''
 
-        eri = _make_mo_eris_incore(self)
+        eri = _make_mo_eris_incore(self, mo_coeff)
 
         return eri
 

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -87,8 +87,8 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     himem_required *= 8e-6
     himem_required *= lib.num_threads()
 
-    if (himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory \
-            and agf2.allow_lowmem_build:
+    if ((himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory
+            and agf2.allow_lowmem_build) or agf2.allow_lowmem_build == 'force':
         log.debug('Thread-private memory overhead %.3f exceeds max_memory, using '
                   'low-memory version.', himem_required)
         build_mats_dfuagf2 = _agf2.build_mats_dfuagf2_lowmem
@@ -113,8 +113,8 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     himem_required *= 8e-6
     himem_required *= lib.num_threads()
 
-    if (himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory \
-            and agf2.allow_lowmem_build:
+    if ((himem_required*1.05 + lib.current_memory()[0]) > agf2.max_memory
+            and agf2.allow_lowmem_build) or agf2.allow_lowmem_build == 'force':
         log.debug('Thread-private memory overhead %.3f exceeds max_memory, using '
                   'low-memory version.', himem_required)
         build_mats_dfuagf2 = _agf2.build_mats_dfuagf2_lowmem
@@ -151,7 +151,8 @@ class DFUAGF2(uagf2.UAGF2):
             Avoid all I/O. Default is False.
         allow_lowmem_build : bool
             Allow the self-energy build to switch to a serially slower
-            code with loweer thread-private memory overhead if needed.
+            code with lower thread-private memory overhead if needed. One
+            of True, False or 'force'. Default value is True.
         conv_tol : float
             Convergence threshold for AGF2 energy. Default value is 1e-7
         conv_tol_rdm1 : float

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -29,7 +29,6 @@ from pyscf.lib import logger
 from pyscf import __config__
 from pyscf import ao2mo, df
 from pyscf.agf2 import uagf2, dfragf2, aux, mpi_helper, _agf2
-from pyscf.mp.ump2 import get_frozen_mask
 
 BLKMIN = getattr(__config__, 'agf2_blkmin', 100)
 
@@ -101,8 +100,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     se_a.remove_uncoupled(tol=tol)
 
     if not (agf2.frozen is None or agf2.frozen == 0):
-        with lib.temporary_env(agf2, _nocc=None, _nmo=None):
-            mask = get_frozen_mask(agf2)
+        mask = uagf2.get_frozen_mask(agf2)
         coupling = np.zeros((nmoa, se_a.naux))
         coupling[mask[0]] = se_a.coupling
         se_a = aux.SelfEnergy(se_a.energy, coupling, chempot=se_a.chempot)
@@ -128,8 +126,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     se_b.remove_uncoupled(tol=tol)
 
     if not (agf2.frozen is None or agf2.frozen == 0):
-        with lib.temporary_env(agf2, _nocc=None, _nmo=None):
-            mask = get_frozen_mask(agf2)
+        mask = uagf2.get_frozen_mask(agf2)
         coupling = np.zeros((nmoa, se_b.naux))
         coupling[mask[1]] = se_b.coupling
         se_b = aux.SelfEnergy(se_b.energy, coupling, chempot=se_b.chempot)
@@ -305,8 +302,7 @@ def _make_qmo_eris_incore(agf2, eri, coeffs_a, coeffs_b):
 
     cxa, cxb = np.eye(agf2.nmo[0]), np.eye(agf2.nmo[1])
     if not (agf2.frozen is None or agf2.frozen == 0):
-        with lib.temporary_env(agf2, _nocc=None, _nmo=None):
-            mask = get_frozen_mask(agf2)
+        mask = uagf2.get_frozen_mask(agf2)
         cxa = cxa[:,mask[0]]
         cxb = cxb[:,mask[1]]
 
@@ -385,6 +381,3 @@ if __name__ == '__main__':
     uagf2.ipagf2(nroots=5)
     uagf2.eaagf2(nroots=5)
 
-    print()
-    keys = ['1b', '2b', 'mp2', 'corr', 'tot']
-    print('  '.join(['%s %16.12f' % (key, getattr(uagf2, 'e_'+key, None)) for key in keys]))

--- a/pyscf/agf2/dfuagf2.py
+++ b/pyscf/agf2/dfuagf2.py
@@ -72,6 +72,11 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     tol = agf2.weight_tol
     facs = dict(os_factor=os_factor, ss_factor=ss_factor)
 
+    ci_a, ei_a = gf_occ[0].coupling, gf_occ[0].energy
+    ci_b, ei_b = gf_occ[1].coupling, gf_occ[1].energy
+    ca_a, ea_a = gf_vir[0].coupling, gf_vir[0].energy
+    ca_b, ea_b = gf_vir[1].coupling, gf_vir[1].energy
+
     qeri = _make_qmo_eris_incore(agf2, eri, gf_occ, gf_vir)
     (qxi_a, qja_a), (qxi_b, qja_b) = qeri
     qxi = (qxi_a, qxi_b)
@@ -89,7 +94,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     else:
         build_mats_dfuagf2 = _agf2.build_mats_dfuagf2_incore
 
-    vv, vev = build_mats_dfuagf2(qxi, qja, gf_occ, gf_vir, **facs)
+    vv, vev = build_mats_dfuagf2(qxi, qja, (ei_a, ei_b), (ea_a, ea_b), **facs)
     e, c = _agf2.cholesky_build(vv, vev)
     se_a = aux.SelfEnergy(e, c, chempot=gf_occ[0].chempot)
     se_a.remove_uncoupled(tol=tol)
@@ -109,7 +114,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
         build_mats_dfuagf2 = _agf2.build_mats_dfuagf2_incore
 
     rv = np.s_[::-1]
-    vv, vev = build_mats_dfuagf2(qxi[rv], qja[rv], gf_occ[rv], gf_vir[rv], **facs)
+    vv, vev = build_mats_dfuagf2(qxi[rv], qja[rv], (ei_b, ei_a), (ea_b, ea_a), **facs)
     e, c = _agf2.cholesky_build(vv, vev)
     se_b = aux.SelfEnergy(e, c, chempot=gf_occ[1].chempot)
     se_b.remove_uncoupled(tol=tol)

--- a/pyscf/agf2/mpi_helper.py
+++ b/pyscf/agf2/mpi_helper.py
@@ -50,6 +50,7 @@ def bcast(buf, root=0):
 
     is_array = isinstance(buf, np.ndarray)
     buf = np.asarray(buf, order='C')
+    buf = buf.astype(buf.dtype.char)
     shape, mpi_dtype = comm.bcast((buf.shape, buf.dtype.char))
 
     if rank != root:
@@ -77,6 +78,7 @@ def reduce(sendbuf, root=0, op=getattr(mpi, 'SUM', None)):
 
     is_array = isinstance(sendbuf, np.ndarray)
     sendbuf = np.asarray(sendbuf, order='C')
+    sendbuf = sendbuf.astype(sendbuf.dtype.char)
     shape, mpi_dtype = comm.bcast((sendbuf.shape, sendbuf.dtype.char))
     assert sendbuf.shape == shape and sendbuf.dtype.char == mpi_dtype
 
@@ -98,6 +100,7 @@ def allreduce(sendbuf, root=0, op=getattr(mpi, 'SUM', None)):
 
     is_array = isinstance(sendbuf, np.ndarray)
     sendbuf = np.asarray(sendbuf, order='C')
+    sendbuf = sendbuf.astype(sendbuf.dtype.char)
     shape, mpi_dtype = comm.bcast((sendbuf.shape, sendbuf.dtype.char))
     assert sendbuf.shape == shape and sendbuf.dtype.char == mpi_dtype
 

--- a/pyscf/agf2/mpi_helper.py
+++ b/pyscf/agf2/mpi_helper.py
@@ -29,12 +29,13 @@ from pyscf import __config__
 INT_MAX = 2147483647
 BLKSIZE = INT_MAX // 32 + 1
 
+# attempt to successfully load and init the MPI, else assume 1 core:
 try:
     from mpi4py import MPI as mpi
     comm = mpi.COMM_WORLD
     size = comm.Get_size()
     rank = comm.Get_rank()
-except: #NOTE should we check for ImportError? This is OSError in python2, check how pyscf handles this elsewhere
+except:
     mpi = None
     comm = None
     size = 1

--- a/pyscf/agf2/mpi_helper.py
+++ b/pyscf/agf2/mpi_helper.py
@@ -77,6 +77,35 @@ def reduce(obj, root=0, op=getattr(mpi, 'SUM', None)):
     return m
 
 
+def broadcast(obj, root=0):
+    ''' Broadcast an object from the root process to other processes.
+
+    Args:
+        obj : Most things
+            Object to broadcast
+
+    Kwargs:
+        root : int
+            Rank of the root process
+
+    Returns:
+        obj : Most things
+            Broadcasted object
+    '''
+
+    if size == 1:
+        return obj
+
+    is_array = isinstance(obj, np.ndarray)
+
+    if is_array:
+        obj = comm.Bcast(obj, root=root)
+    else:
+        obj = comm.bcast(obj, root=root)
+
+    return obj
+
+
 def nrange(start, stop=None, step=1):
     if stop is None:
         start, stop = 0, start

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -548,7 +548,7 @@ class RAGF2(lib.StreamObject):
         mem_now = lib.current_memory()[0]
 
         if (self._scf._eri is not None and 
-                (mem_incore+mem_now < self.max_memory and not self.incore_complete)):
+                (mem_incore+mem_now < self.max_memory or self.incore_complete)):
             eri = _make_mo_eris_incore(self, mo_coeff)
         else:
             logger.warn(self, 'MO eris are outcore - this may be very '

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -938,7 +938,7 @@ class _ChemistsERIs:
         mo_e = self.fock.diagonal()
         gap = abs(mo_e[:self.nocc,None] - mo_e[None,self.nocc:]).min()
         if gap < 1e-5:
-            logger.warn(agf2, 'HOMO-LUMO gap %s too small for RAGF2', gap)
+            logger.warn(agf2, 'HOMO-LUMO gap %s may be too small for AGF2', gap)
 
         return self
 

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -156,7 +156,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     else:
         vv, vev = _agf2.build_mats_ragf2_outcore(qeri, gf_occ, gf_vir, **facs)
 
-    e, c = _agf2.cholesky_build(vv, vev, gf_occ, gf_vir)
+    e, c = _agf2.cholesky_build(vv, vev)
     se = aux.SelfEnergy(e, c, chempot=gf_occ.chempot)
     se.remove_uncoupled(tol=tol)
 

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -549,12 +549,12 @@ class RAGF2(lib.StreamObject):
 
         if (self._scf._eri is not None and 
                 (mem_incore+mem_now < self.max_memory and not self.incore_complete)):
-            eri = _make_mo_eris_incore(self)
+            eri = _make_mo_eris_incore(self, mo_coeff)
         else:
             logger.warn(self, 'MO eris are outcore - this may be very '
                               'slow for agf2. increasing max_memory or '
                               'using density fitting is recommended.')
-            eri = _make_mo_eris_outcore(self)
+            eri = _make_mo_eris_outcore(self, mo_coeff)
 
         return eri
 

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -144,6 +144,9 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     tol = agf2.weight_tol
     facs = dict(os_factor=os_factor, ss_factor=ss_factor)
 
+    ci, ei = gf_occ.coupling, gf_occ.energy
+    ca, ea = gf_vir.coupling, gf_vir.energy
+
     mem_incore = (gf_occ.nphys*gf_occ.naux**2*gf_vir.naux) * 8/1e6
     mem_now = lib.current_memory()[0]
     if (mem_incore+mem_now < agf2.max_memory) and not agf2.incore_complete:
@@ -152,9 +155,9 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
         qeri = _make_qmo_eris_outcore(agf2, eri, gf_occ, gf_vir)
 
     if isinstance(qeri, np.ndarray):
-        vv, vev = _agf2.build_mats_ragf2_incore(qeri, gf_occ, gf_vir, **facs)
+        vv, vev = _agf2.build_mats_ragf2_incore(qeri, ei, ea, **facs)
     else:
-        vv, vev = _agf2.build_mats_ragf2_outcore(qeri, gf_occ, gf_vir, **facs)
+        vv, vev = _agf2.build_mats_ragf2_outcore(qeri, ei, ea, **facs)
 
     e, c = _agf2.cholesky_build(vv, vev)
     se = aux.SelfEnergy(e, c, chempot=gf_occ.chempot)

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -768,7 +768,7 @@ class RAGF2(lib.StreamObject):
         v_ip = list(gf_occ.coupling[:,-nroots:].T)[::-1]
         return e_ip, v_ip
 
-    def ipagf2(self, nroots=1):
+    def ipagf2(self, nroots=5):
         ''' Find the (N-1)-electron charged excitations, corresponding
             to the largest :attr:`nroots` poles of the occupied
             Green's function.
@@ -794,7 +794,7 @@ class RAGF2(lib.StreamObject):
         else:
             return e_ip, v_ip
 
-    def get_ea(self, gf, nroots=1):
+    def get_ea(self, gf, nroots=5):
         gf_vir = gf.get_virtual()
         e_ea = list(gf_vir.energy[:nroots])
         v_ea = list(gf_vir.coupling[:,:nroots].T)

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -202,6 +202,7 @@ def get_jk(agf2, eri, rdm1, with_j=True, with_k=True):
 
         blksize = _agf2.get_blksize(agf2.max_memory, (nmo*npair, nmo**3))
         blksize = min(nmo, max(BLKMIN, blksize))
+        logger.debug1(agf2, 'blksize (ragf2.get_jk) = %d' % blksize)
 
         tril2sq = lib.square_mat_in_trilu_indices(nmo)
         for p0, p1 in lib.prange(0, nmo, blksize):
@@ -786,7 +787,7 @@ class RAGF2(lib.StreamObject):
 
         for n, en, vn in zip(range(nroots), e_ip, v_ip):
             qpwt = np.linalg.norm(vn)**2
-            logger.note(self, 'IP root %d E = %.16g  qpwt = %0.6g', n, en, qpwt)
+            logger.note(self, 'IP energy level %d E = %.16g  qpwt = %0.6g', n, en, qpwt)
 
         if nroots == 1:
             return e_ip[0], v_ip[0]
@@ -812,7 +813,7 @@ class RAGF2(lib.StreamObject):
 
         for n, en, vn in zip(range(nroots), e_ea, v_ea):
             qpwt = np.linalg.norm(vn)**2
-            logger.note(self, 'EA root %d E = %.16g  qpwt = %0.6g', n, en, qpwt)
+            logger.note(self, 'EA energy level %d E = %.16g  qpwt = %0.6g', n, en, qpwt)
 
         if nroots == 1:
             return e_ea[0], v_ea[0]
@@ -947,7 +948,7 @@ def _make_qmo_eris_incore(agf2, eri, gf_occ, gf_vir):
     qeri = ao2mo.incore.general(eri.eri, coeffs, compact=False, verbose=log)
     qeri = qeri.reshape(shape)
 
-    log.timer_debug1('QMO integral transformation', *cput0)
+    log.timer('QMO integral transformation', *cput0)
 
     return qeri
 
@@ -975,7 +976,7 @@ def _make_qmo_eris_outcore(agf2, eri, gf_occ, gf_vir):
 
     blksize = _agf2.get_blksize(agf2.max_memory, (nmo*npair, nj*na, npair), (nmo*ni, nj*na))
     blksize = min(nmo, max(BLKMIN, blksize))
-    log.debug1('blksize = %d', blksize)
+    log.debug1('blksize (ragf2._make_qmo_eris_outcore) = %d', blksize)
 
     tril2sq = lib.square_mat_in_trilu_indices(nmo)
     for p0, p1 in lib.prange(0, nmo, blksize):
@@ -991,7 +992,7 @@ def _make_qmo_eris_outcore(agf2, eri, gf_occ, gf_vir):
         buf = lib.einsum('xpja,pi->xija', buf, ci)
         eri.feri['qmo'][p0:p1] = np.asarray(buf, order='C')
         
-    log.timer_debug1('QMO integral transformation', *cput0)
+    log.timer('QMO integral transformation', *cput0)
 
     return eri.feri['qmo']
 

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -698,6 +698,7 @@ class RAGF2(lib.StreamObject):
         logger.note(self, 'E(%s) = %.16g  E_corr = %.16g',
                     self.__class__.__name__, self.e_tot, self.e_corr)
         logger.note(self, 'IP = %.16g  EA = %.16g', ip, ea)
+        logger.note(self, 'Quasiparticle gap = %.16g', ip+ea)
 
         return self
 

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -796,7 +796,7 @@ class RAGF2(lib.StreamObject):
         return myagf2
 
 
-    def get_ip(self, gf, nroots=1):
+    def get_ip(self, gf, nroots=5):
         gf_occ = gf.get_occupied()
         e_ip = list(-gf_occ.energy[-nroots:])[::-1]
         v_ip = list(gf_occ.coupling[:,-nroots:].T)[::-1]
@@ -821,7 +821,7 @@ class RAGF2(lib.StreamObject):
 
         for n, en, vn in zip(range(nroots), e_ip, v_ip):
             qpwt = np.linalg.norm(vn)**2
-            logger.note(self, 'IP energy level %d E = %.16g  qpwt = %0.6g', n, en, qpwt)
+            logger.note(self, 'IP energy level %d E = %.16g  QP weight = %0.6g', n, en, qpwt)
 
         if nroots == 1:
             return e_ip[0], v_ip[0]
@@ -847,7 +847,7 @@ class RAGF2(lib.StreamObject):
 
         for n, en, vn in zip(range(nroots), e_ea, v_ea):
             qpwt = np.linalg.norm(vn)**2
-            logger.note(self, 'EA energy level %d E = %.16g  qpwt = %0.6g', n, en, qpwt)
+            logger.note(self, 'EA energy level %d E = %.16g  QP weight = %0.6g', n, en, qpwt)
 
         if nroots == 1:
             return e_ea[0], v_ea[0]

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -147,7 +147,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
 
     mem_incore = (gf_occ.nphys*gf_occ.naux**2*gf_vir.naux) * 8/1e6
     mem_now = lib.current_memory()[0]
-    if (mem_incore+mem_now < agf2.max_memory) and not agf2.incore_complete:
+    if (mem_incore+mem_now < agf2.max_memory) or agf2.incore_complete:
         qeri = _make_qmo_eris_incore(agf2, eri, (ci, ci, ca))
     else:
         qeri = _make_qmo_eris_outcore(agf2, eri, (ci, ci, ca))

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -377,9 +377,10 @@ def energy_2body(agf2, gf, se):
         vv = vxk * vxl[:,None]
         e2b += lib.einsum('xk,yk,k->', vv, vv.conj(), 1./dlk)
 
-    e2b = mpi_helper.reduce(e2b)
-
     e2b *= 2
+
+    mpi_helper.barrier()
+    e2b = mpi_helper.allreduce(e2b)
 
     return np.ravel(e2b.real)[0] #NOTE: i've had some problems with some einsum implementations not returning scalars... worth doing ravel()[0]?
 

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -152,7 +152,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     se = aux.SelfEnergy(e, c, chempot=gf_occ.chempot)
     se.remove_uncoupled(tol=tol)
 
-    log.timer_debug1('se part', *cput0)
+    log.timer('se part', *cput0)
 
     return se
 
@@ -311,6 +311,7 @@ def fock_loop(agf2, eri, gf, se):
 
     log.info('fock converged = %s  chempot = %.9g  dN = %.3g  |ddm| = %.3g',
              converged, se.chempot, nerr, derr)
+    log.timer('fock loop', *cput0)
 
     return gf, se, converged
 

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -508,9 +508,9 @@ class RAGF2(lib.StreamObject):
 
     def __init__(self, mf, frozen=None, mo_energy=None, mo_coeff=None, mo_occ=None):
 
-        if mo_energy is None: mo_energy = mf.mo_energy
-        if mo_coeff  is None: mo_coeff  = mf.mo_coeff
-        if mo_occ    is None: mo_occ    = mf.mo_occ
+        if mo_energy is None: mo_energy = mpi_helper.bcast(mf.mo_energy)
+        if mo_coeff  is None: mo_coeff  = mpi_helper.bcast(mf.mo_coeff)
+        if mo_occ    is None: mo_occ    = mpi_helper.bcast(mf.mo_occ)
 
         self.mol = mf.mol
         self._scf = mf
@@ -940,7 +940,8 @@ class RAGF2(lib.StreamObject):
 
     @property
     def e_corr(self):
-        return self.e_tot - self._scf.e_tot
+        e_hf = mpi_helper.bcast(self._scf.e_tot)
+        return self.e_tot - e_hf
 
     @property
     def qmo_energy(self):
@@ -996,7 +997,10 @@ class _ChemistsERIs:
         self.h1e = np.dot(np.dot(mo_coeff.conj().T, h1e_ao), mo_coeff)
         self.fock = np.dot(np.dot(mo_coeff.conj().T, fock_ao), mo_coeff)
 
-        self.e_hf = agf2._scf.e_tot
+        self.h1e = mpi_helper.bcast(self.h1e)
+        self.fock = mpi_helper.bcast(self.fock)
+
+        self.e_hf = mpi_helper.bcast(agf2._scf.e_tot)
 
         self.nmo = agf2.nmo
         self.nocc = agf2.nocc

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -205,7 +205,7 @@ def get_jk(agf2, eri, rdm1, with_j=True, with_k=True):
 
         tril2sq = lib.square_mat_in_trilu_indices(nmo)
         for p0, p1 in lib.prange(0, nmo, blksize):
-            idx = np.concatenate(tril2sq[p0:p1])
+            idx = list(np.concatenate(tril2sq[p0:p1]))
             eri0 = eri[idx]
 
             # vj built in tril layout with scaled rdm1_tril
@@ -979,7 +979,7 @@ def _make_qmo_eris_outcore(agf2, eri, gf_occ, gf_vir):
 
     tril2sq = lib.square_mat_in_trilu_indices(nmo)
     for p0, p1 in lib.prange(0, nmo, blksize):
-        idx = np.concatenate(tril2sq[p0:p1])
+        idx = list(np.concatenate(tril2sq[p0:p1]))
 
         buf = eri.eri[idx] # (blk, nmo, npair)
         buf = buf.reshape((p1-p0)*nmo, -1) # (blk*nmo, npair)

--- a/pyscf/agf2/ragf2_slow.py
+++ b/pyscf/agf2/ragf2_slow.py
@@ -172,7 +172,7 @@ class RAGF2(ragf2.RAGF2):
 
         self.nmom = nmom
 
-        self._keys.update(['_nmom'])
+        self._keys.update(['nmom'])
 
     build_se_part = build_se_part
 
@@ -227,54 +227,6 @@ class RAGF2(ragf2.RAGF2):
         ragf2.RAGF2.dump_flags(self, verbose=verbose)
         logger.info(self, 'nmom = %s', repr(self.nmom))
         return self
-
-    def dump_chk(self, gf=None, se=None, frozen=None, nmom=None, mo_energy=None, mo_coeff=None, mo_occ=None):
-        if not self.chkfile:
-            return self
-
-        if mo_energy is None: mo_energy = self.mo_energy
-        if mo_coeff  is None: mo_coeff  = self.mo_coeff
-        if mo_occ    is None: mo_occ    = self.mo_occ
-        if frozen is None: frozen = self.frozen
-        if frozen is None: frozen = 0
-        if nmom is None: nmom = self.nmom
-
-        ngf, nse = nmom
-        if ngf is None: ngf = -1
-        if nse is None: nse = -1
-
-        agf2_chk = { 'e_1b': self.e_1b,
-                     'e_2b': self.e_2b,
-                     'e_mp2': self.e_mp2,
-                     'converged': self.converged,
-                     'mo_energy': mo_energy,
-                     'mo_coeff': mo_coeff,
-                     'mo_occ': mo_occ,
-                     'frozen': frozen,
-                     'nmom': (ngf, nse),
-        }
-
-        if gf is None: gf = self.gf
-        if se is None: se = self.se
-
-        if gf is not None: agf2_chk['gf'] = ragf2._aux_to_dict(gf)
-        if se is not None: agf2_chk['se'] = ragf2._aux_to_dict(se)
-
-        if self._nmo is not None: agf2_chk['_nmo'] = self._nmo
-        if self._nocc is not None: agf2_chk['_nocc'] = self._nocc
-
-        lib.chkfile.dump(self.chkfile, 'agf2', agf2_chk)
-
-    
-    @property
-    def nmom(self):
-        return self._nmom
-    @nmom.setter
-    def nmom(self, val):
-        ngf, nse = val
-        if ngf == -1: ngf = None
-        if nse == -1: nse = None
-        self._nmom = (ngf, nse)
 
 
 class _ChemistsERIs(ragf2._ChemistsERIs):

--- a/pyscf/agf2/ragf2_slow.py
+++ b/pyscf/agf2/ragf2_slow.py
@@ -74,7 +74,8 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
 
     eja = lib.direct_sum('j,a->ja', gf_occ.energy, -gf_vir.energy)
     
-    qeri = _make_qmo_eris_incore(agf2, eri, gf_occ, gf_vir)
+    coeffs = (gf_occ.coupling, gf_occ.coupling, gf_vir.coupling)
+    qeri = _make_qmo_eris_incore(agf2, eri, coeffs)
 
     p1 = 0
     for i in range(nocc):

--- a/pyscf/agf2/ragf2_slow.py
+++ b/pyscf/agf2/ragf2_slow.py
@@ -98,7 +98,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     se = aux.SelfEnergy(e, v, chempot=gf_occ.chempot)
     se.remove_uncoupled(tol=tol)
 
-    log.timer_debug1('se part', *cput0)
+    log.timer('se part', *cput0)
     
     return se
 

--- a/pyscf/agf2/ragf2_slow.py
+++ b/pyscf/agf2/ragf2_slow.py
@@ -155,8 +155,8 @@ class RAGF2(ragf2.RAGF2):
             One-body part of :attr:`e_tot`
         e_2b : float
             Two-body part of :attr:`e_tot`
-        e_mp2 : float
-            MP2 correlation energy
+        e_init : float
+            Initial correlation energy (truncated MP2)
         converged : bool
             Whether convergence was successful
         se : SelfEnergy

--- a/pyscf/agf2/ragf2_slow.py
+++ b/pyscf/agf2/ragf2_slow.py
@@ -144,9 +144,9 @@ class RAGF2(ragf2.RAGF2):
         weight_tol : float
             Threshold in spectral weight of auxiliaries to be considered
             zero. Default 1e-11.
-        diis_space : int
+        fock_diis_space : int
             DIIS space size for Fock loop iterations. Default value is 6.
-        diis_min_space : 
+        fock_diis_min_space : 
             Minimum space of DIIS. Default value is 1.
         os_factor : float
             Opposite-spin factor for spin-component-scaled (SCS)
@@ -247,6 +247,9 @@ class RAGF2(ragf2.RAGF2):
         ragf2.RAGF2.dump_flags(self, verbose=verbose)
         logger.info(self, 'nmom = %s', repr(self.nmom))
         return self
+
+    def run_diis(self, se, diis=None):
+        return se
 
 
 class _ChemistsERIs(ragf2._ChemistsERIs):

--- a/pyscf/agf2/ragf2_slow.py
+++ b/pyscf/agf2/ragf2_slow.py
@@ -172,7 +172,7 @@ class RAGF2(ragf2.RAGF2):
 
         self.nmom = nmom
 
-        self._keys.update(['nmom'])
+        self._keys.update(['_nmom'])
 
     build_se_part = build_se_part
 
@@ -228,7 +228,7 @@ class RAGF2(ragf2.RAGF2):
         logger.info(self, 'nmom = %s', repr(self.nmom))
         return self
 
-    def dump_chk(self, gf=None, se=None, nmom=None, mo_energy=None, mo_coeff=None, mo_occ=None):
+    def dump_chk(self, gf=None, se=None, frozen=None, nmom=None, mo_energy=None, mo_coeff=None, mo_occ=None):
         if not self.chkfile:
             return self
 
@@ -239,23 +239,42 @@ class RAGF2(ragf2.RAGF2):
         if frozen is None: frozen = 0
         if nmom is None: nmom = self.nmom
 
+        ngf, nse = nmom
+        if ngf is None: ngf = -1
+        if nse is None: nse = -1
+
         agf2_chk = { 'e_1b': self.e_1b,
                      'e_2b': self.e_2b,
+                     'e_mp2': self.e_mp2,
                      'converged': self.converged,
                      'mo_energy': mo_energy,
                      'mo_coeff': mo_coeff,
                      'mo_occ': mo_occ,
                      'frozen': frozen,
-                     'nmom': nmom,
+                     'nmom': (ngf, nse),
         }
 
-        if self.gf is not None: agf2_chk['gf'] = ragf2._aux_to_dict(gf)
-        if self.se is not None: agf2_chk['se'] = ragf2._aux_to_dict(se)
+        if gf is None: gf = self.gf
+        if se is None: se = self.se
+
+        if gf is not None: agf2_chk['gf'] = ragf2._aux_to_dict(gf)
+        if se is not None: agf2_chk['se'] = ragf2._aux_to_dict(se)
 
         if self._nmo is not None: agf2_chk['_nmo'] = self._nmo
         if self._nocc is not None: agf2_chk['_nocc'] = self._nocc
 
         lib.chkfile.dump(self.chkfile, 'agf2', agf2_chk)
+
+    
+    @property
+    def nmom(self):
+        return self._nmom
+    @nmom.setter
+    def nmom(self, val):
+        ngf, nse = val
+        if ngf == -1: ngf = None
+        if nse == -1: nse = None
+        self._nmom = (ngf, nse)
 
 
 class _ChemistsERIs(ragf2._ChemistsERIs):

--- a/pyscf/agf2/ragf2_slow.py
+++ b/pyscf/agf2/ragf2_slow.py
@@ -156,6 +156,8 @@ class RAGF2(ragf2.RAGF2):
         ss_factor : float
             Same-spin factor for spin-component-scaled (SCS)
             calculations. Default 1.0
+        damping : float
+            Damping factor for the self-energy. Default value is 0.0
 
     Saved results
 
@@ -188,7 +190,7 @@ class RAGF2(ragf2.RAGF2):
 
     build_se_part = build_se_part
 
-    def build_se(self, eri=None, gf=None, os_factor=None, ss_factor=None):
+    def build_se(self, eri=None, gf=None, os_factor=None, ss_factor=None, se_prev=None):
         ''' Builds the auxiliaries of the self-energy.
 
         Args:
@@ -204,6 +206,8 @@ class RAGF2(ragf2.RAGF2):
             ss_factor : float
                 Same-spin factor for spin-component-scaled (SCS)
                 calculations. Default 1.0
+            se_prev : SelfEnergy
+                Previous self-energy for damping. Default value is None
 
         Returns:
             :class:`SelfEnergy`
@@ -232,6 +236,12 @@ class RAGF2(ragf2.RAGF2):
 
         se = aux.combine(se_vir, se_occ)
         se = se.compress(phys=fock, n=(self.nmom[0], None))
+
+        if se_prev is not None and self.damping != 0.0:
+            se.coupling *= np.sqrt(1.0-self.damping)
+            se_prev.coupling *= np.sqrt(self.damping)
+            se = aux.combine(se, se_prev)
+            se = se.compress(n=self.nmom)
 
         return se
 

--- a/pyscf/agf2/ragf2_slow.py
+++ b/pyscf/agf2/ragf2_slow.py
@@ -27,7 +27,6 @@ from pyscf import lib
 from pyscf.lib import logger
 from pyscf import __config__
 from pyscf.agf2 import aux, ragf2
-from pyscf.mp.mp2 import get_frozen_mask
 
 
 def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
@@ -67,8 +66,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     tol = agf2.weight_tol
 
     if not (agf2.frozen is None or agf2.frozen == 0):
-        with lib.temporary_env(agf2, _nocc=None, _nmo=None):
-            mask = get_frozen_mask(agf2)
+        mask = ragf2.get_frozen_mask(agf2)
         nmo -= np.sum(~mask)
 
     e = np.zeros((naux))

--- a/pyscf/agf2/ragf2_slow.py
+++ b/pyscf/agf2/ragf2_slow.py
@@ -27,6 +27,7 @@ from pyscf import lib
 from pyscf.lib import logger
 from pyscf import __config__
 from pyscf.agf2 import aux, ragf2
+from pyscf.mp.mp2 import get_frozen_mask
 
 
 def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
@@ -65,6 +66,11 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     naux = nocc * nocc * nvir
     tol = agf2.weight_tol
 
+    if not (agf2.frozen is None or agf2.frozen == 0):
+        with lib.temporary_env(agf2, _nocc=None, _nmo=None):
+            mask = get_frozen_mask(agf2)
+        nmo -= np.sum(~mask)
+
     e = np.zeros((naux))
     v = np.zeros((nmo, naux))
 
@@ -98,6 +104,11 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
 
     se = aux.SelfEnergy(e, v, chempot=gf_occ.chempot)
     se.remove_uncoupled(tol=tol)
+
+    if not (agf2.frozen is None or agf2.frozen == 0):
+        coupling = np.zeros((agf2.nmo, se.naux))
+        coupling[mask] = se.coupling
+        se = aux.SelfEnergy(se.energy, coupling, chempot=se.chempot)
 
     log.timer('se part', *cput0)
     

--- a/pyscf/agf2/test/test_c_agf2.py
+++ b/pyscf/agf2/test/test_c_agf2.py
@@ -29,10 +29,12 @@ class KnownValues(unittest.TestCase):
         self.nocc = 20
         self.nvir = 80
         self.naux = 400
+        np.random.seed(1)
 
     @classmethod
     def tearDownClass(self):
         del self.nmo, self.nocc, self.nvir, self.naux
+        np.random.seed()
 
     def test_c_ragf2(self):
         xija = np.random.random((self.nmo, self.nocc, self.nocc, self.nvir))

--- a/pyscf/agf2/test/test_c_agf2.py
+++ b/pyscf/agf2/test/test_c_agf2.py
@@ -40,8 +40,8 @@ class KnownValues(unittest.TestCase):
         xija = np.random.random((self.nmo, self.nocc, self.nocc, self.nvir))
         gf_occ = aux.GreensFunction(np.random.random(self.nocc), np.eye(self.nmo, self.nocc))
         gf_vir = aux.GreensFunction(np.random.random(self.nvir), np.eye(self.nmo, self.nvir))
-        vv1, vev1 = _agf2.build_mats_ragf2_outcore(xija, gf_occ, gf_vir)
-        vv2, vev2 = _agf2.build_mats_ragf2_incore(xija, gf_occ, gf_vir)
+        vv1, vev1 = _agf2.build_mats_ragf2_outcore(xija, gf_occ.energy, gf_vir.energy)
+        vv2, vev2 = _agf2.build_mats_ragf2_incore(xija, gf_occ.energy, gf_vir.energy)
         self.assertAlmostEqual(np.max(np.absolute(vv1-vv2)), 0.0, 10)
         self.assertAlmostEqual(np.max(np.absolute(vev1-vev2)), 0.0, 10)
 
@@ -50,8 +50,8 @@ class KnownValues(unittest.TestCase):
         qja = np.random.random((self.naux, self.nocc*self.nvir)) / self.naux
         gf_occ = aux.GreensFunction(np.random.random(self.nocc), np.eye(self.nmo, self.nocc))
         gf_vir = aux.GreensFunction(np.random.random(self.nvir), np.eye(self.nmo, self.nvir))
-        vv1, vev1 = _agf2.build_mats_dfragf2_outcore(qxi, qja, gf_occ, gf_vir)
-        vv2, vev2 = _agf2.build_mats_dfragf2_incore(qxi, qja, gf_occ, gf_vir)
+        vv1, vev1 = _agf2.build_mats_dfragf2_outcore(qxi, qja, gf_occ.energy, gf_vir.energy)
+        vv2, vev2 = _agf2.build_mats_dfragf2_incore(qxi, qja, gf_occ.energy, gf_vir.energy)
         self.assertAlmostEqual(np.max(np.absolute(vv1-vv2)), 0.0, 10)
         self.assertAlmostEqual(np.max(np.absolute(vev1-vev2)), 0.0, 10)
 
@@ -61,8 +61,8 @@ class KnownValues(unittest.TestCase):
                   aux.GreensFunction(np.random.random(self.nocc), np.eye(self.nmo, self.nocc)))
         gf_vir = (aux.GreensFunction(np.random.random(self.nvir), np.eye(self.nmo, self.nvir)),
                   aux.GreensFunction(np.random.random(self.nvir), np.eye(self.nmo, self.nvir)))
-        vv1, vev1 = _agf2.build_mats_uagf2_outcore(xija, gf_occ, gf_vir)
-        vv2, vev2 = _agf2.build_mats_uagf2_incore(xija, gf_occ, gf_vir)
+        vv1, vev1 = _agf2.build_mats_uagf2_outcore(xija, (gf_occ[0].energy, gf_occ[1].energy), (gf_vir[0].energy, gf_vir[1].energy))
+        vv2, vev2 = _agf2.build_mats_uagf2_incore(xija, (gf_occ[0].energy, gf_occ[1].energy), (gf_vir[0].energy, gf_vir[1].energy))
         self.assertAlmostEqual(np.max(np.absolute(vv1-vv2)), 0.0, 10)
         self.assertAlmostEqual(np.max(np.absolute(vev1-vev2)), 0.0, 10)
 
@@ -73,8 +73,8 @@ class KnownValues(unittest.TestCase):
                   aux.GreensFunction(np.random.random(self.nocc), np.eye(self.nmo, self.nocc)))
         gf_vir = (aux.GreensFunction(np.random.random(self.nvir), np.eye(self.nmo, self.nvir)),
                   aux.GreensFunction(np.random.random(self.nvir), np.eye(self.nmo, self.nvir)))
-        vv1, vev1 = _agf2.build_mats_dfuagf2_outcore(qxi, qja, gf_occ, gf_vir)
-        vv2, vev2 = _agf2.build_mats_dfuagf2_incore(qxi, qja, gf_occ, gf_vir)
+        vv1, vev1 = _agf2.build_mats_dfuagf2_outcore(qxi, qja, (gf_occ[0].energy, gf_occ[1].energy), (gf_vir[0].energy, gf_vir[1].energy))
+        vv2, vev2 = _agf2.build_mats_dfuagf2_incore(qxi, qja, (gf_occ[0].energy, gf_occ[1].energy), (gf_vir[0].energy, gf_vir[1].energy))
         self.assertAlmostEqual(np.max(np.absolute(vv1-vv2)), 0.0, 10)
         self.assertAlmostEqual(np.max(np.absolute(vev1-vev2)), 0.0, 10)
 

--- a/pyscf/agf2/test/test_dfragf2_h2o.py
+++ b/pyscf/agf2/test/test_dfragf2_h2o.py
@@ -20,8 +20,6 @@ import unittest
 import numpy as np
 from pyscf import gto, scf, agf2, lib
 
-#NOTE: uses loose tolerance comparison aganst exact-ERI results
-
 
 class KnownValues(unittest.TestCase):
 

--- a/pyscf/agf2/test/test_dfragf2_h2o.py
+++ b/pyscf/agf2/test/test_dfragf2_h2o.py
@@ -43,7 +43,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(self.mf.e_tot,  -76.0167894720742   , 4)
         self.assertAlmostEqual(self.gf2.e_1b,  -75.89108074396137  , 4)
         self.assertAlmostEqual(self.gf2.e_2b,  -0.33248785652834784, 4)
-        self.assertAlmostEqual(self.gf2.e_mp2, -0.17330473289845347, 4)
+        self.assertAlmostEqual(self.gf2.e_init, -0.17330473289845347, 4)
 
     def test_dfragf2_h2o_ip(self):
         # tests the AGF2 ionization potentials for H2O/cc-pvdz

--- a/pyscf/agf2/test/test_dfuagf2_beh.py
+++ b/pyscf/agf2/test/test_dfuagf2_beh.py
@@ -43,7 +43,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(self.mf.e_tot,  -15.0910903300424    , 4)
         self.assertAlmostEqual(self.gf2.e_1b,  -15.069681001221705  , 4)
         self.assertAlmostEqual(self.gf2.e_2b,  -0.049461593728309786, 4)
-        self.assertAlmostEqual(self.gf2.e_mp2, -0.025198374705580943, 4)
+        self.assertAlmostEqual(self.gf2.e_init, -0.025198374705580943, 4)
 
     def test_dfuagf2_beh_ip(self):
         # tests the AGF2 ionization potentials for BeH/cc-pvdz

--- a/pyscf/agf2/test/test_dfuagf2_beh.py
+++ b/pyscf/agf2/test/test_dfuagf2_beh.py
@@ -20,8 +20,6 @@ import unittest
 import numpy as np
 from pyscf import gto, scf, agf2, lib
 
-#NOTE: uses loose tolerance comparison aganst exact-ERI results
-
 
 class KnownValues(unittest.TestCase):
 

--- a/pyscf/agf2/test/test_ragf2_h2o.py
+++ b/pyscf/agf2/test/test_ragf2_h2o.py
@@ -43,7 +43,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(self.mf.e_tot,  -76.0167894720742   , 10)
         self.assertAlmostEqual(self.gf2.e_1b,  -75.89108074396137  ,  6)
         self.assertAlmostEqual(self.gf2.e_2b,  -0.33248785652834784,  6)
-        self.assertAlmostEqual(self.gf2.e_mp2, -0.17330473289845347,  6)
+        self.assertAlmostEqual(self.gf2.e_init, -0.17330473289845347,  6)
 
     def test_ragf2_h2o_ip(self):
         # tests the AGF2 ionization potentials for H2O/cc-pvdz

--- a/pyscf/agf2/test/test_ragf2_h2o.py
+++ b/pyscf/agf2/test/test_ragf2_h2o.py
@@ -86,7 +86,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(v_ea,     0.9903734898112396  , 6)
         gf2.dump_chk()
         gf2 = agf2.RAGF2(self.mf)
-        gf2.__dict__.update(lib.chkfile.load(gf2.chkfile, 'agf2'))
+        gf2.__dict__.update(agf2.chkfile.load(gf2.chkfile, 'agf2'))
         e_ip, v_ip = self.gf2.ipagf2(nroots=1)
         e_ea, v_ea = self.gf2.eaagf2(nroots=1)
         v_ip = np.linalg.norm(v_ip)**2

--- a/pyscf/agf2/test/test_ragf2_slow_h2o.py
+++ b/pyscf/agf2/test/test_ragf2_slow_h2o.py
@@ -45,7 +45,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(mf.e_tot,  -76.0167894720742   , 10)
         self.assertAlmostEqual(gf2.e_1b,  -75.89108074396137  ,  6)
         self.assertAlmostEqual(gf2.e_2b,  -0.33248785652834784,  6)
-        self.assertAlmostEqual(gf2.e_mp2, -0.17330473289845347,  6)
+        self.assertAlmostEqual(gf2.e_init, -0.17330473289845347,  6)
 
         e_ip, v_ip = gf2.ipagf2(nroots=3)
         v_ip = [np.linalg.norm(v)**2 for v in v_ip]
@@ -76,7 +76,7 @@ class KnownValues(unittest.TestCase):
         gf2.conv_tol = 1e-7
         gf2.run()
         self.assertTrue(gf2.converged)
-        self.assertAlmostEqual(gf2.e_mp2, -0.029669047726821392, 4)
+        self.assertAlmostEqual(gf2.e_init, -0.029669047726821392, 4)
         #TODO
 
     def test_moments(self):

--- a/pyscf/agf2/test/test_ragf2_slow_h2o.py
+++ b/pyscf/agf2/test/test_ragf2_slow_h2o.py
@@ -77,7 +77,6 @@ class KnownValues(unittest.TestCase):
         gf2.run()
         self.assertTrue(gf2.converged)
         self.assertAlmostEqual(gf2.e_init, -0.029669047726821392, 4)
-        #TODO
 
     def test_moments(self):
         # tests conservation of moments with compression

--- a/pyscf/agf2/test/test_uagf2_beh.py
+++ b/pyscf/agf2/test/test_uagf2_beh.py
@@ -85,7 +85,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(v_ea,          0.9740024912068087   , 6)
         gf2.dump_chk()
         gf2 = agf2.UAGF2(self.mf)
-        gf2.__dict__.update(lib.chkfile.load(gf2.chkfile, 'agf2'))
+        gf2.__dict__.update(agf2.chkfile.load(gf2.chkfile, 'agf2'))
         e_ip, v_ip = self.gf2.ipagf2(nroots=1)
         e_ea, v_ea = self.gf2.eaagf2(nroots=1)
         v_ip = np.linalg.norm(v_ip)**2

--- a/pyscf/agf2/test/test_uagf2_beh.py
+++ b/pyscf/agf2/test/test_uagf2_beh.py
@@ -43,7 +43,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(self.mf.e_tot,  -15.0910903300424    , 10)
         self.assertAlmostEqual(self.gf2.e_1b,  -15.069681001221705  ,  6)
         self.assertAlmostEqual(self.gf2.e_2b,  -0.049461593728309786,  6)
-        self.assertAlmostEqual(self.gf2.e_mp2, -0.025198374705580943,  6)
+        self.assertAlmostEqual(self.gf2.e_init, -0.025198374705580943,  6)
 
     def test_uagf2_beh_ip(self):
         # tests the AGF2 ionization potentials for BeH/cc-pvdz

--- a/pyscf/agf2/test/test_uagf2_slow_beh.py
+++ b/pyscf/agf2/test/test_uagf2_slow_beh.py
@@ -45,7 +45,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(mf.e_tot,  -15.0910903300424    , 10)
         self.assertAlmostEqual(gf2.e_1b,  -15.069681001221705  ,  6)
         self.assertAlmostEqual(gf2.e_2b,  -0.049461593728309786,  6)
-        self.assertAlmostEqual(gf2.e_mp2, -0.025198374705580943,  6)
+        self.assertAlmostEqual(gf2.e_init, -0.025198374705580943,  6)
 
         e_ip, v_ip = gf2.ipagf2(nroots=3)
         v_ip = [np.linalg.norm(v)**2 for v in v_ip]
@@ -76,7 +76,7 @@ class KnownValues(unittest.TestCase):
         gf2.conv_tol = 1e-7
         gf2.run()
         self.assertTrue(gf2.converged)
-        self.assertAlmostEqual(gf2.e_mp2, -0.0153603737842962, 4)
+        self.assertAlmostEqual(gf2.e_init, -0.0153603737842962, 4)
         #TODO
 
 

--- a/pyscf/agf2/test/test_uagf2_slow_beh.py
+++ b/pyscf/agf2/test/test_uagf2_slow_beh.py
@@ -77,7 +77,6 @@ class KnownValues(unittest.TestCase):
         gf2.run()
         self.assertTrue(gf2.converged)
         self.assertAlmostEqual(gf2.e_init, -0.0153603737842962, 4)
-        #TODO
 
 
 if __name__ == '__main__':

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -328,6 +328,8 @@ class UAGF2(ragf2.RAGF2):
             Print level. Default value equals to :class:`Mole.verbose`
         max_memory : float or int
             Allowed memory in MB. Default value equals to :class:`Mole.max_memory`
+        incore_complete : bool
+            Avoid all I/O. Default is False.
         conv_tol : float
             Convergence threshold for AGF2 energy. Default value is 1e-7
         conv_tol_rdm1 : float

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -778,7 +778,7 @@ def _make_qmo_eris_outcore(agf2, eri, gf_occ, gf_vir, spin=None):
 
         tril2sq = lib.square_mat_in_trilu_indices(nmoa)
         for p0, p1 in lib.prange(0, nmoa, blksize):
-            idx = np.concatenate(tril2sq[p0:p1])
+            idx = list(np.concatenate(tril2sq[p0:p1]))
 
             # aa
             buf = eri.eri_aa[idx] # (blk, nmoa, npaira)
@@ -814,7 +814,7 @@ def _make_qmo_eris_outcore(agf2, eri, gf_occ, gf_vir, spin=None):
 
         tril2sq = lib.square_mat_in_trilu_indices(nmob)
         for p0, p1 in lib.prange(0, nmob, blksize):
-            idx = np.concatenate(tril2sq[p0:p1])
+            idx = list(np.concatenate(tril2sq[p0:p1]))
 
             # ba
             buf = eri.eri_ba[idx] # (blk, nmob, npaira)

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -682,7 +682,7 @@ class _ChemistsERIs:
         gap_b = abs(mo_e[1][:noccb,None] - mo_e[1][None,noccb:]).min()
         gap = min(gap_a, gap_b)
         if gap < 1e-5:
-            logger.warn(agf2, 'HOMO-LUMO gap %s too small for UAGF2', gap)
+            logger.warn(agf2, 'HOMO-LUMO gap %s may be too small for AGF2', gap)
 
         return self
 

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -86,7 +86,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     else:
         vv, vev = _agf2.build_mats_uagf2_outcore(qeri, gf_occ, gf_vir, **facs)
 
-    e, c = _agf2.cholesky_build(vv, vev, gf_occ[0], gf_vir[0])
+    e, c = _agf2.cholesky_build(vv, vev)
     se_a = aux.SelfEnergy(e, c, chempot=gf_occ[0].chempot)
     se_a.remove_uncoupled(tol=tol)
 
@@ -105,7 +105,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     else:
         vv, vev = _agf2.build_mats_uagf2_outcore(qeri, gf_occ[rv], gf_vir[rv], **facs)
 
-    e, c = _agf2.cholesky_build(vv, vev, gf_occ[1], gf_vir[1])
+    e, c = _agf2.cholesky_build(vv, vev)
     se_b = aux.SelfEnergy(e, c, chempot=gf_occ[1].chempot)
     se_b.remove_uncoupled(tol=tol)
 

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -90,7 +90,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     se_a = aux.SelfEnergy(e, c, chempot=gf_occ[0].chempot)
     se_a.remove_uncoupled(tol=tol)
 
-    cput0 = log.timer_debug1('se part (alpha)', *cput0)
+    cput0 = log.timer('se part (alpha)', *cput0)
 
     mem_incore = (nmo[1]*nob*(nob*nvb+noa*nva)) * 8/1e6
     mem_now = lib.current_memory()[0]
@@ -109,7 +109,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     se_b = aux.SelfEnergy(e, c, chempot=gf_occ[1].chempot)
     se_b.remove_uncoupled(tol=tol)
 
-    cput0 = log.timer_debug1('se part (beta)', *cput0)
+    cput0 = log.timer('se part (beta)', *cput0)
 
     return (se_a, se_b)
 
@@ -240,6 +240,7 @@ def fock_loop(agf2, eri, gf, se):
              sea.chempot, nerra, derra)
     log.info(' beta:  chempot = %.9g  dN = %.3g  |ddm| = %.3g', 
              seb.chempot, nerrb, derrb)
+    log.timer('fock loop', *cput0)
 
     return gf, se, converged
 

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -414,12 +414,12 @@ class UAGF2(ragf2.RAGF2):
 
         if (self._scf._eri is not None and
                 (mem_incore+mem_now < self.max_memory and not self.incore_complete)):
-            eri = _make_mo_eris_incore(self)
+            eri = _make_mo_eris_incore(self, mo_coeff)
         else:
             logger.warn(self, 'MO eris are outcore - this may be very '
                               'slow for agf2. increasing max_memory or '
                               'using density fitting is recommended.')
-            eri = _make_mo_eris_outcore(self)
+            eri = _make_mo_eris_outcore(self, mo_coeff)
 
         return eri
 

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -413,7 +413,7 @@ class UAGF2(ragf2.RAGF2):
         mem_now = lib.current_memory()[0]
 
         if (self._scf._eri is not None and
-                (mem_incore+mem_now < self.max_memory and not self.incore_complete)):
+                (mem_incore+mem_now < self.max_memory or self.incore_complete)):
             eri = _make_mo_eris_incore(self, mo_coeff)
         else:
             logger.warn(self, 'MO eris are outcore - this may be very '

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -631,7 +631,13 @@ class UAGF2(ragf2.RAGF2):
     def qmo_occ(self):
         coeff_a = self.gf[0].get_occupied().coupling
         coeff_b = self.gf[1].get_occupied().coupling
-        return (np.linalg.norm(coeff_a, axis=0)**2, np.linalg.norm(coeff_b, axis=0)**2)
+        occ_a = np.linalg.norm(coeff_a, axis=0) ** 2
+        occ_b = np.linalg.norm(coeff_b, axis=0) ** 2
+        vir_a = np.zeros_like(self.gf[0].get_virtual().energy)
+        vir_b = np.zeros_like(self.gf[1].get_virtual().energy)
+        qmo_occ_a = np.concatenate([occ_a, vir_a])
+        qmo_occ_b = np.concatenate([occ_b, vir_b])
+        return qmo_occ_a, qmo_occ_b
 
 
 def get_frozen_mask(agf2):

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -471,9 +471,6 @@ class UAGF2(ragf2.RAGF2):
         nmoa, nmob = self.nmo
         nocca, noccb = self.nocc
 
-        #with lib.temporary_env(self, _nmo=None, _nocc=None):
-        #    mask = get_frozen_mask(self)
-
         mo_energy = self.mo_energy
         focka = np.diag(mo_energy[0])
         fockb = np.diag(mo_energy[1])
@@ -481,8 +478,6 @@ class UAGF2(ragf2.RAGF2):
         cpt_a = binsearch_chempot(focka, nmoa, nocca, occupancy=1)[0]
         cpt_b = binsearch_chempot(fockb, nmob, noccb, occupancy=1)[1]
 
-        #gf_a = aux.GreensFunction(mo_energy[0][mask[0]], np.eye(nmoa)[:,mask[0]], chempot=cpt_a)
-        #gf_b = aux.GreensFunction(mo_energy[1][mask[1]], np.eye(nmob)[:,mask[1]], chempot=cpt_b)
         gf_a = aux.GreensFunction(mo_energy[0], np.eye(nmoa), chempot=cpt_a)
         gf_b = aux.GreensFunction(mo_energy[1], np.eye(nmob), chempot=cpt_b)
 

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -74,6 +74,11 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     tol = agf2.weight_tol
     facs = dict(os_factor=os_factor, ss_factor=ss_factor)
 
+    ci_a, ei_a = gf_occ[0].coupling, gf_occ[0].energy
+    ci_b, ei_b = gf_occ[1].coupling, gf_occ[1].energy
+    ca_a, ea_a = gf_vir[0].coupling, gf_vir[0].energy
+    ca_b, ea_b = gf_vir[1].coupling, gf_vir[1].energy
+
     mem_incore = (nmo[0]*noa*(noa*nva+nob*nvb)) * 8/1e6
     mem_now = lib.current_memory()[0]
     if (mem_incore+mem_now < agf2.max_memory) and not agf2.incore_complete:
@@ -82,9 +87,9 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
         qeri = _make_qmo_eris_outcore(agf2, eri, gf_occ, gf_vir, spin=0)
 
     if isinstance(qeri[0], np.ndarray):
-        vv, vev = _agf2.build_mats_uagf2_incore(qeri, gf_occ, gf_vir, **facs)
+        vv, vev = _agf2.build_mats_uagf2_incore(qeri, (ei_a, ei_b), (ea_a, ea_b), **facs)
     else:
-        vv, vev = _agf2.build_mats_uagf2_outcore(qeri, gf_occ, gf_vir, **facs)
+        vv, vev = _agf2.build_mats_uagf2_outcore(qeri, (ei_a, ei_b), (ea_a, ea_b), **facs)
 
     e, c = _agf2.cholesky_build(vv, vev)
     se_a = aux.SelfEnergy(e, c, chempot=gf_occ[0].chempot)
@@ -101,9 +106,9 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
 
     rv = np.s_[::-1]
     if isinstance(qeri[0], np.ndarray):
-        vv, vev = _agf2.build_mats_uagf2_incore(qeri, gf_occ[rv], gf_vir[rv], **facs)
+        vv, vev = _agf2.build_mats_uagf2_incore(qeri, (ei_b, ei_a), (ea_b, ea_a), **facs)
     else:
-        vv, vev = _agf2.build_mats_uagf2_outcore(qeri, gf_occ[rv], gf_vir[rv], **facs)
+        vv, vev = _agf2.build_mats_uagf2_outcore(qeri, (ei_b, ei_a), (ea_b, ea_a), **facs)
 
     e, c = _agf2.cholesky_build(vv, vev)
     se_b = aux.SelfEnergy(e, c, chempot=gf_occ[1].chempot)

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -368,8 +368,8 @@ class UAGF2(ragf2.RAGF2):
             One-body part of :attr:`e_tot`
         e_2b : float
             Two-body part of :attr:`e_tot`
-        e_mp2 : float
-            MP2 correlation energy
+        e_init : float
+            Initial correlation energy (truncated MP2)
         converged : bool
             Whether convergence was successful
         se : tuple of SelfEnergy
@@ -435,9 +435,9 @@ class UAGF2(ragf2.RAGF2):
         if se is None: se = self.build_se(gf=self.gf)
 
         mo_energy = _mo_energy_without_core(self, self.mo_energy)
-        self.e_mp2 = energy_mp2(self, mo_energy, se)
+        self.e_init = energy_mp2(self, mo_energy, se)
 
-        return self.e_mp2
+        return self.e_init
 
     def init_gf(self):
         ''' Builds the Hartree-Fock Green's function.

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -735,7 +735,7 @@ def _make_qmo_eris_incore(agf2, eri, gf_occ, gf_vir, spin=None):
     elif spin == 1:
         qeri = (qeri_bb, qeri_ba)
 
-    log.timer_debug1('QMO integral transformation', *cput0)
+    log.timer('QMO integral transformation', *cput0)
 
     return qeri
 
@@ -774,7 +774,7 @@ def _make_qmo_eris_outcore(agf2, eri, gf_occ, gf_vir, spin=None):
         blksize = _agf2.get_blksize(agf2.max_memory, (nmoa**3, nmoa*nja*naa),
                                                 (nmoa*nmob**2, nmoa*njb*nab))
         blksize = min(nmoa, max(BLKMIN, blksize))
-        log.debug1('blksize = %d', blksize)
+        log.debug1('blksize (uagf2._make_qmo_eris_outcore) = %d', blksize)
 
         tril2sq = lib.square_mat_in_trilu_indices(nmoa)
         for p0, p1 in lib.prange(0, nmoa, blksize):
@@ -810,7 +810,7 @@ def _make_qmo_eris_outcore(agf2, eri, gf_occ, gf_vir, spin=None):
         blksize = int((max_memory/8e-6) / max(nmob**3+nmob*njb*nab, 
                                               nmob*nmoa**2*nja*naa))
         blksize = min(nmob, max(BLKMIN, blksize))
-        log.debug1('blksize = %d', blksize)
+        log.debug1('blksize (uagf2._make_qmo_eris_outcore) = %d', blksize)
 
         tril2sq = lib.square_mat_in_trilu_indices(nmob)
         for p0, p1 in lib.prange(0, nmob, blksize):
@@ -846,7 +846,7 @@ def _make_qmo_eris_outcore(agf2, eri, gf_occ, gf_vir, spin=None):
     elif spin == 1:
         qeri = (eri.feri['qmo/bb'], eri.feri['qmo/ba'])
 
-    log.timer_debug1('QMO integral transformation', *cput0)
+    log.timer('QMO integral transformation', *cput0)
 
     return qeri
 

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -28,7 +28,7 @@ from pyscf.lib import logger
 from pyscf import __config__
 from pyscf import ao2mo
 from pyscf.scf import _vhf
-from pyscf.agf2 import aux, ragf2, _agf2
+from pyscf.agf2 import aux, ragf2, _agf2, mpi_helper
 from pyscf.agf2.chempot import binsearch_chempot, minimize_chempot
 from pyscf.mp.ump2 import get_frozen_mask as _get_frozen_mask
 
@@ -770,7 +770,10 @@ class _ChemistsERIs:
         self.fock = (np.dot(np.dot(mo_coeff[0].conj().T, fock_ao[0]), mo_coeff[0]),
                      np.dot(np.dot(mo_coeff[1].conj().T, fock_ao[1]), mo_coeff[1]))
 
-        self.e_hf = agf2._scf.e_tot
+        self.h1e = (mpi_helper.bcast(self.h1e[0]), mpi_helper.bcast(self.h1e[1]))
+        self.fock = (mpi_helper.bcast(self.fock[0]), mpi_helper.bcast(self.fock[1]))
+
+        self.e_hf = mpi_helper.bcast(agf2._scf.e_tot)
 
         self.nmo = agf2.nmo
         nocca, noccb = self.nocc = agf2.nocc

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -882,7 +882,7 @@ def _make_qmo_eris_outcore(agf2, eri, coeffs_a, coeffs_b, spin=None):
         tril2sq = lib.square_mat_in_trilu_indices(nmob)
         for p0, p1 in lib.prange(0, nmob, blksize):
             inds = np.arange(p0, p1)[mask[1][p0:p1]]
-            idx = list(np.concatnate(tril2sq[inds]))
+            idx = list(np.concatenate(tril2sq[inds]))
 
             # ba
             buf = eri.eri_ba[idx] # (blk, nmob, npaira)

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -600,6 +600,22 @@ class UAGF2(ragf2.RAGF2):
     def nmo(self, val):
         self._nmo = val
 
+    @property
+    def qmo_energy(self):
+        return (self.gf[0].energy, self.gf[1].energy)
+
+    @property
+    def qmo_coeff(self):
+        ''' Gives the couplings in AO basis '''
+        return (np.dot(self.mo_coeff[0], self.gf[0].coupling),
+                np.dot(self.mo_coeff[1], self.gf[1].coupling))
+
+    @property
+    def qmo_occ(self):
+        coeff_a = self.gf[0].get_occupied().coupling
+        coeff_b = self.gf[1].get_occupied().coupling
+        return (np.linalg.norm(coeff_a, axis=0)**2, np.linalg.norm(coeff_b, axis=0)**2)
+
 
 class _ChemistsERIs:
     ''' (pq|rs)

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -81,7 +81,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
 
     mem_incore = (nmo[0]*noa*(noa*nva+nob*nvb)) * 8/1e6
     mem_now = lib.current_memory()[0]
-    if (mem_incore+mem_now < agf2.max_memory) and not agf2.incore_complete:
+    if (mem_incore+mem_now < agf2.max_memory) or agf2.incore_complete:
         qeri = _make_qmo_eris_incore(agf2, eri, (ci_a, ci_a, ca_a), (ci_b, ci_b, ca_b), spin=0)
     else:
         qeri = _make_qmo_eris_outcore(agf2, eri, (ci_a, ci_a, ca_a), (ci_b, ci_b, ca_b), spin=0)
@@ -105,7 +105,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
 
     mem_incore = (nmo[1]*nob*(nob*nvb+noa*nva)) * 8/1e6
     mem_now = lib.current_memory()[0]
-    if (mem_incore+mem_now < agf2.max_memory) and not agf2.incore_complete:
+    if (mem_incore+mem_now < agf2.max_memory) or agf2.incore_complete:
         qeri = _make_qmo_eris_incore(agf2, eri, (ci_a, ci_a, ca_a), (ci_b, ci_b, ca_b), spin=1)
     else:
         qeri = _make_qmo_eris_outcore(agf2, eri, (ci_a, ci_a, ca_a), (ci_b, ci_b, ca_b), spin=1)

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -30,7 +30,7 @@ from pyscf import ao2mo
 from pyscf.scf import _vhf
 from pyscf.agf2 import aux, ragf2, _agf2
 from pyscf.agf2.chempot import binsearch_chempot, minimize_chempot
-from pyscf.mp.ump2 import get_nocc, get_nmo, get_frozen_mask
+from pyscf.mp.ump2 import get_frozen_mask
 
 BLKMIN = getattr(__config__, 'agf2_blkmin', 1)
 
@@ -471,8 +471,8 @@ class UAGF2(ragf2.RAGF2):
         nmoa, nmob = self.nmo
         nocca, noccb = self.nocc
 
-        with lib.temporary_env(self, _nmo=None, _nocc=None):
-            mask = get_frozen_mask(self)
+        #with lib.temporary_env(self, _nmo=None, _nocc=None):
+        #    mask = get_frozen_mask(self)
 
         mo_energy = self.mo_energy
         focka = np.diag(mo_energy[0])
@@ -481,8 +481,10 @@ class UAGF2(ragf2.RAGF2):
         cpt_a = binsearch_chempot(focka, nmoa, nocca, occupancy=1)[0]
         cpt_b = binsearch_chempot(fockb, nmob, noccb, occupancy=1)[1]
 
-        gf_a = aux.GreensFunction(mo_energy[0][mask[0]], np.eye(nmoa)[:,mask[0]], chempot=cpt_a)
-        gf_b = aux.GreensFunction(mo_energy[1][mask[1]], np.eye(nmob)[:,mask[1]], chempot=cpt_b)
+        #gf_a = aux.GreensFunction(mo_energy[0][mask[0]], np.eye(nmoa)[:,mask[0]], chempot=cpt_a)
+        #gf_b = aux.GreensFunction(mo_energy[1][mask[1]], np.eye(nmob)[:,mask[1]], chempot=cpt_b)
+        gf_a = aux.GreensFunction(mo_energy[0], np.eye(nmoa), chempot=cpt_a)
+        gf_b = aux.GreensFunction(mo_energy[1], np.eye(nmob), chempot=cpt_b)
 
         gf = (gf_a, gf_b)
 
@@ -922,26 +924,6 @@ def _make_qmo_eris_outcore(agf2, eri, coeffs_a, coeffs_b, spin=None):
 
 if __name__ == '__main__':
     from pyscf import gto, scf, mp
-
-    #mol = gto.M(atom='H 0 0 0; Li 0 0 1', basis='cc-pvdz', verbose=6)
-    #rhf = scf.RHF(mol)
-    #rhf.conv_tol = 1e-11
-    #rhf.run()
-    #uhf = scf.UHF(mol)
-    #uhf.conv_tol = 1e-11
-    #uhf.run()
-
-    #myragf2 = ragf2.RAGF2(rhf)
-    #myragf2.run()
-
-    #uagf2 = UAGF2(uhf)
-    #uagf2.run()
-
-    #print()
-    #keys = ['1b', '2b', 'mp2', 'corr', 'tot']
-    #print('  '.join(['%s %16.12f' % (key, getattr(myragf2, 'e_'+key, None)) for key in keys]))
-    #print('  '.join(['%s %16.12f' % (key, getattr(uagf2, 'e_'+key, None)) for key in keys]))
-
 
     mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='cc-pvdz', charge=-1, spin=1, verbose=3)
     uhf = scf.UHF(mol)

--- a/pyscf/agf2/uagf2_slow.py
+++ b/pyscf/agf2/uagf2_slow.py
@@ -28,7 +28,6 @@ from pyscf.lib import logger
 from pyscf import __config__
 from pyscf import ao2mo
 from pyscf.agf2 import aux, ragf2, uagf2, ragf2_slow
-from pyscf.mp.ump2 import get_frozen_mask
 
 
 def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
@@ -86,8 +85,7 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
         naux = nva*noa*(noa-1)//2 + nvb*noa*nob
 
         if not (agf2.frozen is None or agf2.frozen == 0):
-            with lib.temporary_env(agf2, _nocc=None, _nmo=None):
-                mask = get_frozen_mask(agf2)
+            mask = uagf2.get_frozen_mask(agf2)
             nmoa -= np.sum(~mask[ab][0])
             nmob -= np.sum(~mask[ab][1])
 

--- a/pyscf/agf2/uagf2_slow.py
+++ b/pyscf/agf2/uagf2_slow.py
@@ -93,7 +93,9 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
         eja_a = lib.direct_sum('j,a->ja', gfo_a.energy, -gfv_a.energy)
         eja_b = lib.direct_sum('j,a->ja', gfo_b.energy, -gfv_b.energy)
 
-        qeri = _make_qmo_eris_incore(agf2, eri, gf_occ, gf_vir, spin=spin)
+        ca = (gf_occ[0].coupling, gf_occ[0].coupling, gf_vir[0].coupling)
+        cb = (gf_occ[1].coupling, gf_occ[1].coupling, gf_vir[1].coupling)
+        qeri = _make_qmo_eris_incore(agf2, eri, ca, cb, spin=spin)
         qeri_aa, qeri_ab = qeri
 
         p1 = 0

--- a/pyscf/agf2/uagf2_slow.py
+++ b/pyscf/agf2/uagf2_slow.py
@@ -181,8 +181,8 @@ class UAGF2(uagf2.UAGF2):
             One-body part of :attr:`e_tot`
         e_2b : float
             Two-body part of :attr:`e_tot`
-        e_mp2 : float
-            MP2 correlation energy
+        e_init : float
+            Initial correlation energy (truncated MP2)
         converged : bool
             Whether convergence was successful
         se : tuple of SelfEnergy

--- a/pyscf/agf2/uagf2_slow.py
+++ b/pyscf/agf2/uagf2_slow.py
@@ -27,7 +27,9 @@ from pyscf import lib
 from pyscf.lib import logger
 from pyscf import __config__
 from pyscf import ao2mo
-from pyscf.agf2 import aux, uagf2
+from pyscf.agf2 import aux, ragf2, uagf2
+
+#TODO: can we do a double inheritance with RAGF2_slow to make this class nicer?
 
 
 def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
@@ -198,7 +200,7 @@ class UAGF2(uagf2.UAGF2):
 
         self.nmom = nmom
 
-        self._keys.update(['nmom'])
+        self._keys.update(['_nmom'])
 
     build_se_part = build_se_part
 
@@ -259,7 +261,7 @@ class UAGF2(uagf2.UAGF2):
         logger.info(self, 'nmom = %s', repr(self.nmom))
         return self
 
-    def dump_chk(self, gf=None, se=None, nmom=None, mo_energy=None, mo_coeff=None, mo_occ=None):
+    def dump_chk(self, gf=None, se=None, frozen=None, nmom=None, mo_energy=None, mo_coeff=None, mo_occ=None):
         if not self.chkfile:
             return self
 
@@ -270,6 +272,10 @@ class UAGF2(uagf2.UAGF2):
         if frozen is None: frozen = 0
         if nmom is None: nmom = self.nmom
 
+        ngf, nse = nmom
+        if ngf is None: ngf = -1
+        if nse is None: nse = -1
+
         agf2_chk = { 'e_1b': self.e_1b,
                      'e_2b': self.e_2b, 
                      'e_mp2': self.e_mp2,
@@ -278,16 +284,30 @@ class UAGF2(uagf2.UAGF2):
                      'mo_coeff': mo_coeff,
                      'mo_occ': mo_occ,
                      'frozen': frozen,
-                     'nmom': nmom,
+                     'nmom': (ngf, nse),
         }
 
-        if self.gf is not None: agf2_chk['gf'] = _aux_to_dict(gf)
-        if self.se is not None: agf2_chk['se'] = _aux_to_dict(se)
+        if gf is None: gf = self.gf
+        if se is None: se = self.se
+
+        if gf is not None: agf2_chk['gf'] = ragf2._aux_to_dict(gf)
+        if se is not None: agf2_chk['se'] = ragf2._aux_to_dict(se)
 
         if self._nmo is not None: agf2_chk['_nmo'] = self._nmo
         if self._nocc is not None: agf2_chk['_nocc'] = self._nocc
 
         lib.chkfile.dump(self.chkfile, 'agf2', agf2_chk)
+
+
+    @property
+    def nmom(self):
+        return self._nmom
+    @nmom.setter
+    def nmom(self, val):
+        ngf, nse = val
+        if ngf == -1: ngf = None
+        if nse == -1: nse = None
+        self._nmom = (ngf, nse)
 
 
 class _ChemistsERIs(uagf2._ChemistsERIs):

--- a/pyscf/agf2/uagf2_slow.py
+++ b/pyscf/agf2/uagf2_slow.py
@@ -120,11 +120,11 @@ def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
 
     se_a = _build_se_part_spin(0)
 
-    cput0 = log.timer_debug1('se part (alpha)', *cput0)
+    cput0 = log.timer('se part (alpha)', *cput0)
 
     se_b = _build_se_part_spin(1)
 
-    cput0 = log.timer_debug1('se part (beta)', *cput0)
+    cput0 = log.timer('se part (beta)', *cput0)
 
     return (se_a, se_b)
 

--- a/pyscf/agf2/uagf2_slow.py
+++ b/pyscf/agf2/uagf2_slow.py
@@ -172,9 +172,9 @@ class UAGF2(uagf2.UAGF2):
         weight_tol : float
             Threshold in spectral weight of auxiliaries to be considered
             zero. Default 1e-11.
-        diis_space : int
+        fock_diis_space : int
             DIIS space size for Fock loop iterations. Default value is 6.
-        diis_min_space : 
+        fock_diis_min_space : 
             Minimum space of DIIS. Default value is 1.
         os_factor : float
             Opposite-spin factor for spin-component-scaled (SCS)
@@ -285,6 +285,9 @@ class UAGF2(uagf2.UAGF2):
         uagf2.UAGF2.dump_flags(self, verbose=verbose)
         logger.info(self, 'nmom = %s', repr(self.nmom))
         return self
+
+    def run_diis(self, se, diis=None):
+        return se
 
 
 class _ChemistsERIs(uagf2._ChemistsERIs):

--- a/pyscf/agf2/uagf2_slow.py
+++ b/pyscf/agf2/uagf2_slow.py
@@ -27,7 +27,7 @@ from pyscf import lib
 from pyscf.lib import logger
 from pyscf import __config__
 from pyscf import ao2mo
-from pyscf.agf2 import aux, ragf2, uagf2
+from pyscf.agf2 import aux, ragf2, uagf2, ragf2_slow
 
 #TODO: can we do a double inheritance with RAGF2_slow to make this class nicer?
 
@@ -262,41 +262,8 @@ class UAGF2(uagf2.UAGF2):
         return self
 
     def dump_chk(self, gf=None, se=None, frozen=None, nmom=None, mo_energy=None, mo_coeff=None, mo_occ=None):
-        if not self.chkfile:
-            return self
-
-        if mo_energy is None: mo_energy = self.mo_energy
-        if mo_coeff  is None: mo_coeff  = self.mo_coeff
-        if mo_occ    is None: mo_occ    = self.mo_occ
-        if frozen is None: frozen = self.frozen
-        if frozen is None: frozen = 0
-        if nmom is None: nmom = self.nmom
-
-        ngf, nse = nmom
-        if ngf is None: ngf = -1
-        if nse is None: nse = -1
-
-        agf2_chk = { 'e_1b': self.e_1b,
-                     'e_2b': self.e_2b, 
-                     'e_mp2': self.e_mp2,
-                     'converged': self.converged,
-                     'mo_energy': mo_energy,
-                     'mo_coeff': mo_coeff,
-                     'mo_occ': mo_occ,
-                     'frozen': frozen,
-                     'nmom': (ngf, nse),
-        }
-
-        if gf is None: gf = self.gf
-        if se is None: se = self.se
-
-        if gf is not None: agf2_chk['gf'] = ragf2._aux_to_dict(gf)
-        if se is not None: agf2_chk['se'] = ragf2._aux_to_dict(se)
-
-        if self._nmo is not None: agf2_chk['_nmo'] = self._nmo
-        if self._nocc is not None: agf2_chk['_nocc'] = self._nocc
-
-        lib.chkfile.dump(self.chkfile, 'agf2', agf2_chk)
+        ragf2_slow.RAGF2.dump_chk(self, gf=gf, se=se, frozen=frozen, nmom=nmom, 
+                                  mo_energy=mo_energy, mo_coeff=mo_coeff, mo_occ=mo_occ)
 
 
     @property

--- a/pyscf/agf2/uagf2_slow.py
+++ b/pyscf/agf2/uagf2_slow.py
@@ -184,6 +184,8 @@ class UAGF2(uagf2.UAGF2):
         ss_factor : float
             Same-spin factor for spin-component-scaled (SCS)
             calculations. Default 1.0
+        damping : float
+            Damping factor for the self-energy. Default value is 0.0
 
     Saved results
 
@@ -216,7 +218,7 @@ class UAGF2(uagf2.UAGF2):
 
     build_se_part = build_se_part
 
-    def build_se(self, eri=None, gf=None, os_factor=None, ss_factor=None):
+    def build_se(self, eri=None, gf=None, os_factor=None, ss_factor=None, se_prev=None):
         ''' Builds the auxiliaries of the self-energy.
 
         Args:
@@ -232,6 +234,8 @@ class UAGF2(uagf2.UAGF2):
             ss_factor : float
                 Same-spin factor for spin-component-scaled (SCS)
                 calculations. Default 1.0
+            se_prev : SelfEnergy
+                Previous self-energy for damping. Default value is None
 
         Returns
             :class:`SelfEnergy`
@@ -265,6 +269,17 @@ class UAGF2(uagf2.UAGF2):
 
         se_b = aux.combine(se_occ[1], se_vir[1])
         se_b = se_b.compress(phys=fockb, n=(self.nmom[0], None))
+
+        if se_prev is not None and self.damping != 0.0:
+            se_a_prev, se_b_prev = se_prev
+            se_a.coupling *= np.sqrt(1.0-self.damping)
+            se_b.coupling *= np.sqrt(1.0-self.damping)
+            se_a_prev.coupling *= np.sqrt(self.damping)
+            se_b_prev.coupling *= np.sqrt(self.damping)
+            se_a = aux.combine(se_a, se_a_prev)
+            se_b = aux.combine(se_b, se_b_prev)
+            se_a = se_a.compress(n=(None,0))
+            se_b = se_b.compress(n=(None,0))
 
         return (se_a, se_b)
 

--- a/pyscf/agf2/uagf2_slow.py
+++ b/pyscf/agf2/uagf2_slow.py
@@ -200,7 +200,7 @@ class UAGF2(uagf2.UAGF2):
 
         self.nmom = nmom
 
-        self._keys.update(['_nmom'])
+        self._keys.update(['nmom'])
 
     build_se_part = build_se_part
 
@@ -260,21 +260,6 @@ class UAGF2(uagf2.UAGF2):
         uagf2.UAGF2.dump_flags(self, verbose=verbose)
         logger.info(self, 'nmom = %s', repr(self.nmom))
         return self
-
-    def dump_chk(self, gf=None, se=None, frozen=None, nmom=None, mo_energy=None, mo_coeff=None, mo_occ=None):
-        ragf2_slow.RAGF2.dump_chk(self, gf=gf, se=se, frozen=frozen, nmom=nmom, 
-                                  mo_energy=mo_energy, mo_coeff=mo_coeff, mo_occ=mo_occ)
-
-
-    @property
-    def nmom(self):
-        return self._nmom
-    @nmom.setter
-    def nmom(self, val):
-        ngf, nse = val
-        if ngf == -1: ngf = None
-        if nse == -1: nse = None
-        self._nmom = (ngf, nse)
 
 
 class _ChemistsERIs(uagf2._ChemistsERIs):

--- a/pyscf/agf2/uagf2_slow.py
+++ b/pyscf/agf2/uagf2_slow.py
@@ -29,8 +29,6 @@ from pyscf import __config__
 from pyscf import ao2mo
 from pyscf.agf2 import aux, ragf2, uagf2, ragf2_slow
 
-#TODO: can we do a double inheritance with RAGF2_slow to make this class nicer?
-
 
 def build_se_part(agf2, eri, gf_occ, gf_vir, os_factor=1.0, ss_factor=1.0):
     ''' Builds either the auxiliaries of the occupied self-energy,

--- a/pyscf/lib/agf2/ragf2.c
+++ b/pyscf/lib/agf2/ragf2.c
@@ -14,6 +14,7 @@
    
  *
  *  Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+ *          Alejandro Santana-Bonilla <alejandro.santana_bonilla@kcl.ac.uk>
  *          George H. Booth <george.booth@kcl.ac.uk>
  */
 

--- a/pyscf/lib/agf2/ragf2.h
+++ b/pyscf/lib/agf2/ragf2.h
@@ -14,6 +14,7 @@
    
  *
  *  Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+ *          Alejandro Santana-Bonilla <alejandro.santana_bonilla@kcl.ac.uk>
  *          George H. Booth <george.booth@kcl.ac.uk>
  */
 

--- a/pyscf/lib/agf2/uagf2.c
+++ b/pyscf/lib/agf2/uagf2.c
@@ -18,8 +18,10 @@
  */
 
 #include<stdlib.h>
+#include<stdbool.h>
 #include<assert.h>
 #include<math.h>
+#include<stdio.h>
 
 //#include "omp.h"
 #include "config.h"
@@ -239,6 +241,150 @@ void AGF2udf_vv_vev_islice(double *qxi,
     free(xja);
     free(xJA);
     free(exJA);
+
+#pragma omp critical
+    for (i = 0; i < (nmo*nmo); i++) {
+        vv[i] += vv_priv[i];
+        vev[i] += vev_priv[i];
+    }
+
+    free(vv_priv);
+    free(vev_priv);
+}
+}
+
+
+/*
+ *  Removes an index from DGEMM and into a for loop to reduce the
+ *  thread-private memory overhead, at the cost of serial speed
+ */
+void AGF2udf_vv_vev_islice_lowmem(double *qxi,
+                                  double *qja,
+                                  double *qJA,
+                                  double *e_i,
+                                  double *e_I,
+                                  double *e_a,
+                                  double *e_A,
+                                  double os_factor,
+                                  double ss_factor,
+                                  int nmo,
+                                  int noa,
+                                  int nob,
+                                  int nva,
+                                  int nvb,
+                                  int naux,
+                                  int start,
+                                  int end,
+                                  double *vv,
+                                  double *vev)
+{
+    const double D0 = 0.0;
+    const double D1 = 1.0;
+    const char TRANS_T = 'T';
+    const char TRANS_N = 'N';
+    const int one = 1;
+
+#pragma omp parallel
+{
+    double *qx_i = calloc(naux*nmo, sizeof(double));
+    double *qx_j = calloc(naux*nmo, sizeof(double));
+    double *qa_i = calloc(naux*nva, sizeof(double));
+    double *qa_j = calloc(naux*nva, sizeof(double));
+    double *qA_i = calloc(naux*nvb, sizeof(double));
+    double *qA_j = calloc(naux*nvb, sizeof(double));
+    double *xa_i = calloc(nmo*nva, sizeof(double));
+    double *xa_j = calloc(nmo*nva, sizeof(double));
+    double *xA_i = calloc(nmo*nvb, sizeof(double));
+    double *xA_j = calloc(nmo*nvb, sizeof(double));
+    double *ea = calloc(nva, sizeof(double));
+    double *eA = calloc(nvb, sizeof(double));
+    double *exA_i = calloc(nmo*nvb, sizeof(double));
+
+    double *vv_priv = calloc(nmo*nmo, sizeof(double));
+    double *vev_priv = calloc(nmo*nmo, sizeof(double));
+
+    bool do_os, do_ss;
+    int i, j, ij;
+
+#pragma omp for
+    for (ij = start; ij < end; ij++) {
+        // i = 0 -> noa
+        // j = 0 -> max(noa, nob)
+        i = ij / ((noa > nob) ? noa : nob);
+        j = ij % ((noa > nob) ? noa : nob);
+
+        do_os = j < nob;
+        do_ss = j < noa;
+
+        // build qx_i
+        AGF2slice_01i(qxi, naux, nmo, noa, i, qx_i);
+
+        // build qx_j
+        AGF2slice_01i(qxi, naux, nmo, noa, j, qx_j);
+
+        // build qa_i
+        AGF2slice_0i2(qja, naux, noa, nva, i, qa_i);
+
+        // build qa_j
+        AGF2slice_0i2(qja, naux, noa, nva, j, qa_j);
+
+        if (do_ss) {
+            // build xija
+            dgemm_(&TRANS_N, &TRANS_T, &nva, &nmo, &naux, &D1, qa_i, &nva, qx_j, &nmo, &D0, xa_i, &nva);
+
+            // build xjia
+            dgemm_(&TRANS_N, &TRANS_T, &nva, &nmo, &naux, &D1, qa_j, &nva, qx_i, &nmo, &D0, xa_j, &nva);
+
+            // build eija
+            AGF2sum_inplace_ener(e_i[i], &(e_i[j]), e_a, one, nva, ea);
+
+            // inplace xjia = xija - xjia
+            AGF2sum_inplace(xa_i, xa_j, nmo*nva, ss_factor, -ss_factor);
+
+            // vv_xy += xija * (yija - yjia)
+            dgemm_(&TRANS_T, &TRANS_N, &nmo, &nmo, &nva, &D1, xa_j, &nva, xa_i, &nva, &D1, vv_priv, &nmo);
+
+            // inplace xija = eija * xija
+            AGF2prod_inplace_ener(ea, xa_i, nmo, nva);
+
+            // vev_xy += xija * eija * (yija - yjia)
+            dgemm_(&TRANS_T, &TRANS_N, &nmo, &nmo, &nva, &D1, xa_j, &nva, xa_i, &nva, &D1, vev_priv, &nmo);
+        }
+
+        if (do_os) {
+            // build qA_j
+            AGF2slice_0i2(qJA, naux, nob, nvb, j, qA_j);
+
+            // build xiJA
+            dgemm_(&TRANS_N, &TRANS_T, &nvb, &nmo, &naux, &D1, qA_j, &nvb, qx_i, &nmo, &D0, xA_i, &nvb);
+
+            // build eiJA
+            AGF2sum_inplace_ener(e_i[i], &(e_I[j]), e_A, one, nvb, eA);
+
+            // vv_xy += xiJA * yiJA
+            dgemm_(&TRANS_T, &TRANS_N, &nmo, &nmo, &nvb, &os_factor, xA_i, &nvb, xA_i, &nvb, &D1, vv_priv, &nmo);
+
+            // outplace xiJA = eiJA * xiJA
+            AGF2prod_outplace_ener(eA, xA_i, nmo, nvb, exA_i);
+
+            // vev_xy += xiJA * eiJA * yiJA
+            dgemm_(&TRANS_T, &TRANS_N, &nmo, &nmo, &nvb, &os_factor, xA_i, &nvb, exA_i, &nvb, &D1, vev_priv, &nmo);
+        }
+    }
+
+    free(qx_i);
+    free(qx_j);
+    free(qa_i);
+    free(qa_j);
+    free(qA_i);
+    free(qA_j);
+    free(xa_i);
+    free(xa_j);
+    free(xA_i);
+    free(xA_j);
+    free(ea);
+    free(eA);
+    free(exA_i);
 
 #pragma omp critical
     for (i = 0; i < (nmo*nmo); i++) {

--- a/pyscf/lib/agf2/uagf2.c
+++ b/pyscf/lib/agf2/uagf2.c
@@ -14,6 +14,7 @@
    
  *
  *  Author: Oliver J. Backhouse <olbackhouse@gmail.com>
+ *          Alejandro Santana-Bonilla <alejandro.santana_bonilla@kcl.ac.uk>
  *          George H. Booth <george.booth@kcl.ac.uk>
  */
 


### PR DESCRIPTION
Codes to implement the auxiliary second-order Green's function perturbation theory for molecular systems. Features:

- Exact-ERI AGF2 for restricted and unrestricted HF references
- Density-fitted AGF2 for restricted and unrestricted HF references
- Optional MPI parallelism via mpi4py for DF-AGF2 (does not break import chain for non-standard mpi4py dependency)
- Compiled C code with OpenMP flags to permit hybrid parallelism
- Methods to access higher-order moment truncations in the AGF2 method via _slow methods.

AGF2 refers to the AGF2(1,0) of the following publications:
- "Wave function perspective and efficient truncation of renormalized second-order perturbation theory", O. J. Backhouse, M. Nusspickel and G. H. Booth, J. Chem. Theory Comput., 16, 1090 (2020).
- "Efficient excitations and spectra within a perturbative renormalization approach", O. J. Backhouse and G. H. Booth, J. Chem. Theory Comput., 16, 6294 (2020).