### PR TITLE
Update the camb3lyp example to libxc 5 series

### DIFF
--- a/examples/dft/12-camb3lyp.py
+++ b/examples/dft/12-camb3lyp.py
@@ -3,36 +3,42 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-'''
-The default XC functional library (libxc) supports the energy and nuclear
-gradients for range separated functionals.  Nuclear Hessian and TDDFT gradients
-need xcfun library.  See also example 32-xcfun_as_default.py for how to set
-xcfun library as the default XC functional library.
+'''Density functional calculations can be run with either the default
+backend library, libxc, or an alternative library, xcfun. See also
+example 32-xcfun_as_default.py for how to set xcfun as the default XC
+functional library.
+
 '''
 
 from pyscf import gto, dft
+from pyscf.hessian import uks as uks_hess
+from pyscf import tdscf
 
 mol = gto.M(atom="H; F 1 1.", basis='631g')
+
+# Calculation using libxc
 mf = dft.UKS(mol)
 mf.xc = 'CAMB3LYP'
 mf.kernel()
-
 mf.nuc_grad_method().kernel()
 
-
-from pyscf.hessian import uks as uks_hess
-# Switching to xcfun library on the fly
-mf._numint.libxc = dft.xcfun
+# We can also evaluate the geometric hessian
 hess = uks_hess.Hessian(mf).kernel()
 print(hess.reshape(2,3,2,3))
 
-
-from pyscf import tdscf
-# Switching to xcfun library on the fly
-mf._numint.libxc = dft.xcfun
+# or TDDFT gradients
 tdks = tdscf.TDA(mf)
 tdks.nstates = 3
 tdks.kernel()
-
 tdks.nuc_grad_method().kernel()
 
+# Switch to the xcfun library on the fly
+mf._numint.libxc = dft.xcfun
+# Repeat the geometric hessian
+hess = uks_hess.Hessian(mf).kernel()
+print(hess.reshape(2,3,2,3))
+# and the TDDFT gradient calculation
+tdks = tdscf.TDA(mf)
+tdks.nstates = 3
+tdks.kernel()
+tdks.nuc_grad_method().kernel()


### PR DESCRIPTION
Since version 5.0.0, libxc has 4th derivatives for all functionals.