### PR TITLE
Range-separated functionals are hybrids, too

### DIFF
--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -747,7 +747,13 @@ def is_hybrid_xc(xc_code):
         if xc_code.isdigit():
             return _itrf.LIBXC_is_hybrid(ctypes.c_int(int(xc_code)))
         else:
-            return ('HF' in xc_code or hybrid_coeff(xc_code) != 0)
+            if 'HF' in xc_code:
+                return True
+            if hybrid_coeff(xc_code) != 0:
+                return True
+            if rsh_coeff(xc_code) != [0, 0, 0]:
+                return True
+            return False
     elif isinstance(xc_code, int):
         return _itrf.LIBXC_is_hybrid(ctypes.c_int(xc_code))
     else:


### PR DESCRIPTION
Fixes the issue that when the functional is passed by LibXC keyword like `hyb_gga_xc_cam_b3lyp`, the wrong TDDFT driver gets called since PySCF assumes the functional is not a hybrid.

Closes #793.