### PR TITLE
Fix J matrix of AFTDF

### DIFF
--- a/pyscf/pbc/df/aft_jk.py
+++ b/pyscf/pbc/df/aft_jk.py
@@ -26,7 +26,7 @@ from pyscf import lib
 from pyscf.lib import logger
 from pyscf.pbc.df.df_jk import zdotNN, zdotCN, zdotNC, _ewald_exxdiv_for_G0
 from pyscf.pbc.df.df_jk import _format_dms, _format_kpts_band, _format_jks
-from pyscf.pbc.lib.kpts_helper import is_zero, gamma_point, conj_mapping
+from pyscf.pbc.lib.kpts_helper import is_zero, gamma_point
 
 
 def get_j_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None):

--- a/pyscf/pbc/df/aft_jk.py
+++ b/pyscf/pbc/df/aft_jk.py
@@ -26,7 +26,7 @@ from pyscf import lib
 from pyscf.lib import logger
 from pyscf.pbc.df.df_jk import zdotNN, zdotCN, zdotNC, _ewald_exxdiv_for_G0
 from pyscf.pbc.df.df_jk import _format_dms, _format_kpts_band, _format_jks
-from pyscf.pbc.lib.kpts_helper import is_zero, gamma_point
+from pyscf.pbc.lib.kpts_helper import is_zero, gamma_point, conj_mapping
 
 
 def get_j_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None):
@@ -44,29 +44,34 @@ def get_j_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None):
     weight = 1./len(kpts)
     for aoaoks, p0, p1 in mydf.ft_loop(mesh, kpt_allow, kpts, max_memory=max_memory):
         _update_vj_(vj_kpts, aoaoks, dms, coulG[p0:p1], weight)
-    aoaoks = p0 = p1 = None
+        aoaoks = None
 
     if gamma_point(kpts):
         vj_kpts = vj_kpts.real.copy()
     return _format_jks(vj_kpts, dm_kpts, kpts_band, kpts)
 
 def _update_vj_(vj_kpts, aoaoks, dms, coulG, weight):
-    n_dm = vj_kpts.shape[0]
+    r'''Compute the Coulomb matrix
+    J_{kl} = \sum_{ij} \sum_G 4\pi/G^2 * FT(\rho_{ij}) IFT(\rho_{kl}) dm_{ji}
+    for analytical FT tensor FT(\rho_{ij})
+    '''
+    # FT(\rho_{ij, kpt}) = \int exp(-i G*r) conj(\psi_{i,kpt}) \psi_{j,kpt} dr
+    # IFT(\rho_{ij, kpt}) = \int exp(i G*r) conj(\psi_{i,kpt}) \psi_{j,kpt} dr
+    # IFT(\rho_{ij, kpt}) = conj(FT(\rho_{ji, kpt}))
+    # rhoG[k] = einsum('ij,gji->g', dms[i,k], IFT(\rho))
+    #         = einsum('ij,gji->g', dms[i,k], aoao.conj().transpose(0,2,1))
+    #         = einsum('ij,gij->g', dms[i,k].conj(), aoao).conj()
+    # vG = sum_k rhoG[k] * coulG
+    # vj[k] = einsum('g,gji->g', vG, aoao[k])
     nao = vj_kpts.shape[-1]
-    vG = [0] * n_dm
+    rhoG = 0
     for k, aoao in enumerate(aoaoks):
         aoao = aoao.reshape(-1,nao,nao)
-        for i in range(n_dm):
-            # einsum('ij,Lji->L', dms[i,k], aoao.conj())
-            # = einsum('ij,Lji->L', dms[i,k].conj(), aoao).conj()
-            rho = numpy.einsum('ij,Lji->L', dms[i,k], aoao).conj()
-            vG[i] += rho * coulG
-    for i in range(n_dm):
-        vG[i] *= weight
+        rhoG += numpy.einsum('nij,Lij->nL', dms[:,k].conj(), aoao).conj()
+    vG = rhoG * coulG * weight
     for k, aoao in enumerate(aoaoks):
         aoao = aoao.reshape(-1,nao,nao)
