### PR TITLE
allow for ghost atoms & IAOs/IBOs

### DIFF
--- a/pyscf/lo/iao.py
+++ b/pyscf/lo/iao.py
@@ -30,6 +30,7 @@ from pyscf import gto
 from pyscf import scf
 from pyscf import __config__
 from pyscf.lo.orth import vec_lowdin
+from pyscf.data.elements import is_ghost_atom
 
 # Alternately, use ANO for minao
 # orthogonalize iao with coefficients obtained by
@@ -110,6 +111,8 @@ def iao(mol, orbocc, minao=MINAO, kpts=None):
 def reference_mol(mol, minao=MINAO):
     '''Create a molecule which uses reference minimal basis'''
     pmol = mol.copy()
+    # remove ghost atoms
+    pmol.atom = [atom for atom in gto.format_atom(pmol.atom, unit='au') if not is_ghost_atom(atom[0])]
     if getattr(pmol, 'rcut', None) is not None:
         pmol.rcut = None
     pmol.build(False, False, basis=minao)

--- a/pyscf/lo/ibo.py
+++ b/pyscf/lo/ibo.py
@@ -86,7 +86,7 @@ def ibo(mol, orbocc, locmethod='IBO', iaos=None, s=None,
     return ibos
 
 def ibo_loc(mol, orbocc, iaos, s, exponent, grad_tol, max_iter,
-            minao, verbose=logger.NOTE):
+            minao=MINAO, verbose=logger.NOTE):
     '''Intrinsic Bonding Orbitals. [Ref. JCTC, 9, 4834]
 
     This implementation follows Knizia's implementation execept that the
@@ -215,7 +215,7 @@ def ibo_loc(mol, orbocc, iaos, s, exponent, grad_tol, max_iter,
     return numpy.dot(iaos, (orth.vec_lowdin(CIb)))
 
 
-def PipekMezey(mol, orbocc, iaos, s, exponent, minao):
+def PipekMezey(mol, orbocc, iaos, s, exponent, minao=MINAO):
     '''
     Note this localization is slightly different to Knizia's implementation.
     The localization here reserves orthogonormality during optimization.

--- a/pyscf/lo/ibo.py
+++ b/pyscf/lo/ibo.py
@@ -34,7 +34,10 @@ from pyscf.lo import iao
 from pyscf.lo import orth, pipek
 from pyscf import __config__
 
-def ibo(mol, orbocc, locmethod='IBO', iaos=None, s=None, exponent=4, grad_tol=1e-8, max_iter=200, verbose=logger.NOTE):
+MINAO = getattr(__config__, 'lo_iao_minao', 'minao')
+
+def ibo(mol, orbocc, locmethod='IBO', iaos=None, s=None,
+        exponent=4, grad_tol=1e-8, max_iter=200, verbose=logger.NOTE):
     '''Intrinsic Bonding Orbitals
 
     This function serves as a wrapper to the underlying localization functions
@@ -81,7 +84,7 @@ def ibo(mol, orbocc, locmethod='IBO', iaos=None, s=None, exponent=4, grad_tol=1e
     return ibos
 
 def ibo_loc(mol, orbocc, iaos, s, exponent, grad_tol, max_iter,
-            verbose=logger.NOTE):
+            minao=MINAO, verbose=logger.NOTE):
     '''Intrinsic Bonding Orbitals. [Ref. JCTC, 9, 4834]
 
     This implementation follows Knizia's implementation execept that the
