### PR TITLE
Improve naming of frozen orbital example

### DIFF
--- a/examples/mcscf/19-frozen_orbital.py
+++ b/examples/mcscf/19-frozen_orbital.py
@@ -20,7 +20,8 @@ myhf = scf.RHF(mol).run()
 mycas = mcscf.CASSCF(myhf, 6, 8)
 
 #
-# Freeze the inner most two 1s orbitals
+# Freeze the two innermost oxygen 1s orbitals in the orbital
+# optimization
 #
 mycas.frozen = 2
 mycas.kernel()


### PR DESCRIPTION
As discussed in the user docs, the naming of the CASSCF "frozen core" example is ambiguous, so I suggest renaming it to "frozen orbital" which is unambiguous.