-        for i in range(n_dm):
-            vj_kpts[i,k] += numpy.einsum('L,Lij->ij', vG[i], aoao)
+        vj_kpts[:,k] += numpy.einsum('nL,Lij->nij', vG, aoao)
 
 def get_j_for_bands(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None):
     log = logger.Logger(mydf.stdout, mydf.verbose)
@@ -80,19 +85,16 @@ def get_j_for_bands(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=N
     mesh = mydf.mesh
     coulG = mydf.weighted_coulG(kpt_allow, False, mesh)
     ngrids = len(coulG)
-    vG = numpy.zeros((nset,ngrids), dtype=numpy.complex128)
+    rhoG = numpy.zeros((nset,ngrids), dtype=numpy.complex128)
     max_memory = (mydf.max_memory - lib.current_memory()[0]) * .8
 
     for aoaoks, p0, p1 in mydf.ft_loop(mesh, kpt_allow, kpts, max_memory=max_memory):
-        #:rho = numpy.einsum('lkL,lk->L', pqk.conj(), dm)
         for k, aoao in enumerate(aoaoks):
-            for i in range(nset):
-                rho = numpy.einsum('ij,Lji->L', dms[i,k],
-                                   aoao.reshape(-1,nao,nao).conj())
-                vG[i,p0:p1] += rho * coulG[p0:p1]
+            rhoG[:,p0:p1] += numpy.einsum('nij,Lij->nL', dms[:,k].conj(),
+                                          aoao.reshape(-1,nao,nao)).conj()
     aoao = aoaoks = p0 = p1 = None
     weight = 1./len(kpts)
-    vG *= weight
+    vG = rhoG * coulG * weight
     t1 = log.timer_debug1('get_j pass 1 to compute J(G)', *t1)
 
     kpts_band, input_band = _format_kpts_band(kpts_band, kpts), kpts_band
@@ -101,9 +103,8 @@ def get_j_for_bands(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=N
     for aoaoks, p0, p1 in mydf.ft_loop(mesh, kpt_allow, kpts_band,
                                         max_memory=max_memory):
         for k, aoao in enumerate(aoaoks):
-            for i in range(nset):
-                vj_kpts[i,k] += numpy.einsum('L,Lij->ij', vG[i,p0:p1],
-                                             aoao.reshape(-1,nao,nao))
+            vj_kpts[:,k] += numpy.einsum('nL,Lij->nij', vG[:,p0:p1],
+                                         aoao.reshape(-1,nao,nao))
     aoao = aoaoks = p0 = p1 = None
 
     if gamma_point(kpts_band):

--- a/pyscf/pbc/lib/kpts_helper.py
+++ b/pyscf/pbc/lib/kpts_helper.py
@@ -81,10 +81,13 @@ def conj_mapping(cell, kpts):
     minus_kpts = -scaled_kpts
     minus_kpts[minus_kpts == -.5] = .5
     uniq_m_kpts, m_index, m_inverse = unique(minus_kpts)
-    if abs(uniq_kpts - uniq_m_kpts).max() > KPT_DIFF_TOL:
+    lex_order = np.lexsort(uniq_kpts.T)
+    m_lex_order = np.lexsort(uniq_m_kpts.T)
+    if abs(uniq_kpts[lex_order] - uniq_m_kpts[m_lex_order]).max() > KPT_DIFF_TOL:
         raise KPointSymmetryError('k points not symmetric')
 
-    return index[m_inverse]
+    index[lex_order] = m_lex_order
+    return index
 
 def get_kconserv(cell, kpts):
     r'''Get the momentum conservation array for a set of k-points.

--- a/pyscf/pbc/lib/kpts_helper.py
+++ b/pyscf/pbc/lib/kpts_helper.py
@@ -43,7 +43,9 @@ def unique(kpts):
         digits = int(-np.log10(KPT_DIFF_TOL))
         uniq_index, uniq_inverse = np.unique(
             kpts.round(digits), return_index=True, return_inverse=True, axis=0)[1:3]
-        return kpts[uniq_index], uniq_index, uniq_inverse
+        idx = uniq_index.argsort()
+        rank = idx.argsort()
+        return kpts[uniq_index[idx]], uniq_index[idx], rank[uniq_inverse]
     except TypeError:
         # Old numpy does not support unique of 2D array
         nkpts = len(kpts)

--- a/pyscf/pbc/lib/kpts_helper.py
+++ b/pyscf/pbc/lib/kpts_helper.py
@@ -39,25 +39,50 @@ def member(kpt, kpts):
 
 def unique(kpts):
     kpts = np.asarray(kpts)
-    nkpts = len(kpts)
-    uniq_kpts = []
-    uniq_index = []
-    uniq_inverse = np.zeros(nkpts, dtype=int)
-    seen = np.zeros(nkpts, dtype=bool)
-    n = 0
-    for i, kpt in enumerate(kpts):
-        if not seen[i]:
-            uniq_kpts.append(kpt)
-            uniq_index.append(i)
-            idx = abs(kpt-kpts).sum(axis=1) < KPT_DIFF_TOL
-            uniq_inverse[idx] = n
-            seen[idx] = True
-            n += 1
-    return np.asarray(uniq_kpts), np.asarray(uniq_index), uniq_inverse
+    try:
+        digits = int(-np.log10(KPT_DIFF_TOL))
+        uniq_index, uniq_inverse = np.unique(
+            kpts.round(digits), return_index=True, return_inverse=True, axis=0)[1:3]
+        return kpts[uniq_index], uniq_index, uniq_inverse
+    except TypeError:
+        # Old numpy does not support unique of 2D array
+        nkpts = len(kpts)
+        uniq_kpts = []
+        uniq_index = []
+        uniq_inverse = np.zeros(nkpts, dtype=int)
+        seen = np.zeros(nkpts, dtype=bool)
+        n = 0
+        for i, kpt in enumerate(kpts):
+            if not seen[i]:
+                uniq_kpts.append(kpt)
+                uniq_index.append(i)
+                idx = abs(kpt-kpts).sum(axis=1) < KPT_DIFF_TOL
+                uniq_inverse[idx] = n
+                seen[idx] = True
+                n += 1
+        return np.asarray(uniq_kpts), np.asarray(uniq_index), uniq_inverse
 
 def loop_kkk(nkpts):
     range_nkpts = range(nkpts)
     return itertools.product(range_nkpts, range_nkpts, range_nkpts)
+
+def conj_mapping(cell, kpts):
+    '''Find the mapping index: -kpts = kpts[index]'''
+    scaled_kpts = cell.get_scaled_kpts(kpts).round(5)
+    scaled_kpts = np.modf(scaled_kpts)[0]
+    scaled_kpts[scaled_kpts > .5] -= 1
+    scaled_kpts[scaled_kpts <= -.5] += 1
+    uniq_kpts, index, inverse = unique(scaled_kpts)
+    if len(index) != len(inverse):
+        raise KPointSymmetryError('duplicated k points')
+
+    minus_kpts = -scaled_kpts
+    minus_kpts[minus_kpts == -.5] = .5
+    uniq_m_kpts, m_index, m_inverse = unique(minus_kpts)
+    if abs(uniq_kpts - uniq_m_kpts).max() > KPT_DIFF_TOL:
+        raise KPointSymmetryError('k points not symmetric')
+
+    return index[m_inverse]
 
 def get_kconserv(cell, kpts):
     r'''Get the momentum conservation array for a set of k-points.
@@ -351,3 +376,5 @@ class KptsHelper(lib.StreamObject):
         if operation == 3:
             return np.conj(eri_kpt.transpose(3,2,1,0))
 
+class KPointSymmetryError(RuntimeError):
+    pass

--- a/pyscf/pbc/lib/test/test_kpts.py
+++ b/pyscf/pbc/lib/test/test_kpts.py
@@ -14,37 +14,45 @@
 # limitations under the License.
 
 import unittest
-import numpy
-from numpy import testing
+import numpy as np
 from pyscf.pbc import gto as pbcgto
-from pyscf.pbc import tools
 from pyscf.pbc.scf import khf
+from pyscf.pbc.lib import kpts_helper
 from pyscf import lib
+
+cell = pbcgto.Cell()
+cell.atom = 'He 0 0 0'
+cell.a = '''0.      1.7834  1.7834
+            1.7834  0.      1.7834
+            1.7834  1.7834  0.    '''
+cell.verbose = 0
+cell.build()
+
+def tearDownModule():
+    global cell
+    del cell
 
 class KnownValues(unittest.TestCase):
     def test_kconserve(self):
-        cell = pbcgto.Cell()
-        cell.atom = 'He 0 0 0'
-        cell.a = '''0.      1.7834  1.7834
-                    1.7834  0.      1.7834
-                    1.7834  1.7834  0.    '''
-        cell.build()
         kpts = cell.make_kpts([3,4,5])
-        kconserve = tools.get_kconserv(cell, kpts)
+        kconserve = kpts_helper.get_kconserv(cell, kpts)
         self.assertAlmostEqual(lib.finger(kconserve), 84.88659638289468, 9)
 
     def test_kconserve3(self):
-        cell = pbcgto.Cell()
-        cell.atom = 'He 0 0 0'
-        cell.a = '''0.      1.7834  1.7834
-                    1.7834  0.      1.7834
-                    1.7834  1.7834  0.    '''
-        cell.build()
         kpts = cell.make_kpts([2,2,2])
         nkpts = kpts.shape[0]
         kijkab = [range(nkpts),range(nkpts),1,range(nkpts),range(nkpts)]
-        kconserve = tools.get_kconserv3(cell, kpts, kijkab)
+        kconserve = kpts_helper.get_kconserv3(cell, kpts, kijkab)
         self.assertAlmostEqual(lib.finger(kconserve), -3.1172758206126852, 0)
+
+    def test_conj_kpts(self):
+        kpts = cell.make_kpts([8,5,2])
+        idx = np.arange(kpts.shape[0])
+        np.random.shuffle(idx)
+        kpts = kpts[idx]
+        idx = kpts_helper.conj_mapping(cell, kpts)
+        check = (kpts+kpts[idx]).dot(cell.lattice_vectors().T/(2*np.pi)) + 1e-14
+        self.assertAlmostEqual(np.modf(check)[0].max(), 0, 12)
 
 if __name__ == "__main__":
     print("Tests for kpts_helper")

--- a/pyscf/pbc/scf/rsjk.py
+++ b/pyscf/pbc/scf/rsjk.py
@@ -656,6 +656,9 @@ class _LongRangeAFT(aft.AFTDF):
         if kpts_band is not None:
             return self.get_j_for_bands(dm_kpts, hermi, kpts, kpts_band)
 
+        if len(kpts) == 1 and not is_zero(kpts):
+            raise NotImplementedError('Single k-point get-j')
+
         cell = self.cell
         dm_kpts = lib.asarray(dm_kpts, order='C')
         dms = _format_dms(dm_kpts, kpts)

--- a/pyscf/pbc/x2c/sfx2c1e.py
+++ b/pyscf/pbc/x2c/sfx2c1e.py
@@ -196,7 +196,7 @@ class SpinFreeX2C(X2C):
 
 
 # Use Ewald-like technique to compute spVsp.
-# spVsp may not be divergent because the numeriator spsp and the denorminator
+# spVsp may not be divergent because the numerator spsp and the denominator
 # in Coulomb kernel 4pi/G^2 are likely cancelled.  Even a real space lattice
 # sum can converge to a finite value, it's difficult to accurately converge
 # this value, i.e., large number of images in lattice summation is required.


### PR DESCRIPTION
AFTDF get_j_kpts has a bug in inversed FT for AO basis product. It was treated as `ao_pair.conj()` . It is not correct in general case where basis functions have to be assumed complex.