### PR TITLE
pbc/df slice j3c from disk

### DIFF
--- a/pyscf/pbc/df/df.py
+++ b/pyscf/pbc/df/df.py
@@ -923,7 +923,7 @@ def _getitem(h5group, label, kpti_kptj, kptij_lst, ignore_key_error=False):
                 return numpy.zeros(0)
             else:
                 raise KeyError('Key "%s" not found' % key)
-        swap = False
+        hermi = False
     else:
         # swap ki,kj due to the hermiticity
         kptji = kpti_kptj[[1,0]]
@@ -940,17 +940,25 @@ def _getitem(h5group, label, kpti_kptj, kptij_lst, ignore_key_error=False):
                 return numpy.zeros(0)
             else:
                 raise KeyError('Key "%s" not found' % key)
-        swap = True
+        hermi = True
 #TODO: put the numpy.hstack() call in _load_and_unpack class to lazily load
 # the 3D tensor if it is too big.
-    dat = _load_and_unpack(h5group[key],swap)
+    dat = _load_and_unpack(h5group[key],hermi)
     return dat
 
 class _load_and_unpack(object):
-    '''Load data lazily'''
-    def __init__(self, dat, swap):
+    '''
+    This class returns an array-like object to an hdf5 file that can 
+    be sliced, to allow for lazy loading
+
+    hermi : boolean
+    Take the conjugate transpose of the slice
+    
+    See PR 1086 and Issue 1076
+    '''
+    def __init__(self, dat, hermi):
         self.dat = dat
-        self.swap = swap
+        self.hermi = hermi
     def __getitem__(self, s):
         dat = self.dat
         if isinstance(dat, h5py.Group):
@@ -958,7 +966,7 @@ class _load_and_unpack(object):
         else: # For mpi4pyscf, pyscf-1.5.1 or older
             v = numpy.asarray(dat[s])
 
-        if self.swap:
+        if self.hermi:
             nao = int(numpy.sqrt(v.shape[-1]))
             v1 = lib.transpose(v.reshape(-1,nao,nao), axes=(0,2,1)).conj()
             return v1.reshape(v.shape)

--- a/pyscf/pbc/df/df.py
+++ b/pyscf/pbc/df/df.py
@@ -941,19 +941,18 @@ def _getitem(h5group, label, kpti_kptj, kptij_lst, ignore_key_error=False):
             else:
                 raise KeyError('Key "%s" not found' % key)
         hermi = True
-#TODO: put the numpy.hstack() call in _load_and_unpack class to lazily load
-# the 3D tensor if it is too big.
+
     dat = _load_and_unpack(h5group[key],hermi)
     return dat
 
 class _load_and_unpack(object):
     '''
-    This class returns an array-like object to an hdf5 file that can 
+    This class returns an array-like object to an hdf5 file that can
     be sliced, to allow for lazy loading
 
     hermi : boolean
     Take the conjugate transpose of the slice
-    
+
     See PR 1086 and Issue 1076
     '''
     def __init__(self, dat, hermi):


### PR DESCRIPTION
This PR allows j3c to be sliced from the disk. The previous behaviour was to load the entire tensor for a single k-point into memory, which caused OoM errors for very large gamma point df tensors.

`dat = numpy.hstack([dat[str(i)] for i in range(len(dat))])`

was found in `_getitem` and places the entire tensor for a given kpoint in memory, as `dat[str(i)]` is not sliced according to the `load` function in `sr_loop`. I modify the code to use the `_load_and_unpack` function, where j3c is now sliced on demand (notice the use of the slice object [s]):

`v = numpy.hstack([dat[str(i)][s] for i in range(len(dat))])`

Now, only the slice needed is loaded, according to the calculated blksize in sr_loop. The PR should not change the behaviour for k-point sampling, as the blksize is usually large enough that the entire df tensor is loaded for any given kpoint.

This PR fixes #1076 and provides the same functionality as the molecular equivalent, ao2mo.outcore._load_from_h5g