### PR TITLE
import imp now compatible with python 3

### DIFF
--- a/pyscf/dmrgscf/chemps2.py
+++ b/pyscf/dmrgscf/chemps2.py
@@ -17,7 +17,10 @@
 #
 
 import os, sys
-import imp
+if sys.version_info >= (3,):
+    import importlib as imp
+else:
+    import imp
 import numpy
 import pyscf.ao2mo
 

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -22,7 +22,10 @@ Some helper functions
 
 import os, sys
 import warnings
-import imp
+if sys.version_info >= (3,):
+    import importlib as imp
+else:
+    import imp
 import tempfile
 import functools
 import itertools

--- a/pyscf/pbc/mpitools/mpi_pool.py
+++ b/pyscf/pbc/mpitools/mpi_pool.py
@@ -23,7 +23,11 @@ __all__ = ["MPIPool", "MPIPoolException"]
 
 import os
 import sys
-import imp
+if sys.version_info >= (3,):
+    import importlib as imp
+else:
+    import imp
+
 import types
 import marshal
 #import traceback


### PR DESCRIPTION
Solves issue https://github.com/pyscf/pyscf/issues/773.