### PR TITLE
fix type error for DFT+U calculations at gamma

### DIFF
--- a/pyscf/pbc/dft/krkspu.py
+++ b/pyscf/pbc/dft/krkspu.py
@@ -97,7 +97,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=0, vhf_last=0, hermi=1,
                 P_k = rdm1_lo[k][U_mesh]
                 SC = np.dot(S_k, C_k)
                 vxc[k] += mdot(SC, (np.eye(P_k.shape[-1]) - P_k)
-                               * (val * 0.5), SC.conj().T)
+                               * (val * 0.5), SC.conj().T).astype(vxc.dtype,copy=False)
                 E_U += (val * 0.5) * (P_k.trace() - np.dot(P_k, P_k).trace() * 0.5)
                 P_loc += P_k
             P_loc = P_loc.real / nkpts

--- a/pyscf/pbc/dft/krkspu.py
+++ b/pyscf/pbc/dft/krkspu.py
@@ -97,7 +97,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=0, vhf_last=0, hermi=1,
                 P_k = rdm1_lo[k][U_mesh]
                 SC = np.dot(S_k, C_k)
                 vxc[k] += mdot(SC, (np.eye(P_k.shape[-1]) - P_k)
-                               * (val * 0.5), SC.conj().T).astype(vxc.dtype,copy=False)
+                               * (val * 0.5), SC.conj().T).astype(vxc[k].dtype,copy=False)
                 E_U += (val * 0.5) * (P_k.trace() - np.dot(P_k, P_k).trace() * 0.5)
                 P_loc += P_k
             P_loc = P_loc.real / nkpts

--- a/pyscf/pbc/dft/kukspu.py
+++ b/pyscf/pbc/dft/kukspu.py
@@ -76,8 +76,8 @@ def get_veff(ks, cell=None, dm=None, dm_last=0, vhf_last=0, hermi=1,
                     C_k = C_ao_lo[s, k][:, idx]
                     P_k = rdm1_lo[s, k][U_mesh]
                     SC = np.dot(S_k, C_k)
-                    vxc[s, k] += mdot(SC, (np.eye(P_k.shape[-1]) - P_k * 2.0)
-                                      * (val * 0.5), SC.conj().T).astype(vxc.dtype,copy=False)
+                    vxc[s][k] += mdot(SC, (np.eye(P_k.shape[-1]) - P_k * 2.0)
+                                      * (val * 0.5), SC.conj().T).astype(vxc[s][k].dtype,copy=False)
                     E_U += (val * 0.5) * (P_k.trace() - np.dot(P_k, P_k).trace())
                     P_loc += P_k
                 P_loc = P_loc.real / nkpts

--- a/pyscf/pbc/dft/kukspu.py
+++ b/pyscf/pbc/dft/kukspu.py
@@ -77,7 +77,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=0, vhf_last=0, hermi=1,
                     P_k = rdm1_lo[s, k][U_mesh]
                     SC = np.dot(S_k, C_k)
                     vxc[s, k] += mdot(SC, (np.eye(P_k.shape[-1]) - P_k * 2.0)
-                                      * (val * 0.5), SC.conj().T)
+                                      * (val * 0.5), SC.conj().T).astype(vxc.dtype,copy=False)
                     E_U += (val * 0.5) * (P_k.trace() - np.dot(P_k, P_k).trace())
                     P_loc += P_k
                 P_loc = P_loc.real / nkpts


### PR DESCRIPTION
When `vxc` is real (e.g. at the gamma point), numpy will raise an error when adding the (U-J)/2 term to vxc at each kpt (and each spin for KUKSpU).
`numpy.core._exceptions.UFuncTypeError: Cannot cast ufunc 'add' output from dtype('complex128') to dtype('float64') with casting rule 'same_kind'`
I changed it so that this term will be cast to the same type as vxc (you could also check to see if the imaginary parts are all approximately zero, but I didn't do that here).

You can reproduce the error by setting `kmesh = [1,1,1]` in https://github.com/pyscf/pyscf/blob/master/pyscf/pbc/dft/test/test_kukspu.py or https://github.com/pyscf/pyscf/blob/master/pyscf/pbc/dft/test/test_krkspu.py

