### PR TITLE
Various minor DFT changes

### DIFF
--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -622,8 +622,8 @@ def _dot_ao_dm(mol, ao, dm, non0tab, shls_slice, ao_loc, nbas, out=None):
        ao.ctypes.data_as(ctypes.c_void_p),
        dm.ctypes.data_as(ctypes.c_void_p),
        ctypes.c_int(nao), ctypes.c_int(dm.shape[1]),
-       ctypes.c_int(ngrids), pnbas,
-       pnon0tab, pshls_slice, ctypes.c_int(nbas))
+       ctypes.c_int(ngrids), ctypes.c_int(nbas),
+       pnon0tab, pshls_slice, pao_loc)
     return vm
 
 def _scale_ao(ao, wv, out=None):

--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -610,7 +610,7 @@ def _dot_ao_dm(mol, ao, dm, non0tab, shls_slice, ao_loc, nbas, out=None):
         dm = numpy.asarray(dm, numpy.complex128)
 
     if non0tab is None or shls_slice is None or ao_loc is None:
-        pnon0tab = pshls_slice = pao_loc = pnbas = lib.c_null_ptr()
+        pnon0tab = pshls_slice = pao_loc = lib.c_null_ptr()
     else:
         pnon0tab    = non0tab.ctypes.data_as(ctypes.c_void_p)
         pshls_slice = (ctypes.c_int*2)(*shls_slice)

--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -610,11 +610,12 @@ def _dot_ao_dm(mol, ao, dm, non0tab, shls_slice, ao_loc, nbas, out=None):
         dm = numpy.asarray(dm, numpy.complex128)
 
     if non0tab is None or shls_slice is None or ao_loc is None:
-        pnon0tab = pshls_slice = pao_loc = lib.c_null_ptr()
+        pnon0tab = pshls_slice = pao_loc = pnbas = lib.c_null_ptr()
     else:
         pnon0tab    = non0tab.ctypes.data_as(ctypes.c_void_p)
         pshls_slice = (ctypes.c_int*2)(*shls_slice)
         pao_loc     = ao_loc.ctypes.data_as(ctypes.c_void_p)
+        pnbas       = ctypes.c_int(nbas)
 
     vm = numpy.ndarray((ngrids,dm.shape[1]), dtype=ao.dtype, order='F', buffer=out)
     dm = numpy.asarray(dm, order='C')
@@ -622,7 +623,7 @@ def _dot_ao_dm(mol, ao, dm, non0tab, shls_slice, ao_loc, nbas, out=None):
        ao.ctypes.data_as(ctypes.c_void_p),
        dm.ctypes.data_as(ctypes.c_void_p),
        ctypes.c_int(nao), ctypes.c_int(dm.shape[1]),
-       ctypes.c_int(ngrids), ctypes.c_int(nbas),
+       ctypes.c_int(ngrids), pnbas,
        pnon0tab, pshls_slice, pao_loc)
     return vm
 

--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -615,7 +615,6 @@ def _dot_ao_dm(mol, ao, dm, non0tab, shls_slice, ao_loc, nbas, out=None):
         pnon0tab    = non0tab.ctypes.data_as(ctypes.c_void_p)
         pshls_slice = (ctypes.c_int*2)(*shls_slice)
         pao_loc     = ao_loc.ctypes.data_as(ctypes.c_void_p)
-        pnbas       = ctypes.c_int(nbas)
 
     vm = numpy.ndarray((ngrids,dm.shape[1]), dtype=ao.dtype, order='F', buffer=out)
     dm = numpy.asarray(dm, order='C')
@@ -624,7 +623,7 @@ def _dot_ao_dm(mol, ao, dm, non0tab, shls_slice, ao_loc, nbas, out=None):
        dm.ctypes.data_as(ctypes.c_void_p),
        ctypes.c_int(nao), ctypes.c_int(dm.shape[1]),
        ctypes.c_int(ngrids), pnbas,
-       pnon0tab, pshls_slice, pao_loc)
+       pnon0tab, pshls_slice, ctypes.c_int(nbas))
     return vm
 
 def _scale_ao(ao, wv, out=None):

