### PR TITLE
Add a memory check to KMP2

### DIFF
--- a/pyscf/pbc/mp/kmp2.py
+++ b/pyscf/pbc/mp/kmp2.py
@@ -74,7 +74,8 @@ def kernel(mp, mo_energy, mo_coeff, verbose=logger.NOTE, with_t2=WITH_T2):
     if with_t2:
         mem_usage += (nkpts**3 * (nocc * nvir)**2) * 16 / 1e6
     if mem_usage > mem_avail:
-        raise MemoryError('Insufficient memory! MP2 memory usage {:.2f} MB (currently available {:.2f} MB)'.format(mem_usage, mem_avail))
+        raise MemoryError('Insufficient memory! MP2 memory usage %d MB (currently available %d MB)'
+                          % (mem_usage, mem_avail))
 
     eia = np.zeros((nocc,nvir))
     eijab = np.zeros((nocc,nocc,nvir,nvir))


### PR DESCRIPTION
KMP2 calculations may be killed by an OOM error without traceback if the max memory is insufficient (especially when users don't realize that `with_t2` is true by default). In this PR a MemoryError will be raised if estimated memory usage exceeds currently available memory.

Thanks @hongzhouye for bringing it up!