### PR TITLE
Release 2.0.0a

### DIFF
--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -25,5 +25,6 @@ jobs:
           tag_name: ${{ steps.release_info.outputs.version_tag }}
           release_name: PySCF ${{ steps.release_info.outputs.version_tag }} release
           body_path: RELEASE.md
+          prerelease: true
           # draft: true
 

--- a/pyscf/__init__.py
+++ b/pyscf/__init__.py
@@ -35,7 +35,7 @@ to try out the package::
 
 '''
 
-__version__ = '2.0a'
+__version__ = '2.0.0a'
 
 import os
 import sys


### PR DESCRIPTION
This PR should trigger the release pipeline to build pip wheels, conda and docker for 2.0.0a