### PR TITLE
Fixing timing and import problems with benchmark scripts

### DIFF
--- a/examples/2-benchmark/benchmarking_utils.py
+++ b/examples/2-benchmark/benchmarking_utils.py
@@ -1,0 +1,18 @@
+import os
+import pyscf
+from pyscf.lib.logger import perf_counter, process_clock
+
+def setup_logger():
+    log = pyscf.lib.logger.Logger(verbose=5)
+    with open('/proc/cpuinfo') as f:
+        for line in f:
+            if 'model name' in line:
+                log.note(line[:-1])
+                break
+    with open('/proc/meminfo') as f:
+        log.note(f.readline()[:-1])
+    log.note('OMP_NUM_THREADS=%s\n', os.environ.get('OMP_NUM_THREADS', None))
+    return log
+
+def get_cpu_timings():
+    return process_clock(), perf_counter()

--- a/examples/2-benchmark/bz.py
+++ b/examples/2-benchmark/bz.py
@@ -1,19 +1,9 @@
 #!/usr/bin/env python
-import os
-import time
 import pyscf
 from pyscf.tools.mo_mapping import mo_comps
+from benchmarking_utils import setup_logger, get_cpu_timings
 
-log = pyscf.lib.logger.Logger(verbose=5)
-with open('/proc/cpuinfo') as f:
-    for line in f:
-        if 'model name' in line:
-            log.note(line[:-1])
-            break
-with open('/proc/meminfo') as f:
-    log.note(f.readline()[:-1])
-log.note('OMP_NUM_THREADS=%s\n', os.environ.get('OMP_NUM_THREADS', None))
-
+log = setup_logger()
 
 for bas in ('3-21g', '6-31g**', 'cc-pVTZ', 'ANO-Roos-TZ'):
     mol = pyscf.M(atom = '''
@@ -31,7 +21,7 @@ c   0.000000000000000 -1.406124906933854  0.000000000000000
 h   0.000000000000000 -2.509154418614532  0.000000000000000
 ''',
                   basis = bas)
-    cpu0 = time.clock(), time.time()
+    cpu0 = get_cpu_timings()
 
     mf = mol.RHF().run()
     cpu0 = log.timer('C6H6 %s RHF'%bas, *cpu0)

--- a/examples/2-benchmark/c60.py
+++ b/examples/2-benchmark/c60.py
@@ -1,29 +1,19 @@
 #!/usr/bin/env python
 
-import os
-import time
 import pyscf
 from pyscf.tools import c60struct
+from benchmarking_utils import setup_logger, get_cpu_timings
 
-log = pyscf.lib.logger.Logger(verbose=5)
-with open('/proc/cpuinfo') as f:
-    for line in f:
-        if 'model name' in line:
-            log.note(line[:-1])
-            break
-with open('/proc/meminfo') as f:
-    log.note(f.readline()[:-1])
-log.note('OMP_NUM_THREADS=%s\n', os.environ.get('OMP_NUM_THREADS', None))
-
+log = setup_logger()
 
 for bas in ('6-31g**', 'cc-pVTZ'):
     mol = pyscf.M(atom=[('C', r) for r in c60struct.make60(1.46,1.38)],
                   basis=bas,
                   max_memory=40000)
 
-    cpu0 = time.clock(), time.time()
+    cpu0 = get_cpu_timings()
     mf = pyscf.scf.fast_newton(mol.RHF())
-    cpu0 = logger.timer('SOSCF/%s' % bas, *cpu0)
+    cpu0 = log.timer('SOSCF/%s' % bas, *cpu0)
 
     mf = mol.RHF().density_fit().run()
-    cpu0 = logger.timer('density-fitting-HF/%s' % bas, *cpu0)
+    cpu0 = log.timer('density-fitting-HF/%s' % bas, *cpu0)

--- a/examples/2-benchmark/ccsd_iteration.py
+++ b/examples/2-benchmark/ccsd_iteration.py
@@ -1,27 +1,17 @@
 #!/usr/bin/env python
 
-import os
-import time
 import pyscf
+from benchmarking_utils import setup_logger, get_cpu_timings
 
