### PR TITLE
AGF2 frozen + outcore bug fixes

### DIFF
--- a/pyscf/agf2/chkfile.py
+++ b/pyscf/agf2/chkfile.py
@@ -102,6 +102,10 @@ def load_agf2(chkfile):
         dic['nmom'] = (dic.get('ngf', None), dic.get('nse', None))
         del(dic['ngf'], dic['nse'])
 
+    if 'frozena' in dic:
+        dic['frozen'] = (dic['frozena'], dic['frozenb'])
+        del(dic['frozena'], dic['frozenb'])
+
     return load_mol(chkfile), dic
 
 
@@ -123,6 +127,11 @@ def dump_agf2(agf2, chkfile=None, key='agf2',
     if mo_energy is None: mo_energy = agf2.mo_energy
     if mo_coeff is None: mo_coeff = agf2.mo_coeff
     if mo_occ is None: mo_occ = agf2.mo_occ
+
+    if isinstance(gf, (tuple, list)):
+        if frozen != None:
+            if isinstance(frozen, int) or isinstance(frozen[0], int):
+                frozen = [frozen, frozen]
 
     if h5py.is_hdf5(chkfile):
         fh5 = h5py.File(chkfile, 'a')
@@ -147,7 +156,6 @@ def dump_agf2(agf2, chkfile=None, key='agf2',
     store('mo_occ', mo_occ)
     store('_nmo', agf2._nmo)
     store('_nocc', agf2._nocc)
-    store('frozen', frozen)
 
     if gf is not None:
         if isinstance(gf, (tuple, list)):
@@ -157,10 +165,14 @@ def dump_agf2(agf2, chkfile=None, key='agf2',
             store('gfb/energy', gf[1].energy)
             store('gfb/coupling', gf[1].coupling)
             store('gfb/chempot', gf[1].chempot)
+            if frozen is not None:
+                store('frozena', frozen[0])
+                store('frozenb', frozen[1])
         else:
             store('gf/energy', gf.energy)
             store('gf/coupling', gf.coupling)
             store('gf/chempot', gf.chempot)
+            store('frozen', frozen)
 
     if se is not None:
         if isinstance(se, (tuple, list)):

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -43,8 +43,8 @@ def kernel(agf2, eri=None, gf=None, se=None, verbose=None, dump_chk=True):
     name = agf2.__class__.__name__
 
     if eri is None: eri = agf2.ao2mo()
-    if gf is None: gf = self.gf
-    if se is None: se = self.se
+    if gf is None: gf = agf2.gf
+    if se is None: se = agf2.se
     if verbose is None: verbose = agf2.verbose
 
     if gf is None:

--- a/pyscf/agf2/ragf2.py
+++ b/pyscf/agf2/ragf2.py
@@ -1107,19 +1107,25 @@ def _make_qmo_eris_outcore(agf2, eri, coeffs):
     log.debug1('blksize (ragf2._make_qmo_eris_outcore) = %d', blksize)
 
     tril2sq = lib.square_mat_in_trilu_indices(nmo)
+    q1 = 0
     for p0, p1 in lib.prange(0, nmo, blksize):
+        if not np.any(mask[p0:p1]):
+            # block is fully frozen
+            continue
+
         inds = np.arange(p0, p1)[mask[p0:p1]]
+        q0, q1 = q1, q1 + len(inds)
         idx = list(np.concatenate(tril2sq[inds]))
 
         buf = eri.eri[idx] # (blk, nmo, npair)
-        buf = buf.reshape((len(inds))*nmo, -1) # (blk*nmo, npair)
+        buf = buf.reshape((q1-q0)*nmo, -1) # (blk*nmo, npair)
 
         jasym, nja, cja, sja = ao2mo.incore._conc_mos(cj, ca, compact=True)
         buf = ao2mo._ao2mo.nr_e2(buf, cja, sja, 's2kl', 's1')
-        buf = buf.reshape(len(inds), nmo, nj, na)
+        buf = buf.reshape(q1-q0, nmo, nj, na)
 
         buf = lib.einsum('xpja,pi->xija', buf, ci)
-        eri.feri['qmo'][inds] = np.asarray(buf, order='C')
+        eri.feri['qmo'][q0:q1] = np.asarray(buf, order='C')
         
     log.timer('QMO integral transformation', *cput0)
 

--- a/pyscf/agf2/test/test_ragf2_h2o.py
+++ b/pyscf/agf2/test/test_ragf2_h2o.py
@@ -98,6 +98,70 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e_ea,     0.15581330758457984 , 6)
         self.assertAlmostEqual(v_ea,     0.9903734898112396  , 6)
 
+    def test_ragf2_frozen(self):
+        # test the frozen implementation
+        mf = scf.RHF(self.mol)
+        mf.conv_tol = self.mf.conv_tol
+        mf.run()
+        gf2 = agf2.RAGF2(mf)
+        gf2.conv_tol = 1e-7
+        gf2.frozen = [2]
+        gf2.run()
+        e_ip, v_ip = gf2.ipagf2(nroots=1)
+        e_ea, v_ea = gf2.eaagf2(nroots=1)
+        v_ip = np.linalg.norm(v_ip)**2
+        v_ea = np.linalg.norm(v_ea)**2
+        self.assertAlmostEqual(gf2.e_1b, -75.90803303224045 , 6)
+        self.assertAlmostEqual(gf2.e_2b, -0.2378736532302642, 6)
+        self.assertAlmostEqual(e_ip,     0.45937490994065694, 6)
+        self.assertAlmostEqual(v_ip,     0.9726061540589924 , 6)
+        self.assertAlmostEqual(e_ea,     0.15201672352177295, 6)
+        self.assertAlmostEqual(v_ea,     0.988560730917133  , 6)
+
+    def test_ragf2_frozen_outcore(self):
+        # test the frozen implementation with outcore QMOs
+        mf = scf.RHF(self.mol)
+        mf.conv_tol = self.mf.conv_tol
+        mf.run()
+        gf2 = agf2.RAGF2(mf)
+        gf2.conv_tol = 1e-7
+        gf2.frozen = [2]
+        eri = gf2.ao2mo()
+        gf2.max_memory = 1
+        gf2.incore_complete = False
+        gf2.kernel(eri=eri)
+        e_ip, v_ip = gf2.ipagf2(nroots=1)
+        e_ea, v_ea = gf2.eaagf2(nroots=1)
+        v_ip = np.linalg.norm(v_ip)**2
+        v_ea = np.linalg.norm(v_ea)**2
+        self.assertAlmostEqual(gf2.e_1b, -75.90803303224045 , 6)
+        self.assertAlmostEqual(gf2.e_2b, -0.2378736532302642, 6)
+        self.assertAlmostEqual(e_ip,     0.45937490994065694, 6)
+        self.assertAlmostEqual(v_ip,     0.9726061540589924 , 6)
+        self.assertAlmostEqual(e_ea,     0.15201672352177295, 6)
+        self.assertAlmostEqual(v_ea,     0.988560730917133  , 6)
+
+    def test_ragf2_frozen_fully_outcore(self):
+        # test the frozen implementation with outcore MOs and QMOs
+        mf = scf.RHF(self.mol)
+        mf.conv_tol = self.mf.conv_tol
+        mf.max_memory = 1
+        mf.run()
+        gf2 = agf2.RAGF2(mf)
+        gf2.conv_tol = 1e-7
+        gf2.frozen = [2]
+        gf2.kernel()
+        e_ip, v_ip = gf2.ipagf2(nroots=1)
+        e_ea, v_ea = gf2.eaagf2(nroots=1)
+        v_ip = np.linalg.norm(v_ip)**2
+        v_ea = np.linalg.norm(v_ea)**2
+        self.assertAlmostEqual(gf2.e_1b, -75.90803303224045 , 6)
+        self.assertAlmostEqual(gf2.e_2b, -0.2378736532302642, 6)
+        self.assertAlmostEqual(e_ip,     0.45937490994065694, 6)
+        self.assertAlmostEqual(v_ip,     0.9726061540589924 , 6)
+        self.assertAlmostEqual(e_ea,     0.15201672352177295, 6)
+        self.assertAlmostEqual(v_ea,     0.988560730917133  , 6)
+
 
 if __name__ == '__main__':
     print('RAGF2 calculations for H2O')

--- a/pyscf/agf2/test/test_ragf2_h2o.py
+++ b/pyscf/agf2/test/test_ragf2_h2o.py
@@ -122,6 +122,7 @@ class KnownValues(unittest.TestCase):
         # test the frozen implementation with outcore QMOs
         mf = scf.RHF(self.mol)
         mf.conv_tol = self.mf.conv_tol
+        mf.incore_complete = True
         mf.run()
         gf2 = agf2.RAGF2(mf)
         gf2.conv_tol = 1e-7

--- a/pyscf/agf2/test/test_uagf2_beh.py
+++ b/pyscf/agf2/test/test_uagf2_beh.py
@@ -97,6 +97,50 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e_ea,          0.03781071654337435  , 6)
         self.assertAlmostEqual(v_ea,          0.9740024912068087   , 6)
 
+    def test_uagf2_frozen_outcore(self):
+        # test the frozen implementation with outcore QMOs
+        mf = scf.UHF(self.mol)
+        mf.conv_tol = self.mf.conv_tol
+        mf.run()
+        gf2 = agf2.UAGF2(mf)
+        gf2.conv_tol = 1e-7
+        gf2.frozen = [[1], []]
+        eri = gf2.ao2mo()
+        gf2.max_memory = 1
+        gf2.incore_complete = False
+        gf2.run(eri=eri)
+        e_ip, v_ip = gf2.ipagf2(nroots=1)
+        e_ea, v_ea = gf2.eaagf2(nroots=1)
+        v_ip = np.linalg.norm(v_ip)**2
+        v_ea = np.linalg.norm(v_ea)**2
+        self.assertAlmostEqual(gf2.e_1b, -15.074739470012476  , 6)
+        self.assertAlmostEqual(gf2.e_2b, -0.02869128199243178 , 6)
+        self.assertAlmostEqual(e_ip,     0.30429793411749156  , 6)
+        self.assertAlmostEqual(v_ip,     0.994829573647208    , 6)
+        self.assertAlmostEqual(e_ea,     -0.006073553177668935, 6)
+        self.assertAlmostEqual(v_ea,     0.8287871847529051   , 6)
+
+    def test_uagf2_frozen_fully_outcore(self):
+        # test the frozen implementation with outcore MOs and QMOs
+        mf = scf.UHF(self.mol)
+        mf.conv_tol = self.mf.conv_tol
+        mf.max_memory = 1
+        mf.run()
+        gf2 = agf2.UAGF2(mf)
+        gf2.conv_tol = 1e-7
+        gf2.frozen = [[1], []]
+        gf2.run()
+        e_ip, v_ip = gf2.ipagf2(nroots=1)
+        e_ea, v_ea = gf2.eaagf2(nroots=1)
+        v_ip = np.linalg.norm(v_ip)**2
+        v_ea = np.linalg.norm(v_ea)**2
+        self.assertAlmostEqual(gf2.e_1b, -15.074739470012476  , 6)
+        self.assertAlmostEqual(gf2.e_2b, -0.02869128199243178 , 6)
+        self.assertAlmostEqual(e_ip,     0.30429793411749156  , 6)
+        self.assertAlmostEqual(v_ip,     0.994829573647208    , 6)
+        self.assertAlmostEqual(e_ea,     -0.006073553177668935, 6)
+        self.assertAlmostEqual(v_ea,     0.8287871847529051   , 6)
+
 
 if __name__ == '__main__':
     print('UAGF2 calculations for BeH')

--- a/pyscf/agf2/test/test_uagf2_beh.py
+++ b/pyscf/agf2/test/test_uagf2_beh.py
@@ -101,6 +101,7 @@ class KnownValues(unittest.TestCase):
         # test the frozen implementation with outcore QMOs
         mf = scf.UHF(self.mol)
         mf.conv_tol = self.mf.conv_tol
+        mf.incore_complete = True
         mf.run()
         gf2 = agf2.UAGF2(mf)
         gf2.conv_tol = 1e-7

--- a/pyscf/agf2/uagf2.py
+++ b/pyscf/agf2/uagf2.py
@@ -954,31 +954,37 @@ def _make_qmo_eris_outcore(agf2, eri, coeffs_a, coeffs_b, spin=None):
         log.debug1('blksize (uagf2._make_qmo_eris_outcore) = %d', blksize)
 
         tril2sq = lib.square_mat_in_trilu_indices(nmoa)
+        q1 = 0
         for p0, p1 in lib.prange(0, nmoa, blksize):
+            if not np.any(mask[0][p0:p1]):
+                # block is fully frozen
+                continue
+
             inds = np.arange(p0, p1)[mask[0][p0:p1]]
+            q0, q1 = q1, q1 + len(inds)
             idx = list(np.concatenate(tril2sq[inds]))
 
             # aa
             buf = eri.eri_aa[idx] # (blk, nmoa, npaira)
-            buf = buf.reshape((len(inds))*nmoa, -1) # (blk*nmoa, npaira)
+            buf = buf.reshape((q1-q0)*nmoa, -1) # (blk*nmoa, npaira)
 
             jasym_aa, nja_aa, cja_aa, sja_aa = ao2mo.incore._conc_mos(cja, caa)
             buf = ao2mo._ao2mo.nr_e2(buf, cja_aa, sja_aa, 's2kl', 's1')
-            buf = buf.reshape(len(inds), nmoa, nja, naa)
+            buf = buf.reshape(q1-q0, nmoa, nja, naa)
 
             buf = lib.einsum('xpja,pi->xija', buf, cia)
-            eri.feri['qmo/aa'][inds] = np.asarray(buf, order='C')
+            eri.feri['qmo/aa'][q0:q1] = np.asarray(buf, order='C')
 
             # ab
             buf = eri.eri_ab[idx] # (blk, nmoa, npairb)
-            buf = buf.reshape((len(inds))*nmob, -1) # (blk*nmoa, npairb)
+            buf = buf.reshape((q1-q0)*nmob, -1) # (blk*nmoa, npairb)
 
             jasym_ab, nja_ab, cja_ab, sja_ab = ao2mo.incore._conc_mos(cjb, cab)
             buf = ao2mo._ao2mo.nr_e2(buf, cja_ab, sja_ab, 's2kl', 's1')
-            buf = buf.reshape(len(inds), nmoa, njb, nab)
+            buf = buf.reshape(q1-q0, nmoa, njb, nab)
 
             buf = lib.einsum('xpja,pi->xija', buf, cia)
-            eri.feri['qmo/ab'][inds] = np.asarray(buf, order='C')
+            eri.feri['qmo/ab'][q0:q1] = np.asarray(buf, order='C')
 
     if spin is None or spin == 1:
         eri.feri.create_dataset('qmo/ba', (nmob-frozenb, nib, nja, naa), 'f8')
@@ -991,31 +997,37 @@ def _make_qmo_eris_outcore(agf2, eri, coeffs_a, coeffs_b, spin=None):
         log.debug1('blksize (uagf2._make_qmo_eris_outcore) = %d', blksize)
 
         tril2sq = lib.square_mat_in_trilu_indices(nmob)
+        q1 = 0
         for p0, p1 in lib.prange(0, nmob, blksize):
+            if not np.any(mask[1][p0:p1]):
+                # block is fully frozen
+                continue
+
             inds = np.arange(p0, p1)[mask[1][p0:p1]]
+            q0, q1 = q1, q1 + len(inds)
             idx = list(np.concatenate(tril2sq[inds]))
 
             # ba
             buf = eri.eri_ba[idx] # (blk, nmob, npaira)
-            buf = buf.reshape((len(inds))*nmob, -1) # (blk*nmob, npaira)
+            buf = buf.reshape((q1-q0)*nmob, -1) # (blk*nmob, npaira)
 
             jasym_ba, nja_ba, cja_ba, sja_ba = ao2mo.incore._conc_mos(cja, caa)
             buf = ao2mo._ao2mo.nr_e2(buf, cja_ba, sja_ba, 's2kl', 's1')
-            buf = buf.reshape(len(inds), nmob, nja, naa)
+            buf = buf.reshape(q1-q0, nmob, nja, naa)
 
             buf = lib.einsum('xpja,pi->xija', buf, cib)
-            eri.feri['qmo/ba'][inds] = np.asarray(buf, order='C')
+            eri.feri['qmo/ba'][q0:q1] = np.asarray(buf, order='C')
 
             # bb
             buf = eri.eri_bb[idx] # (blk, nmob, npairb)
-            buf = buf.reshape((len(inds))*nmob, -1) # (blk*nmob, npairb)
+            buf = buf.reshape((q1-q0)*nmob, -1) # (blk*nmob, npairb)
 
             jasym_bb, nja_bb, cja_bb, sja_bb = ao2mo.incore._conc_mos(cjb, cab)
             buf = ao2mo._ao2mo.nr_e2(buf, cja_bb, sja_bb, 's2kl', 's1')
-            buf = buf.reshape(len(inds), nmob, njb, nab)
+            buf = buf.reshape(q1-q0, nmob, njb, nab)
 
             buf = lib.einsum('xpja,pi->xija', buf, cib)
-            eri.feri['qmo/bb'][inds] = np.asarray(buf, order='C')
+            eri.feri['qmo/bb'][q0:q1] = np.asarray(buf, order='C')
 
     if spin is None:
         qeri = ((eri.feri['qmo/aa'], eri.feri['qmo/ab']), 


### PR DESCRIPTION
The contents of this PR:

- Fixes bug when performing RAGF2 or UAGF2 calculations with both `frozen` set and out-of-core ERI storage
- Fixes bug when trying to dump checkpoint files for UAGF2 objects in which the `frozen` is not the same for alpha and beta spin
- Adds test cases for the combination of `frozen` and out-of-core ERI storage
- Fixes an incorrect variable name in the `kernel` function