### PR TITLE
Example on how to restructure the examples directory

### DIFF
--- a/examples/scf/00-simple_hf.py
+++ b/examples/scf/00-simple_hf.py
@@ -11,29 +11,13 @@ A simple example to run HF calculation.
 '''
 
 import pyscf
+from systems import mol_HF_ccpvdz
 
-mol = pyscf.M(
-    atom = 'H 0 0 0; F 0 0 1.1',  # in Angstrom
-    basis = 'ccpvdz',
-    symmetry = True,
-)
-
-myhf = mol.HF()
+myhf = mol_HF_ccpvdz.HF()
 myhf.kernel()
-
 # Orbital energies, Mulliken population etc.
 myhf.analyze()
 
-
-#
 # myhf object can also be created using the APIs of gto, scf module
-#
-from pyscf import gto, scf
-mol = gto.M(
-    atom = 'H 0 0 0; F 0 0 1.1',  # in Angstrom
-    basis = 'ccpvdz',
-    symmetry = True,
-)
-myhf = scf.HF(mol)
+myhf = pyscf.scf.HF(mol_HF_ccpvdz)
 myhf.kernel()
-

--- a/examples/scf/01-h2o.py
+++ b/examples/scf/01-h2o.py
@@ -4,36 +4,11 @@
 #
 
 '''
-Another input style.
-
-There are three different methods to initialize a Mole object.
-1. To use function pyscf.M or gto.M as shown by 00-simple_hf.py.
-2. As this script did, first create gto.Mole object, assign value to each
-   attributes (see pyscf/gto/mole.py file for the details of attributes), then
-   call mol.build() to initialize the mol object.
-3. First create Mole object, then call .build() function with keyword arguments
-   eg
-
-   >>> mol = gto.Mole()
-   >>> mol.build(atom='O 0 0 0; H 0 -2.757 2.587; H 0 2.757  2.587', basis='ccpvdz', symmetry=1)
-
-mol.build() should be called to update the Mole object whenever Mole's
-attributes are changed in your script. Note to mute the noise produced by
-mol.build function, you can execute mol.build(0,0) instead.
+The contents of this example got moved to systems.py
 '''
 
-from pyscf import gto, scf
+from pyscf import scf
+from systems import mol_H2O_ccpvdz
 
-mol = gto.Mole()
-mol.verbose = 5
-#mol.output = 'out_h2o'
-mol.atom = '''
-O 0 0      0
-H 0 -2.757 2.587
-H 0  2.757 2.587'''
-mol.basis = 'ccpvdz'
-mol.symmetry = 1
-mol.build()
-
-mf = scf.RHF(mol)
+mf = scf.RHF(mol_H2O_ccpvdz)
 mf.kernel()

--- a/examples/scf/systems.py
+++ b/examples/scf/systems.py
@@ -1,0 +1,37 @@
+import pyscf
+
+'''There are three different methods to initialize a Mole object.
+1. Using the function pyscf.M or gto.M:
+
+'''
+mol_HF_ccpvdz = pyscf.M(
+    atom = 'H 0 0 0; F 0 0 1.1',  # in Angstrom
+    basis = 'ccpvdz',
+    symmetry = True
+)
+
+'''2. First creating a gto.Mole object, then assigning a value to each
+of the attributes (see pyscf/gto/mole.py file for the details of
+attributes), then calling mol.build() to initialize the mol object.
+
+'''
+mol_H2O_ccpvdz = gto.Mole()
+mol_H2O_ccpvdz.verbose = 5
+mol_H2O_ccpvdz.atom = '''
+O 0 0      0
+H 0 -2.757 2.587
+H 0  2.757 2.587'''
+mol_H2O_ccpvdz.basis = 'ccpvdz'
+mol_H2O_ccpvdz.symmetry = 1
+mol_H2O_ccpvdz.build()
+
+''' 3. First creating a Mole object, then calling .build() function
+with keyword arguments e.g.
+
+   >>> mol = gto.Mole()
+   >>> mol.build(atom='O 0 0 0; H 0 -2.757 2.587; H 0 2.757  2.587', basis='ccpvdz', symmetry=1)
+
+mol.build() should be called to update the Mole object whenever Mole's
+attributes are changed in your script. Note to mute the noise produced by
+mol.build function, you can execute mol.build(0,0) instead.
+'''


### PR DESCRIPTION
As was just discussed on Slack, it'd be good to refactor the examples in a way that they can be included verbatim in the user documentation. This means removing any redundant, lower-level entries in the example code so that the example can focus on the task at hand.

The way I see this is that the first examples discuss the `gto` module and show how to build molecules in PySCF. Next, in the SCF examples, the code can just `import` the molecules from the `gto` examples, and discuss how to set up SCF calculations. Similarly, in MP2 and CC examples, the HF calculation can be `import`ed from the SCF example, so the only code that is necessary is the bit to do the MP2/CC calculation.

The benefits of this approach are that

-  the example codes will be more focused on the task at hand,
-  they'll become shorter so they'll easily fit in a PDF manual,
-  there'll be no code duplication between the PySCF examples and the user manual,
-  the examples in the manual will be included in the continuous integration tests, and
-  the users can easily run the examples in the manual just by running the PySCF example file.