### PR TITLE
Locally alias time functions in logger

### DIFF
--- a/pyscf/adc/uadc.py
+++ b/pyscf/adc/uadc.py
@@ -19,7 +19,7 @@
 '''
 Unrestricted algebraic diagrammatic construction
 '''
-import time
+
 import numpy as np
 from pyscf import lib
 from pyscf.lib import logger
@@ -32,7 +32,7 @@ def kernel(adc, nroots=1, guess=None, eris=None, verbose=None):
     if adc.method not in ("adc(2)", "adc(2)-x", "adc(3)"):
        raise NotImplementedError(adc.method)
 
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(adc.stdout, adc.verbose)
     if adc.verbose >= logger.WARN:
         adc.check_sanity()

--- a/pyscf/adc/uadc_ao2mo.py
+++ b/pyscf/adc/uadc_ao2mo.py
@@ -19,6 +19,7 @@
 import numpy as np
 import pyscf.ao2mo as ao2mo
 
+
 ### Integral transformation for integrals in Chemists' notation###
 def transform_integrals_incore(myadc):
 

--- a/pyscf/ao2mo/incore.py
+++ b/pyscf/ao2mo/incore.py
@@ -271,11 +271,11 @@ if __name__ == '__main__':
     mol.build()
     rhf = scf.RHF(mol)
     rhf.scf()
-    import time
-    print(time.clock())
+
+    print(logger.process_clock())
     eri0 = full(rhf._eri, rhf.mo_coeff)
     print(abs(eri0).sum()-5384.460843787659) # should = 0
     eri0 = general(rhf._eri, (rhf.mo_coeff,)*4)
     print(abs(eri0).sum()-5384.460843787659)
-    print(time.clock())
+    print(logger.process_clock())
 

--- a/pyscf/ao2mo/outcore.py
+++ b/pyscf/ao2mo/outcore.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
+
 import numpy
 import h5py
 from pyscf import gto
@@ -206,7 +206,7 @@ def general(mol, mo_coeffs, erifile, dataname='eri_mo',
     if any(c.dtype == numpy.complex for c in mo_coeffs):
         raise NotImplementedError('Integral transformation for complex orbitals')
 
-    time_0pass = (time.clock(), time.time())
+    time_0pass = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mol, verbose)
 
     nmoi = mo_coeffs[0].shape[1]
@@ -325,7 +325,7 @@ def general(mol, mo_coeffs, erifile, dataname='eri_mo',
                     async_write(icomp, row0, row1, outbuf)
                     outbuf, buf_write = buf_write, outbuf  # avoid flushing writing buffer
 
-                    ti1 = (time.clock(), time.time())
+                    ti1 = (logger.process_clock(), logger.perf_counter())
                     log.debug1('step 2 [%d/%d] CPU time: %9.2f, Wall time: %9.2f',
                                istep, ijmoblks, ti1[0]-ti0[0], ti1[1]-ti0[1])
                     ti0 = ti1
@@ -398,7 +398,7 @@ def half_e1(mol, mo_coeffs, swapfile,
         raise NotImplementedError('Integral transformation for complex orbitals')
 
     intor = mol._add_suffix(intor)
-    time0 = (time.clock(), time.time())
+    time0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mol, verbose)
 
     nao = mo_coeffs[0].shape[0]
@@ -797,18 +797,18 @@ if __name__ == '__main__':
     rhf = scf.RHF(mol)
     rhf.scf()
 
-    print(time.clock())
+    print(logger.process_clock())
     full(mol, rhf.mo_coeff, 'h2oeri.h5', max_memory=10, ioblk_size=5)
-    print(time.clock())
+    print(logger.process_clock())
     eri0 = incore.full(rhf._eri, rhf.mo_coeff)
     feri = h5py.File('h2oeri.h5', 'r')
     print('full', abs(eri0-feri['eri_mo']).sum())
     feri.close()
 
-    print(time.clock())
+    print(logger.process_clock())
     c = rhf.mo_coeff
     general(mol, (c,c,c,c), 'h2oeri.h5', max_memory=10, ioblk_size=5)
-    print(time.clock())
+    print(logger.process_clock())
     feri = h5py.File('h2oeri.h5', 'r')
     print('general', abs(eri0-feri['eri_mo']).sum())
     feri.close()

--- a/pyscf/ao2mo/r_outcore.py
+++ b/pyscf/ao2mo/r_outcore.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
+
 import tempfile
 import numpy
 import h5py
@@ -39,7 +39,7 @@ def full(mol, mo_coeff, erifile, dataname='eri_mo',
 def general(mol, mo_coeffs, erifile, dataname='eri_mo',
             intor='int2e_spinor', aosym='s4', comp=None,
             max_memory=MAX_MEMORY, ioblk_size=IOBLK_SIZE, verbose=logger.WARN):
-    time_0pass = (time.clock(), time.time())
+    time_0pass = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mol, verbose)
     if '_spinor' not in intor:
         log.warn('r_ao2mo requires spinor integrals.\n'
@@ -143,14 +143,14 @@ def general(mol, mo_coeffs, erifile, dataname='eri_mo',
             tioi += ti2[1]-ti0[1]
             pbuf = _ao2mo.r_e2(buf[:nrow], mokl, klshape, tao, ao_loc, aosym)
 
-            tw1 = time.time()
+            tw1 = logger.perf_counter()
             if comp == 1:
                 h5d_eri[row0:row1] = pbuf
             else:
                 h5d_eri[icomp,row0:row1] = pbuf
-            tioi += time.time()-tw1
+            tioi += logger.perf_counter()-tw1
 
-            ti1 = (time.clock(), time.time())
+            ti1 = (logger.process_clock(), logger.perf_counter())
             log.debug('step 2 [%d/%d] CPU time: %9.2f, Wall time: %9.2f, I/O time: %9.2f',
                       istep, ijmoblks, ti1[0]-ti0[0], ti1[1]-ti0[1], tioi)
             ti0 = ti1
@@ -169,7 +169,7 @@ def half_e1(mol, mo_coeffs, swapfile,
             intor='int2e_spinor', aosym='s4', comp=None,
             max_memory=MAX_MEMORY, ioblk_size=IOBLK_SIZE, verbose=logger.WARN,
             ao2mopt=None):
-    time0 = (time.clock(), time.time())
+    time0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mol, verbose)
 
     ijsame = iden_coeffs(mo_coeffs[0], mo_coeffs[1])
@@ -352,11 +352,11 @@ if __name__ == '__main__':
     eri0 = numpy.dot(eri0.reshape(-1,nao), mo)
     eri0 = eri0.reshape((nmo,)*4)
 
-    print(time.clock())
+    print(logger.process_clock())
     full(mol, mo, 'h2oeri.h5', max_memory=10, ioblk_size=5)
     with h5py.File('h2oeri.h5', 'r') as feri:
         eri1 = numpy.array(feri['eri_mo']).reshape((nmo,)*4)
 
-    print(time.clock())
+    print(logger.process_clock())
     print(numpy.allclose(eri0, eri1))
 

--- a/pyscf/ao2mo/test/bz_nr.py
+++ b/pyscf/ao2mo/test/bz_nr.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pyscf.lib import logger
 from pyscf import scf
 from pyscf import gto
 
@@ -42,10 +43,9 @@ mol.build()
 
 ##############
 # SCF result
-import time
 rhf = scf.RHF(mol)
 print('E_RHF =', rhf.scf())
-print(time.clock())
+print(logger.process_clock())
 
 import os
 import tempfile
@@ -61,7 +61,7 @@ cv = rhf.mo_coeff[:,nocc:]
 ao2mo.outcore.general(mol, (co,cv,co,cv), eritmp, max_memory=100, dataname='mp2_bz')
 f = h5py.File(eritmp, 'r')
 
-print(time.clock())
+print(logger.process_clock())
 eia = rhf.mo_energy[:nocc].reshape(nocc,1) - rhf.mo_energy[nocc:]
 nvir = eia.shape[1]
 emp2 = 0
@@ -79,4 +79,4 @@ print('E_MP2 =', emp2) # -0.80003653259
 f.close()
 os.remove(eritmp)
 
-print(time.clock())
+print(logger.process_clock())

--- a/pyscf/cc/ccsd.py
+++ b/pyscf/cc/ccsd.py
@@ -22,7 +22,7 @@ RCCSD for real integrals
 (ij|kl) = (ji|kl) = (kl|ij) = ...
 '''
 
-import time
+
 import ctypes
 from functools import reduce
 import numpy
@@ -51,7 +51,7 @@ def kernel(mycc, eris=None, t1=None, t2=None, max_cycle=50, tol=1e-8,
     elif t2 is None:
         t2 = mycc.get_init_guess(eris)[1]
 
-    cput1 = cput0 = (time.clock(), time.time())
+    cput1 = cput0 = (logger.process_clock(), logger.perf_counter())
     eold = 0
     eccsd = mycc.energy(t1, t2, eris)
     log.info('Init E_corr(CCSD) = %.15g', eccsd)
@@ -95,7 +95,7 @@ def update_amps(mycc, t1, t2, eris):
         raise NotImplementedError
     assert(isinstance(eris, _ChemistsERIs))
 
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(mycc.stdout, mycc.verbose)
     nocc, nvir = t1.shape
     fock = eris.fock
@@ -275,7 +275,7 @@ def update_amps(mycc, t1, t2, eris):
 
 
 def _add_ovvv_(mycc, t1, t2, eris, fvv, t1new, t2new, fswap):
-    time1 = time.clock(), time.time()
+    time1 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(mycc.stdout, mycc.verbose)
     nocc, nvir = t1.shape
     nvir_pair = nvir * (nvir+1) // 2
@@ -376,7 +376,7 @@ def _add_vvvv_tril(mycc, t1, t2, eris, out=None, with_ovvv=None):
     Using symmetry t2[ijab] = t2[jiba] and Ht2[ijab] = Ht2[jiba], compute the
     lower triangular part of  Ht2
     '''
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(mycc.stdout, mycc.verbose)
     if with_ovvv is None:
         with_ovvv = mycc.direct
@@ -428,7 +428,7 @@ def _add_vvvv_full(mycc, t1, t2, eris, out=None, with_ovvv=False):
     '''Ht2 = numpy.einsum('ijcd,acdb->ijab', t2, vvvv)
     without using symmetry t2[ijab] = t2[jiba] in t2 or Ht2
     '''
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(mycc.stdout, mycc.verbose)
     if t1 is None:
         tau = t2
@@ -486,7 +486,7 @@ def _contract_s4vvvv_t2(mycc, mol, vvvv, t2, out=None, verbose=None):
         return numpy.zeros_like(t2)
 
     _dgemm = lib.numpy_helper._dgemm
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.new_logger(mycc, verbose)
 
     nvira, nvirb = t2.shape[-2:]
@@ -597,7 +597,7 @@ def _contract_s1vvvv_t2(mycc, mol, vvvv, t2, out=None, verbose=None):
     # _contract_s4vvvv_t2(mycc, mol, vvvv, t2, out, verbose)
     assert(vvvv is not None)
 
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.new_logger(mycc, verbose)
 
     nvira, nvirb = t2.shape[-2:]
@@ -989,7 +989,7 @@ http://sunqm.net/pyscf/code-rule.html#api-rules for the details of API conventio
     def get_init_guess(self, eris=None):
         return self.init_amps(eris)[1:]
     def init_amps(self, eris=None):
-        time0 = time.clock(), time.time()
+        time0 = logger.process_clock(), logger.perf_counter()
         if eris is None:
             eris = self.ao2mo(self.mo_coeff)
         mo_e = eris.mo_energy
@@ -1332,7 +1332,7 @@ class _ChemistsERIs:
         raise NotImplementedError
 
 def _make_eris_incore(mycc, mo_coeff=None):
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     eris = _ChemistsERIs()
     eris._common_init_(mycc, mo_coeff)
     nocc = eris.nocc
@@ -1389,7 +1389,7 @@ def _make_eris_incore(mycc, mo_coeff=None):
     return eris
 
 def _make_eris_outcore(mycc, mo_coeff=None):
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(mycc.stdout, mycc.verbose)
     eris = _ChemistsERIs()
     eris._common_init_(mycc, mo_coeff)
@@ -1423,7 +1423,7 @@ def _make_eris_outcore(mycc, mo_coeff=None):
         vvv = lib.pack_tril(eri[:,:,nocc:,nocc:].reshape((p1-p0)*nocc,nvir,nvir))
         eris.ovvv[:,p0:p1] = vvv.reshape(p1-p0,nocc,nvpair).transpose(1,0,2)
 
-    cput1 = time.clock(), time.time()
+    cput1 = logger.process_clock(), logger.perf_counter()
     if not mycc.direct:
         max_memory = max(MEMORYMIN, mycc.max_memory-lib.current_memory()[0])
         eris.feri2 = lib.H5TmpFile()
@@ -1481,7 +1481,7 @@ def _make_eris_outcore(mycc, mo_coeff=None):
     return eris
 
 def _make_df_eris_outcore(mycc, mo_coeff=None):
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(mycc.stdout, mycc.verbose)
     eris = _ChemistsERIs()
     eris._common_init_(mycc, mo_coeff)

--- a/pyscf/cc/ccsd_lambda.py
+++ b/pyscf/cc/ccsd_lambda.py
@@ -23,7 +23,7 @@ the 4-index integrals (ij|kl) = (ij|lk) = (ji|kl) are assumed.
 Note MO integrals are treated in chemist's notation
 '''
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -36,7 +36,7 @@ def kernel(mycc, eris=None, t1=None, t2=None, l1=None, l2=None,
            max_cycle=50, tol=1e-8, verbose=logger.INFO,
            fintermediates=None, fupdate=None):
     if eris is None: eris = mycc.ao2mo()
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mycc, verbose)
 
     if t1 is None: t1 = mycc.t1
@@ -235,7 +235,7 @@ def make_intermediates(mycc, t1, t2, eris):
 # update L1, L2
 def update_lambda(mycc, t1, t2, l1, l2, eris=None, imds=None):
     if imds is None: imds = make_intermediates(mycc, t1, t2, eris)
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(mycc.stdout, mycc.verbose)
     nocc, nvir = t1.shape
     fov = eris.fock[:nocc,nocc:]

--- a/pyscf/cc/ccsd_rdm.py
+++ b/pyscf/cc/ccsd_rdm.py
@@ -16,7 +16,7 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -66,7 +66,7 @@ def _gamma2_outcore(mycc, t1, t2, l1, l2, h5fobj, compress_vvvv=False):
                                   chunks=(nocc,1,nvir,nocc))
     fswap = lib.H5TmpFile()
 
-    time1 = time.clock(), time.time()
+    time1 = logger.process_clock(), logger.perf_counter()
     pvOOv = lib.einsum('ikca,jkcb->aijb', l2, t2)
     moo = numpy.einsum('dljd->jl', pvOOv) * 2
     mvv = numpy.einsum('blld->db', pvOOv) * 2
@@ -154,7 +154,7 @@ def _gamma2_outcore(mycc, t1, t2, l1, l2, h5fobj, compress_vvvv=False):
                blksize, nocc, int((nvir+blksize-1)/blksize))
     dovvv = h5fobj.create_dataset('dovvv', (nocc,nvir,nvir,nvir), dtype,
                                   chunks=(nocc,min(nocc,nvir),1,nvir))
-    time1 = time.clock(), time.time()
+    time1 = logger.process_clock(), logger.perf_counter()
     for istep, (p0, p1) in enumerate(lib.prange(0, nvir, blksize)):
         l2tmp = l2[:,:,p0:p1]
         gvvvv = lib.einsum('ijab,ijcd->abcd', l2tmp, t2)

--- a/pyscf/cc/ccsd_t.py
+++ b/pyscf/cc/ccsd_t.py
@@ -20,7 +20,7 @@
 RHF-CCSD(T) for real integrals
 '''
 
-import time
+
 import ctypes
 import numpy
 from pyscf import lib
@@ -32,7 +32,7 @@ from pyscf.cc import _ccsd
 
 # JCP 94, 442 (1991); DOI:10.1063/1.460359.  Error in Eq (1), should be [ia] >= [jb] >= [kc]
 def kernel(mycc, eris, t1=None, t2=None, verbose=logger.NOTE):
-    cpu1 = cpu0 = (time.clock(), time.time())
+    cpu1 = cpu0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mycc, verbose)
     if t1 is None: t1 = mycc.t1
     if t2 is None: t2 = mycc.t2
@@ -132,7 +132,7 @@ def kernel(mycc, eris, t1=None, t2=None, verbose=logger.NOTE):
     return et
 
 def _sort_eri(mycc, eris, nocc, nvir, vvop, log):
-    cpu1 = (time.clock(), time.time())
+    cpu1 = (logger.process_clock(), logger.perf_counter())
     mol = mycc.mol
     nmo = nocc + nvir
 

--- a/pyscf/cc/dfccsd.py
+++ b/pyscf/cc/dfccsd.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
+
 import ctypes
 import numpy
 from pyscf import lib
@@ -56,7 +56,7 @@ def _contract_vvvv_t2(mycc, mol, vvL, t2, out=None, verbose=None):
             if vvvv is None, contract t2 to AO-integrals using AO-direct algorithm
     '''
     _dgemm = lib.numpy_helper._dgemm
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.new_logger(mol, verbose)
 
     naux = vvL.shape[-1]

--- a/pyscf/cc/eom_gccsd.py
+++ b/pyscf/cc/eom_gccsd.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
+
 import numpy as np
 
 from pyscf import lib
@@ -640,7 +640,7 @@ class _IMDS:
         self.made_ee_imds = False
 
     def _make_shared(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = self.t1, self.t2, self.eris
         self.Foo = imd.Foo(t1, t2, eris)
@@ -659,7 +659,7 @@ class _IMDS:
         if not self._made_shared:
             self._make_shared()
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = self.t1, self.t2, self.eris
 
@@ -673,7 +673,7 @@ class _IMDS:
         return self
 
     def make_t3p2_ip(self, cc):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = cc.t1, cc.t2, self.eris
         delta_E_corr, pt1, pt2, Wovoo, Wvvvo = \
@@ -694,7 +694,7 @@ class _IMDS:
         if not self._made_shared:
             self._make_shared()
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = self.t1, self.t2, self.eris
 
@@ -708,7 +708,7 @@ class _IMDS:
         return self
 
     def make_t3p2_ea(self, cc):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = cc.t1, cc.t2, self.eris
         delta_E_corr, pt1, pt2, Wovoo, Wvvvo = \
@@ -729,7 +729,7 @@ class _IMDS:
         if not self._made_shared:
             self._make_shared()
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = self.t1, self.t2, self.eris
 

--- a/pyscf/cc/eom_rccsd.py
+++ b/pyscf/cc/eom_rccsd.py
@@ -18,7 +18,7 @@
 #         Timothy Berkelbach <tim.berkelbach@gmail.com>
 #
 
-import time
+
 import numpy as np
 
 from pyscf import lib
@@ -31,7 +31,7 @@ from pyscf import __config__
 
 def kernel(eom, nroots=1, koopmans=False, guess=None, left=False,
            eris=None, imds=None, **kwargs):
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(eom.stdout, eom.verbose)
     if eom.verbose >= logger.WARN:
         eom.check_sanity()
@@ -398,7 +398,7 @@ def ipccsd_diag(eom, imds=None):
 
 def ipccsd_star_contract(eom, ipccsd_evals, ipccsd_evecs, lipccsd_evecs, imds=None):
     from pyscf.cc.ccsd_t import _sort_eri, _sort_t2_vooo_
-    cpu1 = (time.clock(), time.time())
+    cpu1 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(eom.stdout, eom.verbose)
     if imds is None:
         imds = eom.make_imds()
@@ -748,7 +748,7 @@ def eaccsd_diag(eom, imds=None):
     return vector
 
 def eaccsd_star_contract(eom, eaccsd_evals, eaccsd_evecs, leaccsd_evecs, imds=None):
-    cpu1 = (time.clock(), time.time())
+    cpu1 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(eom.stdout, eom.verbose)
     if imds is None:
         imds = eom.make_imds()
@@ -1750,7 +1750,7 @@ class _IMDS:
         self._made_shared_2e = False
 
     def _make_shared_1e(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = self.t1, self.t2, self.eris
         self.Loo = imd.Loo(t1, t2, eris)
@@ -1762,7 +1762,7 @@ class _IMDS:
         return self
 
     def _make_shared_2e(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris
@@ -1780,7 +1780,7 @@ class _IMDS:
         if not self._made_shared_2e and ip_partition != 'mp':
             self._make_shared_2e()
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris
@@ -1795,7 +1795,7 @@ class _IMDS:
 
     def make_t3p2_ip(self, cc, ip_partition=None):
         assert(ip_partition is None)
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = cc.t1, cc.t2, self.eris
         delta_E_corr, pt1, pt2, Wovoo, Wvvvo = \
@@ -1816,7 +1816,7 @@ class _IMDS:
         if not self._made_shared_2e and ea_partition != 'mp':
             self._make_shared_2e()
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris
@@ -1833,7 +1833,7 @@ class _IMDS:
 
     def make_t3p2_ea(self, cc, ea_partition=None):
         assert(ea_partition is None)
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = cc.t1, cc.t2, self.eris
         delta_E_corr, pt1, pt2, Wovoo, Wvvvo = \
@@ -1850,7 +1850,7 @@ class _IMDS:
 
 
     def make_ee(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris

--- a/pyscf/cc/eom_uccsd.py
+++ b/pyscf/cc/eom_uccsd.py
@@ -21,7 +21,7 @@
 #         Chong Sun
 #
 
-import time
+
 import numpy as np
 
 from pyscf import lib
@@ -624,7 +624,7 @@ def eaccsd_matvec(eom, vector, imds=None, diag=None):
     return vector
 
 def _add_vvvv_ea(mycc, r2, eris):
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(mycc.stdout, mycc.verbose)
     r2aaa, r2aba, r2bab, r2bbb = r2
     nocca, noccb = mycc.nocc
@@ -1949,7 +1949,7 @@ class _IMDS:
         self.made_ee_imds = False
 
     def _make_shared(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = self.t1, self.t2, self.eris
         self.Foo, self.FOO = uintermediates.Foo(t1, t2, eris)
@@ -1976,7 +1976,7 @@ class _IMDS:
         if not self._made_shared:
             self._make_shared()
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = self.t1, self.t2, self.eris
 
@@ -1993,7 +1993,7 @@ class _IMDS:
         if not self._made_shared:
             self._make_shared()
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = self.t1, self.t2, self.eris
 
@@ -2070,7 +2070,7 @@ class _IMDS:
         return self
 
     def make_ee(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris

--- a/pyscf/cc/gccsd.py
+++ b/pyscf/cc/gccsd.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
+
 import numpy as np
 from functools import reduce
 
@@ -403,7 +403,7 @@ def _make_eris_incore(mycc, mo_coeff=None, ao2mofn=None):
     return eris
 
 def _make_eris_outcore(mycc, mo_coeff=None):
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(mycc.stdout, mycc.verbose)
 
     eris = _PhysicistsERIs()

--- a/pyscf/cc/gccsd_lambda.py
+++ b/pyscf/cc/gccsd_lambda.py
@@ -16,7 +16,7 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -101,7 +101,7 @@ def make_intermediates(mycc, t1, t2, eris):
 
 # update L1, L2
 def update_lambda(mycc, t1, t2, l1, l2, eris, imds):
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(mycc.stdout, mycc.verbose)
     nocc, nvir = t1.shape
     fov = eris.fock[:nocc,nocc:]

--- a/pyscf/cc/rccsd.py
+++ b/pyscf/cc/rccsd.py
@@ -26,7 +26,7 @@ Note MO integrals are treated in chemist's notation
 Ref: Hirata et al., J. Chem. Phys. 120, 2581 (2004)
 '''
 
-import time
+
 import numpy as np
 
 from pyscf import lib
@@ -246,7 +246,7 @@ class _ChemistsERIs(ccsd._ChemistsERIs):
             return self.ovvv
 
 def _make_eris_incore(mycc, mo_coeff=None, ao2mofn=None):
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     eris = _ChemistsERIs()
     eris._common_init_(mycc, mo_coeff)
     nocc = eris.nocc
@@ -268,7 +268,7 @@ def _make_eris_incore(mycc, mo_coeff=None, ao2mofn=None):
     return eris
 
 def _make_eris_outcore(mycc, mo_coeff=None):
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(mycc.stdout, mycc.verbose)
     eris = _ChemistsERIs()
     eris._common_init_(mycc, mo_coeff)

--- a/pyscf/cc/rccsd_lambda.py
+++ b/pyscf/cc/rccsd_lambda.py
@@ -24,7 +24,7 @@ Note MO integrals are treated in chemist's notation
 '''
 
 
-import time
+
 import numpy as np
 from pyscf import lib
 from pyscf.lib import logger
@@ -151,7 +151,7 @@ def make_intermediates(mycc, t1, t2, eris):
 
 # update L1, L2
 def update_lambda(mycc, t1, t2, l1, l2, eris, imds):
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(mycc.stdout, mycc.verbose)
     nocc, nvir = t1.shape
     l1new = np.zeros_like(l1)

--- a/pyscf/cc/rccsd_slow.py
+++ b/pyscf/cc/rccsd_slow.py
@@ -21,7 +21,7 @@ Ref: Hirata et al., J. Chem. Phys. 120, 2581 (2004)
 '''
 
 from functools import reduce
-import time
+
 import numpy as np
 
 from pyscf import lib
@@ -252,7 +252,7 @@ class RCCSD(ccsd.CCSD):
             guess : list of ndarray
                 List of guess vectors to use for targeting via overlap.
         '''
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
         size = self.nip()
         nroots = min(nroots,size)
@@ -537,7 +537,7 @@ class RCCSD(ccsd.CCSD):
         Kwargs:
             See ipccd()
         '''
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
         size = self.nea()
         nroots = min(nroots,size)
@@ -848,7 +848,7 @@ class RCCSD(ccsd.CCSD):
             guess : list of ndarray
                 List of guess vectors to use for targeting via overlap.
         '''
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
         size = self.nee()
         nroots = min(nroots,size)
@@ -980,7 +980,7 @@ class _IMDS:
         self._made_shared_2e = False
 
     def _make_shared_1e(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1,t2,eris = self.t1, self.t2, self.eris
@@ -991,7 +991,7 @@ class _IMDS:
         log.timer('EOM-CCSD shared one-electron intermediates', *cput0)
 
     def _make_shared_2e(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1,t2,eris = self.t1, self.t2, self.eris
@@ -1008,7 +1008,7 @@ class _IMDS:
             self._make_shared_2e()
             self._made_shared_2e = True
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1,t2,eris = self.t1, self.t2, self.eris
@@ -1027,7 +1027,7 @@ class _IMDS:
             self._make_shared_2e()
             self._made_shared_2e = True
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1,t2,eris = self.t1, self.t2, self.eris

--- a/pyscf/cc/uccsd.py
+++ b/pyscf/cc/uccsd.py
@@ -21,7 +21,7 @@
 UCCSD with spatial integrals
 '''
 
-import time
+
 from functools import reduce
 import numpy as np
 
@@ -39,7 +39,7 @@ MEMORYMIN = getattr(__config__, 'cc_ccsd_memorymin', 2000)
 # This is unrestricted (U)CCSD, in spatial-orbital form.
 
 def update_amps(cc, t1, t2, eris):
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(cc.stdout, cc.verbose)
     t1a, t1b = t1
     t2aa, t2ab, t2bb = t2
@@ -418,7 +418,7 @@ def _add_vvVV(mycc, t1, t2ab, eris, out=None):
     '''Ht2 = np.einsum('iJcD,acBD->iJaB', t2ab, vvVV)
     without using symmetry in t2ab or Ht2
     '''
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     if t2ab.size == 0:
         return np.zeros_like(t2ab)
     if t1 is not None:
@@ -452,7 +452,7 @@ def _add_vvVV(mycc, t1, t2ab, eris, out=None):
         return eris._contract_vvVV_t2(mycc, t2ab, mycc.direct, out, log)
 
 def _add_vvvv(mycc, t1, t2, eris, out=None, with_ovvv=False, t2sym=None):
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(mycc.stdout, mycc.verbose)
     if t1 is None:
         t2aa, t2ab, t2bb = t2
@@ -552,7 +552,7 @@ class UCCSD(ccsd.CCSD):
     get_frozen_mask = get_frozen_mask
 
     def init_amps(self, eris=None):
-        time0 = time.clock(), time.time()
+        time0 = logger.process_clock(), logger.perf_counter()
         if eris is None:
             eris = self.ao2mo(self.mo_coeff)
         nocca, noccb = self.nocc
@@ -997,7 +997,7 @@ def _make_eris_outcore(mycc, mo_coeff=None):
     eris.OVvo = eris.feri.create_dataset('OVvo', (noccb,nvirb,nvira,nocca), 'f8')
     eris.OVvv = eris.feri.create_dataset('OVvv', (noccb,nvirb,nvira*(nvira+1)//2), 'f8')
 
-    cput1 = time.clock(), time.time()
+    cput1 = logger.process_clock(), logger.perf_counter()
     mol = mycc.mol
     # <ij||pq> = <ij|pq> - <ij|qp> = (ip|jq) - (iq|jp)
     tmpf = lib.H5TmpFile()

--- a/pyscf/cc/uccsd_lambda.py
+++ b/pyscf/cc/uccsd_lambda.py
@@ -16,7 +16,7 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -294,7 +294,7 @@ def make_intermediates(mycc, t1, t2, eris):
 
 # update L1, L2
 def update_lambda(mycc, t1, t2, l1, l2, eris, imds):
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(mycc.stdout, mycc.verbose)
 
     t1a, t1b = t1

--- a/pyscf/cc/uccsd_slow.py
+++ b/pyscf/cc/uccsd_slow.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from functools import reduce
-import time
+
 import numpy
 import numpy as np
 
@@ -124,7 +124,7 @@ class UCCSD(ccsd.CCSD):
     get_frozen_mask = get_frozen_mask
 
     def init_amps(self, eris):
-        time0 = time.clock(), time.time()
+        time0 = logger.process_clock(), logger.perf_counter()
         mo_e = eris.fock.diagonal()
         nocc = self.nocc
         eia = mo_e[:nocc,None] - mo_e[None,nocc:]
@@ -484,7 +484,7 @@ class UCCSD(ccsd.CCSD):
 class _PhysicistsERIs:
     def __init__(self, cc, mo_coeff=None, method='incore',
                  ao2mofn=ao2mo.outcore.general_iofree):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         moidx = cc.get_frozen_mask()
         if mo_coeff is None:
             self.mo_coeff = mo_coeff = [cc.mo_coeff[0][:,moidx[0]],
@@ -537,7 +537,7 @@ class _PhysicistsERIs:
             self.ovvv = self.feri1.create_dataset('ovvv', (nocc,nvir,nvir,nvir), ds_type)
             self.vvvv = self.feri1.create_dataset('vvvv', (nvir,nvir,nvir,nvir), ds_type)
 
-            cput1 = time.clock(), time.time()
+            cput1 = logger.process_clock(), logger.perf_counter()
             # <ij||pq> = <ij|pq> - <ij|qp> = (ip|jq) - (iq|jp)
             buf = ao2mofn(cc._scf.mol, (orbo,so_coeff,orbo,so_coeff), compact=0)
             if mo_coeff[0].dtype == np.float: buf = buf.real
@@ -555,7 +555,7 @@ class _PhysicistsERIs:
             self.ooov[:,:,:,:] = buf1[:,:,:nocc,nocc:]
             self.oovv[:,:,:,:] = buf1[:,:,nocc:,nocc:]
 
-            cput1 = time.clock(), time.time()
+            cput1 = logger.process_clock(), logger.perf_counter()
             # <ia||pq> = <ia|pq> - <ia|qp> = (ip|aq) - (iq|ap)
             buf = ao2mofn(cc._scf.mol, (orbo,so_coeff,orbv,so_coeff), compact=0)
             if mo_coeff[0].dtype == np.float: buf = buf.real
@@ -673,7 +673,7 @@ class _IMDS:
         self.made_ee_imds = False
 
     def _make_shared(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.cc.stdout, self.cc.verbose)
 
         t1,t2,eris = self.cc.t1, self.cc.t2, self.cc.eris
@@ -692,7 +692,7 @@ class _IMDS:
             self._make_shared()
             self._made_shared = True
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.cc.stdout, self.cc.verbose)
 
         t1,t2,eris = self.cc.t1, self.cc.t2, self.cc.eris
@@ -710,7 +710,7 @@ class _IMDS:
             self._make_shared()
             self._made_shared = True
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.cc.stdout, self.cc.verbose)
 
         t1,t2,eris = self.cc.t1, self.cc.t2, self.cc.eris
@@ -728,7 +728,7 @@ class _IMDS:
             self._make_shared()
             self._made_shared = True
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.cc.stdout, self.cc.verbose)
 
         t1,t2,eris = self.cc.t1, self.cc.t2, self.cc.eris

--- a/pyscf/cc/uccsd_t.py
+++ b/pyscf/cc/uccsd_t.py
@@ -20,7 +20,7 @@
 UCCSD(T)
 '''
 
-import time
+
 import ctypes
 import numpy
 from pyscf import lib
@@ -28,7 +28,7 @@ from pyscf.lib import logger
 from pyscf.cc import _ccsd
 
 def kernel(mycc, eris, t1=None, t2=None, verbose=logger.NOTE):
-    cpu1 = cpu0 = (time.clock(), time.time())
+    cpu1 = cpu0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mycc, verbose)
     if t1 is None: t1 = mycc.t1
     if t2 is None: t2 = mycc.t2
@@ -172,7 +172,7 @@ def _gen_contract_aaa(t1T, t2T, vooo, fock, mo_energy, orbsym, log):
     mo_energy = numpy.asarray(mo_energy, order='C')
     fvo = fock[nocc:,:nocc].copy()
 
-    cpu2 = [time.clock(), time.time()]
+    cpu2 = [logger.process_clock(), logger.perf_counter()]
     orbsym = numpy.hstack((numpy.sort(orbsym[:nocc]),numpy.sort(orbsym[nocc:])))
     o_ir_loc = numpy.append(0, numpy.cumsum(numpy.bincount(orbsym[:nocc], minlength=8)))
     v_ir_loc = numpy.append(0, numpy.cumsum(numpy.bincount(orbsym[nocc:], minlength=8)))
@@ -224,7 +224,7 @@ def _gen_contract_baa(ts, vooo, fock, mo_energy, orbsym, log):
     fvo = focka[nocca:,:nocca].copy()
     fVO = fockb[noccb:,:noccb].copy()
 
-    cpu2 = [time.clock(), time.time()]
+    cpu2 = [logger.process_clock(), logger.perf_counter()]
     dtype = numpy.result_type(t2aaT.dtype, vooo.dtype)
     if dtype == numpy.complex:
         drv = _ccsd.libcc.CCuccsd_t_zbaa
@@ -256,7 +256,7 @@ def _gen_contract_baa(ts, vooo, fock, mo_energy, orbsym, log):
     return contract
 
 def _sort_eri(mycc, eris, h5tmp, log):
-    cpu1 = (time.clock(), time.time())
+    cpu1 = (logger.process_clock(), logger.perf_counter())
     nocca, noccb = mycc.nocc
     nmoa = eris.focka.shape[0]
     nmob = eris.fockb.shape[0]

--- a/pyscf/ci/cisd.py
+++ b/pyscf/ci/cisd.py
@@ -20,7 +20,7 @@
 Solve CISD equation  H C = C e  where e = E_HF + E_CORR
 '''
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -102,7 +102,7 @@ def make_diagonal(myci, eris):
     return numpy.hstack((ehf, e1diag.reshape(-1), e2diag.reshape(-1)))
 
 def contract(myci, civec, eris):
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(myci.stdout, myci.verbose)
     nocc = myci.nocc
     nmo = myci.nmo

--- a/pyscf/ci/gcisd.py
+++ b/pyscf/ci/gcisd.py
@@ -21,7 +21,7 @@ General spin-orbital CISD
 '''
 
 import warnings
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -325,7 +325,7 @@ class GCISD(cisd.CISD):
     def get_init_guess(self, eris=None, nroots=1, diag=None):
         # MP2 initial guess
         if eris is None: eris = self.ao2mo(self.mo_coeff)
-        time0 = time.clock(), time.time()
+        time0 = logger.process_clock(), logger.perf_counter()
         mo_e = eris.mo_energy
         nocc = self.nocc
         eia = mo_e[:nocc,None] - mo_e[None,nocc:]

--- a/pyscf/cornell_shci/shci.py
+++ b/pyscf/cornell_shci/shci.py
@@ -27,7 +27,7 @@ need to contact Cyrus Umrigar to get the program.
 import os
 import sys
 import json
-import time
+
 import tempfile
 import copy
 import glob

--- a/pyscf/df/df.py
+++ b/pyscf/df/df.py
@@ -20,7 +20,7 @@
 J-metric density fitting
 '''
 
-import time
+
 import copy
 import tempfile
 import numpy
@@ -123,7 +123,7 @@ class DF(lib.StreamObject):
         return self
 
     def build(self):
-        t0 = (time.clock(), time.time())
+        t0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         self.check_sanity()

--- a/pyscf/df/df_jk.py
+++ b/pyscf/df/df_jk.py
@@ -17,7 +17,7 @@
 #
 
 import copy
-import time
+
 import ctypes
 import numpy
 import scipy.linalg
@@ -206,7 +206,7 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
         dfobj._cderi is None):
         return get_j(dfobj, dm, hermi, direct_scf_tol), None
 
