### PR TITLE
Removes Ewald parameters from cell object

### DIFF
--- a/pyscf/pbc/grad/krhf.py
+++ b/pyscf/pbc/grad/krhf.py
@@ -212,7 +212,7 @@ def grad_nuc(cell, atmlst):
     '''
     Derivatives of nuclear repulsion energy wrt nuclear coordinates
     '''
-    ew_eta = cell.ew_eta
+    ew_eta = cell.get_ewald_params()[0]
     chargs = cell.atom_charges()
     coords = cell.atom_coords()
     Lall = cell.get_lattice_Ls()

--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -697,10 +697,10 @@ def get_ewald_params(cell, precision=None, mesh=None):
         ew_eta, ew_cut : float
             The Ewald 'eta' and 'cut' parameters.
     '''
-    if cell.natm == 0:
-        return 0, 0
     if precision is None:
         precision = cell.precision
+    if cell.natm == 0:
+        return 0, 0
     elif (cell.dimension < 2 or
           (cell.dimension == 2 and cell.low_dim_ft_type == 'inf_vacuum')):
 # Non-uniform PW grids are used for low-dimensional ewald summation.  The cutoff

--- a/pyscf/pbc/prop/efg/rhf.py
+++ b/pyscf/pbc/prop/efg/rhf.py
@@ -92,8 +92,7 @@ EFG = kernel
 
 
 def _get_quad_nuc(cell, atm_id):
-    ew_eta = cell.ew_eta
-    ew_cut = cell.ew_cut
+    ew_eta, ew_cut = cell.get_ewald_params()
     chargs = cell.atom_charges()
     coords = cell.atom_coords()
     Lall = cell.get_lattice_Ls(rcut=ew_cut)

--- a/pyscf/pbc/prop/efg/test/test_integral.py
+++ b/pyscf/pbc/prop/efg/test/test_integral.py
@@ -24,8 +24,8 @@ from pyscf.pbc.prop.efg import EFG
 from pyscf.gto import PTR_COORD
 
 def ewald_deriv1(cell, atm_id):
-    ew_eta = cell.ew_eta
-    ew_cut = cell.ew_cut*4
+    ew_eta, ew_cut = cell.get_ewald_params()
+    ew_cut *= 4
     chargs = cell.atom_charges()
     coords = cell.atom_coords()
     Lall = cell.get_lattice_Ls(rcut=ew_cut)
@@ -53,8 +53,7 @@ def ewald_deriv1(cell, atm_id):
     return ewovrl + ewg
 
 def ewald_deriv2(cell, atm_id):
-    ew_eta = cell.ew_eta
-    ew_cut = cell.ew_cut
+    ew_eta, ew_cut = cell.get_ewald_params()
     chargs = cell.atom_charges()
     coords = cell.atom_coords()
     Lall = cell.get_lattice_Ls(rcut=ew_cut)


### PR DESCRIPTION
This PR removes the attributes `_ew_eta` and `_ew_cut` from `pbc.gto.Cell` objects.

As stated here https://github.com/pyscf/pyscf/pull/861#issuecomment-808814269 , the calculation of these parameters is cheap - and storing them in the cell object can lead to inconsistencies, for example when building a supercell vs `pbc.tools.super_cell` (see #861). This replaces #861 .

