### PR TITLE
Printing fix for ah_level_shift in CASSCF.

### DIFF
--- a/pyscf/mcscf/mc1step.py
+++ b/pyscf/mcscf/mc1step.py
@@ -751,7 +751,7 @@ class CASSCF(casci.CASCI):
         log.info('augmented hessian ah_max_cycle = %d', self.ah_max_cycle)
         log.info('augmented hessian ah_conv_tol = %g', self.ah_conv_tol)
         log.info('augmented hessian ah_linear dependence = %g', self.ah_lindep)
-        log.info('augmented hessian ah_level shift = %d', self.ah_level_shift)
+        log.info('augmented hessian ah_level shift = %g', self.ah_level_shift)
         log.info('augmented hessian ah_start_tol = %g', self.ah_start_tol)
         log.info('augmented hessian ah_start_cycle = %d', self.ah_start_cycle)
         log.info('augmented hessian ah_grad_trust_region = %g', self.ah_grad_trust_region)

--- a/pyscf/mcscf/newton_casscf.py
+++ b/pyscf/mcscf/newton_casscf.py
@@ -788,7 +788,7 @@ class CASSCF(mc1step.CASSCF):
         log.info('augmented hessian ah_max_cycle = %d', self.ah_max_cycle)
         log.info('augmented hessian ah_conv_tol = %g', self.ah_conv_tol)
         log.info('augmented hessian ah_linear dependence = %g', self.ah_lindep)
-        log.info('augmented hessian ah_level shift = %d', self.ah_level_shift)
+        log.info('augmented hessian ah_level shift = %g', self.ah_level_shift)
         log.info('augmented hessian ah_start_tol = %g', self.ah_start_tol)
         log.info('augmented hessian ah_start_cycle = %d', self.ah_start_cycle)
         log.info('augmented hessian ah_grad_trust_region = %g', self.ah_grad_trust_region)

--- a/pyscf/mcscf/umc1step.py
+++ b/pyscf/mcscf/umc1step.py
@@ -428,7 +428,7 @@ class UCASSCF(ucasci.UCASCI):
         log.info('augmented hessian max_cycle = %d', self.ah_max_cycle)
         log.info('augmented hessian conv_tol = %g', self.ah_conv_tol)
         log.info('augmented hessian linear dependence = %g', self.ah_lindep)
-        log.info('augmented hessian level shift = %d', self.ah_level_shift)
+        log.info('augmented hessian level shift = %g', self.ah_level_shift)
         log.info('augmented hessian start_tol = %g', self.ah_start_tol)
         log.info('augmented hessian start_cycle = %d', self.ah_start_cycle)
         log.info('augmented hessian grad_trust_region = %g', self.ah_grad_trust_region)


### PR DESCRIPTION
`ah_level_shift` in CASSCF was formatted as an integer, not as a floating point number.