### PR TITLE
Add X2C for GHF which includes the SOC contributions

### DIFF
--- a/examples/scf/44-soc_ecp.py
+++ b/examples/scf/44-soc_ecp.py
@@ -29,7 +29,8 @@ s = .5 * lib.PauliMatrices
 # Note to the phase factor -1j to remove the phase 1j above when adding to
 # core Hamiltonian
 ecpso = -1j * lib.einsum('sxy,spq->xpyq', s, mol.intor('ECPso'))
-hcore = mf.get_hcore() + ecpso.reshape(hcore.shape)
+hcore = mf.get_hcore()
+hcore = hcore + ecpso.reshape(hcore.shape)
 mf.get_hcore = lambda *args: hcore
 mf.kernel()
 

--- a/examples/x2c/03-x2c_ghf.py
+++ b/examples/x2c/03-x2c_ghf.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+'''
+X2C can be solved in different AO basis: the (j-adapted) spinor basis and the
+spin-orbital real-spherical GTO basis. Ideally, they should converge to the
+same SCF solutions. However, different solutions may be found in many
+open-shell systems. It often caused by symmetry (the z-component of total
+angular momentum) broken in GHF calculations.
+'''
+
+import numpy as np
+from pyscf import gto
+
+#
+# For simple systems, X2C with spinor basis and X2C with spin-orbital basis
+# under GHF framework give the same results.
+#
+mol = gto.M(atom='Ne', basis='ccpvdz-dk')
+print('X2C-GHF')
+mol.GHF().x2c1e().run()
+print('j-adapted X2C-UHF')
+mol.X2C().run()
+
+#
+# Different results for X2C with spinor basis and X2C with spin-orbital basis.
+#
+mol = gto.M(atom='C', basis='ccpvdz-dk')
+print('X2C-GHF')
+mol.GHF().x2c1e().run()
+print('j-adapted X2C-UHF')
+mf = mol.X2C().run()
+
+#
+# Using the j-adapted results to construct initial guess for X2C-GHF, SCF can
+# be converged to the correct result in one iteration.
+#
+# The transformation from spin orbital basis to spinor basis
+c = np.vstack(mol.sph2spinor_coeff())
+# Construct new initial guess from the spinor basis solution
+mo1 = c.dot(mf.mo_coeff)
+dm = mf.make_rdm1(mo1, mf.mo_occ)
+
+x2c_ghf = mol.GHF().x2c1e()
+x2c_ghf.verbose = 4
+x2c_ghf.max_cycle = 1
+x2c_ghf.kernel(dm0=dm)

--- a/pyscf/dft/test/test_grids.py
+++ b/pyscf/dft/test/test_grids.py
@@ -84,7 +84,7 @@ class KnownValues(unittest.TestCase):
 
         grid.radi_method = radi.becke
         grid.build(with_non0tab=False)
-        self.assertAlmostEqual(numpy.linalg.norm(grid.weights), 45009387.132578261, 6)
+        self.assertAlmostEqual(lib.fp(grid.weights), 2486249.209827192, 7)
 
     def test_prune(self):
         grid = gen_grid.Grids(h2o)

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -1838,6 +1838,11 @@ def atom_mass_list(mol, isotope_avg=False):
 def condense_to_shell(mol, mat, compressor='max'):
     '''The given matrix is first partitioned to blocks, based on AO shell as
     delimiter. Then call compressor function to abstract each block.
+
+    Args:
+        compressor: string or function
+            if compressor is a string, its value can be  sum, max, min, abssum,
+            absmax, absmin, norm
     '''
     ao_loc = mol.ao_loc_nr()
     if callable(compressor):

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -566,6 +566,13 @@ class StreamObject(object):
         obj.__dict__.update(self.__dict__)
         return obj
 
+    def add_keys(self, **kwargs):
+        '''Add or update attributes of the object and register these attributes in ._keys'''
+        if kwargs:
+            self.__dict__.update(**kwargs)
+            self._keys = self._keys.union(kwargs.keys())
+        return self
+
 _warn_once_registry = {}
 def check_sanity(obj, keysref, stdout=sys.stdout):
     '''Check misinput of class attributes, check whether a class method is

--- a/pyscf/lib/numpy_helper.py
+++ b/pyscf/lib/numpy_helper.py
@@ -1028,10 +1028,14 @@ def condense(opname, a, loc_x, loc_y=None):
             for j,j0 in enumerate(loc_y):
                 j1 = loc_y[j+1]
                 out[i,j] = op(a[i0:i1,j0:j1])
+
+    opname can be  sum, max, min, abssum, absmax, absmin, norm
     '''
