### PR TITLE
Molden file loading

### DIFF
--- a/pyscf/tools/molden.py
+++ b/pyscf/tools/molden.py
@@ -210,6 +210,8 @@ def _parse_gto(lines, envs):
 # * Do not use iter() here. Python 2 and 3 are different in iter()
     def read_one_bas(lsym, nb, fac=1):
         fac = float(fac)
+        if fac == float(0):
+            fac = float(1)
         bas = [lib.param.ANGULARMAP[lsym.lower()],]
         for i in range(int(nb)):
             dat = _d2e(next(lines_iter)).split()

--- a/pyscf/tools/molden.py
+++ b/pyscf/tools/molden.py
@@ -297,7 +297,7 @@ _SEC_PARSER = {'N_ATOMS'  : _parse_natoms,
                'CHARGE'   : _parse_charge,
                'MO'       : _parse_mo,
                'CORE'     : _parse_core,
-               'MOLDEN FORMAT' : lambda *args: None
+               'MOLDEN FORMAT' : lambda *args: None,
               }
 
 def load(moldenfile, verbose=0):

--- a/pyscf/tools/molden.py
+++ b/pyscf/tools/molden.py
@@ -300,6 +300,8 @@ _SEC_PARSER = {'N_ATOMS'  : _parse_natoms,
                'MOLDEN FORMAT' : lambda *args: None,
               }
 
+_SEC_ORDER = ['N_ATOMS', 'ATOMS', 'GTO', 'CHARGE', 'MO', 'CORE', 'MOLDEN FORMAT']
+
 def load(moldenfile, verbose=0):
     '''Extract mol and orbitals from molden file
     '''
@@ -336,7 +338,7 @@ def load(moldenfile, verbose=0):
             else:
                 sys.stderr.write('Unknown section %s\n' % sec_title)
 
-    for sec_kind in _SEC_PARSER:
+    for sec_kind in _SEC_ORDER:
         if sec_kind in sec_kinds:
             secs_of_kind = len(sec_kinds[sec_kind])
             for n in range(secs_of_kind):

--- a/pyscf/tools/molden.py
+++ b/pyscf/tools/molden.py
@@ -336,10 +336,11 @@ def load(moldenfile, verbose=0):
             else:
                 sys.stderr.write('Unknown section %s\n' % sec_title)
 
-        for section in _SEC_PARSER:
-            if section in sec_kinds:
-                for n in range(len(sec_kinds[section])):
-                    if section == 'MO':
+        for sec_kind in _SEC_PARSER:
+            if sec_kind in sec_kinds:
+                secs_of_kind = len(sec_kinds[sec_kind])
+                for n in range(secs_of_kind):
+                    if sec_kind == 'MO':
 
                         res = _parse_mo(sec_kinds['MO'][n], tokens)
                         if n == 0:  # alpha orbitals
@@ -353,7 +354,7 @@ def load(moldenfile, verbose=0):
                             spins        = spins       , res[5]
 
                     else:
-                        _SEC_PARSER[section](sec_kinds[section][n], tokens)
+                        _SEC_PARSER[sec_kind](sec_kinds[sec_kind][n], tokens)
 
     if 'mo' not in sec_kinds:
         if spins[-1][0] == 'B':  # If including beta orbitals

--- a/pyscf/tools/molden.py
+++ b/pyscf/tools/molden.py
@@ -265,7 +265,7 @@ def _parse_mo(lines, envs):
 
     orb_list = []
     for orb_prim_data in mo_coeff_prim:
-        orb_list.extend(list(orb))
+        orb_list.extend(list(orb_prim_data))
     number_of_aos = max(orb_list)
     number_of_mos = len(mo_coeff_prim)
 

--- a/pyscf/tools/molden.py
+++ b/pyscf/tools/molden.py
@@ -297,7 +297,7 @@ _SEC_PARSER = {'N_ATOMS'  : _parse_natoms,
                'CHARGE'   : _parse_charge,
                'MO'       : _parse_mo,
                'CORE'     : _parse_core,
-               'MOLDEN FORMAT' : lambda *args: None,
+               'MOLDEN FORMAT' : lambda *args: None
               }
 
 def load(moldenfile, verbose=0):

--- a/pyscf/tools/molden.py
+++ b/pyscf/tools/molden.py
@@ -356,7 +356,7 @@ def load(moldenfile, verbose=0):
                     else:
                         _SEC_PARSER[sec_kind](sec_kinds[sec_kind][n], tokens)
 
-    if 'mo' not in sec_kinds:
+    if 'MO' not in sec_kinds:
         if spins[-1][0] == 'B':  # If including beta orbitals
             offset = spins.index(spins[-1])
             mo_energy    = mo_energy   [:offset], mo_energy   [offset:]

--- a/pyscf/tools/molden.py
+++ b/pyscf/tools/molden.py
@@ -247,12 +247,13 @@ def _parse_mo(lines, envs):
     spins = []
     mo_occ = []
     mo_coeff = []
