### PR TITLE
Remove extra exponent from He cc-pCVDZ

### DIFF
--- a/pyscf/gto/basis/cc-pCVDZ.dat
+++ b/pyscf/gto/basis/cc-pCVDZ.dat
@@ -3,9 +3,6 @@
 #
 
 #BASIS SET:
-He    P
-      1.2750000              1.0000000  
-#BASIS SET:
 Li    S
       0.9060000              1.0000000        
 Li    P


### PR DESCRIPTION
Fixes #1068

The cc-pCVDZ augmentation erroneusly duplicated the P exponent of cc-pVDZ.