--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -102,7 +102,7 @@ def eval_ao(mol, coords, deriv=0, shls_slice=None,
     return mol.eval_gto(feval, coords, comp, shls_slice, non0tab, out=out)
 
 #TODO: \nabla^2 rho and tau = 1/2 (\nabla f)^2
-def eval_rho(mol, ao, dm, non0tab=None, xctype='LDA', hermi=0, verbose=None):
+def eval_rho(mol, ao, dm, non0tab=None, xctype='LDA', hermi=0, idx=None, verbose=None):
     r'''Calculate the electron density for LDA functional, and the density
     derivatives for GGA functional.
 
@@ -125,6 +125,8 @@ def eval_rho(mol, ao, dm, non0tab=None, xctype='LDA', hermi=0, verbose=None):
             LDA/GGA/mGGA.  It affects the shape of the return density.
         hermi : bool
             dm is hermitian or not
+        idx : 1D integer array
+            mask array to restrict the contraction between ao and dm in _contract_rho().
         verbose : int or object of :class:`Logger`
             No effects.
 
@@ -162,15 +164,15 @@ def eval_rho(mol, ao, dm, non0tab=None, xctype='LDA', hermi=0, verbose=None):
     if xctype == 'LDA' or xctype == 'HF':
         c0 = _dot_ao_dm(mol, ao, dm, non0tab, shls_slice, ao_loc)
         #:rho = numpy.einsum('pi,pi->p', ao, c0)
-        rho = _contract_rho(ao, c0)
+        rho = _contract_rho(ao, c0, idx)
     elif xctype in ('GGA', 'NLC'):
         rho = numpy.empty((4,ngrids))
         c0 = _dot_ao_dm(mol, ao[0], dm, non0tab, shls_slice, ao_loc)
         #:rho[0] = numpy.einsum('pi,pi->p', c0, ao[0])
-        rho[0] = _contract_rho(c0, ao[0])
+        rho[0] = _contract_rho(c0, ao[0], idx)
         for i in range(1, 4):
             #:rho[i] = numpy.einsum('pi,pi->p', c0, ao[i])
-            rho[i] = _contract_rho(c0, ao[i])
+            rho[i] = _contract_rho(c0, ao[i], idx)
             rho[i] *= 2 # *2 for +c.c. in the next two lines
             #c1 = _dot_ao_dm(mol, ao[i], dm, non0tab, shls_slice, ao_loc)
             #rho[i] += numpy.einsum('pi,pi->p', c1, ao[0])
@@ -179,25 +181,24 @@ def eval_rho(mol, ao, dm, non0tab=None, xctype='LDA', hermi=0, verbose=None):
         rho = numpy.empty((6,ngrids))
         c0 = _dot_ao_dm(mol, ao[0], dm, non0tab, shls_slice, ao_loc)
         #:rho[0] = numpy.einsum('pi,pi->p', ao[0], c0)
-        rho[0] = _contract_rho(ao[0], c0)
+        rho[0] = _contract_rho(ao[0], c0, idx)
         rho[5] = 0
         for i in range(1, 4):
             #:rho[i] = numpy.einsum('pi,pi->p', c0, ao[i]) * 2 # *2 for +c.c.
-            rho[i] = _contract_rho(c0, ao[i]) * 2
+            rho[i] = _contract_rho(c0, ao[i], idx) * 2
             c1 = _dot_ao_dm(mol, ao[i], dm.T, non0tab, shls_slice, ao_loc)
             #:rho[5] += numpy.einsum('pi,pi->p', c1, ao[i])
-            rho[5] += _contract_rho(c1, ao[i])
+            rho[5] += _contract_rho(c1, ao[i], idx)
         XX, YY, ZZ = 4, 7, 9
         ao2 = ao[XX] + ao[YY] + ao[ZZ]
         #:rho[4] = numpy.einsum('pi,pi->p', c0, ao2)
-        rho[4] = _contract_rho(c0, ao2)
+        rho[4] = _contract_rho(c0, ao2, idx)
         rho[4] += rho[5]
         rho[4] *= 2
         rho[5] *= .5
     return rho
 
-def eval_rho2(mol, ao, mo_coeff, mo_occ, non0tab=None, xctype='LDA',
-              verbose=None):
+def eval_rho2(mol, ao, mo_coeff, mo_occ, non0tab=None, xctype='LDA', idx=None, verbose=None):
     r'''Calculate the electron density for LDA functional, and the density
     derivatives for GGA functional.  This function has the same functionality
     as :func:`eval_rho` except that the density are evaluated based on orbital
@@ -221,6 +222,8 @@ def eval_rho2(mol, ao, mo_coeff, mo_occ, non0tab=None, xctype='LDA',
             array can be obtained by calling :func:`make_mask`
         xctype : str
             LDA/GGA/mGGA.  It affects the shape of the return density.
+        idx : 1D integer array
+            mask array to restrict the contraction between ao and dm in _contract_rho().
         verbose : int or object of :class:`Logger`
             No effects.
 
@@ -247,34 +250,34 @@ def eval_rho2(mol, ao, mo_coeff, mo_occ, non0tab=None, xctype='LDA',
         if xctype == 'LDA' or xctype == 'HF':
             c0 = _dot_ao_dm(mol, ao, cpos, non0tab, shls_slice, ao_loc)
             #:rho = numpy.einsum('pi,pi->p', c0, c0)
-            rho = _contract_rho(c0, c0)
+            rho = _contract_rho(c0, c0, idx)
         elif xctype in ('GGA', 'NLC'):
             rho = numpy.empty((4,ngrids))
             c0 = _dot_ao_dm(mol, ao[0], cpos, non0tab, shls_slice, ao_loc)
             #:rho[0] = numpy.einsum('pi,pi->p', c0, c0)
-            rho[0] = _contract_rho(c0, c0)
+            rho[0] = _contract_rho(c0, c0, idx)
             for i in range(1, 4):
                 c1 = _dot_ao_dm(mol, ao[i], cpos, non0tab, shls_slice, ao_loc)
                 #:rho[i] = numpy.einsum('pi,pi->p', c0, c1) * 2 # *2 for +c.c.
-                rho[i] = _contract_rho(c0, c1) * 2
+                rho[i] = _contract_rho(c0, c1, idx) * 2
         else: # meta-GGA
             # rho[4] = \nabla^2 rho, rho[5] = 1/2 |nabla f|^2
             rho = numpy.empty((6,ngrids))
             c0 = _dot_ao_dm(mol, ao[0], cpos, non0tab, shls_slice, ao_loc)
             #:rho[0] = numpy.einsum('pi,pi->p', c0, c0)
-            rho[0] = _contract_rho(c0, c0)
+            rho[0] = _contract_rho(c0, c0, idx)
             rho[5] = 0
             for i in range(1, 4):
                 c1 = _dot_ao_dm(mol, ao[i], cpos, non0tab, shls_slice, ao_loc)
                 #:rho[i] = numpy.einsum('pi,pi->p', c0, c1) * 2 # *2 for +c.c.
                 #:rho[5] += numpy.einsum('pi,pi->p', c1, c1)
-                rho[i] = _contract_rho(c0, c1) * 2
-                rho[5] += _contract_rho(c1, c1)
+                rho[i] = _contract_rho(c0, c1, idx) * 2
+                rho[5] += _contract_rho(c1, c1, idx)
             XX, YY, ZZ = 4, 7, 9
             ao2 = ao[XX] + ao[YY] + ao[ZZ]
             c1 = _dot_ao_dm(mol, ao2, cpos, non0tab, shls_slice, ao_loc)
             #:rho[4] = numpy.einsum('pi,pi->p', c0, c1)
-            rho[4] = _contract_rho(c0, c1)
+            rho[4] = _contract_rho(c0, c1, idx)
             rho[4] += rho[5]
             rho[4] *= 2
 
@@ -293,31 +296,31 @@ def eval_rho2(mol, ao, mo_coeff, mo_occ, non0tab=None, xctype='LDA',
         if xctype == 'LDA' or xctype == 'HF':
             c0 = _dot_ao_dm(mol, ao, cneg, non0tab, shls_slice, ao_loc)
             #:rho -= numpy.einsum('pi,pi->p', c0, c0)
-            rho -= _contract_rho(c0, c0)
+            rho -= _contract_rho(c0, c0, idx)
         elif xctype == 'GGA':
             c0 = _dot_ao_dm(mol, ao[0], cneg, non0tab, shls_slice, ao_loc)
             #:rho[0] -= numpy.einsum('pi,pi->p', c0, c0)
-            rho[0] -= _contract_rho(c0, c0)
+            rho[0] -= _contract_rho(c0, c0, idx)
             for i in range(1, 4):
                 c1 = _dot_ao_dm(mol, ao[i], cneg, non0tab, shls_slice, ao_loc)
                 #:rho[i] -= numpy.einsum('pi,pi->p', c0, c1) * 2 # *2 for +c.c.
-                rho[i] -= _contract_rho(c0, c1) * 2 # *2 for +c.c.
+                rho[i] -= _contract_rho(c0, c1, idx) * 2 # *2 for +c.c.
         else:
             c0 = _dot_ao_dm(mol, ao[0], cneg, non0tab, shls_slice, ao_loc)
             #:rho[0] -= numpy.einsum('pi,pi->p', c0, c0)
-            rho[0] -= _contract_rho(c0, c0)
+            rho[0] -= _contract_rho(c0, c0, idx)
             rho5 = 0
             for i in range(1, 4):
                 c1 = _dot_ao_dm(mol, ao[i], cneg, non0tab, shls_slice, ao_loc)
                 #:rho[i] -= numpy.einsum('pi,pi->p', c0, c1) * 2 # *2 for +c.c.
                 #:rho5 += numpy.einsum('pi,pi->p', c1, c1)
-                rho[i] -= _contract_rho(c0, c1) * 2 # *2 for +c.c.
-                rho5 += _contract_rho(c1, c1)
+                rho[i] -= _contract_rho(c0, c1, idx) * 2 # *2 for +c.c.
+                rho5 += _contract_rho(c1, c1, idx)
             XX, YY, ZZ = 4, 7, 9
             ao2 = ao[XX] + ao[YY] + ao[ZZ]
             c1 = _dot_ao_dm(mol, ao2, cneg, non0tab, shls_slice, ao_loc)
             #:rho[4] -= numpy.einsum('pi,pi->p', c0, c1) * 2
-            rho[4] -= _contract_rho(c0, c1) * 2
+            rho[4] -= _contract_rho(c0, c1, idx) * 2
             rho[4] -= rho5 * 2
 
             rho[5] -= rho5 * .5
@@ -638,11 +641,14 @@ def _scale_ao(ao, wv, out=None):
         aow = numpy.einsum('nip,np->pi', ao, wv)
     return aow
 
-def _contract_rho(bra, ket):
+def _contract_rho(bra, ket, idx):
     #:rho  = numpy.einsum('pi,pi->p', bra.real, ket.real)
     #:rho += numpy.einsum('pi,pi->p', bra.imag, ket.imag)
     bra = bra.T
     ket = ket.T
+    if idx is not None:
+        bra = bra[idx]
+        ket = ket[idx]
     nao, ngrids = bra.shape
     rho = numpy.empty(ngrids)
 

--- a/pyscf/dft/r_numint.py
+++ b/pyscf/dft/r_numint.py
@@ -58,13 +58,13 @@ def eval_ao(mol, coords, deriv=0, with_s=True, shls_slice=None,
     else:
         return aoLa, aoLb
 
-def _dm2c_to_rho2x2(mol, ao, dm, non0tab, shls_slice, ao_loc, out=None):
+def _dm2c_to_rho2x2(mol, ao, dm, non0tab, shls_slice, ao_loc, nbas, out=None):
     aoa, aob = ao
-    out = _dot_ao_dm(mol, aoa, dm, non0tab, shls_slice, ao_loc, out=out)
+    out = _dot_ao_dm(mol, aoa, dm, non0tab, shls_slice, ao_loc, nbas, out=out)
     rhoaa = numpy.einsum('pi,pi->p', aoa.real, out.real)
     rhoaa+= numpy.einsum('pi,pi->p', aoa.imag, out.imag)
     rhoba = numpy.einsum('pi,pi->p', aob, out.conj())
-    out = _dot_ao_dm(mol, aob, dm, non0tab, shls_slice, ao_loc, out=out)
+    out = _dot_ao_dm(mol, aob, dm, non0tab, shls_slice, ao_loc, nbas, out=out)
     rhoab = numpy.einsum('pi,pi->p', aoa, out.conj())
     rhobb = numpy.einsum('pi,pi->p', aob.real, out.real)
     rhobb+= numpy.einsum('pi,pi->p', aob.imag, out.imag)
@@ -90,9 +90,10 @@ def eval_rho(mol, ao, dm, non0tab=None, xctype='LDA', hermi=0, verbose=None):
                              dtype=numpy.uint8)
     shls_slice = (0, mol.nbas)
     ao_loc = mol.ao_loc_2c()
+    nbas = mol.nbas
 
     if xctype == 'LDA':
-        tmp = _dm2c_to_rho2x2(mol, ao, dm, non0tab, shls_slice, ao_loc)
+        tmp = _dm2c_to_rho2x2(mol, ao, dm, non0tab, shls_slice, ao_loc, nbas)
         rho, m = _rho2x2_to_rho_m(tmp)
     elif xctype == 'GGA':
         raise NotImplementedError

--- a/pyscf/dft/test/test_numint.py
+++ b/pyscf/dft/test/test_numint.py
@@ -80,8 +80,8 @@ class KnownValues(unittest.TestCase):
         ao_loc = h4.ao_loc_nr()
         ao = mf_h4._numint.eval_ao(h4, mf_h4.grids.coords).copy() + 0j
         nao = ao.shape[1]
-        v1 = dft.numint._dot_ao_dm(h4, ao, dm, mf_h4.grids.non0tab, (0,h4.nbas), ao_loc)
-        v2 = dft.numint._dot_ao_dm(h4, ao, dm, None, None, None)
+        v1 = dft.numint._dot_ao_dm(h4, ao, dm, mf_h4.grids.non0tab, (0,h4.nbas), ao_loc, h4.nbas)
+        v2 = dft.numint._dot_ao_dm(h4, ao, dm, None, None, None, None)
         self.assertAlmostEqual(abs(v1-v2).max(), 0, 9)
 
     def test_dot_ao_dm_high_cost(self):
@@ -94,7 +94,7 @@ class KnownValues(unittest.TestCase):
         dm = dm + dm.T
         res0 = lib.dot(ao, dm)
         res1 = dft.numint._dot_ao_dm(mol, ao, dm, non0tab,
-                                     shls_slice=(0,mol.nbas), ao_loc=ao_loc)
+                                     shls_slice=(0,mol.nbas), ao_loc=ao_loc, nbas=mol.nbas)
         self.assertTrue(numpy.allclose(res0, res1))
 
     def test_dot_ao_ao(self):

--- a/pyscf/dft/test/test_numint.py
+++ b/pyscf/dft/test/test_numint.py
@@ -81,7 +81,7 @@ class KnownValues(unittest.TestCase):
         ao = mf_h4._numint.eval_ao(h4, mf_h4.grids.coords).copy() + 0j
         nao = ao.shape[1]
         v1 = dft.numint._dot_ao_dm(h4, ao, dm, mf_h4.grids.non0tab, (0,h4.nbas), ao_loc, h4.nbas)
-        v2 = dft.numint._dot_ao_dm(h4, ao, dm, None, None, None, None)
+        v2 = dft.numint._dot_ao_dm(h4, ao, dm, None, None, None, h4.nbas)
         self.assertAlmostEqual(abs(v1-v2).max(), 0, 9)
 
     def test_dot_ao_dm_high_cost(self):

--- a/pyscf/eph/uks.py
+++ b/pyscf/eph/uks.py
@@ -43,8 +43,9 @@ def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
     nao, nmo = mo_coeff[0].shape
     ni = mf._numint
     xctype = ni._xc_type(mf.xc)
+    nbas = mol.nbas
     aoslices = mol.aoslice_by_atom()
-    shls_slice = (0, mol.nbas)
+    shls_slice = (0, nbas)
     ao_loc = mol.ao_loc_nr()
     dm0a, dm0b = mf.make_rdm1(mo_coeff, mo_occ)
 
@@ -61,8 +62,8 @@ def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
             vrho = vxc[0]
             u_u, u_d, d_d = fxc[0].T
 
-            ao_dm0a = numint._dot_ao_dm(mol, ao[0], dm0a, mask, shls_slice, ao_loc)
-            ao_dm0b = numint._dot_ao_dm(mol, ao[0], dm0b, mask, shls_slice, ao_loc)
+            ao_dm0a = numint._dot_ao_dm(mol, ao[0], dm0a, mask, shls_slice, ao_loc, nbas)
+            ao_dm0b = numint._dot_ao_dm(mol, ao[0], dm0b, mask, shls_slice, ao_loc, nbas)
             for ia in range(mol.natm):
                 p0, p1 = aoslices[ia][2:]
 # First order density = rho1 * 2.  *2 is not applied because + c.c. in the end
@@ -94,9 +95,9 @@ def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
 
             wva, wvb = numint._uks_gga_wv0((rhoa,rhob), vxc, weight)
 
-            ao_dm0a = [numint._dot_ao_dm(mol, ao[i], dm0a, mask, shls_slice, ao_loc)
+            ao_dm0a = [numint._dot_ao_dm(mol, ao[i], dm0a, mask, shls_slice, ao_loc, nbas)
                        for i in range(4)]
-            ao_dm0b = [numint._dot_ao_dm(mol, ao[i], dm0b, mask, shls_slice, ao_loc)
+            ao_dm0b = [numint._dot_ao_dm(mol, ao[i], dm0b, mask, shls_slice, ao_loc, nbas)
                        for i in range(4)]
             for ia in range(mol.natm):
                 wva = dR_rho1a = rks_hess._make_dR_rho1(ao, ao_dm0a, ia, aoslices)
@@ -135,6 +136,7 @@ def get_eph(ephobj, mo1, omega, vec, mo_rep):
     omg, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=mol.spin)
 
     vnuc_deriv = ephobj.vnuc_generator(mol)
+    nbas = mol.nbas
     aoslices = mol.aoslice_by_atom()
 
     mo_coeff, mo_occ = mf.mo_coeff, mf.mo_occ
@@ -157,7 +159,7 @@ def get_eph(ephobj, mo1, omega, vec, mo_rep):
         moia = np.hstack((mo1a[ia], mo1b[ia]))
         v1 = vind(moia)
         shl0, shl1, p0, p1 = aoslices[ia]
-        shls_slice = (shl0, shl1) + (0, mol.nbas)*3
+        shls_slice = (shl0, shl1) + (0, nbas)*3
         if abs(hyb)>1e-10:
             vja, vjb, vka, vkb = \
                     rhf_hess._get_jk(mol, 'int2e_ip1', 3, 's2kl',

--- a/pyscf/pbc/dft/numint.py
+++ b/pyscf/pbc/dft/numint.py
@@ -126,8 +126,9 @@ def eval_rho(cell, ao, dm, non0tab=None, xctype='LDA', hermi=0, idx=None, verbos
 
     # complex orbitals or density matrix
     if numpy.iscomplexobj(ao) or numpy.iscomplexobj(dm):
-        shls_slice = (0, cell.nbas)
+        nbas = cell.nbas
         ao_loc = cell.ao_loc_nr()
+        shls_slice = (0, nbas)
         dm = dm.astype(numpy.complex128)
 # For GGA, function eval_rho returns   real(|\nabla i> D_ij <j| + |i> D_ij <\nabla j|)
 #       = real(|\nabla i> D_ij <j| + |i> D_ij <\nabla j|)
@@ -147,12 +148,12 @@ def eval_rho(cell, ao, dm, non0tab=None, xctype='LDA', hermi=0, idx=None, verbos
             return _contract_rho(bra, aodm, idx)
 
         if xctype == 'LDA' or xctype == 'HF':
-            c0 = _dot_ao_dm(cell, ao, dm, non0tab, shls_slice, ao_loc)
+            c0 = _dot_ao_dm(cell, ao, dm, non0tab, shls_slice, ao_loc, nbas)
             rho = dot_bra(ao, c0, idx)
 
         elif xctype == 'GGA':
             rho = numpy.empty((4,ngrids))
-            c0 = _dot_ao_dm(cell, ao[0], dm, non0tab, shls_slice, ao_loc)
+            c0 = _dot_ao_dm(cell, ao[0], dm, non0tab, shls_slice, ao_loc, nbas)
             rho[0] = dot_bra(ao[0], c0, idx)
             for i in range(1, 4):
                 rho[i] = dot_bra(ao[i], c0, idx) * 2
@@ -160,12 +161,12 @@ def eval_rho(cell, ao, dm, non0tab=None, xctype='LDA', hermi=0, idx=None, verbos
         else:
             # rho[4] = \nabla^2 rho, rho[5] = 1/2 |nabla f|^2
             rho = numpy.empty((6,ngrids))
-            c0 = _dot_ao_dm(cell, ao[0], dm, non0tab, shls_slice, ao_loc)
+            c0 = _dot_ao_dm(cell, ao[0], dm, non0tab, shls_slice, ao_loc, nbas)
             rho[0] = dot_bra(ao[0], c0, idx)
             rho[5] = 0
             for i in range(1, 4):
                 rho[i] = dot_bra(ao[i], c0, idx) * 2  # *2 for +c.c.
-                c1 = _dot_ao_dm(cell, ao[i], dm, non0tab, shls_slice, ao_loc)
+                c1 = _dot_ao_dm(cell, ao[i], dm, non0tab, shls_slice, ao_loc, nbas)
                 rho[5] += dot_bra(ao[i], c1, idx)
             XX, YY, ZZ = 4, 7, 9
             ao2 = ao[XX] + ao[YY] + ao[ZZ]
@@ -200,35 +201,36 @@ def eval_rho2(cell, ao, mo_coeff, mo_occ, non0tab=None, xctype='LDA', idx=None, 
             #:return rho
             return _contract_rho(bra, ket, idx)
 
-        shls_slice = (0, cell.nbas)
+        nbas = cell.nbas
         ao_loc = cell.ao_loc_nr()
+        shls_slice = (0, nbas)
         pos = mo_occ > OCCDROP
         cpos = numpy.einsum('ij,j->ij', mo_coeff[:,pos], numpy.sqrt(mo_occ[pos]))
 
         if pos.sum() > 0:
             if xctype == 'LDA' or xctype == 'HF':
-                c0 = _dot_ao_dm(cell, ao, cpos, non0tab, shls_slice, ao_loc)
+                c0 = _dot_ao_dm(cell, ao, cpos, non0tab, shls_slice, ao_loc, nbas)
                 rho = dot(c0, c0, idx)
             elif xctype == 'GGA':
                 rho = numpy.empty((4,ngrids))
-                c0 = _dot_ao_dm(cell, ao[0], cpos, non0tab, shls_slice, ao_loc)
+                c0 = _dot_ao_dm(cell, ao[0], cpos, non0tab, shls_slice, ao_loc, nbas)
                 rho[0] = dot(c0, c0, idx)
                 for i in range(1, 4):
-                    c1 = _dot_ao_dm(cell, ao[i], cpos, non0tab, shls_slice, ao_loc)
+                    c1 = _dot_ao_dm(cell, ao[i], cpos, non0tab, shls_slice, ao_loc, nbas)
                     rho[i] = dot(c0, c1, idx) * 2  # *2 for +c.c.
             else: # meta-GGA
                 # rho[4] = \nabla^2 rho, rho[5] = 1/2 |nabla f|^2
                 rho = numpy.empty((6,ngrids))
-                c0 = _dot_ao_dm(cell, ao[0], cpos, non0tab, shls_slice, ao_loc)
+                c0 = _dot_ao_dm(cell, ao[0], cpos, non0tab, shls_slice, ao_loc, nbas)
                 rho[0] = dot(c0, c0, idx)
                 rho[5] = 0
                 for i in range(1, 4):
-                    c1 = _dot_ao_dm(cell, ao[i], cpos, non0tab, shls_slice, ao_loc)
+                    c1 = _dot_ao_dm(cell, ao[i], cpos, non0tab, shls_slice, ao_loc, nbas)
                     rho[i] = dot(c0, c1, idx) * 2  # *2 for +c.c.
                     rho[5]+= dot(c1, c1, idx)
                 XX, YY, ZZ = 4, 7, 9
                 ao2 = ao[XX] + ao[YY] + ao[ZZ]
-                c1 = _dot_ao_dm(cell, ao2, cpos, non0tab, shls_slice, ao_loc)
+                c1 = _dot_ao_dm(cell, ao2, cpos, non0tab, shls_slice, ao_loc, nbas)
                 rho[4] = dot(c0, c1, idx)
                 rho[4]+= rho[5]
                 rho[4]*= 2
@@ -245,25 +247,25 @@ def eval_rho2(cell, ao, mo_coeff, mo_occ, non0tab=None, xctype='LDA', idx=None, 
         if neg.sum() > 0:
             cneg = numpy.einsum('ij,j->ij', mo_coeff[:,neg], numpy.sqrt(-mo_occ[neg]))
             if xctype == 'LDA' or xctype == 'HF':
-                c0 = _dot_ao_dm(cell, ao, cneg, non0tab, shls_slice, ao_loc)
+                c0 = _dot_ao_dm(cell, ao, cneg, non0tab, shls_slice, ao_loc, nbas)
                 rho -= dot(c0, c0, idx)
             elif xctype == 'GGA':
-                c0 = _dot_ao_dm(cell, ao[0], cneg, non0tab, shls_slice, ao_loc)
+                c0 = _dot_ao_dm(cell, ao[0], cneg, non0tab, shls_slice, ao_loc, nbas)
                 rho[0] -= dot(c0, c0, idx)
                 for i in range(1, 4):
-                    c1 = _dot_ao_dm(cell, ao[i], cneg, non0tab, shls_slice, ao_loc)
+                    c1 = _dot_ao_dm(cell, ao[i], cneg, non0tab, shls_slice, ao_loc, nbas)
                     rho[i] -= dot(c0, c1, idx) * 2  # *2 for +c.c.
             else:
-                c0 = _dot_ao_dm(cell, ao[0], cneg, non0tab, shls_slice, ao_loc)
+                c0 = _dot_ao_dm(cell, ao[0], cneg, non0tab, shls_slice, ao_loc, nbas)
                 rho[0] -= dot(c0, c0, idx)
                 rho5 = 0
                 for i in range(1, 4):
-                    c1 = _dot_ao_dm(cell, ao[i], cneg, non0tab, shls_slice, ao_loc)
+                    c1 = _dot_ao_dm(cell, ao[i], cneg, non0tab, shls_slice, ao_loc, nbas)
                     rho[i] -= dot(c0, c1, idx) * 2  # *2 for +c.c.
                     rho5 -= dot(c1, c1, idx)
                 XX, YY, ZZ = 4, 7, 9
                 ao2 = ao[XX] + ao[YY] + ao[ZZ]
-                c1 = _dot_ao_dm(cell, ao2, cneg, non0tab, shls_slice, ao_loc)
+                c1 = _dot_ao_dm(cell, ao2, cneg, non0tab, shls_slice, ao_loc, nbas)
                 rho[4] -= dot(c0, c1, idx) * 2
                 rho[4] -= rho5 * 2
                 rho[5] -= rho5 * .5


### PR DESCRIPTION
Various minor DFT changes related to the use of PySCF in a project of mine (https://github.com/januseriksen/decodense):

 - Commit #2901915 - This replaces pyscf#610 (introduces identical functionality).
 - Commit #bd1dbe8 - This is related to calling the code in ```numint.py:eval_rho()``` from within multiprocessing regions. Pickling of open files (e.g., in a ```mol``` object) is an issue and we may then allow for passing ```nbas``` and ```ao_loc``` explicitly instead (with ```mol``` set to ```None```). Also, calling into ```lib.dot()``` doesn't appear to work - at least locally on my Mac(?) - and we can then enforce the use of ```np.dot()``` instead by setting the ```ENFORCE_NUMPY``` config variable.

I trust these changes are not disruptive.