-    t0 = t1 = (time.clock(), time.time())
+    t0 = t1 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(dfobj.stdout, dfobj.verbose)
     fmmm = _ao2mo.libao2mo.AO2MOmmm_bra_nr_s2
     fdrv = _ao2mo.libao2mo.AO2MOnr_e2_drv
@@ -310,7 +310,7 @@ def get_j(dfobj, dm, hermi=1, direct_scf_tol=1e-13):
     from pyscf.scf import _vhf
     from pyscf.scf import jk
     from pyscf.df import addons
-    t0 = t1 = (time.clock(), time.time())
+    t0 = t1 = (logger.process_clock(), logger.perf_counter())
 
     mol = dfobj.mol
     if dfobj._vjopt is None:
@@ -407,7 +407,7 @@ def get_j(dfobj, dm, hermi=1, direct_scf_tol=1e-13):
 
 def r_get_jk(dfobj, dms, hermi=1, with_j=True, with_k=True):
     '''Relativistic density fitting JK'''
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
     mol = dfobj.mol
     c1 = .5 / lib.param.LIGHT_SPEED
     tao = mol.tmap()

--- a/pyscf/df/grad/rks.py
+++ b/pyscf/df/grad/rks.py
@@ -22,7 +22,7 @@
 # # Author: Qiming Sun <osirpt.sun@gmail.com>
 # #
 
-import time
+
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf.grad import rks as rks_grad
@@ -34,7 +34,7 @@ def get_veff(ks_grad, mol=None, dm=None):
     '''
     if mol is None: mol = ks_grad.mol
     if dm is None: dm = ks_grad.base.make_rdm1()
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     mf = ks_grad.base
     ni = mf._numint

--- a/pyscf/df/grad/uks.py
+++ b/pyscf/df/grad/uks.py
@@ -23,7 +23,7 @@
 # #
 
 
-import time
+
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf.grad import uks as uks_grad
@@ -35,7 +35,7 @@ def get_veff(ks_grad, mol=None, dm=None):
     '''
     if mol is None: mol = ks_grad.mol
     if dm is None: dm = ks_grad.base.make_rdm1()
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     mf = ks_grad.base
     ni = mf._numint

--- a/pyscf/df/hessian/rhf.py
+++ b/pyscf/df/hessian/rhf.py
@@ -32,7 +32,7 @@ Ref:
     Kossmann, Ute Becker, Edward Valeev, Frank Neese. Mol. Phys. 113, 1961 (2015)
 '''
 
-import time
+
 import numpy
 import numpy as np
 import scipy.linalg
@@ -54,7 +54,7 @@ def _partial_hess_ejk(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
     '''Partial derivative
     '''
     log = logger.new_logger(hessobj, verbose)
-    time0 = t1 = (time.clock(), time.time())
+    time0 = t1 = (logger.process_clock(), logger.perf_counter())
 
     mol = hessobj.mol
     mf = hessobj.base

--- a/pyscf/df/hessian/rks.py
+++ b/pyscf/df/hessian/rks.py
@@ -26,7 +26,7 @@
 Non-relativistic RKS analytical Hessian
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -37,7 +37,7 @@ from pyscf.df.hessian import rhf as df_rhf_hess
 def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
                       atmlst=None, max_memory=4000, verbose=None):
     log = logger.new_logger(hessobj, verbose)
-    time0 = t1 = (time.clock(), time.time())
+    time0 = t1 = (logger.process_clock(), logger.perf_counter())
 
     mol = hessobj.mol
     mf = hessobj.base

--- a/pyscf/df/hessian/uhf.py
+++ b/pyscf/df/hessian/uhf.py
@@ -26,7 +26,7 @@
 Non-relativistic UHF analytical Hessian
 '''
 
-import time
+
 import numpy
 import numpy as np
 import scipy.linalg
@@ -47,7 +47,7 @@ def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
 def _partial_hess_ejk(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
                       atmlst=None, max_memory=4000, verbose=None, with_k=True):
     log = logger.new_logger(hessobj, verbose)
-    time0 = t1 = (time.clock(), time.time())
+    time0 = t1 = (logger.process_clock(), logger.perf_counter())
 
     mol = hessobj.mol
     mf = hessobj.base

--- a/pyscf/df/hessian/uks.py
+++ b/pyscf/df/hessian/uks.py
@@ -26,7 +26,7 @@
 Non-relativistic UKS analytical Hessian
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -37,7 +37,7 @@ from pyscf.df.hessian import uhf as df_uhf_hess
 def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
                       atmlst=None, max_memory=4000, verbose=None):
     log = logger.new_logger(hessobj, verbose)
-    time0 = t1 = (time.clock(), time.time())
+    time0 = t1 = (logger.process_clock(), logger.perf_counter())
 
     mol = hessobj.mol
     mf = hessobj.base

--- a/pyscf/df/incore.py
+++ b/pyscf/df/incore.py
@@ -16,7 +16,7 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-import time
+
 import numpy
 import scipy.linalg
 from pyscf import lib
@@ -99,7 +99,7 @@ def cholesky_eri(mol, auxbasis='weigend+etb', auxmol=None,
     '''
     from pyscf.df.outcore import _guess_shell_ranges
     assert(comp == 1)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mol, verbose)
     if auxmol is None:
         auxmol = addons.make_auxmol(mol, auxbasis)
@@ -186,7 +186,7 @@ def cholesky_eri_debug(mol, auxbasis='weigend+etb', auxmol=None,
         2D array of (naux,nao*(nao+1)/2) in C-contiguous
     '''
     assert(comp == 1)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mol, verbose)
     if auxmol is None:
         auxmol = addons.make_auxmol(mol, auxbasis)

--- a/pyscf/df/outcore.py
+++ b/pyscf/df/outcore.py
@@ -16,7 +16,7 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-import time
+
 import tempfile
 import numpy
 import scipy.linalg
