### PR TITLE
Updates for segfault in github actions

### DIFF
--- a/pyscf/lib/pbc/ft_ao.c
+++ b/pyscf/lib/pbc/ft_ao.c
@@ -695,10 +695,10 @@ void PBC_ft_latsum_drv(int (*intor)(), void (*eval_gz)(), void (*fill)(),
         int i, j, ij;
         int nenv = PBCsizeof_env(shls_slice, atm, natm, bas, nbas, env);
         nenv = MAX(nenv, PBCsizeof_env(shls_slice+2, atm, natm, bas, nbas, env));
-        double *env_loc = malloc(sizeof(double)*nenv);
+        double *env_loc = malloc(sizeof(double)*nenv+400);
         NPdcopy(env_loc, env, nenv);
         size_t count = nkpts + IMGBLK;
-        double complex *buf = malloc(sizeof(double complex)*count*INTBUFMAX*comp);
+        double complex *buf = malloc(sizeof(double complex)*count*INTBUFMAX*comp+400);
 #pragma omp for schedule(dynamic)
         for (ij = 0; ij < nish*njsh; ij++) {
                 i = ij / njsh;
@@ -748,10 +748,10 @@ void PBC_ft_bvk_drv(int (*intor)(), void (*eval_gz)(), void (*fill)(),
         int i, j, ij;
         int nenv = PBCsizeof_env(shls_slice, atm, natm, bas, nbas, env);
         nenv = MAX(nenv, PBCsizeof_env(shls_slice+2, atm, natm, bas, nbas, env));
-        double *env_loc = malloc(sizeof(double)*nenv);
+        double *env_loc = malloc(sizeof(double)*nenv+400);
         NPdcopy(env_loc, env, nenv);
         size_t count = nkpts + bvk_nimgs;
-        double complex *buf = malloc(sizeof(double complex)*count*INTBUFMAX*comp);
+        double complex *buf = malloc(sizeof(double complex)*count*INTBUFMAX*comp+400);
 #pragma omp for schedule(dynamic)
         for (ij = 0; ij < nish*njsh; ij++) {
                 i = ij / njsh;


### PR DESCRIPTION
The buffer size in analytical Fourier transform might be the cause of seg fault in CI job on macos. Actually, this patch is just a guess. The CI jobs seems not failed with segfault error with this patch. I didn't find anything in the code that writes data over buffer boundary.