### PR TITLE
Natural Orbitals for DFCASCI with approximate CI solvers

### DIFF
--- a/pyscf/mcscf/casci.py
+++ b/pyscf/mcscf/casci.py
@@ -312,11 +312,13 @@ def cas_natorb(mc, mo_coeff=None, ci=None, eris=None, sort=False,
             aaaa = ao2mo.incore.full(aaaa, ucas)
         else:
             if getattr(mc, 'with_df', None):
-                raise NotImplementedError('cas_natorb for DFCASCI/DFCASSCF')
+                aaaa = mc.with_df.ao2mo(mocas)
+            else:
+                aaaa = ao2mo.kernel(mc.mol, mocas)
             corevhf = mc.get_veff(mc.mol, dm_core)
             ecore += numpy.einsum('ij,ji', dm_core, corevhf) * .5
             h1eff += reduce(numpy.dot, (mocas.conj().T, corevhf, mocas))
-            aaaa = ao2mo.kernel(mc.mol, mocas)
+
 
         # See label_symmetry_ function in casci_symm.py which initialize the
         # orbital symmetry information in fcisolver.  This orbital symmetry


### PR DESCRIPTION
## Summary
Previously, PySCF did not support natural orbital transformations when performing density-fitting with CASCI (DFCASCI) calculations _when the CI solver was an approximate solver_ (e.g. SHCI). PySCF had all infrastructure to do this already so modified the `cas_natorb` function to handle these cases. 

## Related Issues/PRs
- This PR fixes #987.
- PySCF Extension [shciscf PR 2](https://github.com/pyscf/shciscf/pull/2)

## Tests
I'm adding tests to the [shciscf extension](https://github.com/pyscf/shciscf) since I don't think they belong in the main PySCF project. See the link above for more details.