### PR TITLE
add checks on shape of rho for GGA functionals

### DIFF
--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -1490,17 +1490,19 @@ def _eval_xc(hyb, fn_facs, rho, spin=0, relativity=0, deriv=1, verbose=None):
             nvar = 5
 
     # Check that the density rho has the appropriate shape
+    # should it be >= or ==, in test test_xcfun.py, test_vs_libxc_rks
+    # the density contain 6 rows independently of the functional
     if nvar == 1 or (nvar ==2 and spin > 0):  # LDA
         for rho_ud in [rho_u, rho_d]:
-            assert rho_ud.shape[0] == 1
+            assert rho_ud.shape[0] >= 1
 
     elif nvar == 2 or nvar == 5:  # GGA
         for rho_ud in [rho_u, rho_d]:
-            assert rho_ud.shape[0] == 4
+            assert rho_ud.shape[0] >= 4
 
     elif nvar == 4 or nvar == 9:  # MGGA
         for rho_ud in [rho_u, rho_d]:
-            assert rho_ud.shape[0] == 6
+            assert rho_ud.shape[0] >= 6
 
 
     else:

--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -1499,9 +1499,8 @@ def _eval_xc(hyb, fn_facs, rho, spin=0, relativity=0, deriv=1, verbose=None):
             assert rho_ud.shape[0] == 4
 
     elif nvar == 4 or nvar == 9:  # MGGA
-        # Are the condition on rho different than for GGA ?
         for rho_ud in [rho_u, rho_d]:
-            assert rho_ud.shape[0] == 4
+            assert rho_ud.shape[0] == 6
 
 
     else:

--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -1486,8 +1486,14 @@ def _eval_xc(hyb, fn_facs, rho, spin=0, relativity=0, deriv=1, verbose=None):
     else:  # GGA
         if spin == 0:
             nvar = 2
+            assert len(rho_u.shape) == 2
+            assert rho_u.shape[0] == 4
         else:
             nvar = 5
+            for rho_ud in [rho_u, rho_d]:
+                assert len(rho_ud.shape) == 2
+                assert rho_ud.shape[0] == 4
+
     outlen = (math.factorial(nvar+deriv) //
               (math.factorial(nvar) * math.factorial(deriv)))
     outbuf = numpy.zeros((outlen,ngrids))

--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -1486,13 +1486,26 @@ def _eval_xc(hyb, fn_facs, rho, spin=0, relativity=0, deriv=1, verbose=None):
     else:  # GGA
         if spin == 0:
             nvar = 2
-            assert len(rho_u.shape) == 2
-            assert rho_u.shape[0] == 4
         else:
             nvar = 5
-            for rho_ud in [rho_u, rho_d]:
-                assert len(rho_ud.shape) == 2
-                assert rho_ud.shape[0] == 4
+
+    # Check that the density rho has the appropriate shape
+    if nvar == 1 or (nvar ==2 and spin > 0):  # LDA
+        for rho_ud in [rho_u, rho_d]:
+            assert rho_ud.shape[0] == 1
+
+    elif nvar == 2 or nvar == 5:  # GGA
+        for rho_ud in [rho_u, rho_d]:
+            assert rho_ud.shape[0] == 4
+
+    elif nvar == 4 or nvar == 9:  # MGGA
+        # Are the condition on rho different than for GGA ?
+        for rho_ud in [rho_u, rho_d]:
+            assert rho_ud.shape[0] == 4
+
+
+    else:
+        raise ValueError("Unknow nvar {}".format(nvar))
 
     outlen = (math.factorial(nvar+deriv) //
               (math.factorial(nvar) * math.factorial(deriv)))


### PR DESCRIPTION
add a small check on the shape of the density in `eval_xc` 

close https://github.com/pyscf/pyscf/issues/968