@@ -45,7 +45,7 @@ def cholesky_eri(mol, erifile, auxbasis='weigend+etb', dataname='j3c', tmpdir=No
     assert(aosym in ('s1', 's2ij'))
     assert(comp == 1)
     log = logger.new_logger(mol, verbose)
-    time0 = (time.clock(), time.time())
+    time0 = (logger.process_clock(), logger.perf_counter())
 
     if auxmol is None:
         auxmol = make_auxmol(mol, auxbasis)
@@ -105,7 +105,7 @@ def cholesky_eri_b(mol, erifile, auxbasis='weigend+etb', dataname='j3c',
     '''
     assert(aosym in ('s1', 's2ij'))
     log = logger.new_logger(mol, verbose)
-    time0 = (time.clock(), time.time())
+    time0 = (logger.process_clock(), logger.perf_counter())
 
     if auxmol is None:
         auxmol = make_auxmol(mol, auxbasis)
@@ -201,7 +201,7 @@ def general(mol, mo_coeffs, erifile, auxbasis='weigend+etb', dataname='eri_mo', 
     ''' Transform ij of (ij|L) to MOs.
     '''
     assert(aosym in ('s1', 's2ij'))
-    time0 = (time.clock(), time.time())
+    time0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mol, verbose)
 
     if tmpdir is None:

--- a/pyscf/dft/dks.py
+++ b/pyscf/dft/dks.py
@@ -20,7 +20,7 @@
 4-component Dirac-Kohn-Sham
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -61,7 +61,7 @@ def get_veff(ks, mol=None, dm=None, dm_last=0, vhf_last=0, hermi=1):
     '''
     if mol is None: mol = ks.mol
     if dm is None: dm = ks.make_rdm1()
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     ground_state = (isinstance(dm, numpy.ndarray) and dm.ndim == 2)
 

--- a/pyscf/dft/gks.py
+++ b/pyscf/dft/gks.py
@@ -20,7 +20,7 @@
 Generalized Kohn-Sham
 '''
 
-import time
+
 import numpy
 import scipy.linalg
 from pyscf import lib
@@ -34,7 +34,7 @@ def get_veff(ks, mol=None, dm=None, dm_last=0, vhf_last=0, hermi=1):
     '''
     if mol is None: mol = ks.mol
     if dm is None: dm = ks.make_rdm1()
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     ground_state = (isinstance(dm, numpy.ndarray) and dm.ndim == 2)
 

--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -2077,7 +2077,7 @@ _NumInt = NumInt
 
 
 if __name__ == '__main__':
-    import time
+    
     from pyscf import gto
     from pyscf import dft
 
@@ -2096,7 +2096,7 @@ if __name__ == '__main__':
     numpy.random.seed(1)
     dm1 = numpy.random.random((dm.shape))
     dm1 = lib.hermi_triu(dm1)
-    print(time.clock())
+    print(logger.process_clock())
     res = mf._numint.nr_vxc(mol, mf.grids, mf.xc, dm1, spin=0)
     print(res[1] - -37.084047825971282)
     res = mf._numint.nr_vxc(mol, mf.grids, mf.xc, (dm1,dm1), spin=1)
@@ -2105,4 +2105,4 @@ if __name__ == '__main__':
     print(res[1] - -8.6313329288394947)
     res = mf._numint.nr_vxc(mol, mf.grids, mf.xc, (dm,dm), spin=1)
     print(res[1] - -21.520301399504582)
-    print(time.clock())
+    print(logger.process_clock())

--- a/pyscf/dft/r_numint.py
+++ b/pyscf/dft/r_numint.py
@@ -322,7 +322,7 @@ _RNumInt = RNumInt
 
 
 if __name__ == '__main__':
-    import time
+    
     from pyscf import gto
     from pyscf.dft import dks
 
@@ -338,7 +338,7 @@ if __name__ == '__main__':
     mf.grids.build()
     dm = mf.get_init_guess(key='minao')
 
-    print(time.clock())
+    print(logger.process_clock())
     res = mf._numint.r_vxc(mol, mf.grids, mf.xc, dm, spin=0)
     print(res[1] - 0)
-    print(time.clock())
+    print(logger.process_clock())

--- a/pyscf/dft/rks.py
+++ b/pyscf/dft/rks.py
@@ -20,7 +20,7 @@
 Non-relativistic restricted Kohn-Sham
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -65,7 +65,7 @@ def get_veff(ks, mol=None, dm=None, dm_last=0, vhf_last=0, hermi=1):
     '''
     if mol is None: mol = ks.mol
     if dm is None: dm = ks.make_rdm1()
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     ground_state = (isinstance(dm, numpy.ndarray) and dm.ndim == 2)
 
@@ -186,7 +186,7 @@ def get_vsap(ks, mol=None):
         matrix Vsap = Vnuc + J + Vxc.
     '''
     if mol is None: mol = ks.mol
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     if ks.grids.coords is None:
         ks.grids.build(with_non0tab=True)

--- a/pyscf/dft/uks.py
+++ b/pyscf/dft/uks.py
@@ -20,7 +20,7 @@
 Non-relativistic Unrestricted Kohn-Sham
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -39,7 +39,7 @@ def get_veff(ks, mol=None, dm=None, dm_last=0, vhf_last=0, hermi=1):
         dm = numpy.asarray((dm*.5,dm*.5))
     ground_state = (dm.ndim == 3 and dm.shape[0] == 2)
 
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     if ks.grids.coords is None:
         ks.grids.build(with_non0tab=True)

--- a/pyscf/dmrgscf/dmrgci.py
+++ b/pyscf/dmrgscf/dmrgci.py
@@ -25,7 +25,7 @@ import ctypes
 import os
 import sys
 import struct
-import time
+
 import tempfile
 from subprocess import check_call, check_output, STDOUT, CalledProcessError
 import numpy
@@ -379,12 +379,12 @@ class DMRGCI(lib.StreamObject):
                 logger.debug1(self, 'Block Input conf')
                 logger.debug1(self, open(inFile, 'r').read())
 
-            start = time.time()
+            start = logger.perf_counter()
             mpisave=self.mpiprefix
             #self.mpiprefix=""
             executeBLOCK(self)
             self.mpiprefix=mpisave
-            end = time.time()
+            end = logger.perf_counter()
             print('......production of RDMs took %10.2f sec' %(end-start))
 
             if self.verbose >= logger.DEBUG1:
@@ -402,7 +402,7 @@ class DMRGCI(lib.StreamObject):
         # are written as E3[i1,j2,k3,l3,m2,n1]
         # and are also stored here as E3[i1,j2,k3,l3,m2,n1]
         # This is NOT done with SQA in mind.
-        start = time.time()
+        start = logger.perf_counter()
         threepdm = numpy.zeros( (norb, norb, norb, norb, norb, norb) )
         file3pdm = "spatial_threepdm.%d.%d.txt" %(state, state)
         with open(os.path.join(self.scratchDirectory, "node0", file3pdm), "r") as f:
@@ -418,7 +418,7 @@ class DMRGCI(lib.StreamObject):
         twopdm /= (nelectrons-2)
         onepdm = numpy.einsum('ijjk->ki', twopdm)
         onepdm /= (nelectrons-1)
-        end = time.time()
+        end = logger.perf_counter()
         print('......reading the RDM took    %10.2f sec' %(end-start))
         return onepdm, twopdm, threepdm
 
@@ -458,12 +458,12 @@ class DMRGCI(lib.StreamObject):
                 logger.debug1(self, 'Block Input conf')
                 logger.debug1(self, open(inFile, 'r').read())
 
-            start = time.time()
+            start = logger.perf_counter()
             mpisave=self.mpiprefix
             #self.mpiprefix=""
             executeBLOCK(self)
             self.mpiprefix=mpisave
-            end = time.time()
+            end = logger.perf_counter()
             print('......production of RDMs took %10.2f sec' %(end-start))
 
             if self.verbose >= logger.DEBUG1:
@@ -477,7 +477,7 @@ class DMRGCI(lib.StreamObject):
         # are written as E3[i1,j2,k3,l3,m2,n1]
         # and are stored here as E3[i1,j2,k3,n1,m2,l3]
         # This is done with SQA in mind.
-        start = time.time()
+        start = logger.perf_counter()
         if (filetype == "binary") :
           # The binary files coming from STACKBLOCK and BLOCK are different
           # - STACKBLOCK uses the 6-fold symmetry, this must be unpacked
@@ -514,7 +514,7 @@ class DMRGCI(lib.StreamObject):
             a,b,c, d,e,f, integral = int(linesp[0]), int(linesp[1]), int(linesp[2]),\
                                      int(linesp[3]), int(linesp[4]), int(linesp[5]), float(linesp[6])
             self.populate(E3, [a,b,c,  f,e,d], integral)
-        end = time.time()
+        end = logger.perf_counter()
         print('......reading the RDM took    %10.2f sec' %(end-start))
         print('')
         return E3
@@ -540,12 +540,12 @@ class DMRGCI(lib.StreamObject):
               logger.debug1(self, 'Block Input conf')
               logger.debug1(self, open(inFile, 'r').read())
 
-            start = time.time()
+            start = logger.perf_counter()
             mpisave=self.mpiprefix
             #self.mpiprefix=""
             executeBLOCK(self)
             self.mpiprefix=mpisave
-            end = time.time()
+            end = logger.perf_counter()
             print('......production of RDMs took %10.2f sec' %(end-start))
 
             if self.verbose >= logger.DEBUG1:
@@ -560,7 +560,7 @@ class DMRGCI(lib.StreamObject):
         # are written as E4[i1,j2,k3,l4,m4,n3,o2,p1]
         # and are stored here as E4[i1,j2,k3,l4,p1,o2,n3,m4]
         # This is done with SQA in mind.
-        start = time.time()
+        start = logger.perf_counter()
         if (filetype == "binary") :
           # The binary files coming from STACKBLOCK and BLOCK are different:
           # - STACKBLOCK does not have 4RDM
@@ -598,7 +598,7 @@ class DMRGCI(lib.StreamObject):
               a,b,c,d, e,f,g,h, integral = int(linesp[0]), int(linesp[1]), int(linesp[2]), int(linesp[3]),\
                                            int(linesp[4]), int(linesp[5]), int(linesp[6]), int(linesp[7]), float(linesp[8])
               self.populate(E4, [a,b,c,d,  h,g,f,e], integral)
-        end = time.time()
+        end = logger.perf_counter()
         print('......reading the RDM took    %10.2f sec' %(end-start))
         print('')
         return E4

--- a/pyscf/dmrgscf/nevpt_mpi.py
+++ b/pyscf/dmrgscf/nevpt_mpi.py
@@ -19,7 +19,7 @@
 
 import os
 import sys
-import time
+
 import math
 import copy
 import subprocess
@@ -69,7 +69,7 @@ def writeh1e_sym(h1e,f,tol,shift0 =1,shift1 =1):
 
 def write_chk(mc,root,chkfile):
 
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
     fh5 = h5py.File(chkfile,'w')
 
     if mc.fcisolver.nroots > 1:
@@ -233,7 +233,7 @@ def DMRG_COMPRESS_NEVPT(mc, maxM=500, root=0, nevptsolver=None, tol=1e-7,
         logger.debug1(nevptsolver, 'Block Input conf')
         logger.debug1(nevptsolver, block_conf)
 
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     # function nevpt_integral_mpi is called in this cmd
     cmd = ' '.join((nevptsolver.mpiprefix,

--- a/pyscf/eph/rhf.py
+++ b/pyscf/eph/rhf.py
@@ -22,7 +22,7 @@ Analytical electron-phonon matrix for restricted hartree fock
 import numpy as np
 from pyscf.hessian import rhf
 from pyscf.lib import logger
-import time
+
 from pyscf import lib
 import scipy
 from pyscf.scf._response_functions import _gen_rhf_response
@@ -31,7 +31,7 @@ AU_TO_CM = 2.19475 * 1e5
 CUTOFF_FREQUENCY = 80
 
 def kernel(ephobj, mo_energy=None, mo_coeff=None, mo_occ=None, mo_rep=False):
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     if mo_energy is None: mo_energy = ephobj.base.mo_energy
     if mo_coeff is None: mo_coeff = ephobj.base.mo_coeff
     if mo_occ is None: mo_occ = ephobj.base.mo_occ

--- a/pyscf/eph/uks.py
+++ b/pyscf/eph/uks.py
@@ -27,7 +27,7 @@ from pyscf.grad import rks as rks_grad
 from pyscf.dft import numint
 from pyscf.eph import rhf as rhf_eph
 from pyscf.eph.uhf import uhf_deriv_generator
-import time
+
 from pyscf import lib
 
 def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):

--- a/pyscf/fci/direct_spin0.py
+++ b/pyscf/fci/direct_spin0.py
@@ -421,7 +421,7 @@ def _unpack(norb, nelec, link_index):
 
 
 if __name__ == '__main__':
-    import time
+    
     from functools import reduce
     from pyscf import gto
     from pyscf import scf
@@ -453,5 +453,5 @@ if __name__ == '__main__':
     eri = ao2mo.incore.general(m._eri, (m.mo_coeff,)*4, compact=False)
     e, c = cis.kernel(h1e, eri, norb, nelec)
     print(e - -15.9977886375)
-    print('t',time.clock())
+    print('t',logger.process_clock())
 

--- a/pyscf/geomopt/berny_solver.py
+++ b/pyscf/geomopt/berny_solver.py
@@ -28,7 +28,7 @@ if dist is None or [int(x) for x in dist.version.split('.')] < [0, 6, 2]:
            'with:\n\n\tpip install -U pyberny')
     raise ImportError(msg)
 
-import time
+
 import numpy
 import logging
 from pyscf import lib
@@ -108,7 +108,7 @@ def kernel(method, assert_convergence=ASSERT_CONV,
         opt.params = conv_params
         opt.kernel()
     '''
-    t0 = time.clock(), time.time()
+    t0 = logger.process_clock(), logger.perf_counter()
     mol = method.mol.copy()
     if 'log' in kwargs:
         log = lib.logger.new_logger(method, kwargs['log'])

--- a/pyscf/geomopt/berny_solver.py
+++ b/pyscf/geomopt/berny_solver.py
@@ -108,7 +108,7 @@ def kernel(method, assert_convergence=ASSERT_CONV,
         opt.params = conv_params
         opt.kernel()
     '''
-    t0 = logger.process_clock(), logger.perf_counter()
+    t0 = lib.logger.process_clock(), lib.logger.perf_counter()
     mol = method.mol.copy()
     if 'log' in kwargs:
         log = lib.logger.new_logger(method, kwargs['log'])

--- a/pyscf/grad/casci.py
+++ b/pyscf/grad/casci.py
@@ -24,7 +24,7 @@ J. Comput. Chem., 5, 589
 '''
 
 import sys
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -45,7 +45,7 @@ def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
     if mo_coeff is None: mo_coeff = mc._scf.mo_coeff
     if ci is None: ci = mc.ci
 
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.new_logger(mc_grad, verbose)
     mol = mc_grad.mol
     ncore = mc.ncore

--- a/pyscf/grad/casscf.py
+++ b/pyscf/grad/casscf.py
@@ -23,7 +23,6 @@ Ref.
 J. Comput. Chem., 5, 589
 '''
 
-import time
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -41,7 +40,7 @@ def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
     if mc.frozen is not None:
         raise NotImplementedError
 
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.new_logger(mc_grad, verbose)
     mol = mc_grad.mol
     ncore = mc.ncore

--- a/pyscf/grad/ccsd.py
+++ b/pyscf/grad/ccsd.py
@@ -20,7 +20,7 @@
 CCSD analytical nuclear gradients
 '''
 
-import time
+
 import ctypes
 import numpy
 from pyscf import lib
@@ -51,7 +51,7 @@ def grad_elec(cc_grad, t1=None, t2=None, l1=None, l2=None, eris=None, atmlst=Non
     if l2 is None: l2 = mycc.l2
 
     log = logger.new_logger(mycc, verbose)
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
 
     log.debug('Build ccsd rdm1 intermediates')
     if d1 is None:
@@ -304,7 +304,7 @@ def _rdm2_mo2ao(mycc, d2, mo_coeff, fsave=None):
 # dm2 = dm2 + dm2.transpose(0,1,3,2)
 # return ao2mo.restore(4, dm2*.5, nmo)
     log = logger.Logger(mycc.stdout, mycc.verbose)
-    time1 = time.clock(), time.time()
+    time1 = logger.process_clock(), logger.perf_counter()
     if fsave is None:
         incore = True
         fsave = lib.H5TmpFile()

--- a/pyscf/grad/dhf.py
+++ b/pyscf/grad/dhf.py
@@ -17,7 +17,7 @@
 Relativistic Dirac-Hartree-Fock
 """
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -38,7 +38,7 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     dm0 = mf.make_rdm1(mf.mo_coeff, mf.mo_occ)
     n2c = dm0.shape[0] // 2
 
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Compute Gradients of NR Hartree-Fock Coulomb repulsion')
     vhf = mf_grad.get_veff(mol, dm0)
     log.timer('gradients of 2e part', *t0)
@@ -191,7 +191,7 @@ class Gradients(GradientsBasics):
         return 0
 
     def kernel(self, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         if mo_energy is None: mo_energy = self.base.mo_energy
         if mo_coeff is None: mo_coeff = self.base.mo_coeff
         if mo_occ is None: mo_occ = self.base.mo_occ

--- a/pyscf/grad/mp2.py
+++ b/pyscf/grad/mp2.py
@@ -20,7 +20,7 @@
 MP2 analytical nuclear gradients
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from functools import reduce
@@ -34,7 +34,7 @@ from pyscf.ao2mo import _ao2mo
 def grad_elec(mp_grad, t2, atmlst=None, verbose=logger.INFO):
     mp = mp_grad.base
     log = logger.new_logger(mp, verbose)
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
 
     log.debug('Build mp2 rdm1 intermediates')
     d1 = mp2._gamma1_intermediates(mp, t2)

--- a/pyscf/grad/rhf.py
+++ b/pyscf/grad/rhf.py
@@ -20,7 +20,7 @@
 Non-relativistic Hartree-Fock analytical nuclear gradients
 '''
 
-import time
+
 import numpy
 import ctypes
 from pyscf import gto
@@ -47,7 +47,7 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     s1 = mf_grad.get_ovlp(mol)
     dm0 = mf.make_rdm1(mo_coeff, mo_occ)
 
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Computing Gradients of NR-HF Coulomb repulsion')
     vhf = mf_grad.get_veff(mol, dm0)
     log.timer('gradients of 2e part', *t0)
@@ -313,7 +313,7 @@ class GradientsBasics(lib.StreamObject):
     def get_jk(self, mol=None, dm=None, hermi=0):
         if mol is None: mol = self.mol
         if dm is None: dm = self.base.make_rdm1()
-        cpu0 = (time.clock(), time.time())
+        cpu0 = (logger.process_clock(), logger.perf_counter())
         vj, vk = get_jk(mol, dm)
         logger.timer(self, 'vj and vk', *cpu0)
         return vj, vk
@@ -404,7 +404,7 @@ class Gradients(GradientsBasics):
     grad_elec = grad_elec
 
     def kernel(self, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         if mo_energy is None: mo_energy = self.base.mo_energy
         if mo_coeff is None: mo_coeff = self.base.mo_coeff
         if mo_occ is None: mo_occ = self.base.mo_occ

--- a/pyscf/grad/rks.py
+++ b/pyscf/grad/rks.py
@@ -18,7 +18,7 @@
 
 '''Non-relativistic RKS analytical nuclear gradients'''
 
-import time
+
 import numpy
 from pyscf import gto
 from pyscf import lib
@@ -37,7 +37,7 @@ def get_veff(ks_grad, mol=None, dm=None):
     '''
     if mol is None: mol = ks_grad.mol
     if dm is None: dm = ks_grad.base.make_rdm1()
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     mf = ks_grad.base
     ni = mf._numint

--- a/pyscf/grad/tdrhf.py
+++ b/pyscf/grad/tdrhf.py
@@ -19,7 +19,7 @@
 # J. Chem. Phys. 117, 7433
 #
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -42,7 +42,7 @@ def grad_elec(td_grad, x_y, singlet=True, atmlst=None,
             TDA energy gradients.
     '''
     log = logger.new_logger(td_grad, verbose)
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
 
     mol = td_grad.mol
     mf = td_grad.base._scf

--- a/pyscf/grad/tdrks.py
+++ b/pyscf/grad/tdrks.py
@@ -19,7 +19,7 @@
 # J. Chem. Phys. 117, 7433
 #
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -47,7 +47,7 @@ def grad_elec(td_grad, x_y, singlet=True, atmlst=None,
             TDA energy gradients.
     '''
     log = logger.new_logger(td_grad, verbose)
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
 
     mol = td_grad.mol
     mf = td_grad.base._scf

--- a/pyscf/grad/tduhf.py
+++ b/pyscf/grad/tduhf.py
@@ -19,7 +19,7 @@
 # J. Chem. Phys. 117, 7433
 #
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -40,7 +40,7 @@ def grad_elec(td_grad, x_y, atmlst=None, max_memory=2000, verbose=logger.INFO):
             TDA energy gradients.
     '''
     log = logger.new_logger(td_grad, verbose)
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
 
     mol = td_grad.mol
     mf = td_grad.base._scf

--- a/pyscf/grad/tduks.py
+++ b/pyscf/grad/tduks.py
@@ -19,7 +19,7 @@
 # J. Chem. Phys. 117, 7433
 #
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -45,7 +45,7 @@ def grad_elec(td_grad, x_y, atmlst=None, max_memory=2000, verbose=logger.INFO):
             TDA energy gradients.
     '''
     log = logger.new_logger(td_grad, verbose)
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
 
     mol = td_grad.mol
     mf = td_grad.base._scf

--- a/pyscf/grad/test/test_casci.py
+++ b/pyscf/grad/test/test_casci.py
@@ -3,7 +3,7 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-import time
+
 from functools import reduce
 import unittest
 import numpy

--- a/pyscf/grad/test/test_casscf.py
+++ b/pyscf/grad/test/test_casscf.py
@@ -3,7 +3,7 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-import time
+
 from functools import reduce
 import unittest
 import numpy

--- a/pyscf/grad/uccsd.py
+++ b/pyscf/grad/uccsd.py
@@ -20,7 +20,7 @@
 UCCSD analytical nuclear gradients
 '''
 
-import time
+
 import ctypes
 import numpy
 from pyscf import lib
@@ -52,7 +52,7 @@ def grad_elec(cc_grad, t1=None, t2=None, l1=None, l2=None, eris=None, atmlst=Non
     if l2 is None: l2 = mycc.l2
 
     log = logger.new_logger(mycc, verbose)
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
 
     log.debug('Build uccsd rdm1 intermediates')
     if d1 is None:
@@ -299,7 +299,7 @@ def _response_dm1(mycc, Xvo, eris=None):
 
 def _rdm2_mo2ao(mycc, d2, mo_coeff, fsave=None):
     log = logger.Logger(mycc.stdout, mycc.verbose)
-    time1 = time.clock(), time.time()
+    time1 = logger.process_clock(), logger.perf_counter()
     if fsave is None:
         incore = True
         fsave = lib.H5TmpFile()

--- a/pyscf/grad/uhf.py
+++ b/pyscf/grad/uhf.py
@@ -20,7 +20,7 @@
 Non-relativistic unrestricted Hartree-Fock analytical nuclear gradients
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -45,7 +45,7 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     s1 = mf_grad.get_ovlp(mol)
     dm0 = mf.make_rdm1(mo_coeff, mo_occ)
 
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Computing Gradients of NR-UHF Coulomb repulsion')
     vhf = mf_grad.get_veff(mol, dm0)
     log.timer('gradients of 2e part', *t0)

--- a/pyscf/grad/uks.py
+++ b/pyscf/grad/uks.py
@@ -18,7 +18,7 @@
 
 '''Non-relativistic UKS analytical nuclear gradients'''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -37,7 +37,7 @@ def get_veff(ks_grad, mol=None, dm=None):
     '''
     if mol is None: mol = ks_grad.mol
     if dm is None: dm = ks_grad.base.make_rdm1()
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     mf = ks_grad.base
     ni = mf._numint

--- a/pyscf/grad/ump2.py
+++ b/pyscf/grad/ump2.py
@@ -20,7 +20,7 @@
 UMP2 analytical nuclear gradients
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from functools import reduce
@@ -35,7 +35,7 @@ from pyscf.grad import mp2 as mp2_grad
 def grad_elec(mp_grad, t2, atmlst=None, verbose=logger.INFO):
     mp = mp_grad.base
     log = logger.new_logger(mp, verbose)
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
 
     log.debug('Build ump2 rdm1 intermediates')
     d1 = ump2._gamma1_intermediates(mp, t2)

--- a/pyscf/gto/ft_ao.py
+++ b/pyscf/gto/ft_ao.py
@@ -186,9 +186,9 @@ if __name__ == '__main__':
     gxyz = lib.cartesian_prod((gxrange, gyrange, gzrange))
     Gv = 2*numpy.pi * numpy.dot(gxyz, b)
 
-    import time
-    print(time.clock())
+    
+    print(logger.process_clock())
     print(numpy.linalg.norm(ft_aopair(mol, Gv, None, 's1', b, gxyz, gs)) - 63.0239113778)
-    print(time.clock())
+    print(logger.process_clock())
     print(numpy.linalg.norm(ft_ao(mol, Gv, None, b, gxyz, gs))-56.8273147065)
-    print(time.clock())
+    print(logger.process_clock())

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -26,6 +26,7 @@ import types
 import re
 import platform
 import gc
+import time
 
 import json
 import ctypes

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -26,7 +26,7 @@ import types
 import re
 import platform
 import gc
-import time
+
 import json
 import ctypes
 import numpy
@@ -2619,7 +2619,7 @@ class Mole(lib.StreamObject):
                 exps = self.bas_exp(i)
                 logger.debug1(self, 'bas %d, expnt(s) = %s', i, str(exps))
 
-        logger.info(self, 'CPU time: %12.2f', time.clock())
+        logger.info(self, 'CPU time: %12.2f', logger.process_clock())
         return self
 
     def set_common_origin(self, coord):

--- a/pyscf/gw/gw.py
+++ b/pyscf/gw/gw.py
@@ -21,7 +21,7 @@
 G0W0 approximation
 '''
 
-import time
+
 from functools import reduce
 import numpy
 import numpy as np
@@ -219,7 +219,7 @@ class GW(lib.StreamObject):
         if td_xy is None:
             td_xy = self._tdscf.xy
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         self.dump_flags()
         self.converged, self.mo_energy, self.mo_coeff = \
                 kernel(self, mo_energy, mo_coeff, td_e, td_xy,
@@ -296,7 +296,7 @@ class _ChemistsERIs:
         return self
 
 def _make_eris_incore(mycc, mo_coeff=None, ao2mofn=None):
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     eris = _ChemistsERIs()
     eris._common_init_(mycc, mo_coeff)
     nocc = eris.nocc
@@ -317,7 +317,7 @@ def _make_eris_incore(mycc, mo_coeff=None, ao2mofn=None):
     return eris
 
 def _make_eris_outcore(mycc, mo_coeff=None):
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(mycc.stdout, mycc.verbose)
     eris = _ChemistsERIs()
     eris._common_init_(mycc, mo_coeff)

--- a/pyscf/hci/hci.py
+++ b/pyscf/hci/hci.py
@@ -27,7 +27,7 @@ Simple usage::
 
 import sys
 import numpy
-import time
+
 import ctypes
 from pyscf import lib
 from pyscf import ao2mo
@@ -456,13 +456,13 @@ def kernel_float_space(myci, h1e, eri, norb, nelec, ci0=None,
 
     if eri_sorted is None and jk is None and jk_sorted is None:
         log.debug("\nSorting two-electron integrals...")
-        t_start = time.time()
+        t_start = logger.perf_counter()
         eri_sorted = abs(eri).argsort()[::-1]
         jk = eri.reshape([norb]*4)
         jk = jk - jk.transpose(2,1,0,3)
         jk = jk.ravel()
         jk_sorted = abs(jk).argsort()[::-1]
-        t_current = time.time() - t_start
+        t_current = logger.perf_counter() - t_start
         log.debug('Timing for sorting the integrals: %10.3f', t_current)
 
     # Initial guess
@@ -488,14 +488,14 @@ def kernel_float_space(myci, h1e, eri, norb, nelec, ci0=None,
         log.info('\nMacroiteration %d', icycle)
         log.info('Number of CI configurations: %d', ci_strs.shape[0])
         hdiag = myci.make_hdiag(h1e, eri, ci_strs, norb, nelec)
-        t_start = time.time()
+        t_start = logger.perf_counter()
         e, ci0 = myci.eig(hop, ci0, precond, tol=float_tol, lindep=lindep,
                           max_cycle=max_cycle, max_space=max_space, nroots=nroots,
                           max_memory=max_memory, verbose=log, **kwargs)
         if not isinstance(ci0, (tuple, list)):
             ci0 = [ci0]
             e = [e]
-        t_current = time.time() - t_start
+        t_current = logger.perf_counter() - t_start
         log.debug('Timing for solving the eigenvalue problem: %10.3f', t_current)
         ci0 = [as_SCIvector(c, ci_strs) for c in ci0]
         de, e_last = min(e)-e_last, min(e)
@@ -506,9 +506,9 @@ def kernel_float_space(myci, h1e, eri, norb, nelec, ci0=None,
             break
 
         last_ci0_size = float(len(ci_strs))
-        t_start = time.time()
+        t_start = logger.perf_counter()
         ci0 = myci.enlarge_space(ci0, h1e, eri, jk, eri_sorted, jk_sorted, norb, nelec)
-        t_current = time.time() - t_start
+        t_current = logger.perf_counter() - t_start
         log.debug('Timing for selecting configurations: %10.3f', t_current)
         if (((1 - myci.conv_ndet_tol) < len(ci0[0]._strs)/last_ci0_size < (1 + myci.conv_ndet_tol))):
             conv = True

--- a/pyscf/hessian/rhf.py
+++ b/pyscf/hessian/rhf.py
@@ -22,7 +22,7 @@ Non-relativistic RHF analytical Hessian
 
 from functools import reduce
 import ctypes
-import time
+
 import numpy
 from pyscf import lib
 from pyscf import gto
@@ -40,7 +40,7 @@ def hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
               mo1=None, mo_e1=None, h1ao=None,
               atmlst=None, max_memory=4000, verbose=None):
     log = logger.new_logger(hessobj, verbose)
-    time0 = t1 = (time.clock(), time.time())
+    time0 = t1 = (logger.process_clock(), logger.perf_counter())
 
     mol = hessobj.mol
     mf = hessobj.base
@@ -106,7 +106,7 @@ def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
 def _partial_hess_ejk(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
                       atmlst=None, max_memory=4000, verbose=None, with_k=True):
     log = logger.new_logger(hessobj, verbose)
-    time0 = t1 = (time.clock(), time.time())
+    time0 = t1 = (logger.process_clock(), logger.perf_counter())
 
     mol = hessobj.mol
     mf = hessobj.base

--- a/pyscf/hessian/rks.py
+++ b/pyscf/hessian/rks.py
@@ -20,7 +20,7 @@
 Non-relativistic RKS analytical Hessian
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -36,7 +36,7 @@ from pyscf.grad import rks  # noqa
 def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
                       atmlst=None, max_memory=4000, verbose=None):
     log = logger.new_logger(hessobj, verbose)
-    time0 = t1 = (time.clock(), time.time())
+    time0 = t1 = (logger.process_clock(), logger.perf_counter())
 
     mol = hessobj.mol
     mf = hessobj.base

--- a/pyscf/hessian/uhf.py
+++ b/pyscf/hessian/uhf.py
@@ -21,7 +21,7 @@ Non-relativistic UHF analytical Hessian
 '''
 
 from functools import reduce
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -40,7 +40,7 @@ def hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
               mo1=None, mo_e1=None, h1ao=None,
               atmlst=None, max_memory=4000, verbose=None):
     log = logger.new_logger(hessobj, verbose)
-    time0 = t1 = (time.clock(), time.time())
+    time0 = t1 = (logger.process_clock(), logger.perf_counter())
 
     mol = hessobj.mol
     mf = hessobj.base
@@ -122,7 +122,7 @@ def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
 def _partial_hess_ejk(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
                       atmlst=None, max_memory=4000, verbose=None, with_k=True):
     log = logger.new_logger(hessobj, verbose)
-    time0 = t1 = (time.clock(), time.time())
+    time0 = t1 = (logger.process_clock(), logger.perf_counter())
 
     mol = hessobj.mol
     mf = hessobj.base

--- a/pyscf/hessian/uks.py
+++ b/pyscf/hessian/uks.py
@@ -20,7 +20,7 @@
 Non-relativistic UKS analytical Hessian
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -35,7 +35,7 @@ _get_jk = rhf_hess._get_jk
 def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
                       atmlst=None, max_memory=4000, verbose=None):
     log = logger.new_logger(hessobj, verbose)
-    time0 = t1 = (time.clock(), time.time())
+    time0 = t1 = (logger.process_clock(), logger.perf_counter())
 
     mol = hessobj.mol
     mf = hessobj.base

--- a/pyscf/icmpspt/icmpspt.py
+++ b/pyscf/icmpspt/icmpspt.py
@@ -27,7 +27,7 @@ S. Sharma, G. Jeanmairet, and A. Alavi,  J. Chem. Phys., 144 (2016), 034103
 
 import pyscf
 import os
-import time
+
 import tempfile
 from functools import reduce
 import numpy
@@ -69,7 +69,7 @@ def writeNEVPTIntegrals(mc, E1, E2, E1eff, aaavsplit, nfro, fully_ic=False, thir
 
 
     # (Note: Integrals are in chemistry notation)
-    start = time.time()
+    start = logger.perf_counter()
     print('Producing the integrals')
     eris = _ERIS(mc, mo)
     eris_sp={}
@@ -94,7 +94,7 @@ def writeNEVPTIntegrals(mc, E1, E2, E1eff, aaavsplit, nfro, fully_ic=False, thir
     if (not isinstance(eris_sp['h1eff'], type(eris['cvcv']))):
       eriscvcv = lib.chkfile.load(eris['cvcv'].name, "eri_mo")#h5py.File(eris['cvcv'].name,'r')["eri_mo"]
     eris_sp['cvcv'] = eriscvcv.reshape(ncor, nvir, ncor, nvir)
-    end = time.time()
+    end = logger.perf_counter()
     print('......production of INT took %10.2f sec' %(end-start))
     print('')
 
@@ -133,7 +133,7 @@ def writeNEVPTIntegrals(mc, E1, E2, E1eff, aaavsplit, nfro, fully_ic=False, thir
 
     # Write out ingredients to intfolder
     # 2 "C"
-    start = time.time()
+    start = logger.perf_counter()
     print("Basic ingredients written to "+intfolder,nfro,ncor,nocc,norb)
     numpy.save(intfolder+"W:ccae", numpy.asfortranarray(eris['pacv'][nfro:ncor,     :    , nfro:    ,     :    ].transpose(0,2,1,3)))
     numpy.save(intfolder+"W:eecc", numpy.asfortranarray(eris_sp['cvcv'][nfro: ,     :    , nfro:    ,     :    ].transpose(1,3,0,2)))
@@ -202,7 +202,7 @@ def writeNEVPTIntegrals(mc, E1, E2, E1eff, aaavsplit, nfro, fully_ic=False, thir
     #  print("Output: {:} Shape: {:}".format(name,test.shape))
     #  numpy.save(intfolder+name, numpy.asfortranarray(test))
 
-    end = time.time()
+    end = logger.perf_counter()
     print('......savings of INGREDIENTS took %10.2f sec' %(end-start))
     print("")
 
@@ -226,7 +226,7 @@ def writeMRLCCIntegrals(mc, E1, E2, nfro, fully_ic=False, third_order=False):
 
 
     # (Note: Integrals are in chemistry notation)
-    start = time.time()
+    start = logger.perf_counter()
     print('Producing the integrals')
     eris={}
     eris_sp={}
@@ -242,7 +242,7 @@ def writeMRLCCIntegrals(mc, E1, E2, nfro, fully_ic=False, third_order=False):
     eris['papa'].shape=(norb, nact, norb, nact)
     eris['ppaa'].shape=(norb, norb, nact, nact)
     eris['pepe'].shape=(norb, nvir, norb, nvir)
-    end = time.time()
+    end = logger.perf_counter()
     print('......production of INT took %10.2f sec' %(end-start))
     print('')
 
@@ -300,7 +300,7 @@ def writeMRLCCIntegrals(mc, E1, E2, nfro, fully_ic=False, third_order=False):
 
     # Write out ingredients to intfolder
     # 2 "C"
-    start = time.time()
+    start = logger.perf_counter()
     print("Basic ingredients written to "+intfolder)
     numpy.save(intfolder+"W:ccae", numpy.asfortranarray(eris['pcpc'][ncor:nocc,     :    , nocc:    ,     :    ].transpose(1,3,0,2)))
     numpy.save(intfolder+"W:eecc", numpy.asfortranarray(eris['pcpc'][nocc:    ,     :    , nocc:    ,     :    ].transpose(0,2,1,3)))
@@ -376,7 +376,7 @@ def writeMRLCCIntegrals(mc, E1, E2, nfro, fully_ic=False, third_order=False):
     #  print("Output: {:} Shape: {:}".format(name,test.shape))
     #  numpy.save(intfolder+name, numpy.asfortranarray(test))
 
-    end = time.time()
+    end = logger.perf_counter()
     print('......savings of INGREDIENTS took %10.2f sec' %(end-start))
     print("")
 
@@ -1016,7 +1016,7 @@ def trans_e1_incore(mc, mo):
 
 def trans_e1_outcore(mc, mo, max_memory=None, ioblk_size=256, tmpdir=None,
                      verbose=0):
-    time0 = (time.clock(), time.time())
+    time0 = (logger.process_clock(), logger.perf_counter())
     mol = mc.mol
     log = logger.Logger(mc.stdout, verbose)
     ncor = mc.ncore
@@ -1051,7 +1051,7 @@ def trans_e1_outcore(mc, mo, max_memory=None, ioblk_size=256, tmpdir=None,
             time1[:] = logger.timer(mol, 'load_buf', *tuple(time1))
         return buf
     time0 = logger.timer(mol, 'halfe1', *time0)
-    time1 = [time.clock(), time.time()]
+    time1 = [logger.process_clock(), logger.perf_counter()]
     ao_loc = numpy.array(mol.ao_loc_nr(), dtype=numpy.int32)
     cvcvfile = tempfile.NamedTemporaryFile(dir=tmpdir)
     with h5py.File(cvcvfile.name, 'r') as f5:

--- a/pyscf/lib/logger.py
+++ b/pyscf/lib/logger.py
@@ -69,7 +69,7 @@ control at which level the timing information should be output.  It is 5
 >>> import sys, time
 >>> from pyscf import lib
 >>> log = lib.logger.Logger(sys.stdout, 4)
->>> t0 = time.clock()
+>>> t0 = logger.process_clock()
 >>> log.timer('test', t0)
 >>> lib.logger.TIMER_LEVEL = 4
 >>> log.timer('test', t0)
@@ -79,10 +79,13 @@ control at which level the timing information should be output.  It is 5
 
 import sys
 import time
-if sys.version_info >= (3,6):
-    time.clock = time.process_time
-    if sys.version_info >= (3,8):
-        time.time = time.perf_counter
+
+if sys.version_info < (3, 0):
+    process_clock = time.clock
+    perf_counter = time.time
+else:
+    process_clock = time.process_time
+    perf_counter = time.perf_counter
 
 from pyscf.lib import parameters as param
 import pyscf.__config__
@@ -165,13 +168,13 @@ def timer(rec, msg, cpu0=None, wall0=None):
     if cpu0 is None:
         cpu0 = rec._t0
     if wall0:
-        rec._t0, rec._w0 = time.clock(), time.time()
+        rec._t0, rec._w0 = process_clock(), perf_counter()
         if rec.verbose >= TIMER_LEVEL:
             flush(rec, '    CPU time for %s %9.2f sec, wall time %9.2f sec'
                   % (msg, rec._t0-cpu0, rec._w0-wall0))
         return rec._t0, rec._w0
     else:
-        rec._t0 = time.clock()
+        rec._t0 = process_clock()
         if rec.verbose >= TIMER_LEVEL:
             flush(rec, '    CPU time for %s %9.2f sec' % (msg, rec._t0-cpu0))
         return rec._t0
@@ -180,10 +183,10 @@ def timer_debug1(rec, msg, cpu0=None, wall0=None):
     if rec.verbose >= DEBUG1:
         return timer(rec, msg, cpu0, wall0)
     elif wall0:
-        rec._t0, rec._w0 = time.clock(), time.time()
+        rec._t0, rec._w0 = process_clock(), perf_counter()
         return rec._t0, rec._w0
     else:
-        rec._t0 = time.clock()
+        rec._t0 = process_clock()
         return rec._t0
 
 class Logger(object):
@@ -197,8 +200,8 @@ class Logger(object):
     def __init__(self, stdout=sys.stdout, verbose=NOTE):
         self.stdout = stdout
         self.verbose = verbose
-        self._t0 = time.clock()
-        self._w0 = time.time()
+        self._t0 = process_clock()
+        self._w0 = perf_counter()
 
     log = log
     error = error

--- a/pyscf/lo/boys.py
+++ b/pyscf/lo/boys.py
@@ -20,7 +20,7 @@
 Foster-Boys localization
 '''
 
-import time
+
 import numpy
 from functools import reduce
 
@@ -42,7 +42,7 @@ def kernel(localizer, mo_coeff=None, callback=None, verbose=None):
         localizer.check_sanity()
     localizer.dump_flags()
 
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(localizer, verbose=verbose)
 
     if localizer.conv_tol_grad is None:

--- a/pyscf/lo/ibo.py
+++ b/pyscf/lo/ibo.py
@@ -26,7 +26,7 @@ much of the code below is adapted from code published freely on the website of G
 Ref: JCTC, 2013, 9, 4834-4843
 '''
 
-from time import time
+import time 
 from functools import reduce
 import numpy
 from pyscf.lib import logger
@@ -117,7 +117,7 @@ def ibo_loc(mol, orbocc, iaos, s, exponent, grad_tol, max_iter,
     iaos = orth.vec_lowdin(iaos, s)
 
     #static variables
-    StartTime = time()
+    StartTime = time.time()
     L  = 0 # initialize a value of the localization function for safety
     #max_iter = 20000 #for some reason the convergence of solid is slower
     #fGradConv = 1e-10 #this ought to be pumped up to about 1e-8 but for testing purposes it's fine
@@ -191,7 +191,7 @@ def ibo_loc(mol, orbocc, iaos, s, exponent, grad_tol, max_iter,
         fGrad = fGrad**.5
 
         log.debug(" {0:5d} {1:12.8f} {2:11.2e} {3:8.2f}"
-                  .format(it+1, L**(1./exponent), fGrad, time()-StartTime))
+                  .format(it+1, L**(1./exponent), fGrad, time.time()-StartTime))
         if fGrad < grad_tol:
             Converged = True
             break

--- a/pyscf/mcscf/casci.py
+++ b/pyscf/mcscf/casci.py
@@ -17,7 +17,7 @@
 #
 
 import sys
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -490,7 +490,7 @@ def kernel(casci, mo_coeff=None, ci0=None, verbose=logger.NOTE):
     '''
     if mo_coeff is None: mo_coeff = casci.mo_coeff
     log = logger.new_logger(casci, verbose)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Start CASCI')
 
     ncas = casci.ncas

--- a/pyscf/mcscf/df.py
+++ b/pyscf/mcscf/df.py
@@ -16,7 +16,7 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-import time
+
 import ctypes
 from functools import reduce
 import numpy
@@ -212,7 +212,7 @@ def approx_hessian(casscf, auxbasis=None, with_df=None):
 
             log = logger.Logger(self.stdout, self.verbose)
             # Add the approximate diagonal term for orbital hessian
-            t1 = t0 = (time.clock(), time.time())
+            t1 = t0 = (logger.process_clock(), logger.perf_counter())
             mo = numpy.asarray(mo_coeff, order='F')
             nao, nmo = mo.shape
             ncore = self.ncore
@@ -273,7 +273,7 @@ class _ERIS(object):
             log.warn('Calculation needs %d MB memory, over CASSCF.max_memory (%d MB) limit',
                      (mem_basic+mem_now)/.9, casscf.max_memory)
 
-        t1 = t0 = (time.clock(), time.time())
+        t1 = t0 = (logger.process_clock(), logger.perf_counter())
         self.feri = lib.H5TmpFile()
         self.ppaa = self.feri.create_dataset('ppaa', (nmo,nmo,ncas,ncas), 'f8')
         self.papa = self.feri.create_dataset('papa', (nmo,ncas,nmo,ncas), 'f8')

--- a/pyscf/mcscf/mc1step.py
+++ b/pyscf/mcscf/mc1step.py
@@ -17,7 +17,7 @@
 #
 
 import sys
-import time
+
 import copy
 from functools import reduce
 import numpy
@@ -208,7 +208,7 @@ def rotate_orb_cc(casscf, mo, fcivec, fcasdm1, fcasdm2, eris, x0_guess=None,
     if max_stepsize is None:
         max_stepsize = casscf.max_stepsize
 
-    t3m = (time.clock(), time.time())
+    t3m = (logger.process_clock(), logger.perf_counter())
     u = 1
     g_orb, gorb_update, h_op, h_diag = \
             casscf.gen_g_hop(mo, u, fcasdm1(), fcasdm2(), eris)
@@ -289,7 +289,7 @@ def rotate_orb_cc(casscf, mo, fcivec, fcasdm1, fcasdm2, eris, x0_guess=None,
                 t3m = log.timer('aug_hess in %d inner iters' % imic, *t3m)
                 yield u, g_kf, ihop+jkcount, dxi
 
-                t3m = (time.clock(), time.time())
+                t3m = (logger.process_clock(), logger.perf_counter())
 # TODO: test whether to update h_op, h_diag to change the orbital hessian.
 # It leads to the different hessian operations in the same davidson
 # diagonalization procedure.  This is generally a bad approximation because it
@@ -334,7 +334,7 @@ def kernel(casscf, mo_coeff, tol=1e-7, conv_tol_grad=None,
     '''quasi-newton CASSCF optimization driver
     '''
     log = logger.new_logger(casscf, verbose)
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Start 1-step CASSCF')
     if callback is None:
         callback = casscf.callback

--- a/pyscf/mcscf/mc2step.py
+++ b/pyscf/mcscf/mc2step.py
@@ -16,7 +16,7 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-import time
+
 import numpy
 import pyscf.lib.logger as logger
 from pyscf.mcscf import mc1step
@@ -30,7 +30,7 @@ def kernel(casscf, mo_coeff, tol=1e-7, conv_tol_grad=None,
         callback = casscf.callback
 
     log = logger.Logger(casscf.stdout, verbose)
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Start 2-step CASSCF')
 
     mo = mo_coeff

--- a/pyscf/mcscf/mc_ao2mo.py
+++ b/pyscf/mcscf/mc_ao2mo.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import ctypes
-import time
+
 from functools import reduce
 import numpy
 import h5py
@@ -76,7 +76,7 @@ def trans_e1_incore(eri_ao, mo, ncore, ncas):
 # level > 1: ppaa, papa only.  It affects accuracy of hdiag
 def trans_e1_outcore(mol, mo, ncore, ncas, erifile,
                      max_memory=None, level=1, verbose=logger.WARN):
-    time0 = (time.clock(), time.time())
+    time0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mol, verbose)
     log.debug1('trans_e1_outcore level %d  max_memory %d', level, max_memory)
     nao, nmo = mo.shape

--- a/pyscf/mcscf/newton_casscf.py
+++ b/pyscf/mcscf/newton_casscf.py
@@ -20,7 +20,7 @@
 Second order CASSCF
 '''
 
-import time
+
 import copy
 from functools import reduce
 import numpy
@@ -479,7 +479,7 @@ def kernel(casscf, mo_coeff, tol=1e-7, conv_tol_grad=None,
     log.warn('SO-CASSCF (Second order CASSCF) is an experimental feature. '
              'Its performance is bad for large systems.')
 
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Start SO-CASSCF (newton CASSCF)')
     if callback is None:
         callback = casscf.callback

--- a/pyscf/mcscf/ucasci.py
+++ b/pyscf/mcscf/ucasci.py
@@ -22,7 +22,7 @@ orbitals)
 '''
 
 import sys
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -88,7 +88,7 @@ def kernel(casci, mo_coeff=None, ci0=None, verbose=logger.NOTE):
     '''
     if mo_coeff is None: mo_coeff = casci.mo_coeff
     log = logger.new_logger(casci, verbose)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Start uhf-based CASCI')
 
     ncas = casci.ncas

--- a/pyscf/mcscf/umc1step.py
+++ b/pyscf/mcscf/umc1step.py
@@ -22,7 +22,7 @@ UCASSCF (CASSCF without spin-degeneracy between alpha and beta orbitals)
 '''
 
 import sys
-import time
+
 import copy
 from functools import reduce
 import numpy
@@ -237,7 +237,7 @@ def kernel(casscf, mo_coeff, tol=1e-7, conv_tol_grad=None,
     if verbose is None:
         verbose = casscf.verbose
     log = logger.Logger(casscf.stdout, verbose)
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Start 1-step CASSCF')
 
     mo = mo_coeff

--- a/pyscf/mcscf/umc2step.py
+++ b/pyscf/mcscf/umc2step.py
@@ -21,7 +21,7 @@ UCASSCF (CASSCF without spin-degeneracy between alpha and beta orbitals)
 2-step optimization algorithm
 '''
 
-import time
+
 import numpy
 import copy
 import pyscf.lib.logger as logger
@@ -31,7 +31,7 @@ def kernel(casscf, mo_coeff, tol=1e-7, conv_tol_grad=None,
     if verbose is None:
         verbose = casscf.verbose
     log = logger.Logger(casscf.stdout, verbose)
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Start 2-step CASSCF')
 
     mo = mo_coeff

--- a/pyscf/mcscf/umc_ao2mo.py
+++ b/pyscf/mcscf/umc_ao2mo.py
@@ -18,7 +18,7 @@ MO integrals for UCASSCF methods
 '''
 
 import ctypes
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -68,7 +68,7 @@ def trans_e1_incore(eri_ao, mo, ncore, ncas):
 
 def trans_e1_outcore(mol, mo, ncore, ncas,
                      max_memory=None, ioblk_size=512, verbose=logger.WARN):
-    time0 = (time.clock(), time.time())
+    time0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mol, verbose)
     nao, nmo = mo[0].shape
     nao_pair = nao*(nao+1)//2
@@ -95,7 +95,7 @@ def trans_e1_outcore(mol, mo, ncore, ncas,
         return buf
 
     time0 = log.timer('halfe1-beta', *time0)
-    time1 = [time.clock(), time.time()]
+    time1 = [logger.process_clock(), logger.perf_counter()]
     ao_loc = numpy.array(mol.ao_loc_nr(), dtype=numpy.int32)
     AAPP, AApp, APPA, tmp, IAPCV, APcv = \
             _trans_aapp_((mo[1],mo[0]), (ncore[1],ncore[0]), ncas, load_bufa,
@@ -129,7 +129,7 @@ def trans_e1_outcore(mol, mo, ncore, ncas,
         return buf
 
     time0 = log.timer('halfe1-alpha', *time0)
-    time1 = [time.clock(), time.time()]
+    time1 = [logger.process_clock(), logger.perf_counter()]
     aapp, aaPP, appa, apPA, Iapcv, apCV = \
             _trans_aapp_(mo, ncore, ncas, load_bufb, ao_loc)
     time0 = log.timer('trans_aapp', *time0)

--- a/pyscf/mp/gmp2.py
+++ b/pyscf/mp/gmp2.py
@@ -17,7 +17,7 @@ GMP2 in spin-orbital form
 E(MP2) = 1/4 <ij||ab><ab||ij>/(ei+ej-ea-eb)
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf import ao2mo
@@ -296,7 +296,7 @@ def _make_eris_incore(mp, mo_coeff=None, ao2mofn=None, verbose=None):
     return eris
 
 def _make_eris_outcore(mp, mo_coeff=None, verbose=None):
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(mp.stdout, mp.verbose)
     eris = _PhysicistsERIs()
     eris._common_init_(mp, mo_coeff)

--- a/pyscf/mp/mp2.py
+++ b/pyscf/mp/mp2.py
@@ -18,7 +18,7 @@
 RMP2
 '''
 
-import time
+
 import copy
 import numpy
 from pyscf import gto
@@ -73,7 +73,7 @@ def kernel(mp, mo_energy=None, mo_coeff=None, eris=None, with_t2=WITH_T2, verbos
 
 # Iteratively solve MP2 if non-canonical HF is provided
 def _iterative_kernel(mp, eris, verbose=None):
-    cput1 = cput0 = (time.clock(), time.time())
+    cput1 = cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mp, verbose)
 
     emp2, t2 = mp.init_amps(eris=eris)
@@ -645,7 +645,7 @@ class _ChemistsERIs:
 
 def _make_eris(mp, mo_coeff=None, ao2mofn=None, verbose=None):
     log = logger.new_logger(mp, verbose)
-    time0 = (time.clock(), time.time())
+    time0 = (logger.process_clock(), logger.perf_counter())
     eris = _ChemistsERIs()
     eris._common_init_(mp, mo_coeff)
     mo_coeff = eris.mo_coeff
@@ -697,7 +697,7 @@ def _make_eris(mp, mo_coeff=None, ao2mofn=None, verbose=None):
 #   or    => (ij|ol) => (oj|ol) => (oj|ov) => (ov|ov)
 #
 def _ao2mo_ovov(mp, orbo, orbv, feri, max_memory=2000, verbose=None):
-    time0 = (time.clock(), time.time())
+    time0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mp, verbose)
 
     mol = mp.mol

--- a/pyscf/mp/mp2f12_slow.py
+++ b/pyscf/mp/mp2f12_slow.py
@@ -23,7 +23,7 @@ Refs:
 With strong orthogonalization ansatz 2
 '''
 
-import time
+
 from functools import reduce
 import numpy
 import scipy.linalg

--- a/pyscf/mp/ump2.py
+++ b/pyscf/mp/ump2.py
@@ -17,7 +17,7 @@
 UMP2 with spatial integals
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf import gto
@@ -490,7 +490,7 @@ class _ChemistsERIs(mp2._ChemistsERIs):
 
 def _make_eris(mp, mo_coeff=None, ao2mofn=None, verbose=None):
     log = logger.new_logger(mp, verbose)
-    time0 = (time.clock(), time.time())
+    time0 = (logger.process_clock(), logger.perf_counter())
     eris = _ChemistsERIs()
     eris._common_init_(mp, mo_coeff)
 
@@ -545,7 +545,7 @@ def _make_eris(mp, mo_coeff=None, ao2mofn=None, verbose=None):
     return eris
 
 def _ao2mo_ovov(mp, orbs, feri, max_memory=2000, verbose=None):
-    time0 = (time.clock(), time.time())
+    time0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mp, verbose)
     orboa = numpy.asarray(orbs[0], order='F')
     orbva = numpy.asarray(orbs[1], order='F')

--- a/pyscf/mrpt/nevpt2.py
+++ b/pyscf/mrpt/nevpt2.py
@@ -18,7 +18,7 @@
 #
 
 import ctypes
-import time
+
 import tempfile
 from functools import reduce
 import numpy
@@ -702,7 +702,7 @@ example examples/dmrg/32-dmrg_casscf_nevpt2_for_FeS.py''')
             log = self.verbose
         else:
             log = logger.Logger(self.stdout, self.verbose)
-        time0 = (time.clock(), time.time())
+        time0 = (logger.process_clock(), logger.perf_counter())
         ncore = self.ncore
         ncas = self.ncas
         nocc = ncore + ncas
@@ -919,7 +919,7 @@ def trans_e1_incore(mc, mo):
 
 def trans_e1_outcore(mc, mo, max_memory=None, ioblk_size=256, tmpdir=None,
                      verbose=0):
-    time0 = (time.clock(), time.time())
+    time0 = (logger.process_clock(), logger.perf_counter())
     mol = mc.mol
     log = logger.Logger(mc.stdout, verbose)
     ncore = mc.ncore
@@ -954,7 +954,7 @@ def trans_e1_outcore(mc, mo, max_memory=None, ioblk_size=256, tmpdir=None,
             time1[:] = logger.timer(mol, 'load_buf', *tuple(time1))
         return buf
     time0 = logger.timer(mol, 'halfe1', *time0)
-    time1 = [time.clock(), time.time()]
+    time1 = [logger.process_clock(), logger.perf_counter()]
     ao_loc = numpy.array(mol.ao_loc_nr(), dtype=numpy.int32)
     cvcvfile = tempfile.NamedTemporaryFile(dir=tmpdir)
     with h5py.File(cvcvfile.name, 'w') as f5:

--- a/pyscf/nao/gw.py
+++ b/pyscf/nao/gw.py
@@ -12,7 +12,7 @@ from timeit import default_timer as timer
 from numpy import stack, dot, zeros, einsum, pi, log, array, require
 import scipy.sparse as sparse
 from pyscf.nao import scf
-import time
+
 
 try:
   import numba as nb
@@ -23,7 +23,7 @@ except:
 def __LINE__():
       return sys._getframe(1).f_lineno
 
-start_time = time.time()
+start_time = logger.perf_counter()
 class gw(scf):
   """ G0W0 with integration along imaginary axis """
 

--- a/pyscf/nao/gw_iter.py
+++ b/pyscf/nao/gw_iter.py
@@ -6,7 +6,7 @@ from timeit import default_timer as timer
 import numpy as np
 from numpy import stack, dot, zeros, einsum, pi, log, array, require
 from pyscf.nao import scf, gw
-import time
+
 
 def profile(fnc):
     """
@@ -28,7 +28,7 @@ def profile(fnc):
         return retval
     return inner
 
-start_time = time.time()
+start_time = logger.perf_counter()
 
 class gw_iter(gw):
   """
@@ -66,16 +66,16 @@ class gw_iter(gw):
     r"""
     This compares np.solve and LinearOpt-lgmres methods for solving linear equation (1-v\chi_{0}) * W_c = v\chi_{0}v
     """
-    import time
+    
     import numpy as np
     ww = 1j*self.ww_ia
-    t = time.time()
+    t = logger.perf_counter()
     si0_1 = self.si_c(ww)      #method 1:  numpy.linalg.solve
-    t1 = time.time() - t
+    t1 = logger.perf_counter() - t
     print('numpy: {} sec'.format(t1))
-    t2 = time.time()
+    t2 = logger.perf_counter()
     si0_2 = self.si_c2(ww)     #method 2:  scipy.sparse.linalg.lgmres
-    t3 = time.time() - t2
+    t3 = logger.perf_counter() - t2
     print('lgmres: {} sec'.format(t3))
     summ = abs(si0_1 + si0_2).sum()
     diff = abs(si0_1 - si0_2).sum()

--- a/pyscf/nao/m_report.py
+++ b/pyscf/nao/m_report.py
@@ -1,9 +1,9 @@
 from __future__ import print_function, division
 import numpy as np
 from pyscf.data.nist import HARTREE2EV
-import time
 
-start_time = time.time()
+
+start_time = logger.perf_counter()
 
 def report_gw (self):
     """ Prints the energy levels of mean-field and G0W0"""
@@ -64,7 +64,7 @@ def report_gw (self):
                 out_file.write("\nWarning: Swapping in QP orbital energies has happened!")
                 print('Energy-sorted MO indices: \t {}'.format(swap))                
                 out_file.write('\nEnergy-sorted MO indices: \t {}'.format(swap))
-        elapsed_time = time.time() - start_time
+        elapsed_time = logger.perf_counter() - start_time
         print('\nTotal running time is: {}\nJOB DONE! \t {}'.format(time.strftime("%H:%M:%S", time.gmtime(elapsed_time)),time.strftime("%c")))
         out_file.write('\nTotal running time is: {}\nJOB DONE! \t {}'.format(time.strftime("%H:%M:%S", time.gmtime(elapsed_time)),time.strftime("%c"))) 
         out_file.close
@@ -140,7 +140,7 @@ def report_mfx(self, dm1=None):
             ss = self.mf.spin_square()
             print('<S^2> and  2S+1                  :%16.7f %16.7f'%(ss[0],ss[1]))
             print('Instead of                       :%16.7f %16.7f'%(s_ref, 2*sp+1))
-    elapsed_time = time.time() - start_time
+    elapsed_time = logger.perf_counter() - start_time
     print('\nMean-field running time is: {}'.format(time.strftime("%H:%M:%S", time.gmtime(elapsed_time))))
     #sys.stdout.close()
 

--- a/pyscf/nao/m_rf0_den.py
+++ b/pyscf/nao/m_rf0_den.py
@@ -8,9 +8,9 @@ import scipy.linalg.blas as blas
 from pyscf.nao.m_libnao import libnao
 from ctypes import c_double, c_int64, c_int, POINTER
 
-import time
-ts = time.time()
-te = time.time()
+
+ts = logger.perf_counter()
+te = logger.perf_counter()
 
 try:
   import numba as nb

--- a/pyscf/nao/mesh_affine_equ.py
+++ b/pyscf/nao/mesh_affine_equ.py
@@ -38,7 +38,7 @@ class mesh_affine_equ():
     return self
 
   def write(self, fname, **kw):
-    import time
+    
     import pyscf
     from pyscf import lib
     """  Result: .cube file with the field in the file fname.  """

--- a/pyscf/pbc/cc/eom_kccsd_ghf.py
+++ b/pyscf/pbc/cc/eom_kccsd_ghf.py
@@ -21,7 +21,7 @@
 #
 
 import itertools
-import time
+
 import numpy as np
 
 from pyscf import lib
@@ -65,7 +65,7 @@ def kernel(eom, nroots=1, koopmans=False, guess=None, left=False,
         dtype : type
             Type for eigenvectors.
     '''
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(eom.stdout, eom.verbose)
     if eom.verbose >= logger.WARN:
         eom.check_sanity()
@@ -1298,7 +1298,7 @@ def kernel_ee(eom, nroots=1, koopmans=False, guess=None, left=False,
     removed, such as those involving `eom.mask_frozen()`. Slowly they will be
     added back for the completion of program.
     '''
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(eom.stdout, eom.verbose)
     if eom.verbose >= logger.WARN:
         eom.check_sanity()
@@ -1862,7 +1862,7 @@ class _IMDS:
         self.made_ee_imds = False
 
     def _make_shared(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         kconserv = self.kconserv
         t1, t2, eris = self.t1, self.t2, self.eris
@@ -1883,7 +1883,7 @@ class _IMDS:
         if not self._made_shared:
             self._make_shared()
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         kconserv = self.kconserv
         t1, t2, eris = self.t1, self.t2, self.eris
@@ -1898,7 +1898,7 @@ class _IMDS:
         return self
 
     def make_t3p2_ip(self, cc):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = cc.t1, cc.t2, self.eris
         delta_E_corr, pt1, pt2, Wovoo, Wvvvo = \
@@ -1918,7 +1918,7 @@ class _IMDS:
         if not self._made_shared:
             self._make_shared()
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         kconserv = self.kconserv
         t1, t2, eris = self.t1, self.t2, self.eris
@@ -1936,7 +1936,7 @@ class _IMDS:
         return self
 
     def make_t3p2_ea(self, cc):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = cc.t1, cc.t2, self.eris
         delta_E_corr, pt1, pt2, Wovoo, Wvvvo = \
@@ -1956,7 +1956,7 @@ class _IMDS:
         if not self._made_shared:
             self._make_shared()
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         kconserv = self.kconserv
         t1, t2, eris = self.t1, self.t2, self.eris

--- a/pyscf/pbc/cc/eom_kccsd_rhf.py
+++ b/pyscf/pbc/cc/eom_kccsd_rhf.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import itertools
-import time
+
 import sys
 import numpy as np
 
@@ -860,7 +860,7 @@ def vector_to_amplitudes_singlet(vector, nkpts, nmo, nocc, kconserv):
         r2 = r_{i k_i, j k_j}^{a k_a, b k_b} is a 7-d array whose elements can
             be accessed via r2[k_i, k_j, k_a, i, j, a, b]
     '''
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(sys.stdout, logger.DEBUG)
     nvir = nmo - nocc
     nov = nocc*nvir
@@ -908,7 +908,7 @@ def amplitudes_to_vector_singlet(r1, r2, kconserv):
         return: a vector with all r1 elements, and r2 elements whose indices
     satisfy (i k_i a k_a) >= (j k_j b k_b)
     '''
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(sys.stdout, logger.DEBUG)
     # r1 indices: k_i, i, a
     nkpts, nocc, nvir = np.asarray(r1.shape)[[0, 1, 2]]
@@ -979,7 +979,7 @@ def eeccsd_matvec_singlet(eom, vector, kshift, imds=None, diag=None):
     This implementation can be checked against the spin-orbital version in 
     `eom_kccsd_ghf.eeccsd_matvec()`.
     """
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(eom.stdout, eom.verbose)
 
     if imds is None: imds = eom.make_imds()
@@ -1327,7 +1327,7 @@ def eeccsd_cis_approx_slow(eom, kshift, nroots=1, imds=None, **kwargs):
 
     Note that such evaluation has N^3 cost, but error free (because matvec() has been proven correct).
     '''
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(eom.stdout, eom.verbose)
 
     if imds is None: imds = eom.make_imds()
@@ -1518,7 +1518,7 @@ class _IMDS:
             self._fimd = None
 
     def _make_shared_1e(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris
@@ -1530,7 +1530,7 @@ class _IMDS:
         log.timer('EOM-CCSD shared one-electron intermediates', *cput0)
 
     def _make_shared_2e(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris
@@ -1556,7 +1556,7 @@ class _IMDS:
             self._make_shared_2e()
             self._made_shared_2e = True
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris
@@ -1579,7 +1579,7 @@ class _IMDS:
         log.timer('EOM-CCSD IP intermediates', *cput0)
 
     def make_t3p2_ip(self, cc):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = cc.t1, cc.t2, self.eris
         delta_E_tot, pt1, pt2, Wovoo, Wvvvo = \
@@ -1601,7 +1601,7 @@ class _IMDS:
             self._make_shared_2e()
             self._made_shared_2e = True
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris
@@ -1630,7 +1630,7 @@ class _IMDS:
         log.timer('EOM-CCSD EA intermediates', *cput0)
 
     def make_t3p2_ea(self, cc):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = cc.t1, cc.t2, self.eris
         delta_E_tot, pt1, pt2, Wovoo, Wvvvo = \
@@ -1647,7 +1647,7 @@ class _IMDS:
         return self
 
     def make_t3p2_ip_ea(self, cc):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = cc.t1, cc.t2, self.eris
         delta_E_tot, pt1, pt2, Wovoo, Wvvvo = \
@@ -1672,7 +1672,7 @@ class _IMDS:
             self._make_shared_2e()
             self._made_shared_2e = True
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris

--- a/pyscf/pbc/cc/eom_kccsd_uhf.py
+++ b/pyscf/pbc/cc/eom_kccsd_uhf.py
@@ -20,7 +20,7 @@
 #          Jason Yu
 #
 
-import time
+
 import itertools
 import numpy as np
 
@@ -1048,7 +1048,7 @@ class _IMDS:
         self.made_ee_imds = False
 
     def _make_shared(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = self.t1, self.t2, self.eris
         self.Foo, self.FOO = kintermediates_uhf.Foo(self._cc, t1, t2, eris)
@@ -1072,7 +1072,7 @@ class _IMDS:
             self._make_shared()
 
         kconserv = self.kconserv
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = self.t1, self.t2, self.eris
 
@@ -1089,7 +1089,7 @@ class _IMDS:
         if not self._made_shared:
             self._make_shared()
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         t1, t2, eris = self.t1, self.t2, self.eris
 

--- a/pyscf/pbc/cc/kccsd.py
+++ b/pyscf/pbc/cc/kccsd.py
@@ -17,7 +17,7 @@
 #          Timothy Berkelbach <tim.berkelbach@gmail.com>
 #
 
-import time
+
 import numpy
 from functools import reduce
 
@@ -66,7 +66,7 @@ def energy(cc, t1, t2, eris):
 
 
 def update_amps(cc, t1, t2, eris):
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(cc.stdout, cc.verbose)
     nkpts, nocc, nvir = t1.shape
     fock = eris.fock
@@ -353,7 +353,7 @@ class GCCSD(gccsd.GCCSD):
         return self
 
     def init_amps(self, eris):
-        time0 = time.clock(), time.time()
+        time0 = logger.process_clock(), logger.perf_counter()
         nocc = self.nocc
         nvir = self.nmo - nocc
         nkpts = self.nkpts
@@ -471,7 +471,7 @@ def _make_eris_incore(cc, mo_coeff=None):
     from pyscf.pbc.cc.ccsd import _adjust_occ
 
     log = logger.Logger(cc.stdout, cc.verbose)
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     eris = gccsd._PhysicistsERIs()
     cell = cc._scf.cell
     kpts = cc.kpts
@@ -711,7 +711,7 @@ class _IMDS:
         self._fimd = None
 
     def _make_shared_1e(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1,t2,eris = self.t1, self.t2, self.eris
@@ -723,7 +723,7 @@ class _IMDS:
         log.timer('EOM-CCSD shared one-electron intermediates', *cput0)
 
     def _make_shared_2e(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1,t2,eris = self.t1, self.t2, self.eris
@@ -749,7 +749,7 @@ class _IMDS:
             self._make_shared_2e()
             self._made_shared_2e = True
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1,t2,eris = self.t1, self.t2, self.eris
@@ -774,7 +774,7 @@ class _IMDS:
             self._make_shared_2e()
             self._made_shared_2e = True
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1,t2,eris = self.t1, self.t2, self.eris

--- a/pyscf/pbc/cc/kccsd_rhf.py
+++ b/pyscf/pbc/cc/kccsd_rhf.py
@@ -17,7 +17,7 @@
 #          Timothy Berkelbach <tim.berkelbach@gmail.com>
 #
 
-import time
+
 from functools import reduce
 import numpy as np
 import h5py
@@ -51,7 +51,7 @@ def get_normt_diff(cc, t1, t2, t1new, t2new):
 
 
 def update_amps(cc, t1, t2, eris):
-    time0 = time1 = time.clock(), time.time()
+    time0 = time1 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(cc.stdout, cc.verbose)
     nkpts, nocc, nvir = t1.shape
     fock = eris.fock
@@ -541,7 +541,7 @@ class RCCSD(pyscf.cc.ccsd.CCSD):
         return vector_to_nested(vec, self.ccsd_vector_desc)
 
     def init_amps(self, eris):
-        time0 = time.clock(), time.time()
+        time0 = logger.process_clock(), logger.perf_counter()
         nocc = self.nocc
         nvir = self.nmo - nocc
         nkpts = self.nkpts
@@ -710,7 +710,7 @@ class _ERIS:  # (pyscf.cc.ccsd._ChemistsERIs):
         from pyscf.pbc import tools
         from pyscf.pbc.cc.ccsd import _adjust_occ
         log = logger.Logger(cc.stdout, cc.verbose)
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         cell = cc._scf.cell
         kpts = cc.kpts
         nkpts = cc.nkpts
@@ -826,7 +826,7 @@ class _ERIS:  # (pyscf.cc.ccsd._ChemistsERIs):
                 self.vvvv = None
 
             # <ij|pq>  = (ip|jq)
-            cput1 = time.clock(), time.time()
+            cput1 = logger.process_clock(), logger.perf_counter()
             for kp in range(nkpts):
                 for kq in range(nkpts):
                     for kr in range(nkpts):
@@ -844,7 +844,7 @@ class _ERIS:  # (pyscf.cc.ccsd._ChemistsERIs):
             cput1 = log.timer_debug1('transforming oopq', *cput1)
 
             # <ia|pq> = (ip|aq)
-            cput1 = time.clock(), time.time()
+            cput1 = logger.process_clock(), logger.perf_counter()
             for kp in range(nkpts):
                 for kq in range(nkpts):
                     for kr in range(nkpts):
@@ -862,7 +862,7 @@ class _ERIS:  # (pyscf.cc.ccsd._ChemistsERIs):
             cput1 = log.timer_debug1('transforming ovpq', *cput1)
 
             ## Without k-point symmetry
-            # cput1 = time.clock(), time.time()
+            # cput1 = logger.process_clock(), logger.perf_counter()
             # for kp in range(nkpts):
             #    for kq in range(nkpts):
             #        for kr in range(nkpts):
@@ -880,7 +880,7 @@ class _ERIS:  # (pyscf.cc.ccsd._ChemistsERIs):
             #                self.vvvv[kp,kr,kq,a,:,:,:] = buf_kpt[:] / nkpts
             # cput1 = log.timer_debug1('transforming vvvv', *cput1)
 
-            cput1 = time.clock(), time.time()
+            cput1 = logger.process_clock(), logger.perf_counter()
             mem_now = lib.current_memory()[0]
             if not vvvv_required:
                 _init_df_eris(cc, self)
@@ -992,7 +992,7 @@ class _IMDS:
             self._fimd = None
 
     def _make_shared_1e(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris
@@ -1004,7 +1004,7 @@ class _IMDS:
         log.timer('EOM-CCSD shared one-electron intermediates', *cput0)
 
     def _make_shared_2e(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris
@@ -1030,7 +1030,7 @@ class _IMDS:
             self._make_shared_2e()
             self._made_shared_2e = True
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris
@@ -1058,7 +1058,7 @@ class _IMDS:
             self._make_shared_2e()
             self._made_shared_2e = True
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         log = logger.Logger(self.stdout, self.verbose)
 
         t1, t2, eris = self.t1, self.t2, self.eris

--- a/pyscf/pbc/cc/kccsd_t_rhf.py
+++ b/pyscf/pbc/cc/kccsd_t_rhf.py
@@ -8,7 +8,7 @@ import ctypes
 import h5py
 import numpy as np
 import pyscf.pbc.cc.kccsd_rhf
-import time
+
 
 from itertools import product
 from pyscf import lib
@@ -49,7 +49,7 @@ def kernel(mycc, eris, t1=None, t2=None, max_memory=2000, verbose=logger.INFO):
         energy_t (float): The real-part of the k-point CCSD(T) energy.
     '''
     assert isinstance(mycc, pyscf.pbc.cc.kccsd_rhf.RCCSD)
-    cpu1 = cpu0 = (time.clock(), time.time())
+    cpu1 = cpu0 = (logger.process_clock(), logger.perf_counter())
     if isinstance(verbose, logger.Logger):
         log = verbose
     else:

--- a/pyscf/pbc/cc/kccsd_t_rhf_slow.py
+++ b/pyscf/pbc/cc/kccsd_t_rhf_slow.py
@@ -8,7 +8,7 @@ import h5py
 import itertools
 import numpy as np
 import pyscf.pbc.cc.kccsd_rhf
-import time
+
 
 from itertools import product
 from pyscf import lib
@@ -54,7 +54,7 @@ def kernel(mycc, eris, t1=None, t2=None, max_memory=2000, verbose=logger.INFO):
         energy_t (float): The real-part of the k-point CCSD(T) energy.
     '''
     assert isinstance(mycc, pyscf.pbc.cc.kccsd_rhf.RCCSD)
-    cpu1 = cpu0 = (time.clock(), time.time())
+    cpu1 = cpu0 = (logger.process_clock(), logger.perf_counter())
     if isinstance(verbose, logger.Logger):
         log = verbose
     else:

--- a/pyscf/pbc/cc/kccsd_uhf.py
+++ b/pyscf/pbc/cc/kccsd_uhf.py
@@ -21,7 +21,7 @@
 #          Alec White
 #
 
-import time
+
 from functools import reduce
 import numpy as np
 import h5py
@@ -59,7 +59,7 @@ def convert_mo_coeff(mo_coeff):
     return mo_coeff
 
 def update_amps(cc, t1, t2, eris):
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(cc.stdout, cc.verbose)
 
     t1a, t1b = t1
@@ -683,7 +683,7 @@ class KUCCSD(uccsd.UCCSD):
             return _make_eris_outcore(self, mo_coeff)
 
     def init_amps(self, eris):
-        time0 = time.clock(), time.time()
+        time0 = logger.process_clock(), logger.perf_counter()
 
         nocca, noccb = self.nocc
         nmoa, nmob = self.nmo
@@ -840,7 +840,7 @@ def _kuccsd_eris_common_(cc, eris, buf=None):
     #if not (cc.frozen is None or cc.frozen == 0):
     #    raise NotImplementedError('cc.frozen = %s' % str(cc.frozen))
 
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(cc)
     cell = cc._scf.cell
     thisdf = cc._scf.with_df

--- a/pyscf/pbc/cc/kintermediates_rhf.py
+++ b/pyscf/pbc/cc/kintermediates_rhf.py
@@ -18,7 +18,7 @@
 #
 
 import numpy as np
-import time
+
 from itertools import product
 from pyscf import lib
 from pyscf.lib import logger
@@ -705,7 +705,7 @@ def get_t3p2_imds(mycc, t1, t2, eris=None, t3p2_ip_out=None, t3p2_ea_out=None):
     the corresponding `kintermediates.py`.
     """
     from pyscf.pbc.cc.kccsd_t_rhf import _get_epqr
-    cpu1 = cpu0 = (time.clock(), time.time())
+    cpu1 = cpu0 = (logger.process_clock(), logger.perf_counter())
     if eris is None:
         eris = mycc.ao2mo()
     fock = eris.fock
@@ -821,7 +821,7 @@ def get_t3p2_imds(mycc, t1, t2, eris=None, t3p2_ip_out=None, t3p2_ea_out=None):
     pt2 = np.zeros((nkpts,nkpts,nkpts,nocc,nocc,nvir,nvir), dtype=dtype)
     for ka, kb in product(range(nkpts), repeat=2):
         for task_id, task in enumerate(tasks):
-            cput2 = (time.clock(), time.time())
+            cput2 = (logger.process_clock(), logger.perf_counter())
             a0,a1,b0,b1,c0,c1 = task
             my_permuted_w = np.zeros((nkpts,)*3 + (a1-a0,b1-b0,c1-c0) + (nocc,)*3, dtype=dtype)
 

--- a/pyscf/pbc/ci/kcis_rhf.py
+++ b/pyscf/pbc/ci/kcis_rhf.py
@@ -17,7 +17,7 @@
 #          Timothy Berkelbach <tim.berkelbach@gmail.com>
 #
 
-import time
+
 from functools import reduce
 import numpy as np
 import h5py
@@ -59,7 +59,7 @@ def kernel(cis, nroots=1, eris=None, kptlist=None, **kargs):
     Returns:
         tuple -- A tuple of excitation energies and corresponding eigenvectors
     """
-    cpu0 = (time.clock(), time.time())
+    cpu0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(cis.stdout, cis.verbose)
     cis.dump_flags()
 
@@ -81,7 +81,7 @@ def kernel(cis, nroots=1, eris=None, kptlist=None, **kargs):
     evecs = [None] * len(kptlist)
     convs = [None] * len(kptlist)
 
-    cpu1 = (time.clock(), time.time())
+    cpu1 = (logger.process_clock(), logger.perf_counter())
     for k, kshift in enumerate(kptlist):
         print("\nkshift =", kshift)
 
@@ -210,7 +210,7 @@ def cis_H(cis, kshift, eris=None):
     Returns:
         2D array -- the Hamiltonian matrix reshaped into (ki,i,a) by (kj,j,b)
     """
-    cpu0 = (time.clock(), time.time())
+    cpu0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(cis.stdout, cis.verbose)
 
     if eris is None:
@@ -455,7 +455,7 @@ class KCIS(lib.StreamObject):
 class _CIS_ERIS:
     def __init__(self, cis, mo_coeff=None, method="incore"):
         log = logger.Logger(cis.stdout, cis.verbose)
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         cell = cis._scf.cell
         nocc = cis.nocc
@@ -575,7 +575,7 @@ class _CIS_ERIS:
                 )
 
                 # <ia|pq> = (ip|aq)
-                cput1 = time.clock(), time.time()
+                cput1 = logger.process_clock(), logger.perf_counter()
                 for kp in range(nkpts):
                     for kq in range(nkpts):
                         for kr in range(nkpts):
@@ -647,7 +647,7 @@ def _init_cis_df_eris(cis, eris):
     eris.dtype = dtype = np.result_type(dtype, *eris.mo_coeff)
     eris.Lpq_mo = Lpq_mo = np.empty((nkpts, nkpts), dtype=object)
 
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
 
     with h5py.File(cis._scf.with_df._cderi, 'r') as f:
         kptij_lst = f['j3c-kptij'][:]

--- a/pyscf/pbc/df/aft.py
+++ b/pyscf/pbc/df/aft.py
@@ -18,7 +18,7 @@
 
 '''Density expansion on plane waves'''
 
-import time
+
 import copy
 import numpy
 from pyscf import lib
@@ -106,7 +106,7 @@ def get_pp_loc_part1(mydf, kpts=None):
         kpts_lst = numpy.reshape(kpts, (-1,3))
 
     log = logger.Logger(mydf.stdout, mydf.verbose)
-    t0 = t1 = (time.clock(), time.time())
+    t0 = t1 = (logger.process_clock(), logger.perf_counter())
 
     mesh = numpy.asarray(mydf.mesh)
     nkpts = len(kpts_lst)

--- a/pyscf/pbc/df/aft_jk.py
+++ b/pyscf/pbc/df/aft_jk.py
@@ -20,7 +20,7 @@
 JK with analytic Fourier transformation
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -65,7 +65,7 @@ def get_j_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None):
 
 def get_j_for_bands(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None):
     log = logger.Logger(mydf.stdout, mydf.verbose)
-    t1 = (time.clock(), time.time())
+    t1 = (logger.process_clock(), logger.perf_counter())
 
     dm_kpts = lib.asarray(dm_kpts, order='C')
     dms = _format_dms(dm_kpts, kpts)
@@ -111,7 +111,7 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None,
                exxdiv=None):
     cell = mydf.cell
     log = logger.Logger(mydf.stdout, mydf.verbose)
-    t1 = (time.clock(), time.time())
+    t1 = (logger.process_clock(), logger.perf_counter())
 
     mesh = mydf.mesh
     dm_kpts = lib.asarray(dm_kpts, order='C')
@@ -243,7 +243,7 @@ def get_jk(mydf, dm, hermi=1, kpt=numpy.zeros(3),
 
     cell = mydf.cell
     log = logger.Logger(mydf.stdout, mydf.verbose)
-    t1 = (time.clock(), time.time())
+    t1 = (logger.process_clock(), logger.perf_counter())
 
     dm = numpy.asarray(dm, order='C')
     dms = _format_dms(dm, [kpt])

--- a/pyscf/pbc/df/df.py
+++ b/pyscf/pbc/df/df.py
@@ -30,7 +30,7 @@ J. Chem. Phys. 147, 164119 (2017)
 '''
 
 import os
-import time
+
 import copy
 import warnings
 import tempfile
@@ -141,7 +141,7 @@ def make_modchg_basis(auxcell, smooth_eta):
 # kpti == kptj: s2 symmetry
 # kpti == kptj == 0 (gamma point): real
 def _make_j3c(mydf, cell, auxcell, kptij_lst, cderi_file):
-    t1 = (time.clock(), time.time())
+    t1 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(mydf.stdout, mydf.verbose)
     max_memory = max(2000, mydf.max_memory-lib.current_memory()[0])
     fused_cell, fuse = fuse_auxcell(mydf, auxcell)
@@ -568,7 +568,7 @@ class GDF(aft.AFTDF):
                                 'DF integrals will be saved in file %s .',
                                 cderi)
             self._cderi = cderi
-            t1 = (time.clock(), time.time())
+            t1 = (logger.process_clock(), logger.perf_counter())
             self._make_j3c(self.cell, self.auxcell, kptij_lst, cderi)
             t1 = logger.timer_debug1(self, 'j3c', *t1)
         return self

--- a/pyscf/pbc/df/df_jk.py
+++ b/pyscf/pbc/df/df_jk.py
@@ -22,7 +22,7 @@ Ref:
 J. Chem. Phys. 147, 164119 (2017)
 '''
 
-import time
+
 import copy
 from functools import reduce
 import numpy
@@ -66,7 +66,7 @@ def density_fit(mf, auxbasis=None, mesh=None, with_df=None):
 
 def get_j_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None):
     log = logger.Logger(mydf.stdout, mydf.verbose)
-    t1 = (time.clock(), time.time())
+    t1 = (logger.process_clock(), logger.perf_counter())
     if mydf._cderi is None or not mydf.has_kpts(kpts_band):
         if mydf._cderi is not None:
             log.warn('DF integrals for band k-points were not found %s. '
@@ -153,7 +153,7 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None,
                  'exxdiv needs to be "ewald" or None', exxdiv)
         raise RuntimeError('GDF does not support exxdiv %s' % exxdiv)
 
-    t1 = (time.clock(), time.time())
+    t1 = (logger.process_clock(), logger.perf_counter())
     if mydf._cderi is None or not mydf.has_kpts(kpts_band):
         if mydf._cderi is not None:
             log.warn('DF integrals for band k-points were not found %s. '
@@ -252,7 +252,7 @@ def get_jk(mydf, dm, hermi=1, kpt=numpy.zeros(3),
 
     cell = mydf.cell
     log = logger.Logger(mydf.stdout, mydf.verbose)
-    t1 = (time.clock(), time.time())
+    t1 = (logger.process_clock(), logger.perf_counter())
     if mydf._cderi is None or not mydf.has_kpts(kpts_band):
         if mydf._cderi is not None:
             log.warn('DF integrals for band k-points were not found %s. '

--- a/pyscf/pbc/df/fft_jk.py
+++ b/pyscf/pbc/df/fft_jk.py
@@ -20,7 +20,7 @@
 JK with discrete Fourier transformation
 '''
 
-import time
+
 import numpy as np
 from pyscf import lib
 from pyscf.pbc import tools
@@ -245,7 +245,7 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=np.zeros((1,3)), kpts_band=None,
     #ao2_dtype = np.result_type(*ao2_kpts)
     vR_dm = np.empty((nset,nao,ngrids), dtype=vk_kpts.dtype)
 
-    t1 = (time.clock(), time.time())
+    t1 = (logger.process_clock(), logger.perf_counter())
     for k2, ao2T in enumerate(ao2_kpts):
         if ao2T.size == 0:
             continue
@@ -358,7 +358,7 @@ def get_k_e1_kpts(mydf, dm_kpts, kpts=np.zeros((1,3)), kpts_band=None,
 
     vR_dm = np.empty((3,nset,nao,ngrids), dtype=vk_kpts.dtype)
 
-    t1 = (time.clock(), time.time())
+    t1 = (logger.process_clock(), logger.perf_counter())
     for k2, ao2T in enumerate(ao2_kpts):
         if ao2T.size == 0:
             continue

--- a/pyscf/pbc/df/fft_jk.py
+++ b/pyscf/pbc/df/fft_jk.py
@@ -245,7 +245,7 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=np.zeros((1,3)), kpts_band=None,
     #ao2_dtype = np.result_type(*ao2_kpts)
     vR_dm = np.empty((nset,nao,ngrids), dtype=vk_kpts.dtype)
 
-    t1 = (logger.process_clock(), logger.perf_counter())
+    t1 = (lib.logger.process_clock(), lib.logger.perf_counter())
     for k2, ao2T in enumerate(ao2_kpts):
         if ao2T.size == 0:
             continue

--- a/pyscf/pbc/df/mdf.py
+++ b/pyscf/pbc/df/mdf.py
@@ -23,7 +23,7 @@ J. Chem. Phys. 147, 164119 (2017)
 '''
 
 import os
-import time
+
 import tempfile
 import numpy
 import h5py
@@ -50,7 +50,7 @@ from pyscf import __config__
 # kpti == kptj: s2 symmetry
 # kpti == kptj == 0 (gamma point): real
 def _make_j3c(mydf, cell, auxcell, kptij_lst, cderi_file):
-    t1 = (time.clock(), time.time())
+    t1 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(mydf.stdout, mydf.verbose)
     max_memory = max(2000, mydf.max_memory-lib.current_memory()[0])
     fused_cell, fuse = fuse_auxcell(mydf, auxcell)

--- a/pyscf/pbc/dft/krks.py
+++ b/pyscf/pbc/dft/krks.py
@@ -25,7 +25,7 @@ See Also:
                            systems at a single k-point
 '''
 
-import time
+
 import numpy as np
 from pyscf import lib
 from pyscf.lib import logger
@@ -58,7 +58,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=0, vhf_last=0, hermi=1,
     if cell is None: cell = ks.cell
     if dm is None: dm = ks.make_rdm1()
     if kpts is None: kpts = ks.kpts
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     omega, alpha, hyb = ks._numint.rsh_and_hybrid_coeff(ks.xc, spin=cell.spin)
     hybrid = abs(hyb) > 1e-10 or abs(alpha) > 1e-10

--- a/pyscf/pbc/dft/kuks.py
+++ b/pyscf/pbc/dft/kuks.py
@@ -24,7 +24,7 @@ See Also:
                            systems at a single k-point
 '''
 
-import time
+
 import numpy as np
 from pyscf import lib
 from pyscf.lib import logger
@@ -43,7 +43,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=0, vhf_last=0, hermi=1,
     if cell is None: cell = ks.cell
     if dm is None: dm = ks.make_rdm1()
     if kpts is None: kpts = ks.kpts
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     omega, alpha, hyb = ks._numint.rsh_and_hybrid_coeff(ks.xc, spin=cell.spin)
     hybrid = abs(hyb) > 1e-10

--- a/pyscf/pbc/dft/rks.py
+++ b/pyscf/pbc/dft/rks.py
@@ -25,7 +25,7 @@ See Also:
                             systems with k-point sampling
 '''
 
-import time
+
 import numpy
 import pyscf.dft
 from pyscf import lib
@@ -60,7 +60,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=0, vhf_last=0, hermi=1,
     if cell is None: cell = ks.cell
     if dm is None: dm = ks.make_rdm1()
     if kpt is None: kpt = ks.kpt
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     omega, alpha, hyb = ks._numint.rsh_and_hybrid_coeff(ks.xc, spin=cell.spin)
     hybrid = abs(hyb) > 1e-10 or abs(alpha) > 1e-10

--- a/pyscf/pbc/dft/uks.py
+++ b/pyscf/pbc/dft/uks.py
@@ -24,7 +24,7 @@ See Also:
                             systems with k-point sampling
 '''
 
-import time
+
 import numpy
 import pyscf.dft
 from pyscf import lib
@@ -44,7 +44,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=0, vhf_last=0, hermi=1,
     if cell is None: cell = ks.cell
     if dm is None: dm = ks.make_rdm1()
     if kpt is None: kpt = ks.kpt
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     omega, alpha, hyb = ks._numint.rsh_and_hybrid_coeff(ks.xc, spin=cell.spin)
     hybrid = abs(hyb) > 1e-10 or abs(alpha) > 1e-10

--- a/pyscf/pbc/grad/krhf.py
+++ b/pyscf/pbc/grad/krhf.py
@@ -28,7 +28,7 @@ from pyscf.pbc.dft.numint import eval_ao_kpts
 from pyscf.pbc import gto, tools
 from pyscf.gto import mole
 import scipy
-import time
+
 
 def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     '''
@@ -49,7 +49,7 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     hcore_deriv = mf_grad.hcore_generator(cell, kpts)
     s1 = mf_grad.get_ovlp(cell, kpts)
     dm0 = mf.make_rdm1(mo_coeff, mo_occ)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Computing Gradients of NR-HF Coulomb repulsion')
     vhf = mf_grad.get_veff(dm0, kpts)
     log.timer('gradients of 2e part', *t0)
@@ -306,7 +306,7 @@ class GradientsBasics(molgrad.GradientsBasics):
         if kpts is None: kpts = self.kpts
         if dm is None: dm = self.base.make_rdm1()
         exxdiv = self.base.exxdiv
-        cpu0 = (time.clock(), time.time())
+        cpu0 = (logger.process_clock(), logger.perf_counter())
         vj, vk = self.base.with_df.get_jk_e1(dm, kpts, exxdiv=exxdiv)
         logger.timer(self, 'vj and vk', *cpu0)
         return vj, vk
@@ -314,7 +314,7 @@ class GradientsBasics(molgrad.GradientsBasics):
     def get_j(self, dm=None, kpts=None):
         if kpts is None: kpts = self.kpts
         if dm is None: dm = self.base.make_rdm1()
-        cpu0 = (time.clock(), time.time())
+        cpu0 = (logger.process_clock(), logger.perf_counter())
         vj = self.base.with_df.get_j_e1(dm, kpts)
         logger.timer(self, 'vj', *cpu0)
         return vj
@@ -323,7 +323,7 @@ class GradientsBasics(molgrad.GradientsBasics):
         if kpts is None: kpts = self.kpts
         if dm is None: dm = self.base.make_rdm1()
         exxdiv = self.base.exxdiv
-        cpu0 = (time.clock(), time.time())
+        cpu0 = (logger.process_clock(), logger.perf_counter())
         vk = self.base.with_df.get_k_e1(dm, kpts, kpts_band, exxdiv)
         logger.timer(self, 'vk', *cpu0)
         return vk
@@ -410,7 +410,7 @@ class Gradients(GradientsBasics):
             logger.note(self, '----------------------------------------------')
 
     def kernel(self, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         if mo_energy is None: mo_energy = self.base.mo_energy
         if mo_coeff is None: mo_coeff = self.base.mo_coeff
         if mo_occ is None: mo_occ = self.base.mo_occ

--- a/pyscf/pbc/grad/krks.py
+++ b/pyscf/pbc/grad/krks.py
@@ -26,14 +26,14 @@ import numpy as np
 from pyscf.pbc.dft import numint
 from pyscf import lib
 from pyscf.lib import logger
-import time
+
 
 def get_veff(ks_grad, dm=None, kpts=None):
     mf = ks_grad.base
     cell = ks_grad.cell
     if dm is None: dm = mf.make_rdm1()
     if kpts is None: kpts = mf.kpts
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     ni = mf._numint
     if ks_grad.grids is not None:

--- a/pyscf/pbc/grad/kuhf.py
+++ b/pyscf/pbc/grad/kuhf.py
@@ -24,7 +24,7 @@ import numpy as np
 from pyscf.lib import logger
 from pyscf.pbc.grad import krhf as rhf_grad
 from pyscf.pbc import gto
-import time
+
 
 def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     mf = mf_grad.base
@@ -42,7 +42,7 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     s1 = mf_grad.get_ovlp(cell, kpts)
     dm0 = mf.make_rdm1(mo_coeff, mo_occ)
 
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Computing Gradients of NR-UHF Coulomb repulsion')
     vhf = mf_grad.get_veff(dm0, kpts)
     log.timer('gradients of 2e part', *t0)

--- a/pyscf/pbc/grad/kuks.py
+++ b/pyscf/pbc/grad/kuks.py
@@ -26,14 +26,14 @@ from pyscf.grad import rks as rks_grad
 from pyscf.pbc.grad import kuhf as uhf_grad
 from pyscf.pbc.dft import numint
 from pyscf.pbc import gto
-import time
+
 
 def get_veff(ks_grad, dm=None, kpts=None):
     mf = ks_grad.base
     cell = ks_grad.cell
     if dm is None: dm = mf.make_rdm1()
     if kpts is None: kpts = mf.kpts
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     ni = mf._numint
     if ks_grad.grids is not None:

--- a/pyscf/pbc/lib/linalg_helper.py
+++ b/pyscf/pbc/lib/linalg_helper.py
@@ -21,7 +21,7 @@ Extension to scipy.linalg module developed for PBC branch.
 '''
 
 from functools import reduce
-import time
+
 import numpy as np
 import scipy.linalg
 
@@ -90,7 +90,7 @@ def davidson(mult_by_A, N, neig, x0=None, Adiag=None, verbose=logger.INFO):
         import sys
         log = logger.Logger(sys.stdout, verbose)
 
-    cput1 = (time.clock(), time.time())
+    cput1 = (logger.process_clock(), logger.perf_counter())
 
     Mmin = min(neig,N)
     Mmax = min(N,2000)

--- a/pyscf/pbc/mp/kump2.py
+++ b/pyscf/pbc/mp/kump2.py
@@ -25,7 +25,7 @@ t2 and eris are never stored in full, only a partial
 eri of size (nkpts,nocc,nocc,nvir,nvir)
 '''
 
-import time
+
 import numpy as np
 
 from pyscf import lib

--- a/pyscf/pbc/mpicc/kccsd_rhf.py
+++ b/pyscf/pbc/mpicc/kccsd_rhf.py
@@ -19,7 +19,7 @@
 
 import copy
 from functools import reduce
-import time
+
 import numpy
 import os
 import numpy as np
@@ -292,7 +292,7 @@ def update_t1(cc,t1,t2,eris,ints1e):
 # following Hirata, ..., Barlett, J. Chem. Phys. 120, 2581 (2004)
 
 def update_amps(cc, t1, t2, eris, max_memory=2000):
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
     log = logger.Logger(cc.stdout, cc.verbose)
     nkpts, nocc, nvir = t1.shape
     fock = eris.fock
@@ -355,8 +355,8 @@ def update_amps(cc, t1, t2, eris, max_memory=2000):
     #t2new = numpy.zeros((nkpts,nkpts,nkpts,nocc,nocc,nvir,nvir),dtype=ds_type)
     t2new_tril = numpy.zeros((tril_shape,nkpts,nocc,nocc,nvir,nvir),dtype=ds_type)
 
-    cput1 = time.clock(), time.time()
-    cput2 = time.clock(), time.time()
+    cput1 = logger.process_clock(), logger.perf_counter()
+    cput2 = logger.process_clock(), logger.perf_counter()
     loader = mpi_load_balancer.load_balancer(BLKSIZE=(1,nkpts,nkpts,))
     loader.set_ranges((range(nkpts),range(nkpts),range(nkpts),))
 
@@ -454,7 +454,7 @@ def update_amps(cc, t1, t2, eris, max_memory=2000):
     comm.Barrier()
     cput2 = log.timer_debug1('transforming Woooo', *cput2)
 
-    cput2 = time.clock(), time.time()
+    cput2 = logger.process_clock(), logger.perf_counter()
 
     mem = 0.5e9
     pre = 1.*nvir*nvir*nvir*nvir*nkpts*16
@@ -525,7 +525,7 @@ def update_amps(cc, t1, t2, eris, max_memory=2000):
     cput2 = log.timer_debug1('transforming Wvvvv', *cput2)
 
     # Making Wvoov and Wovov terms. (part 1/2)
-    cput2 = time.clock(), time.time()
+    cput2 = logger.process_clock(), logger.perf_counter()
 
     mem = 0.5e9
     pre = 1.*nocc*nvir*nvir*nvir*nkpts*16
@@ -650,7 +650,7 @@ def update_amps(cc, t1, t2, eris, max_memory=2000):
 
     # Making Wvoov and Wovov terms (part 2/2)
 
-    cput2 = time.clock(), time.time()
+    cput2 = logger.process_clock(), logger.perf_counter()
     loader = mpi_load_balancer.load_balancer(BLKSIZE=(nkpts,1,nkpts_blksize,))
     loader.set_ranges((range(nkpts),range(nkpts),range(nkpts),))
 
@@ -748,7 +748,7 @@ def update_amps(cc, t1, t2, eris, max_memory=2000):
     comm.Barrier()
     cput2 = log.timer_debug1('transforming Wvoov (bj)', *cput2)
 
-    cput2 = time.clock(), time.time()
+    cput2 = logger.process_clock(), logger.perf_counter()
     loader = mpi_load_balancer.load_balancer(BLKSIZE=(1,nkpts,nkpts_blksize,))
     loader.set_ranges((range(nkpts),range(nkpts),range(nkpts),))
 
@@ -834,7 +834,7 @@ def update_amps(cc, t1, t2, eris, max_memory=2000):
     comm.Barrier()
     cput2 = log.timer_debug1('transforming Wovov (bi)', *cput2)
 
-    cput2 = time.clock(), time.time()
+    cput2 = logger.process_clock(), logger.perf_counter()
     loader = mpi_load_balancer.load_balancer(BLKSIZE=(nkpts,1,nkpts_blksize,))
     loader.set_ranges((range(nkpts),range(nkpts),range(nkpts),))
 
@@ -1019,7 +1019,7 @@ class RCCSD(pyscf.pbc.cc.kccsd_rhf.RCCSD):
         self.__imds__ = None
 
     def _init_amps_tril(self, eris):
-        time0 = time.clock(), time.time()
+        time0 = logger.process_clock(), logger.perf_counter()
         nocc = self.nocc
         nvir = self.nmo - nocc
         nkpts = self.nkpts
@@ -1041,7 +1041,7 @@ class RCCSD(pyscf.pbc.cc.kccsd_rhf.RCCSD):
         loader = mpi_load_balancer.load_balancer(BLKSIZE=(1,1,nkpts,))
         loader.set_ranges((range(nkpts),range(nkpts),range(nkpts),))
 
-        cput1 = time.clock(), time.time()
+        cput1 = logger.process_clock(), logger.perf_counter()
         good2go = True
         while(good2go):
             good2go, data = loader.slave_set()
@@ -1104,7 +1104,7 @@ class RCCSD(pyscf.pbc.cc.kccsd_rhf.RCCSD):
         return self.emp2, t1, t2_tril
 
     def _init_amps(self, eris):
-        time0 = time.clock(), time.time()
+        time0 = logger.process_clock(), logger.perf_counter()
         nocc = self.nocc
         nvir = self.nmo - nocc
         nkpts = self.nkpts
@@ -1234,7 +1234,7 @@ class RCCSD(pyscf.pbc.cc.kccsd_rhf.RCCSD):
         return vector
 
     def ipccsd(self, nroots=2*4, kptlist=None):
-        time0 = time.clock(), time.time()
+        time0 = logger.process_clock(), logger.perf_counter()
         log = logger.Logger(self.stdout, self.verbose)
         nocc = self.nocc
         nvir = self.nmo - nocc
@@ -1310,7 +1310,7 @@ class RCCSD(pyscf.pbc.cc.kccsd_rhf.RCCSD):
 
         imds = self.imds
 
-        cput2 = time.clock(), time.time()
+        cput2 = logger.process_clock(), logger.perf_counter()
         Hr1 = numpy.zeros(r1.shape,dtype=t1.dtype)
         loader = mpi_load_balancer.load_balancer(BLKSIZE=(nkpts,))
         loader.set_ranges((range(nkpts),))
@@ -1398,7 +1398,7 @@ class RCCSD(pyscf.pbc.cc.kccsd_rhf.RCCSD):
         return vector
 
     def lipccsd(self, nroots=2*4, kptlist=None):
-        time0 = time.clock(), time.time()
+        time0 = logger.process_clock(), logger.perf_counter()
         log = logger.Logger(self.stdout, self.verbose)
         nocc = self.nocc
         nvir = self.nmo - nocc
@@ -1459,7 +1459,7 @@ class RCCSD(pyscf.pbc.cc.kccsd_rhf.RCCSD):
 
         imds = self.imds
 
-        cput2 = time.clock(), time.time()
+        cput2 = logger.process_clock(), logger.perf_counter()
         Hr1 = numpy.zeros(r1.shape,dtype=t1.dtype)
         Hr2 = numpy.zeros(r2.shape,dtype=t1.dtype)
 
@@ -1984,7 +1984,7 @@ class RCCSD(pyscf.pbc.cc.kccsd_rhf.RCCSD):
         return vector
 
     def eaccsd(self, nroots=2*4, kptlist=None):
-        time0 = time.clock(), time.time()
+        time0 = logger.process_clock(), logger.perf_counter()
         log = logger.Logger(self.stdout, self.verbose)
         nocc = self.nocc
         nvir = self.nmo - nocc
@@ -2074,7 +2074,7 @@ class RCCSD(pyscf.pbc.cc.kccsd_rhf.RCCSD):
         Hr1 += einsum('ac,c->a',imds.Lvv[kshift],r1)
 
         Hr2 = numpy.zeros(r2.shape,dtype=t1.dtype)
-        cput2 = time.clock(), time.time()
+        cput2 = logger.process_clock(), logger.perf_counter()
         mem = 0.5e9
         pre = 1.*nvir*nvir*nvir*nvir*nkpts*16
         nkpts_blksize  = min(max(int(numpy.floor(mem/pre)),1),nkpts)
@@ -2155,7 +2155,7 @@ class RCCSD(pyscf.pbc.cc.kccsd_rhf.RCCSD):
         return vector
 
     def leaccsd(self, nroots=2*4, kptlist=None):
-        time0 = time.clock(), time.time()
+        time0 = logger.process_clock(), logger.perf_counter()
         log = logger.Logger(self.stdout, self.verbose)
         nocc = self.nocc
         nvir = self.nmo - nocc
@@ -2696,7 +2696,7 @@ class _ERIS:
     def __init__(self, cc, mo_coeff=None, method='incore'):
         from pyscf.pbc import tools
         from pyscf.pbc.cc.ccsd import _adjust_occ
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         moidx = get_frozen_mask(cc)
         cell = cc._scf.cell
         kpts = cc.kpts
@@ -2935,7 +2935,7 @@ class _ERIS:
 
             tmp_block_shape = BLKSIZE + (nocc,nocc,nmo,nmo)
             tmp_block = numpy.empty(shape=tmp_block_shape,dtype=ds_type)
-            cput1 = time.clock(), time.time()
+            cput1 = logger.process_clock(), logger.perf_counter()
             good2go = True
             while(good2go):
                 good2go, data = loader.slave_set()
@@ -2986,7 +2986,7 @@ class _ERIS:
             tmp_block_shape = BLKSIZE + (nocc,nvir,nmo,nmo)
             tmp_block  = numpy.empty(shape=tmp_block_shape,dtype=ds_type)
 
-            cput1 = time.clock(), time.time()
+            cput1 = logger.process_clock(), logger.perf_counter()
             good2go = True
             while(good2go):
                 good2go, data = loader1.slave_set()

--- a/pyscf/pbc/mpicc/kintermediates_rhf.py
+++ b/pyscf/pbc/mpicc/kintermediates_rhf.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import numpy as np
-import time
+
 import pyscf.pbc.tools as tools
 from mpi4py import MPI
 from pyscf.lib import logger

--- a/pyscf/pbc/mpitools/mpi.py
+++ b/pyscf/pbc/mpitools/mpi.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import sys
-import time
+
 import threading
 import traceback
 import numpy

--- a/pyscf/pbc/mpitools/mpi_load_balancer.py
+++ b/pyscf/pbc/mpitools/mpi_load_balancer.py
@@ -15,7 +15,7 @@
 from mpi4py import MPI
 import pyscf.lib
 import numpy as np
-import time
+
 import sys
 from time import sleep
 

--- a/pyscf/pbc/prop/efg/rhf.py
+++ b/pyscf/pbc/prop/efg/rhf.py
@@ -28,7 +28,7 @@ Ref:
 [2] H. Akai et al. Prog. Theor. Phys. Suppl. 101, 11 (1990)
 '''
 
-import time
+
 import numpy
 import scipy.special
 from pyscf import lib
@@ -189,7 +189,7 @@ def _aft_quad_integrals(mydf, dm, efg_nuc):
         raise NotImplementedError
 
     log = lib.logger.new_logger(mydf)
-    t0 = t1 = (time.clock(), time.time())
+    t0 = t1 = (logger.process_clock(), logger.perf_counter())
 
     mesh = mydf.mesh
     kpts = mydf.kpts

--- a/pyscf/pbc/prop/efg/rhf.py
+++ b/pyscf/pbc/prop/efg/rhf.py
@@ -189,7 +189,7 @@ def _aft_quad_integrals(mydf, dm, efg_nuc):
         raise NotImplementedError
 
     log = lib.logger.new_logger(mydf)
-    t0 = t1 = (logger.process_clock(), logger.perf_counter())
+    t0 = t1 = (lib.logger.process_clock(), lib.logger.perf_counter())
 
     mesh = mydf.mesh
     kpts = mydf.kpts

--- a/pyscf/pbc/prop/polarizability/rhf.py
+++ b/pyscf/pbc/prop/polarizability/rhf.py
@@ -20,7 +20,7 @@
 Non-relativistic static/dynamic polarizability and hyper-polarizability
 '''
 
-import time
+
 import numpy as np
 from pyscf import lib
 from pyscf.lib import logger
@@ -439,7 +439,7 @@ def cphf_with_freq(mf, mo_energy, mo_occ, h1, freq=0,
     # library is needed.
     from scipy.optimize import newton_krylov
     log = logger.new_logger(verbose=verbose)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     mo_coeff = np.asarray(mf.mo_coeff)
     nkpt, nao, nmo = mo_coeff.shape

--- a/pyscf/pbc/scf/cphf.py
+++ b/pyscf/pbc/scf/cphf.py
@@ -21,7 +21,7 @@ Restricted coupled pertubed Hartree-Fock solver
 Modified from pyscf.scf.cphf
 '''
 
-import time
+
 import numpy as np
 from pyscf import lib
 from pyscf.lib import logger
@@ -51,7 +51,7 @@ def solve_nos1(fvind, mo_energy, mo_occ, h1,
                max_cycle=20, tol=1e-9, hermi=False, verbose=logger.WARN):
     '''For field independent basis. First order overlap matrix is zero'''
     log = logger.new_logger(verbose=verbose)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     nkpt = len(h1)
     moloc = np.zeros([nkpt+1], dtype=int)
@@ -108,7 +108,7 @@ def solve_withs1(fvind, mo_energy, mo_occ, h1, s1,
         energy matrix
     '''
     log = logger.new_logger(verbose=verbose)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     nkpt = len(h1)
     ncomp = h1[0].shape[0]

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -26,7 +26,7 @@ See Also:
 '''
 
 import sys
-import time
+
 import numpy as np
 import h5py
 from pyscf.scf import hf as mol_hf
@@ -590,7 +590,7 @@ class SCF(mol_hf.SCF):
         if dm is None: dm = self.make_rdm1()
         if kpt is None: kpt = self.kpt
 
-        cpu0 = (time.clock(), time.time())
+        cpu0 = (logger.process_clock(), logger.perf_counter())
         dm = np.asarray(dm)
         nao = dm.shape[-1]
 

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -26,7 +26,7 @@ See Also:
 '''
 
 import sys
-import time
+
 from functools import reduce
 import numpy as np
 import scipy.linalg

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -610,7 +610,7 @@ class KSCF(pbchf.SCF):
         if cell is None: cell = self.cell
         if kpts is None: kpts = self.kpts
         if dm_kpts is None: dm_kpts = self.make_rdm1()
-        cpu0 = (time.clock(), time.time())
+        cpu0 = (logger.process_clock(), logger.perf_counter())
         vj, vk = self.with_df.get_jk(dm_kpts, hermi, kpts, kpts_band,
                                      with_j, with_k, omega, exxdiv=self.exxdiv)
         logger.timer(self, 'vj and vk', *cpu0)

--- a/pyscf/pbc/x2c/sfx2c1e.py
+++ b/pyscf/pbc/x2c/sfx2c1e.py
@@ -17,7 +17,7 @@
 spin-free X2C correction for extended systems (experimental feature)
 '''
 
-import time
+
 from functools import reduce
 import copy
 import numpy
@@ -209,7 +209,7 @@ def get_pnucp(mydf, kpts=None):
         kpts_lst = numpy.reshape(kpts, (-1,3))
 
     log = logger.Logger(mydf.stdout, mydf.verbose)
-    t1 = (time.clock(), time.time())
+    t1 = (logger.process_clock(), logger.perf_counter())
 
     nkpts = len(kpts_lst)
     nao = cell.nao_nr()

--- a/pyscf/prop/esr/uhf.py
+++ b/pyscf/prop/esr/uhf.py
@@ -19,7 +19,7 @@ Refs:
     Mole. Phys. 9, 6, 585, 1964
 '''
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib

--- a/pyscf/prop/gtensor/uhf.py
+++ b/pyscf/prop/gtensor/uhf.py
@@ -27,7 +27,7 @@ Note g-tensor = 1/muB d^2 E/ dB dS
 In some literature, muB is not explicitly presented in the perturbation formula.
 '''
 
-import time
+
 from functools import reduce
 import copy
 import numpy
@@ -474,7 +474,7 @@ class GTensor(lib.StreamObject):
         return self
 
     def kernel(self, mo1=None):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
 

--- a/pyscf/prop/hfc/uhf.py
+++ b/pyscf/prop/hfc/uhf.py
@@ -24,7 +24,7 @@ Refs:
     JCP 118, 3939 (2002); DOI:10.1063/1.1540619
 '''
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -263,7 +263,7 @@ class HyperfineCoupling(lib.StreamObject):
         return self
 
     def kernel(self, mo1=None):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
         mol = self.mol

--- a/pyscf/prop/magnetizability/rhf.py
+++ b/pyscf/prop/magnetizability/rhf.py
@@ -27,7 +27,7 @@ Refs:
 '''
 
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -159,7 +159,7 @@ def para(magobj, gauge_orig=None, h1=None, s1=None, with_cphf=None):
             given function is used to compute induced potential
     '''
     log = logger.Logger(magobj.stdout, magobj.verbose)
-    cput1 = (time.clock(), time.time())
+    cput1 = (logger.process_clock(), logger.perf_counter())
 
     mol = magobj.mol
     mf = magobj._scf
@@ -243,7 +243,7 @@ class Magnetizability(lib.StreamObject):
         return self
 
     def kernel(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
 

--- a/pyscf/prop/magnetizability/uhf.py
+++ b/pyscf/prop/magnetizability/uhf.py
@@ -26,7 +26,7 @@ Refs:
 '''
 
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -89,7 +89,7 @@ def para(magobj, gauge_orig=None, h1=None, s1=None, with_cphf=None):
             given function is used to compute induced potential
     '''
     log = logger.Logger(magobj.stdout, magobj.verbose)
-    cput1 = (time.clock(), time.time())
+    cput1 = (logger.process_clock(), logger.perf_counter())
 
     mol = magobj.mol
     mf = magobj._scf

--- a/pyscf/prop/nmr/dhf.py
+++ b/pyscf/prop/nmr/dhf.py
@@ -21,7 +21,7 @@ NMR shielding of Dirac Hartree-Fock
 '''
 
 import sys
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -208,7 +208,7 @@ def get_fock(nmrobj, dm0=None, gauge_orig=None):
     '''
     if dm0 is None: dm0 = nmrobj._scf.make_rdm1()
     if gauge_orig is None: gauge_orig = nmrobj.gauge_orig
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(nmrobj.stdout, nmrobj.verbose)
     mol = nmrobj.mol
     if nmrobj.mb.upper() == 'RMB':
@@ -306,12 +306,12 @@ class NMR(rhf_nmr.NMR):
         return self
 
     def shielding(self, mo1=None):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         self.dump_flags()
         if self.verbose >= logger.WARN:
             self.check_sanity()
 
-        t0 = (time.clock(), time.time())
+        t0 = (logger.process_clock(), logger.perf_counter())
         unit_ppm = nist.ALPHA**2 * 1e6
         msc_dia = self.dia() * unit_ppm
         t0 = logger.timer(self, 'h11', *t0)

--- a/pyscf/prop/nmr/rhf.py
+++ b/pyscf/prop/nmr/rhf.py
@@ -21,7 +21,7 @@ Non-relativistic NMR shielding tensor
 '''
 
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -187,7 +187,7 @@ def solve_mo1(nmrobj, mo_energy=None, mo_coeff=None, mo_occ=None,
     if mo_occ    is None: mo_occ = nmrobj._scf.mo_occ
     if with_cphf is None: with_cphf = nmrobj.cphf
 
-    cput1 = (time.clock(), time.time())
+    cput1 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(nmrobj.stdout, nmrobj.verbose)
 
     mol = nmrobj.mol
@@ -286,7 +286,7 @@ class NMR(lib.StreamObject):
     def kernel(self, mo1=None):
         return self.shielding(mo1)
     def shielding(self, mo1=None):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
 

--- a/pyscf/prop/nmr/uhf.py
+++ b/pyscf/prop/nmr/uhf.py
@@ -20,7 +20,7 @@
 Non-relativistic NMR shielding tensor
 '''
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -145,7 +145,7 @@ def solve_mo1(nmrobj, mo_energy=None, mo_coeff=None, mo_occ=None,
             If a function is given, CPHF equation will be solved, and the
             given function is used to compute induced potential
     '''
-    cput1 = (time.clock(), time.time())
+    cput1 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(nmrobj.stdout, nmrobj.verbose)
     if mo_energy is None: mo_energy = nmrobj._scf.mo_energy
     if mo_coeff  is None: mo_coeff = nmrobj._scf.mo_coeff

--- a/pyscf/prop/nsr/rhf.py
+++ b/pyscf/prop/nsr/rhf.py
@@ -24,7 +24,7 @@ Refs:
 '''
 
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -122,7 +122,7 @@ class NSR(rhf_nmr.NMR):
     '''Nuclear-spin rotation tensors'''
 
     def kernel(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
 

--- a/pyscf/prop/polarizability/rhf.py
+++ b/pyscf/prop/polarizability/rhf.py
@@ -21,7 +21,7 @@ Non-relativistic static and dynamic polarizability and hyper-polarizability tens
 '''
 
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -129,7 +129,7 @@ def hyper_polarizability(polobj, with_cphf=True):
 def __FIXME_cphf_with_freq(mf, mo_energy, mo_occ, h1, freq=0,
                    max_cycle=20, tol=1e-9, hermi=False, verbose=logger.WARN):
     log = logger.new_logger(verbose=verbose)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     occidx = mo_occ > 0
     viridx = mo_occ == 0
@@ -203,7 +203,7 @@ def cphf_with_freq(mf, mo_energy, mo_occ, h1, freq=0,
     # library is needed.
     from scipy.optimize import newton_krylov
     log = logger.new_logger(verbose=verbose)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     occidx = mo_occ > 0
     viridx = mo_occ == 0

--- a/pyscf/prop/polarizability/uhf.py
+++ b/pyscf/prop/polarizability/uhf.py
@@ -22,7 +22,7 @@ Non-relativistic static and dynamic polarizability and hyper-polarizability tens
 '''
 
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -145,7 +145,7 @@ def hyper_polarizability(polobj, with_cphf=True):
 def ucphf_with_freq(mf, mo_energy, mo_occ, h1, freq=0,
                     max_cycle=20, tol=1e-9, hermi=False, verbose=logger.WARN):
     log = logger.new_logger(verbose=verbose)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     occidxa = mo_occ[0] > 0
     occidxb = mo_occ[1] > 0

--- a/pyscf/prop/rotational_gtensor/rhf.py
+++ b/pyscf/prop/rotational_gtensor/rhf.py
@@ -25,7 +25,7 @@ Refs:
 '''
 
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -152,7 +152,7 @@ class RotationalGTensor(rhf_mag.Magnetizability):
         return self
 
     def kernel(self):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
 

--- a/pyscf/prop/rotational_gtensor/rks.py
+++ b/pyscf/prop/rotational_gtensor/rks.py
@@ -21,7 +21,7 @@ Non-relativistic rotational g-tensor for DFT
 '''
 
 
-import time
+
 from pyscf.prop.nmr import rks as rks_nmr
 from pyscf.prop.rotational_gtensor import rhf as rhf_g
 from pyscf.prop.magnetizability import rks as rks_mag

--- a/pyscf/prop/ssc/dhf.py
+++ b/pyscf/prop/ssc/dhf.py
@@ -24,7 +24,7 @@
 '''
 
 
-import time
+
 import numpy
 import scipy.linalg
 from pyscf import lib
@@ -178,7 +178,7 @@ def make_h1(mol, mo_coeff, mo_occ, atmlst):
 
 def solve_mo1(sscobj, mo_energy=None, mo_coeff=None, mo_occ=None,
               h1=None, s1=None, with_cphf=None):
-    cput1 = (time.clock(), time.time())
+    cput1 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(sscobj.stdout, sscobj.verbose)
     if mo_energy is None: mo_energy = sscobj._scf.mo_energy
     if mo_coeff  is None: mo_coeff = sscobj._scf.mo_coeff
@@ -259,7 +259,7 @@ class SpinSpinCoupling(rhf_ssc.SpinSpinCoupling):
         return self
 
     def kernel(self, mo1=None):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
         mol = self.mol

--- a/pyscf/prop/ssc/rhf.py
+++ b/pyscf/prop/ssc/rhf.py
@@ -26,7 +26,7 @@ JCP 113, 9402 (2000); DOI:10.1063/1.1321296
 '''
 
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -143,7 +143,7 @@ def make_fc(sscobj, nuc_pair=None):
     return numpy.einsum(',k,xy->kxy', nist.ALPHA**4, para, numpy.eye(3))
 
 def solve_mo1_fc(sscobj, h1):
-    cput1 = (time.clock(), time.time())
+    cput1 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(sscobj.stdout, sscobj.verbose)
     mo_energy = sscobj._scf.mo_energy
     mo_coeff = sscobj._scf.mo_coeff
@@ -267,7 +267,7 @@ def _dm1_mo2ao(dm1, ket, bra):
 
 def solve_mo1(sscobj, mo_energy=None, mo_coeff=None, mo_occ=None,
               h1=None, s1=None, with_cphf=None):
-    cput1 = (time.clock(), time.time())
+    cput1 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(sscobj.stdout, sscobj.verbose)
     if mo_energy is None: mo_energy = sscobj._scf.mo_energy
     if mo_coeff  is None: mo_coeff = sscobj._scf.mo_coeff
@@ -371,7 +371,7 @@ class SpinSpinCoupling(lib.StreamObject):
         return self
 
     def kernel(self, mo1=None):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
         mol = self.mol

--- a/pyscf/prop/ssc/uhf.py
+++ b/pyscf/prop/ssc/uhf.py
@@ -21,7 +21,7 @@ Non-relativistic UHF spin-spin coupling (SSC) constants
 '''
 
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -119,7 +119,7 @@ def make_fc(sscobj, nuc_pair=None):
 
 # See also the UHF to GHF stability analysis
 def solve_mo1_fc(sscobj, h1):
-    cput1 = (time.clock(), time.time())
+    cput1 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(sscobj.stdout, sscobj.verbose)
     mol = sscobj.mol
     mf = sscobj._scf
@@ -323,7 +323,7 @@ def make_h1_fcsd(mol, mo_coeff, mo_occ, atmlst):
 
 def solve_mo1(sscobj, mo_energy=None, mo_coeff=None, mo_occ=None,
               h1=None, s1=None, with_cphf=None):
-    cput1 = (time.clock(), time.time())
+    cput1 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(sscobj.stdout, sscobj.verbose)
     if mo_energy is None: mo_energy = sscobj._scf.mo_energy
     if mo_coeff  is None: mo_coeff = sscobj._scf.mo_coeff
@@ -395,7 +395,7 @@ class SpinSpinCoupling(rhf_ssc.SpinSpinCoupling):
         if len(self.nuc_pair) == 0:
             return
 
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
         mol = self.mol

--- a/pyscf/prop/zfs/uhf.py
+++ b/pyscf/prop/zfs/uhf.py
@@ -26,7 +26,7 @@ Refs:
     JCP 127, 164112 (2007); 10.1063/1.2772857
 '''
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -189,7 +189,7 @@ def make_soc2e(zfsobj, mo_coeff, mo_occ):
     return haa, hab, hba, hbb
 
 def solve_mo1(sscobj, h1):
-    cput1 = (time.clock(), time.time())
+    cput1 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(sscobj.stdout, sscobj.verbose)
 
     mo_energy = sscobj._scf.mo_energy
@@ -311,7 +311,7 @@ class ZeroFieldSplitting(lib.StreamObject):
         return self
 
     def kernel(self, mo1=None):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
 

--- a/pyscf/rt/tdscf.py
+++ b/pyscf/rt/tdscf.py
@@ -91,9 +91,9 @@ class RTTDSCF(lib.StreamObject):
         self._keys = set(self.__dict__.keys())
 
         fmat, c_am, v_lm, rho = self.initialcondition(prm)
-        start = time.time()
+        start = logger.perf_counter()
         self.prop(fmat, c_am, v_lm, rho, output)
-        end = time.time()
+        end = logger.perf_counter()
         logger.info(self,"Propagation time: %f", end-start)
 
         logger.warn(self, 'RT-TDSCF is an experimental feature. It is '
@@ -372,7 +372,7 @@ class RTTDSCF(lib.StreamObject):
             v_lm: float
                 Transformation Matrix |LAO><MO|
         """
-        start = time.time()
+        start = logger.perf_counter()
         n_occ = int(sum(self.ks.mo_occ)/2)
         err = 100
         it = 0
@@ -422,7 +422,7 @@ class RTTDSCF(lib.StreamObject):
         logger.log(self, "Converged Energy: %f", etot)
         # logger.log(self, "Eigenvalues: %f", eigs.real)
         # print "Eigenvalues: ", eigs.real
-        end = time.time()
+        end = logger.perf_counter()
         logger.info(self, "Initial Fock Built time: %f", end-start)
         return fmat, c_am, v_lm
 
@@ -617,7 +617,7 @@ class RTTDSCF(lib.StreamObject):
         rhom12 = rho.copy()
         f = open(output,"a")
         logger.log(self,"\n\nPropagation Begins")
-        start = time.time()
+        start = logger.perf_counter()
         while (it<self.params["MaxIter"]):
             rho, rhom12, c_am, v_lm, fmat, jmat, kmat = self.tddftstep(fmat, c_am, v_lm, rho, rhom12, tnow)
             # rho = newrho.copy()
@@ -628,7 +628,7 @@ class RTTDSCF(lib.StreamObject):
             tnow = tnow + self.params["dt"]
             if it%self.params["StatusEvery"] ==0 or \
             it == self.params["MaxIter"]-1:
-                end = time.time()
+                end = logger.perf_counter()
                 logger.log(self, "%f hr/ps", \
                 (end - start)/(60*60*tnow * FSPERAU * 0.001))
             it = it + 1

--- a/pyscf/scf/cphf.py
+++ b/pyscf/scf/cphf.py
@@ -20,7 +20,7 @@
 Restricted coupled pertubed Hartree-Fock solver
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -50,7 +50,7 @@ def solve_nos1(fvind, mo_energy, mo_occ, h1,
                max_cycle=20, tol=1e-9, hermi=False, verbose=logger.WARN):
     '''For field independent basis. First order overlap matrix is zero'''
     log = logger.new_logger(verbose=verbose)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     e_a = mo_energy[mo_occ==0]
     e_i = mo_energy[mo_occ>0]
@@ -83,7 +83,7 @@ def solve_withs1(fvind, mo_energy, mo_occ, h1, s1,
         energy matrix
     '''
     log = logger.new_logger(verbose=verbose)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     occidx = mo_occ > 0
     viridx = mo_occ == 0

--- a/pyscf/scf/dhf.py
+++ b/pyscf/scf/dhf.py
@@ -20,7 +20,7 @@
 Dirac Hartree-Fock
 '''
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -504,7 +504,7 @@ class DHF(hf.SCF):
                omega=None):
         if mol is None: mol = self.mol
         if dm is None: dm = self.make_rdm1()
-        t0 = (time.clock(), time.time())
+        t0 = (logger.process_clock(), logger.perf_counter())
         log = logger.new_logger(self)
         if self.direct_scf and self.opt is None:
             self.opt = self.init_direct_scf(mol)
@@ -541,7 +541,7 @@ class DHF(hf.SCF):
             return vj - vk
 
     def scf(self, dm0=None):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         self.build()
         self.dump_flags()

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -22,7 +22,7 @@ Hartree-Fock
 
 import sys
 import tempfile
-import time
+
 from functools import reduce
 import numpy
 import scipy.linalg
@@ -112,7 +112,7 @@ def kernel(mf, conv_tol=1e-10, conv_tol_grad=None,
         raise RuntimeError('''
 You see this error message because of the API updates in pyscf v0.11.
 Keyword argument "init_dm" is replaced by "dm0"''')
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     if conv_tol_grad is None:
         conv_tol_grad = numpy.sqrt(conv_tol)
         logger.info(mf, 'Set gradient conv threshold to %g', conv_tol_grad)
@@ -1631,7 +1631,7 @@ class SCF(lib.StreamObject):
         converged SCF energy = -98.5521904482821
         -98.552190448282104
         '''
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
 
         self.dump_flags()
         self.build(self.mol)
@@ -1680,7 +1680,7 @@ class SCF(lib.StreamObject):
                omega=None):
         if mol is None: mol = self.mol
         if dm is None: dm = self.make_rdm1()
-        cpu0 = (time.clock(), time.time())
+        cpu0 = (logger.process_clock(), logger.perf_counter())
         if self.direct_scf and self.opt is None:
             self.opt = self.init_direct_scf(mol)
 

--- a/pyscf/scf/ucphf.py
+++ b/pyscf/scf/ucphf.py
@@ -20,7 +20,7 @@
 Unrestricted coupled pertubed Hartree-Fock solver
 '''
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
@@ -46,7 +46,7 @@ def solve_nos1(fvind, mo_energy, mo_occ, h1,
                max_cycle=20, tol=1e-9, hermi=False, verbose=logger.WARN):
     '''For field independent basis. First order overlap matrix is zero'''
     log = logger.new_logger(verbose=verbose)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     occidxa = mo_occ[0] > 0
     occidxb = mo_occ[1] > 0
@@ -90,7 +90,7 @@ def solve_withs1(fvind, mo_energy, mo_occ, h1, s1,
     e1 = h1 - s1*e0 + (e0_j-e0_i)*c1 + vhf[c1]
     '''
     log = logger.new_logger(verbose=verbose)
-    t0 = (time.clock(), time.time())
+    t0 = (logger.process_clock(), logger.perf_counter())
 
     occidxa = mo_occ[0] > 0
     occidxb = mo_occ[1] > 0

--- a/pyscf/sgx/sgx_jk.py
+++ b/pyscf/sgx/sgx_jk.py
@@ -42,7 +42,7 @@ sblk = 200
 Set mf.direct_scf = False because no traditional 2e integrals
 '''
 
-import time
+
 import ctypes
 import numpy
 import scipy.linalg
@@ -57,7 +57,7 @@ from pyscf.scf import _vhf
 
 def get_jk_favork(sgx, dm, hermi=1, with_j=True, with_k=True,
                   direct_scf_tol=1e-13):
-    t0 = time.clock(), time.time()
+    t0 = logger.process_clock(), logger.perf_counter()
     mol = sgx.mol
     grids = sgx.grids
     gthrd = sgx.grids_thrd
@@ -102,18 +102,18 @@ def get_jk_favork(sgx, dm, hermi=1, with_j=True, with_k=True,
             coords = coords[mask]
 
         if sgx.debug:
-            tnuc = tnuc[0] - time.clock(), tnuc[1] - time.time()
+            tnuc = tnuc[0] - logger.process_clock(), tnuc[1] - logger.perf_counter()
             gbn = batch_nuc(mol, coords)
-            tnuc = tnuc[0] + time.clock(), tnuc[1] + time.time()
+            tnuc = tnuc[0] + logger.process_clock(), tnuc[1] + logger.perf_counter()
             if with_j:
                 jg = numpy.einsum('gij,xij->xg', gbn, dms)
             if with_k:
                 gv = lib.einsum('gvt,xgt->xgv', gbn, fg)
             gbn = None
         else:
-            tnuc = tnuc[0] - time.clock(), tnuc[1] - time.time()
+            tnuc = tnuc[0] - logger.process_clock(), tnuc[1] - logger.perf_counter()
             jg, gv = batch_jk(mol, coords, dms, fg.copy())
-            tnuc = tnuc[0] + time.clock(), tnuc[1] + time.time()
+            tnuc = tnuc[0] + logger.process_clock(), tnuc[1] + logger.perf_counter()
 
         if with_j:
             xj = lib.einsum('gv,xg->xgv', ao, jg)
@@ -146,7 +146,7 @@ def get_jk_favork(sgx, dm, hermi=1, with_j=True, with_k=True,
 
 def get_jk_favorj(sgx, dm, hermi=1, with_j=True, with_k=True,
                   direct_scf_tol=1e-13):
-    t0 = time.clock(), time.time()
+    t0 = logger.process_clock(), logger.perf_counter()
     mol = sgx.mol
     grids = sgx.grids
     gthrd = sgx.grids_thrd
@@ -203,19 +203,19 @@ def get_jk_favorj(sgx, dm, hermi=1, with_j=True, with_k=True,
             rhog = None
 
         if sgx.debug:
-            tnuc = tnuc[0] - time.clock(), tnuc[1] - time.time()
+            tnuc = tnuc[0] - logger.process_clock(), tnuc[1] - logger.perf_counter()
             gbn = batch_nuc(mol, coords)
-            tnuc = tnuc[0] + time.clock(), tnuc[1] + time.time()
+            tnuc = tnuc[0] + logger.process_clock(), tnuc[1] + logger.perf_counter()
             if with_j:
                 jpart = numpy.einsum('guv,xg->xuv', gbn, rhog)
             if with_k:
                 gv = lib.einsum('gtv,xgt->xgv', gbn, fg)
             gbn = None
         else:
-            tnuc = tnuc[0] - time.clock(), tnuc[1] - time.time()
+            tnuc = tnuc[0] - logger.process_clock(), tnuc[1] - logger.perf_counter()
             if with_j: rhog = rhog.copy()
             jpart, gv = batch_jk(mol, coords, rhog, fg.copy())
-            tnuc = tnuc[0] + time.clock(), tnuc[1] + time.time()
+            tnuc = tnuc[0] + logger.process_clock(), tnuc[1] + logger.perf_counter()
 
         if with_j:
             vj += jpart
@@ -315,7 +315,7 @@ def _gen_jk_direct(mol, aosym, with_j, with_k, direct_scf_tol, sgxopt=None):
 # pre for get_k
 # Use default mesh grids and weights
 def get_gridss(mol, level=1, gthrd=1e-10):
-    Ktime = (time.clock(), time.time())
+    Ktime = (logger.process_clock(), logger.perf_counter())
     grids = dft.gen_grid.Grids(mol)
     grids.level = level
     grids.build()

--- a/pyscf/shciscf/shci.py
+++ b/pyscf/shciscf/shci.py
@@ -25,7 +25,7 @@ import ctypes
 import os
 import sys
 import struct
-import time
+
 import tempfile
 import warnings
 from subprocess import check_call
@@ -478,12 +478,12 @@ class SHCI(pyscf.lib.StreamObject):
                 logger.debug1(self, "SHCI Input conf")
                 logger.debug1(self, open(inFile, "r").read())
 
-            start = time.time()
+            start = logger.perf_counter()
             mpisave = self.mpiprefix
             # self.mpiprefix=""
             executeSHCI(self)
             self.mpiprefix = mpisave
-            end = time.time()
+            end = logger.perf_counter()
             print("......production of RDMs took %10.2f sec" % (end - start))
             sys.stdout.flush()
 
@@ -502,7 +502,7 @@ class SHCI(pyscf.lib.StreamObject):
         # are written as E3[i1,j2,k3,l3,m2,n1]
         # and are also stored here as E3[i1,j2,k3,l3,m2,n1]
         # This is NOT done with SQA in mind.
-        start = time.time()
+        start = logger.perf_counter()
         threepdm = numpy.zeros((norb, norb, norb, norb, norb, norb))
         file3pdm = "spatial3RDM.%d.%d.txt" % (state, state)
         with open(os.path.join(self.scratchDirectory, file3pdm), "r") as f:
@@ -518,7 +518,7 @@ class SHCI(pyscf.lib.StreamObject):
         twopdm /= nelectrons - 2
         onepdm = numpy.einsum("ijjk->ki", twopdm)
         onepdm /= nelectrons - 1
-        end = time.time()
+        end = logger.perf_counter()
         print("......reading the RDM took    %10.2f sec" % (end - start))
         sys.stdout.flush()
         return onepdm, twopdm, threepdm
@@ -568,12 +568,12 @@ class SHCI(pyscf.lib.StreamObject):
                 logger.debug1(self, "SHCI Input conf")
                 logger.debug1(self, open(inFile, "r").read())
 
-            start = time.time()
+            start = logger.perf_counter()
             mpisave = self.mpiprefix
             # self.mpiprefix=""
             executeSHCI(self)
             self.mpiprefix = mpisave
-            end = time.time()
+            end = logger.perf_counter()
             print("......production of RDMs took %10.2f sec" % (end - start))
             sys.stdout.flush()
 
@@ -591,7 +591,7 @@ class SHCI(pyscf.lib.StreamObject):
         # are written as E3[i1,j2,k3,l3,m2,n1]
         # and are stored here as E3[i1,j2,k3,n1,m2,l3]
         # This is done with SQA in mind.
-        start = time.time()
+        start = logger.perf_counter()
         if filetype == "binary":
             print("Reading binary 3RDM from DICE")
             fname = os.path.join(self.scratchDirectory, "spatial3RDM.%d.%d.bin" % (state, state))
@@ -622,7 +622,7 @@ class SHCI(pyscf.lib.StreamObject):
                     float(linesp[6]),
                 )
                 self.populate(E3, [a, b, c, f, e, d], integral)
-        end = time.time()
+        end = logger.perf_counter()
         print("......reading the RDM took    %10.2f sec" % (end - start))
         print("")
         sys.stdout.flush()
@@ -661,12 +661,12 @@ class SHCI(pyscf.lib.StreamObject):
                 logger.debug1(self, "SHCI Input conf")
                 logger.debug1(self, open(inFile, "r").read())
 
-            start = time.time()
+            start = logger.perf_counter()
             mpisave = self.mpiprefix
             # self.mpiprefix=""
             executeSHCI(self)
             self.mpiprefix = mpisave
-            end = time.time()
+            end = logger.perf_counter()
             print("......production of RDMs took %10.2f sec" % (end - start))
             sys.stdout.flush()
 
@@ -685,7 +685,7 @@ class SHCI(pyscf.lib.StreamObject):
         # are written as E4[i1,j2,k3,l4,m4,n3,o2,p1]
         # and are stored here as E4[i1,j2,k3,l4,p1,o2,n3,m4]
         # This is done with SQA in mind.
-        start = time.time()
+        start = logger.perf_counter()
         if filetype == "binary":
             print("Reading binary 4RDM from DICE")
             fname = os.path.join(self.scratchDirectory, "spatial4RDM.%d.%d.bin" % (state, state))
@@ -722,7 +722,7 @@ class SHCI(pyscf.lib.StreamObject):
                     float(linesp[8]),
                 )
                 self.populate(E4, [a, b, c, d, h, g, f, e], integral)
-        end = time.time()
+        end = logger.perf_counter()
         print("......reading the RDM took    %10.2f sec" % (end - start))
         print("")
         sys.stdout.flush()

--- a/pyscf/solvent/_ddcosmo_tdscf_grad.py
+++ b/pyscf/solvent/_ddcosmo_tdscf_grad.py
@@ -26,7 +26,7 @@ pyscf.grad.tduhf
 pyscf.grad.tduks
 '''
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -104,7 +104,7 @@ def tdrhf_grad_elec(td_grad, x_y, singlet=True, atmlst=None,
     See also function pyscf.grad.tdrhf.grad_elec
     '''
     log = logger.new_logger(td_grad, verbose)
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
 
     mol = td_grad.mol
     mf = td_grad.base._scf
@@ -239,7 +239,7 @@ def tdrks_grad_elec(td_grad, x_y, singlet=True, atmlst=None,
     See also function pyscf.grad.tdrks.grad_elec
     '''
     log = logger.new_logger(td_grad, verbose)
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
 
     mol = td_grad.mol
     mf = td_grad.base._scf
@@ -432,7 +432,7 @@ def tduhf_grad_elec(td_grad, x_y, atmlst=None, max_memory=2000, verbose=logger.I
     See also function pyscf.grad.tduhf.grad_elec
     '''
     log = logger.new_logger(td_grad, verbose)
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
 
     mol = td_grad.mol
     mf = td_grad.base._scf
@@ -632,7 +632,7 @@ def tduks_grad_elec(td_grad, x_y, atmlst=None, max_memory=2000, verbose=logger.I
     See also function pyscf.grad.tduks.grad_elec
     '''
     log = logger.new_logger(td_grad, verbose)
-    time0 = time.clock(), time.time()
+    time0 = logger.process_clock(), logger.perf_counter()
 
     mol = td_grad.mol
     mf = td_grad.base._scf

--- a/pyscf/soscf/ciah.py
+++ b/pyscf/soscf/ciah.py
@@ -17,7 +17,7 @@
 #
 
 import sys
-import time
+
 import numpy
 import scipy.linalg
 from pyscf import lib
@@ -76,7 +76,7 @@ class CIAHOptimizer(lib.StreamObject):
 
 
 def rotate_orb_cc(iah, u0, conv_tol_grad=None, verbose=logger.NOTE):
-    t2m = (time.clock(), time.time())
+    t2m = (logger.process_clock(), logger.perf_counter())
     if isinstance(verbose, logger.Logger):
         log = verbose
     else:

--- a/pyscf/soscf/newton_ah.py
+++ b/pyscf/soscf/newton_ah.py
@@ -21,7 +21,7 @@ Co-iterative augmented hessian second order SCF solver (CIAH-SOSCF)
 '''
 
 import sys
-import time
+
 from functools import reduce
 import numpy
 import scipy.linalg
@@ -328,7 +328,7 @@ def _rotate_orb_cc(mf, h1e, s1e, conv_tol_grad=None, verbose=None):
 #            x *= 1e-2/norm_x
         return x
 
-    t3m = (time.clock(), time.time())
+    t3m = (logger.process_clock(), logger.perf_counter())
     u = g_kf = g_orb = norm_gorb = dxi = kfcount = jkcount = None
     dm0 = vhf0 = None
     g_op = lambda: g_orb
@@ -465,7 +465,7 @@ def _rotate_orb_cc(mf, h1e, s1e, conv_tol_grad=None, verbose=None):
 def kernel(mf, mo_coeff=None, mo_occ=None, dm=None,
            conv_tol=1e-10, conv_tol_grad=None, max_cycle=50, dump_chk=True,
            callback=None, verbose=logger.NOTE):
-    cput0 = (time.clock(), time.time())
+    cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mf, verbose)
     mol = mf._scf.mol
     if mol != mf.mol:
@@ -681,7 +681,7 @@ class _CIAH_SOSCF(object):
         return self._scf.reset(mol)
 
     def kernel(self, mo_coeff=None, mo_occ=None, dm0=None):
-        cput0 = (time.clock(), time.time())
+        cput0 = (logger.process_clock(), logger.perf_counter())
         if dm0 is not None:
             if isinstance(dm0, str):
                 sys.stderr.write('Newton solver reads density matrix from chkfile %s\n' % dm0)

--- a/pyscf/tdscf/rhf.py
+++ b/pyscf/tdscf/rhf.py
@@ -21,7 +21,7 @@
 # Recent Advances in Density Functional Methods, Chapter 5, M. E. Casida
 #
 
-import time
+
 from functools import reduce
 import numpy
 from pyscf import lib
@@ -776,7 +776,7 @@ class TDA(lib.StreamObject):
     def kernel(self, x0=None, nstates=None):
         '''TDA diagonalization solver
         '''
-        cpu0 = (time.clock(), time.time())
+        cpu0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
         if nstates is None:
@@ -949,7 +949,7 @@ class TDHF(TDA):
     def kernel(self, x0=None, nstates=None):
         '''TDHF diagonalization with non-Hermitian eigenvalue solver
         '''
-        cpu0 = (time.clock(), time.time())
+        cpu0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
         if nstates is None:

--- a/pyscf/tdscf/rks.py
+++ b/pyscf/tdscf/rks.py
@@ -20,7 +20,7 @@
 # J. Mol. Struct. THEOCHEM, 914, 3
 #
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf import symm
@@ -105,7 +105,7 @@ class TDDFTNoHybrid(TDA):
     def kernel(self, x0=None, nstates=None):
         '''TDDFT diagonalization solver
         '''
-        cpu0 = (time.clock(), time.time())
+        cpu0 = (logger.process_clock(), logger.perf_counter())
         mf = self._scf
         if mf._numint.libxc.is_hybrid_xc(mf.xc):
             raise RuntimeError('%s cannot be used with hybrid functional'

--- a/pyscf/tdscf/rks.py
+++ b/pyscf/tdscf/rks.py
@@ -105,7 +105,7 @@ class TDDFTNoHybrid(TDA):
     def kernel(self, x0=None, nstates=None):
         '''TDDFT diagonalization solver
         '''
-        cpu0 = (logger.process_clock(), logger.perf_counter())
+        cpu0 = (lib.logger.process_clock(), lib.logger.perf_counter())
         mf = self._scf
         if mf._numint.libxc.is_hybrid_xc(mf.xc):
             raise RuntimeError('%s cannot be used with hybrid functional'

--- a/pyscf/tdscf/uhf.py
+++ b/pyscf/tdscf/uhf.py
@@ -16,7 +16,7 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-import time
+
 import numpy
 from pyscf import lib
 from pyscf import symm
@@ -658,7 +658,7 @@ class TDA(rhf.TDA):
     def kernel(self, x0=None, nstates=None):
         '''TDA diagonalization solver
         '''
-        cpu0 = (time.clock(), time.time())
+        cpu0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
         if nstates is None:
@@ -813,7 +813,7 @@ class TDHF(TDA):
     def kernel(self, x0=None, nstates=None):
         '''TDHF diagonalization with non-Hermitian eigenvalue solver
         '''
-        cpu0 = (time.clock(), time.time())
+        cpu0 = (logger.process_clock(), logger.perf_counter())
         self.check_sanity()
         self.dump_flags()
         if nstates is None:

--- a/pyscf/tdscf/uks.py
+++ b/pyscf/tdscf/uks.py
@@ -16,7 +16,7 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-import time
+
 import numpy
 from pyscf import symm
 from pyscf import lib
@@ -121,7 +121,7 @@ class TDDFTNoHybrid(TDA):
     def kernel(self, x0=None, nstates=None):
         '''TDDFT diagonalization solver
         '''
-        cpu0 = (time.clock(), time.time())
+        cpu0 = (logger.process_clock(), logger.perf_counter())
         mf = self._scf
         if mf._numint.libxc.is_hybrid_xc(mf.xc):
             raise RuntimeError('%s cannot be used with hybrid functional'

--- a/pyscf/x2c/x2c.py
+++ b/pyscf/x2c/x2c.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 
-import time
 from functools import reduce
 import copy
 import numpy
@@ -408,7 +407,7 @@ class X2C_UHF(hf.SCF):
                omega=None):
         if mol is None: mol = self.mol
         if dm is None: dm = self.make_rdm1()
-        t0 = (time.clock(), time.time())
+        t0 = (logger.process_clock(), logger.perf_counter())
         if self.direct_scf and self.opt is None:
             self.opt = self.init_direct_scf(mol)
         vj, vk = get_jk(mol, dm, hermi, self.opt, with_j, with_k)


### PR DESCRIPTION
This commit changes how the compatibility aliasing is done in the
pyscf logger. To accommodate differing time APIs the module was
previously overriding methods in stdlib time to accommodate changes in
behavior between python 2.x and newer version of python 3.x. However,
changing functions and overriding methods in an external module
(especially a stdlib module) is problematic and can break other
people's code using pyscf depending on documented behavior of the
external libraries. To fix this and not cause unexpected side effects
for users this changes how this compatibility aliasing is done, it uses
a local alias in the module and sets things to call the correct method
depending on the python version.

Fixes #814