### PR TITLE
mp/ump2/update_amps: make additional copy of eris.ovOV (Issue #857)

### DIFF
--- a/pyscf/mp/test/test_ump2.py
+++ b/pyscf/mp/test/test_ump2.py
@@ -262,7 +262,7 @@ class KnownValues(unittest.TestCase):
     def test_non_canonical_mp2(self):
         mf = scf.UHF(mol).run(max_cycle=1)
         pt = mp.MP2(mf)
-        self.assertAlmostEqual(pt.kernel()[0], -0.044255887860725873, 7)
+        self.assertAlmostEqual(pt.kernel()[0], -0.171693954168, 7)
 
 
 

--- a/pyscf/mp/ump2.py
+++ b/pyscf/mp/ump2.py
@@ -147,7 +147,7 @@ def update_amps(mp, t2, eris):
 
     eris_ovov = numpy.asarray(eris.ovov).reshape(nocca,nvira,nocca,nvira).conj() * .5
     eris_OVOV = numpy.asarray(eris.OVOV).reshape(noccb,nvirb,noccb,nvirb).conj() * .5
-    eris_ovOV = numpy.asarray(eris.ovOV).reshape(nocca,nvira,noccb,nvirb).conj()
+    eris_ovOV = numpy.asarray(eris.ovOV).reshape(nocca,nvira,noccb,nvirb).conj().copy()
     u2aa = eris_ovov.transpose(0,2,1,3) - eris_ovov.transpose(0,2,3,1)
     u2bb = eris_OVOV.transpose(0,2,1,3) - eris_OVOV.transpose(0,2,3,1)
     u2ab = eris_ovOV.transpose(0,2,1,3)


### PR DESCRIPTION
This is related to issue https://github.com/pyscf/pyscf/issues/857.