### PR TITLE
Update openblas

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,7 +8,6 @@ recursive-include pyscf *.dat
 recursive-include pyscf/lib/deps *.so
 include pyscf/lib/*.so
 
-prune pyscf/lib/deps
 include pyscf/lib/*.dylib
 include pyscf/lib/libcint.dylib
 include pyscf/lib/libxc.dylib

--- a/docker/pypa-env/Dockerfile-2.0-openblas
+++ b/docker/pypa-env/Dockerfile-2.0-openblas
@@ -1,3 +1,6 @@
+FROM quay.io/pypa/manylinux2014_x86_64:latest
+RUN yum install -y openblas-devel.x86_64
+
 FROM quay.io/pypa/manylinux1_x86_64:latest
 
 RUN yum install -y openblas-devel.x86_64 gcc && \
@@ -10,3 +13,9 @@ COPY build-wheels.sh /build-wheels.sh
 CMD ['/build-wheels.sh']
 
 RUN pip config set global.disable-pip-version-check true
+# openblas in quay.io/pypa/manylinux1_x86_64 has a bug that causes segfault
+# (issue https://github.com/pyscf/pyscf/issues/1095). openblas r0-3.3 fixed
+# the bug
+COPY --from 0 /usr/lib64/libopenblas.so /usr/lib64/libopenblas.so.0
+RUN rm -f libopenblas-r0.2.18.so && \
+    ln -fs /usr/lib64/libopenblas.so.0 /usr/lib64/libopenblas.so

--- a/pyscf/__init__.py
+++ b/pyscf/__init__.py
@@ -35,7 +35,7 @@ to try out the package::
 
 '''
 
-__version__ = '2.0.0'
+__version__ = '2.0.1'
 
 import os
 import sys


### PR DESCRIPTION
The openblas library used in pip wheel build has a bug. This patch rebuilds pip wheels with a new version of openblas. It should be able to solve issue #1095 