-    assert(a.dtype == numpy.double)
+    assert a.dtype == numpy.double
     if not opname.startswith('NP_'):
         opname = 'NP_' + opname
+    assert opname[3:] in ('sum', 'max', 'min', 'abssum', 'absmax', 'absmin', 'norm')
+
     op = getattr(_np_helper, opname)
     if loc_y is None:
         loc_y = loc_x
@@ -1041,6 +1045,8 @@ def condense(opname, a, loc_x, loc_y=None):
     nloc_y = loc_y.size - 1
     if a.flags.f_contiguous:
         out = numpy.zeros((nloc_x, nloc_y), order='F')
+        loc_x, loc_y = loc_y, loc_x
+        nloc_x, nloc_y = nloc_x, nloc_y
     else:
         a = numpy.asarray(a, order='C')
         out = numpy.zeros((nloc_x, nloc_y))

--- a/pyscf/lib/numpy_helper.py
+++ b/pyscf/lib/numpy_helper.py
@@ -1044,12 +1044,9 @@ def condense(opname, a, loc_x, loc_y=None):
     nloc_x = loc_x.size - 1
     nloc_y = loc_y.size - 1
     if a.flags.f_contiguous:
-        out = numpy.zeros((nloc_x, nloc_y), order='F')
-        loc_x, loc_y = loc_y, loc_x
-        nloc_x, nloc_y = nloc_x, nloc_y
-    else:
-        a = numpy.asarray(a, order='C')
-        out = numpy.zeros((nloc_x, nloc_y))
+        a = transpose(a.T)
+    a = numpy.asarray(a, order='C')
+    out = numpy.zeros((nloc_x, nloc_y))
     _np_helper.NPcondense(op, out.ctypes.data_as(ctypes.c_void_p),
                           a.ctypes.data_as(ctypes.c_void_p),
                           loc_x.ctypes.data_as(ctypes.c_void_p),

--- a/pyscf/pbc/df/ft_ao.py
+++ b/pyscf/pbc/df/ft_ao.py
@@ -67,8 +67,7 @@ def ft_aopair_kpts(cell, Gv, shls_slice=None, aosym='s1',
     kptjs = numpy.asarray(kptjs, order='C').reshape(-1,3)
     Gv = numpy.asarray(Gv, order='C').reshape(-1,3)
     nGv = Gv.shape[0]
-    GvT = numpy.asarray(Gv.T, order='C')
-    GvT += q.reshape(-1,1)
+    GvT = numpy.asarray(Gv.T, order='C') + q.reshape(-1,1)
 
     if (gxyz is None or b is None or Gvbase is None or (abs(q).sum() > 1e-9)
         # backward compatibility for pyscf-1.2, in which the argument Gvbase is gs

--- a/pyscf/scf/ghf.py
+++ b/pyscf/scf/ghf.py
@@ -527,6 +527,17 @@ class GHF(hf.SCF):
     def nuc_grad_method(self):
         raise NotImplementedError
 
+    def x2c1e(self):
+        '''X2C with spin-orbit coupling effects.
+
+        Note the difference to PySCF-1.7. In PySCF it calls spin-free X2C1E.
+        This result (mol.GHF().x2c() ) should equal to mol.X2C() although they
+        are solved in different AO basis (spherical GTO vs spinor GTO)
+        '''
+        from pyscf.x2c.x2c import x2c1e_ghf
+        return x2c1e_ghf(self)
+    x2c = x2c1e
+
 def _from_rhf_init_dm(dm, breaksym=True):
     dma = dm * .5
     dm = scipy.linalg.block_diag(dma, dma)

--- a/pyscf/x2c/sfx2c1e.py
+++ b/pyscf/x2c/sfx2c1e.py
@@ -52,27 +52,32 @@ def sfx2c1e(mf):
     >>> mf = pyscf.x2c.sfx2c1e.sfx2c1e(scf.UHF(mol))
     >>> mf.scf()
     '''
+    assert isinstance(mf, hf.SCF)
+
     if isinstance(mf, x2c._X2C_SCF):
         if mf.with_x2c is None:
-            return mf.__class__(mf)
+            mf.with_x2c = SpinFreeX2CHelper(mf.mol)
+            return mf
+        elif not isinstance(mf.with_x2c, SpinFreeX2CHelper):
+            # An object associated to x2c.SpinOrbitalX2CHelper
+            raise NotImplementedError
         else:
             return mf
-
-    assert(isinstance(mf, hf.SCF))
 
     mf_class = mf.__class__
     if mf_class.__doc__ is None:
         doc = ''
     else:
         doc = mf_class.__doc__
+
     class SFX2C1E_SCF(x2c._X2C_SCF, mf_class):
         __doc__ = doc + '''
         Attributes for spin-free X2C:
             with_x2c : X2C object
         '''
-        def __init__(self, mf):
-            self.__dict__.update(mf.__dict__)
-            self.with_x2c = SpinFreeX2C(mf.mol)
+        def __init__(self, mol, *args, **kwargs):
+            mf_class.__init__(self, mol, *args, **kwargs)
+            self.with_x2c = SpinFreeX2CHelper(mf.mol)
             self._keys = self._keys.union(['with_x2c'])
 
         def get_hcore(self, mol=None):
@@ -110,17 +115,16 @@ def sfx2c1e(mf):
                 A list: the dipole moment on x, y and z component
             '''
             if mol is None: mol = self.mol
-            if dm is None: dm =self.make_rdm1()
+            if dm is None: dm = self.make_rdm1()
             log = logger.new_logger(mol, verbose)
-
-            if 'unit_symbol' in kwargs:  # pragma: no cover
-                log.warn('Kwarg "unit_symbol" was deprecated. It was replaced by kwarg '
-                         'unit since PySCF-1.5.')
-                unit = kwargs['unit_symbol']
 
             if not (isinstance(dm, numpy.ndarray) and dm.ndim == 2):
                 # UHF denisty matrices
                 dm = dm[0] + dm[1]
+
+            if isinstance(self, ghf.GHF):
+                nao = mol.nao_nr()
+                dm = dm[:nao,:nao] + dm[nao:,nao:]
 
             with mol.with_common_orig((0,0,0)):
                 if picture_change:
@@ -145,12 +149,13 @@ def sfx2c1e(mf):
                 log.note('Dipole moment(X, Y, Z, A.U.): %8.5f, %8.5f, %8.5f', *mol_dip)
             return mol_dip
 
-    return SFX2C1E_SCF(mf)
+    with_x2c = SpinFreeX2CHelper(mf.mol)
+    return mf.view(SFX2C1E_SCF).add_keys(with_x2c=with_x2c)
 
 sfx2c = sfx2c1e
 
 
-class SpinFreeX2C(x2c.X2C):
+class SpinFreeX2CHelper(x2c.X2CHelperMixin):
     '''1-component X2c (spin-free part only)
     '''
     def get_hcore(self, mol=None):
@@ -284,6 +289,8 @@ class SpinFreeX2C(x2c.X2C):
             return sfx2c1e_hess.hcore_hess_generator(self, mol)
         else:
             raise NotImplementedError
+
+SpinFreeX2C = SpinFreeX2CHelper
 
 
 if __name__ == '__main__':

--- a/pyscf/x2c/test/test_x2c.py
+++ b/pyscf/x2c/test/test_x2c.py
@@ -191,6 +191,19 @@ C     F
         ref = mol.intor('int1e_nuc_spinor')
         self.assertAlmostEqual(abs(h1 - ref).max(), 0, 12)
 
+    def test_ghf(self):
+        # Test whether the result of .X2C() is a solution of .GHF().x2c()
+        mol = gto.M(atom='C', basis='ccpvdz-dk')
+        ref = mol.X2C().run()
+        c = numpy.vstack(mol.sph2spinor_coeff())
+        mo1 = c.dot(ref.mo_coeff)
+        dm = ref.make_rdm1(mo1, ref.mo_occ)
+        mf = mol.GHF().x2c1e()
+        mf.max_cycle = 1
+        mf.kernel(dm0=dm)
+        self.assertTrue(mf.converged)
+        self.assertAlmostEqual(mf.e_tot, ref.e_tot, 10)
+
 
 if __name__ == "__main__":
     print("Full Tests for x2c")


### PR DESCRIPTION
* Change the X2C-GHF interface. ghf.x2c() used to generate a spin-free-X2C-GHF method. With this patch, calling ghf.x2c() will generate the standard X2C in regular spin-orbital basis representation (in the GHF framework) while ghf.sfx2c1e() will generate the spin-free-X2C-GHF as before. The new X2C-GHF object theoretically can give the same result as the (j-adapted) spinor X2C method. In practice it often breaks the spin symmetry and converges to a lower energy solution.

* Add a helper method add_keys in StreamObject class. Using it to simplify the initialization of meta-class (e.g. DF, X2C)