### PR TITLE
NEVPT2 from Multistate CI

### DIFF
--- a/pyscf/mrpt/nevpt2.py
+++ b/pyscf/mrpt/nevpt2.py
@@ -732,8 +732,14 @@ example examples/dmrg/32-dmrg_casscf_nevpt2_for_FeS.py''')
         #By defaut, _mc is canonicalized for the first root.
         #For SC-NEVPT based on compressed MPS perturber functions, _mc was already canonicalized.
         if (not self.canonicalized):
-            self.mo_coeff, self.ci[self.root], self.mo_energy = self.canonicalize(
+            # Need to assign roots differently if we have more than one root
+            # See issue #1081 (https://github.com/pyscf/pyscf/issues/1081) for more details
+            self.mo_coeff, single_ci_vec, self.mo_energy = self.canonicalize(
                 self.mo_coeff, ci=self.load_ci(), cas_natorb=True, verbose=self.verbose)
+            if self.fcisolver.nroots == 1:
+                self.ci = single_ci_vec
+            else:
+                self.ci[self.root] = single_ci_vec
 
         if getattr(self.fcisolver, 'nevpt_intermediate', None):
             logger.info(self, 'DMRG-NEVPT')

--- a/pyscf/mrpt/nevpt2.py
+++ b/pyscf/mrpt/nevpt2.py
@@ -658,7 +658,6 @@ class NEVPT(lib.StreamObject):
         else:
             return self.ci[root]
 
-
     def for_dmrg(self):
         '''Some preprocess for dmrg-nevpt'''
         if not self._mc.natorb:
@@ -733,7 +732,7 @@ example examples/dmrg/32-dmrg_casscf_nevpt2_for_FeS.py''')
         #By defaut, _mc is canonicalized for the first root.
         #For SC-NEVPT based on compressed MPS perturber functions, _mc was already canonicalized.
         if (not self.canonicalized):
-            self.mo_coeff, self.ci, self.mo_energy = self.canonicalize(
+            self.mo_coeff, self.ci[self.root], self.mo_energy = self.canonicalize(
                 self.mo_coeff, ci=self.load_ci(), cas_natorb=True, verbose=self.verbose)
 
         if getattr(self.fcisolver, 'nevpt_intermediate', None):


### PR DESCRIPTION
# Summary
This PR fixes #1081 and makes sure that the CI vector returned by `NEVPT2.canonicalize()` only overwrites a single CI vector for fcisolvers targeting multiple states. Thanks to @xubwa for tracking down this problem.

# Fix 
I took a slightly different approach than suggested in #1081 and saved the output of `NEVPT2.canonicalize()` as `single_ci_vec` then in an separate conditional block assign it to `ci` if the fcisolver is only targeting a single root or `ci[root]` if it's targeting multiple.

# New Tests
This PR also includes new tests to make sure we're checking for this use case going forward and is a smaller version of the minimal working examples provided by @xubwa in #1081. The trusted values are from ORCA 4.2.1. 

# Next Steps
 Let me know if there are any suggestions or comments!