+    mo_coeff_prim = [] # primary data, will be reworked for missing values
     for line in lines[1:]:
         line = line.upper()
         if 'SYM' in line:
             irrep_labels.append(line.split('=')[1].strip())
-            orb = []
-            mo_coeff.append(orb)
+            orb_prim = {}
+            mo_coeff_prim.append(orb_prim)
         elif 'ENE' in line:
             mo_energy.append(float(_d2e(line).split('=')[1].strip()))
         elif 'SPIN' in line:
@@ -260,7 +261,22 @@ def _parse_mo(lines, envs):
         elif 'OCC' in line:
             mo_occ.append(float(_d2e(line.split('=')[1].strip())))
         else:
-            orb.append(float(_d2e(line.split()[1])))
+            orb.update({int(line.split()[0]) : float(_d2e(line.split()[1]))})
+
+    orb_list = []
+    for orb_prim_data in mo_coeff_prim:
+        orb_list.extend(list(orb))
+    number_of_aos = max(orb_list)
+    number_of_mos = len(mo_coeff_prim)
+
+    for n in range(number_of_mos):
+        orb = []
+        mo_coeff.append(orb)
+        for m in range(number_of_aos):
+            try:
+                orb.append(mo_coeff_prim[n][m+1])
+            except KeyError:
+                orb.append(0)
 
     mo_energy = numpy.array(mo_energy)
     mo_occ = numpy.array(mo_occ)

--- a/pyscf/tools/molden.py
+++ b/pyscf/tools/molden.py
@@ -336,25 +336,25 @@ def load(moldenfile, verbose=0):
             else:
                 sys.stderr.write('Unknown section %s\n' % sec_title)
 
-        for sec_kind in _SEC_PARSER:
-            if sec_kind in sec_kinds:
-                secs_of_kind = len(sec_kinds[sec_kind])
-                for n in range(secs_of_kind):
-                    if sec_kind == 'MO':
+    for sec_kind in _SEC_PARSER:
+        if sec_kind in sec_kinds:
+            secs_of_kind = len(sec_kinds[sec_kind])
+            for n in range(secs_of_kind):
+                if sec_kind == 'MO':
 
-                        res = _parse_mo(sec_kinds['MO'][n], tokens)
-                        if n == 0:  # alpha orbitals
-                            mol, mo_energy, mo_coeff, mo_occ, irrep_labels, \
-                            spins = res
-                        else:
-                            mo_energy    = mo_energy   , res[1]
-                            mo_coeff     = mo_coeff    , res[2]
-                            mo_occ       = mo_occ      , res[3]
-                            irrep_labels = irrep_labels, res[4]
-                            spins        = spins       , res[5]
-
+                    res = _parse_mo(sec_kinds['MO'][n], tokens)
+                    if n == 0:  # alpha orbitals
+                        mol, mo_energy, mo_coeff, mo_occ, irrep_labels, \
+                        spins = res
                     else:
-                        _SEC_PARSER[sec_kind](sec_kinds[sec_kind][n], tokens)
+                        mo_energy    = mo_energy   , res[1]
+                        mo_coeff     = mo_coeff    , res[2]
+                        mo_occ       = mo_occ      , res[3]
+                        irrep_labels = irrep_labels, res[4]
+                        spins        = spins       , res[5]
+
+                else:
+                    _SEC_PARSER[sec_kind](sec_kinds[sec_kind][n], tokens)
 
     if 'MO' not in sec_kinds:
         if spins[-1][0] == 'B':  # If including beta orbitals

--- a/pyscf/tools/molden.py
+++ b/pyscf/tools/molden.py
@@ -344,8 +344,8 @@ def load(moldenfile, verbose=0):
 
                     res = _parse_mo(sec_kinds['MO'][n], tokens)
                     if n == 0:  # alpha orbitals
-                        mol, mo_energy, mo_coeff, mo_occ, irrep_labels, \
-                        spins = res
+                        (mol, mo_energy, mo_coeff, mo_occ, irrep_labels,
+                        spins) = res
                     else:
                         mo_energy    = mo_energy   , res[1]
                         mo_coeff     = mo_coeff    , res[2]

--- a/pyscf/tools/molden.py
+++ b/pyscf/tools/molden.py
@@ -261,7 +261,7 @@ def _parse_mo(lines, envs):
         elif 'OCC' in line:
             mo_occ.append(float(_d2e(line.split('=')[1].strip())))
         else:
-            orb.update({int(line.split()[0]) : float(_d2e(line.split()[1]))})
+            orb_prim.update({int(line.split()[0]) : float(_d2e(line.split()[1]))})
 
     orb_list = []
     for orb_prim_data in mo_coeff_prim:


### PR DESCRIPTION
MOs and GTOs are enforced to be read after Atoms. This allows the file to have any order. See #754 
The sections are stored in a dictionary.

Additionally, Dalton does write MO coefficients below a certain threshold. Therefore, the value zero has to be added for them. Otherwise the creation of numpy arrays fails.