### PR TITLE
Bug fix with padding in KMP2 when remove_linear_dep_ is applied

### DIFF
--- a/pyscf/pbc/mp/kmp2.py
+++ b/pyscf/pbc/mp/kmp2.py
@@ -431,7 +431,7 @@ def _add_padding(mp, mo_coeff, mo_energy):
     nocc = mp.nocc
 
     # Check if these are padded mo coefficients and energies
-    if not np.all([x.shape[0] == nmo for x in mo_coeff]):
+    if not np.all([x.shape[1] == nmo for x in mo_coeff]):
         mo_coeff = padded_mo_coeff(mp, mo_coeff)
 
     if not np.all([x.shape[0] == nmo for x in mo_energy]):

--- a/pyscf/pbc/mp/test/test_padding.py
+++ b/pyscf/pbc/mp/test/test_padding.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# Copyright 2014-2018 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+
+from pyscf.pbc import gto as pbcgto
+from pyscf.pbc import scf as pbcscf
+import pyscf.pbc.mp
+import pyscf.pbc.mp.kmp2
+from pyscf.scf.addons import remove_linear_dep_
+
+
+a0 = 1.78339987 * 0.96  # squeezed
+atom = "C 0 0 0; C %.10f %.10f %.10f" % (a0*0.5, a0*0.5, a0*0.5)
+a = np.asarray(
+    [[0., a0, a0],
+    [a0, 0., a0],
+    [a0, a0, 0.]])
+basis = "gth-dzvp"
+pseudo = "gth-pade"
+ke_cutoff = 100
+cell = pbcgto.Cell(atom=atom, a=a, basis=basis, pseudo=pseudo,
+                   ke_cutoff=ke_cutoff)
+cell.verbose = 5
+cell.output = '/dev/null'
+cell.build()
+
+def run_kcell(cell, nk):
+    abs_kpts = cell.make_kpts(nk, wrap_around=True)
+    kmf = pbcscf.KRHF(cell, abs_kpts)
+    kmf = remove_linear_dep_(kmf, threshold=1e-5, lindep=1e-6)
+    kmf.conv_tol = 1e-12
+    ekpt = kmf.scf()
+    mp = pyscf.pbc.mp.kmp2.KMP2(kmf).run()
+    return ekpt, mp.e_corr
+
+class KnownValues(unittest.TestCase):
+    def test_222(self):
+        nk = (2, 2, 2)
+        escf, emp = run_kcell(cell,nk)
+        self.assertAlmostEqual(escf, -11.0152342492995, 9)
+        self.assertAlmostEqual(emp, -0.233433093787577, 9)
+
+
+if __name__ == '__main__':
+    print("padding test")
+    unittest.main()


### PR DESCRIPTION
## Issue
If different k-points have different `nmo` e.g., due to using `remove_linear_dep_`, KMP2 will crash in the `kernel` function at [this line](https://github.com/berkelbach-group/pyscf/blob/master/pyscf/pbc/mp/kmp2.py#L77) with an error message:
```
        for ki in range(nkpts):
          for kj in range(nkpts):
            for ka in range(nkpts):
                kb = kconserv[ki,ka,kj]
                orbo_i = mo_coeff[ki][:,:nocc]
                orbo_j = mo_coeff[kj][:,:nocc]
                orbv_a = mo_coeff[ka][:,nocc:]
                orbv_b = mo_coeff[kb][:,nocc:]
                oovv_ij[ka] = fao2mo((orbo_i,orbv_a,orbo_j,orbv_b),
                                (mp.kpts[ki],mp.kpts[ka],mp.kpts[kj],mp.kpts[kb]),
>                               compact=False).reshape(nocc,nvir,nocc,nvir).transpose(0,2,1,3) / nkpts
E               ValueError: cannot reshape array of size 6400 into shape (4,22,4,22)

../kmp2.py:77: ValueError
```

## Reason
[This line](https://github.com/berkelbach-group/pyscf/blob/master/pyscf/pbc/mp/kmp2.py#L434) is supposed to check `nmo` rather than `nao`.

## Solution
Change
```Python
    if not np.all([x.shape[0] == nmo for x in mo_coeff]):
```
to 
```Python
    if not np.all([x.shape[1] == nmo for x in mo_coeff]):
```
## Test case
I also added a test case, `pyscf/pbc/mp/test/test_padding.py`, for this issue.