-log = pyscf.lib.logger.Logger(verbose=5)
-with open('/proc/cpuinfo') as f:
-    for line in f:
-        if 'model name' in line:
-            log.note(line[:-1])
-            break
-with open('/proc/meminfo') as f:
-    log.note(f.readline()[:-1])
-log.note('OMP_NUM_THREADS=%s\n', os.environ.get('OMP_NUM_THREADS', None))
-
+log = setup_logger()
 
 for n in (30, 50):
-    mol = gto.M(atom=['H 0 0 %f' % i for i in range(n)],
-                basis='ccpvqz')
+    mol = pyscf.gto.M(atom=['H 0 0 %f' % i for i in range(n)],
+                      basis='ccpvqz')
     mf = mol.RHF().run()
     mycc = mf.CCSD()
     eris = mycc.ao2mo()
     _, t1, t2 = mycc.get_init_guess()
-    cpu0 = time.clock(), time.time()
+    cpu0 = get_cpu_timings()
     mycc.update_amps(t1, t2, eris)
     log.timer('H%d cc-pVQZ CCSD iteration' % n, *cpu0)

--- a/examples/2-benchmark/fci_iteration.py
+++ b/examples/2-benchmark/fci_iteration.py
@@ -1,17 +1,9 @@
-import os
 import time
 import numpy as np
-from pyscf import gto, scf, lib, fci
+from pyscf import fci
+from benchmarking_utils import setup_logger, get_cpu_timings
 
-log = lib.logger.Logger(verbose=5)
-with open('/proc/cpuinfo') as f:
-    for line in f:
-        if 'model name' in line:
-            log.note(line[:-1])
-            break
-with open('/proc/meminfo') as f:
-    log.note(f.readline()[:-1])
-log.note('OMP_NUM_THREADS=%s\n', os.environ.get('OMP_NUM_THREADS', None))
+log = setup_logger()
 
 for norb in (12, 14, 16, 18):
     nelec = (norb//2, norb//2)
@@ -26,7 +18,7 @@ for norb in (12, 14, 16, 18):
     ci0 *= 1/np.linalg.norm(ci0)
 
     link = fci.cistring.gen_linkstr_index(range(norb), nelec[0], tril=True)
-    cpu0 = time.clock(), time.time()
+    cpu0 = get_cpu_timings()
     fci.direct_spin0.contract_2e(h2, ci0, norb, nelec, link)
     cpu0 = log.timer('FCI-spin0-solver (%do, %de)' % (norb, sum(nelec)), *cpu0)
     fci.direct_spin1.contract_2e(h2, ci0, norb, nelec, (link, link))

--- a/examples/2-benchmark/n2.py
+++ b/examples/2-benchmark/n2.py
@@ -1,23 +1,14 @@
 #!/usr/bin/env python
-import os
-import time
 import pyscf
 from pyscf.tools.mo_mapping import mo_comps
+from benchmarking_utils import setup_logger, get_cpu_timings
 
-log = pyscf.lib.logger.Logger(verbose=5)
-with open('/proc/cpuinfo') as f:
-    for line in f:
-        if 'model name' in line:
-            log.note(line[:-1])
-            break
-with open('/proc/meminfo') as f:
-    log.note(f.readline()[:-1])
-log.note('OMP_NUM_THREADS=%s\n', os.environ.get('OMP_NUM_THREADS', None))
+log = setup_logger()
 
 for bas in ('3-21g', '6-31g*', 'cc-pVTZ', 'ANO-Roos-TZ'):
     mol = pyscf.M(atom = 'N 0 0 0; N 0 0 1.1',
                   basis = bas)
-    cpu0 = time.clock(), time.time()
+    cpu0 = get_cpu_timings()
 
     mf = mol.RHF().run()
     cpu0 = log.timer('N2 %s RHF'%bas, *cpu0)


### PR DESCRIPTION
# Summary
This PR fixes #1131 by doing the following:
1. Switching to PySCF's internal timing utilities (which select the appropriate `time.clock()` vs `time.perf_counter()` based on the Python version)
2. Adds `pyscf.gto` in the `ccsd_iteration.py` script since `gto` wasn't imported
3. Corrects the import of `pyscf.pbc` in `fock_multigrid.py`

I also consolidated some of the boilerplate code used in all benchmark scripts into `benchmarking_utils.py`

# TODO
- While this should definitely be done in another PR, we should think about tabulating the benchmarking results with something like pandas so we can print the results to markdown (or csv) so we can copy and paste them into the docs website.
- Let me know if there are other suggestions about this!