### PR TITLE
Corrections to the Sijr and Srsi classes in SC-NEVPT2

### DIFF
--- a/pyscf/mrpt/nevpt2.py
+++ b/pyscf/mrpt/nevpt2.py
@@ -439,7 +439,7 @@ def Sijr(mc, dms, eris, verbose=None):
     h = 2.0*numpy.einsum('rpji,raji,pa->rji',h2e_v,h2e_v,a3)\
          - 1.0*numpy.einsum('rpji,raij,pa->rji',h2e_v,h2e_v,a3)
     h += h.transpose(0, 2, 1)
-    h[:, ci_diag[1], ci_diag[1]] *= 0.5
+    h[:, ci_diag[0], ci_diag[1]] *= 0.5
 
     diff = mc.mo_energy[nocc:,None,None] - mc.mo_energy[None,:ncore,None] - mc.mo_energy[None,None,:ncore]
 

--- a/pyscf/mrpt/nevpt2.py
+++ b/pyscf/mrpt/nevpt2.py
@@ -1064,7 +1064,7 @@ if __name__ == '__main__':
     print(ci_e)
     #dm1, dm2, dm3, dm4 = fci.rdm.make_dm1234('FCI4pdm_kern_sf',
     #                                         mc.ci, mc.ci, mc.ncas, mc.nelecas)
-    print(sc_nevpt(mc), -0.16978546152699392)
+    print(sc_nevpt(mc), -0.169785157128082)
 
 
     mol = gto.Mole()
@@ -1096,4 +1096,4 @@ if __name__ == '__main__':
     mc.fcisolver.conv_tol = 1e-14
     mc.kernel()
     mc.verbose = 4
-    print(sc_nevpt(mc), -0.094164472700469196)
+    print(sc_nevpt(mc), -0.094164359938171)

--- a/pyscf/mrpt/test/test_nevpt2.py
+++ b/pyscf/mrpt/test/test_nevpt2.py
@@ -67,44 +67,46 @@ eris = nevpt2._ERIS(mc, mc.mo_coeff, method='outcore')
 dms = {'1': dm1, '2': dm2, '3': dm3, '4': dm4}
 
 class KnowValues(unittest.TestCase):
+    # energy values for H14 from Dalton
+
     def test_Sr(self):
         norm, e = nevpt2.Sr(mc, mc.ci, dms, eris)
-        self.assertAlmostEqual(e, -0.020245617857870119, 7)
-        self.assertAlmostEqual(norm, 0.039479583324952064, 7)
+        self.assertAlmostEqual(e, -0.0202461540, delta=1.0e-6)
+        self.assertAlmostEqual(norm, 0.039479583324952064, delta=1.0e-7)
 
     def test_Si(self):
         norm, e = nevpt2.Si(mc, mc.ci, dms, eris)
-        self.assertAlmostEqual(e, -0.0021281408063186956, 7)
-        self.assertAlmostEqual(norm, 0.0037402334190064367, 7)
+        self.assertAlmostEqual(e, -0.0021282083, delta=1.0e-6)
+        self.assertAlmostEqual(norm, 0.0037402334190064367, delta=1.0e-7)
 
     def test_Sijrs(self):
         norm, e = nevpt2.Sijrs(mc, eris)
-        self.assertAlmostEqual(e, -0.0071504286486605891, 7)
-        self.assertAlmostEqual(norm, 0.023107592349719219, 7)
+        self.assertAlmostEqual(e, -0.0071505004, delta=1.0e-6)
+        self.assertAlmostEqual(norm, 0.023107592349719219, delta=1.0e-7)
 
     def test_Sijr(self):
         norm, e = nevpt2.Sijr(mc,dms, eris)
-        self.assertAlmostEqual(e, -0.0050340133565470449, 7)
-        self.assertAlmostEqual(norm, 0.012664066951786257, 7)
+        self.assertAlmostEqual(e, -0.0050346117, delta=1.0e-6)
+        self.assertAlmostEqual(norm, 0.012664066951786257, delta=1.0e-7)
 
     def test_Srsi(self):
         norm, e = nevpt2.Srsi(mc,dms, eris)
-        self.assertAlmostEqual(e, -0.013695728508982102, 7)
-        self.assertAlmostEqual(norm, 0.040695892654346914, 7)
+        self.assertAlmostEqual(e, -0.0136954715, delta=1.0e-6)
+        self.assertAlmostEqual(norm, 0.040695892654346914, delta=1.0e-7)
 
     def test_Srs(self):
         norm, e = nevpt2.Srs(mc, dms, eris)
-        self.assertAlmostEqual(e, -0.017531645975808627, 7)
-        self.assertAlmostEqual(norm, 0.056323606234166601, 7)
+        self.assertAlmostEqual(e, -0.0175312323, delta=1.0e-6)
+        self.assertAlmostEqual(norm, 0.056323606234166601, delta=1.0e-7)
 
     def test_Sir(self):
         norm, e = nevpt2.Sir(mc, dms, eris)
-        self.assertAlmostEqual(e, -0.033866295344083322, 7)
-        self.assertAlmostEqual(norm, 0.074269050656629421, 7)
+        self.assertAlmostEqual(e, -0.0338666048, delta=1.0e-6)
+        self.assertAlmostEqual(norm, 0.074269050656629421, delta=1.0e-7)
 
     def test_energy(self):
         e = nevpt2.NEVPT(mc).kernel()
-        self.assertAlmostEqual(e, -0.10315217594326213, 7)
+        self.assertAlmostEqual(e, -0.1031529251, delta=1.0e-6)
 
     def test_energy1(self):
         mol = gto.M(


### PR DESCRIPTION
I compared the SC-NEVPT2 energies between PySCF and Dalton for a few molecules, including O3 with a (12, 9) space and [Fe(CO)_3NO]^- with a (10, 10) space.

Upon converging CASSCF as tightly as possible, there were deviations between PySCF and Dalton in the ballpark range of 10-30 Microhartree for the Sijr and Srsi classes. With this fix, all energies agree now to well within a Microhartree.

I can make PySCF and Dalton input files available if desired.