### PR TITLE
WIP: Print out libxc version info in calculations

### DIFF
--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -50,6 +50,10 @@ _itrf.LIBXC_hybrid_coeff.restype = ctypes.c_double
 _itrf.LIBXC_nlc_coeff.argtypes = [ctypes.c_int,ctypes.POINTER(ctypes.c_double)]
 _itrf.LIBXC_rsh_coeff.argtypes = [ctypes.c_int,ctypes.POINTER(ctypes.c_double)]
 
+_itrf.LIBXC_version.restype = ctypes.c_char_p
+_itrf.LIBXC_reference.restype = ctypes.c_char_p
+_itrf.LIBXC_reference_doi.restype = ctypes.c_char_p
+
 # Runtime detection of available functionals
 dynamic_func = getattr(__config__, 'dft_libxc_dynamic', False)
 
@@ -1587,3 +1591,18 @@ if __name__ == '__main__':
     mf._numint = define_xc(mf._numint, 'B3LYP5')
     e1 = mf.kernel()
     print(e1 - -75.2753037898599)
+
+def libxc_version():
+    '''Returns the version of libxc'''
+
+    return _itrf.LIBXC_version().decode("UTF-8")
+
+def libxc_reference():
+    '''Returns the reference to libxc'''
+
+    return _itrf.LIBXC_reference().decode("UTF-8")
+
+def libxc_reference_doi():
+    '''Returns the reference to libxc'''
+
+    return _itrf.LIBXC_reference_doi().decode("UTF-8")

--- a/pyscf/lib/dft/libxc_itrf.c
+++ b/pyscf/lib/dft/libxc_itrf.c
@@ -839,3 +839,18 @@ char * LIBXC_functional_name(int ifunc)
 {
   return xc_functional_get_name(ifunc);
 }
+
+const char * LIBXC_version()
+{
+  return xc_version_string();
+}
+
+const char * LIBXC_reference()
+{
+  return xc_reference();
+}
+
+const char * LIBXC_reference_doi()
+{
+  return xc_reference_doi();
+}


### PR DESCRIPTION
DFT calculations should print out information on the functional library used in the calculation. The information should include the name and version of the library, as well as the literature reference. The info should be printed out in combination with the XC functional; libxc can also give out the reference(s) to the XC functional that should likewise be printed out.

This PR implements the necessary changes to the code.