@@ -126,7 +129,9 @@ def ibo_loc(mol, orbocc, iaos, s, exponent, grad_tol, max_iter,
     #dynamic variables
     Converged = False
 
-    Atoms  = [mol.atom_symbol(i) for i in range(mol.natm)]
+    # render Atoms list without ghost atoms
+    iao_mol = iao.reference_mol(mol, minao=minao)
+    Atoms = [iao_mol.atom_pure_symbol(i) for i in range(iao_mol.natm)]
 
     #generates the parameters we need about the atomic structure
     nAtoms = len(Atoms)
@@ -231,7 +236,6 @@ def PipekMezey(mol, orbocc, iaos, s, exponent):
     # Note: PM with Lowdin-orth IAOs is implemented in pipek.PM class
     # TODO: Merge the implemenation here to pipek.PM
 
-    MINAO = getattr(__config__, 'lo_iao_minao', 'minao')
     cs = numpy.dot(iaos.T.conj(), s)
     s_iao = numpy.dot(cs, iaos)
     iao_inv = numpy.linalg.solve(s_iao, cs)
@@ -400,3 +404,4 @@ def MakeAtomIbOffsets(Atoms):
         iBfAt.append(iBfAt[-1] + nAoX[Atom])
     return iBfAt, nCoreX, nAoX, AoLabels
 
+del(MINAO)

--- a/pyscf/lo/ibo.py
+++ b/pyscf/lo/ibo.py
@@ -37,7 +37,7 @@ from pyscf import __config__
 MINAO = getattr(__config__, 'lo_iao_minao', 'minao')
 
 def ibo(mol, orbocc, locmethod='IBO', iaos=None, s=None,
-        exponent=4, grad_tol=1e-8, max_iter=200, verbose=logger.NOTE):
+        exponent=4, grad_tol=1e-8, max_iter=200, minao=MINAO, verbose=logger.NOTE):
     '''Intrinsic Bonding Orbitals
 
     This function serves as a wrapper to the underlying localization functions
@@ -77,14 +77,16 @@ def ibo(mol, orbocc, locmethod='IBO', iaos=None, s=None,
     locmethod = locmethod.strip().upper()
     if locmethod == 'PM':
         EXPONENT = getattr(__config__, 'lo_ibo_PipekMezey_exponent', exponent)
-        ibos = PipekMezey(mol, orbocc, iaos, s, exponent=EXPONENT)
+        ibos = PipekMezey(mol, orbocc, iaos, s, exponent=EXPONENT, minao=minao)
         del(EXPONENT)
     else:
-        ibos = ibo_loc(mol, orbocc, iaos, s, exponent=exponent, grad_tol=grad_tol, max_iter=max_iter, verbose=verbose)
+        ibos = ibo_loc(mol, orbocc, iaos, s, exponent=exponent, \
+                       grad_tol=grad_tol, max_iter=max_iter, \
+                       minao=minao, verbose=verbose)
     return ibos
 
 def ibo_loc(mol, orbocc, iaos, s, exponent, grad_tol, max_iter,
-            minao=MINAO, verbose=logger.NOTE):
+            minao, verbose=logger.NOTE):
     '''Intrinsic Bonding Orbitals. [Ref. JCTC, 9, 4834]
 
     This implementation follows Knizia's implementation execept that the
@@ -213,7 +215,7 @@ def ibo_loc(mol, orbocc, iaos, s, exponent, grad_tol, max_iter,
     return numpy.dot(iaos, (orth.vec_lowdin(CIb)))
 
 
-def PipekMezey(mol, orbocc, iaos, s, exponent):
+def PipekMezey(mol, orbocc, iaos, s, exponent, minao):
     '''
     Note this localization is slightly different to Knizia's implementation.
     The localization here reserves orthogonormality during optimization.
@@ -239,7 +241,7 @@ def PipekMezey(mol, orbocc, iaos, s, exponent):
     cs = numpy.dot(iaos.T.conj(), s)
     s_iao = numpy.dot(cs, iaos)
     iao_inv = numpy.linalg.solve(s_iao, cs)
-    iao_mol = iao.reference_mol(mol, minao=MINAO)
+    iao_mol = iao.reference_mol(mol, minao=minao)
 
     # Define the mulliken population of each atom based on IAO basis.
     # proj[i].trace is the mulliken population of atom i.


### PR DESCRIPTION
This pull request references issue #802 

These simple changes will allow for IAOs/IBOs with a molecular input containing ghost atoms.
