### PR TITLE
Update libcint version

### DIFF
--- a/pyscf/lib/CMakeLists.txt
+++ b/pyscf/lib/CMakeLists.txt
@@ -144,7 +144,7 @@ if(BUILD_LIBCINT)
 if(NOT EXISTS "${PROJECT_SOURCE_DIR}/deps/include/cint.h")
   ExternalProject_Add(libcint
     GIT_REPOSITORY https://github.com/sunqm/libcint.git
-    GIT_TAG v4.4.0
+    GIT_TAG v4.4.1
     PREFIX ${PROJECT_BINARY_DIR}/deps
     INSTALL_DIR ${PROJECT_SOURCE_DIR}/deps
     CMAKE_ARGS -DWITH_F12=${WITH_F12} -DWITH_RANGE_COULOMB=1

--- a/pyscf/lib/gto/test/test_gridao.py
+++ b/pyscf/lib/gto/test/test_gridao.py
@@ -303,6 +303,41 @@ H  0.  0.  1.3''', basis='ccpvtz')
         j3c = mol1.intor('int1e_grids_spinor', grids=grids)
         self.assertAlmostEqual(abs(j3c - ref).max(), 0, 12)
 
+    def test_range_separated_coulomb_int1e_grids(self):
+        mol1 = gto.M(atom='''
+O 0.5 0.5 0.
+H  1.  1.2 0.
+H  0.  0.  1.3''', basis='ccpvtz')
+        ngrids = 201
+        grids = numpy.random.random((ngrids, 3)) * 12 - 5
+        fmol = gto.fakemol_for_charges(grids)
+
+        with mol1.with_range_coulomb(.8):
+            ref = df.incore.aux_e2(mol1, fmol, intor='int3c2e').transpose(2,0,1)
+            j3c = mol1.intor('int1e_grids', grids=grids)
+            self.assertAlmostEqual(abs(j3c - ref).max(), 0, 12)
+
+            ref = df.incore.aux_e2(mol1, fmol, intor='int3c2e_cart').transpose(2,0,1)
+            j3c = mol1.intor('int1e_grids_cart', grids=grids)
+            self.assertAlmostEqual(abs(j3c - ref).max(), 0, 12)
+
+            ref = df.incore.aux_e2(mol1, fmol, intor='int3c2e_spinor').transpose(2,0,1)
+            j3c = mol1.intor('int1e_grids_spinor', grids=grids)
+            self.assertAlmostEqual(abs(j3c - ref).max(), 0, 12)
+
+        with mol1.with_range_coulomb(-.8):
+            ref = df.incore.aux_e2(mol1, fmol, intor='int3c2e').transpose(2,0,1)
+            j3c = mol1.intor('int1e_grids', grids=grids)
+            self.assertAlmostEqual(abs(j3c - ref).max(), 0, 12)
+
+            ref = df.incore.aux_e2(mol1, fmol, intor='int3c2e_cart').transpose(2,0,1)
+            j3c = mol1.intor('int1e_grids_cart', grids=grids)
+            self.assertAlmostEqual(abs(j3c - ref).max(), 0, 12)
+
+            ref = df.incore.aux_e2(mol1, fmol, intor='int3c2e_spinor').transpose(2,0,1)
+            j3c = mol1.intor('int1e_grids_spinor', grids=grids)
+            self.assertAlmostEqual(abs(j3c - ref).max(), 0, 12)
+
     def test_int1e_grids_ip(self):
         ngrids = 201
         grids = numpy.random.random((ngrids, 3)) * 12 - 5


### PR DESCRIPTION
Update libcint version due to a bug in int1e_grids for attenuated Coulomb operators