### PR TITLE
Adds update of Ewald parameters to pbc.tools._build_supcell_

### DIFF
--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -594,6 +594,9 @@ def _build_supcell_(supcell, cell, Ls):
     supcell._atm = np.asarray(_atm, dtype=np.int32)
     supcell._bas = np.asarray(_bas.reshape(-1, BAS_SLOTS), dtype=np.int32)
     supcell._env = _env
+
+    # Update Ewald parameters
+    supcell._ew_eta, supcell._ew_cut = supcell.get_ewald_params(supcell.precision, supcell.mesh)
     return supcell
 
 

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -596,7 +596,7 @@ def _build_supcell_(supcell, cell, Ls):
     supcell._env = _env
 
     # Update Ewald parameters
-    if hasattr(supcell, "_ew_eta"):
+    if hasattr(supcell, "_ew_eta") and hasattr(supcell, "get_ewald_params"):
         supcell._ew_eta, supcell._ew_cut = supcell.get_ewald_params(supcell.precision, supcell.mesh)
     return supcell
 

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -596,7 +596,8 @@ def _build_supcell_(supcell, cell, Ls):
     supcell._env = _env
 
     # Update Ewald parameters
-    supcell._ew_eta, supcell._ew_cut = supcell.get_ewald_params(supcell.precision, supcell.mesh)
+    if hasattr(supcell, "_ew_eta"):
+        supcell._ew_eta, supcell._ew_cut = supcell.get_ewald_params(supcell.precision, supcell.mesh)
     return supcell
 
 


### PR DESCRIPTION
Since ce16dc85f `pbc.tools.super_cell` no longer calls the build function of the super cell - as a result, the Ewald parameters `_ew_eta` and `_ew_cut` do not get updated to adjust to the change of `cell.mesh`. This leads to inconsistent nuclear energies (per primitive cell), as you increase the super cell size. This PR adds the update of the Ewald parameters to `_build_supcell_`.

A potential issue is that the user may have specified `_ew_eta` and `_ew_cut` themselves in the original cell - `_ew_from_build` could be checked for this. In this case neither leaving the parameters as they are, nor updating them behind the users back seem like great options to me. Is it possible to work out the equivalent supercell value from the equations in `get_ewald_params` from the values the user had chosen originally?