### PR TITLE
libxc parameter note

### DIFF
--- a/pyscf/lib/dft/libxc_itrf.c
+++ b/pyscf/lib/dft/libxc_itrf.c
@@ -776,6 +776,9 @@ void LIBXC_eval_xc(int nfn, int *fn_id, double *fac, double *omega,
                 // func->cam_beta does not update the coefficients accordingly.
                 //func->cam_alpha = alpha;
                 //func->cam_beta  = beta;
+                // However, the parameters can be set with the libxc function
+                //void xc_func_set_ext_params_name(xc_func_type *p, const char *name, double par);
+                // since libxc 5.1.0
 #if defined XC_SET_RELATIVITY
                 xc_lda_x_set_params(&func, relativity);
 #endif


### PR DESCRIPTION
Include note in source that that parameters *can* be set in libxc; support for that just needs to be coded in PySCF... the point being that you need to be able to pass the user-supplied arguments for a specific functional to the lowest-level C code where libxc is called, since you need to set the functional parameters in the functional instance when it is created.