### PR TITLE
Fix segfault in GDF which is caused by the failure of malloc

### DIFF
--- a/pyscf/lib/gto/ft_ao.c
+++ b/pyscf/lib/gto/ft_ao.c
@@ -40,17 +40,18 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <math.h>
 #include <assert.h>
 #include <complex.h>
 #include "config.h"
 #include "cint.h"
+#include "gto/gto.h"
 #include "gto/ft_ao.h"
 #include "np_helper/np_helper.h"
 
 #define SQRTPI          1.7724538509055160272981674833411451
 #define EXP_CUTOFF      100
-#define NCTRMAX         72
 
 
 double CINTsquare_dist(const double *r1, const double *r2);
@@ -854,6 +855,10 @@ int GTO_aopair_early_contract(double complex *out, CINTEnvVars *envs,
         const size_t leni = len1 * i_ctr;
         const size_t lenj = len1 * i_ctr * j_ctr;
         double complex *gctrj = malloc(sizeof(double complex)*(lenj+leni+len1));
+        if (gctrj == NULL) {
+                fprintf(stderr, "gctrj = malloc(%zu) falied in GTO_aopair_early_contractv\n",
+                        sizeof(double complex) * (lenj + leni + len1));
+        }
         double complex *g = gctrj + lenj;
         double complex *gctri, *g1d;
 
@@ -970,6 +975,10 @@ int GTO_aopair_lazy_contract(double complex *gctr, CINTEnvVars *envs,
                 lenj = nf * i_ctr * j_ctr * n_comp * NGv;
         }
         double complex *g = malloc(sizeof(double complex) * (len1+leng+leni+lenj));
+        if (g == NULL) {
+                fprintf(stderr, "g = malloc(%zu) falied in GTO_aopair_lazy_contract\n",
+                        sizeof(double complex) * (len1 + leng + leni + lenj));
+        }
         double complex *g1 = g + len1;
         double complex *gout, *gctri, *gctrj;
 
@@ -1291,6 +1300,10 @@ void GTO_ft_c2s_sph(double complex *out, double complex *gctr,
         int ic, jc, k;
         const int buflen = nfi*dj;
         double complex *buf1 = malloc(sizeof(double complex) * buflen*2 * NGv);
+        if (buf1 == NULL) {
+                fprintf(stderr, "buf1 = malloc(%zu) falied in GTO_ft_c2s_sph\n",
+                        sizeof(double complex) * buflen*2 * NGv);
+        }
         double complex *buf2 = buf1 + buflen * NGv;
         double complex *pout, *pij, *buf;
 
@@ -1347,7 +1360,15 @@ int GTO_ft_aopair_drv(double complex *out, int *dims,
         const int n_comp = envs->ncomp_e1 * envs->ncomp_tensor;
         const size_t nc = envs->nf * i_ctr * j_ctr * NGv;
         double complex *gctr = malloc(sizeof(double complex) * nc * n_comp);
+        if (gctr == NULL) {
+                fprintf(stderr, "gctr = malloc(%zu) falied in GTO_ft_aopair_drv\n",
+                        sizeof(double complex) * nc * n_comp);
+        }
         double *cache = malloc(sizeof(double) * (gs[0] + gs[1] + gs[2]) * 3);
+        if (cache == NULL) {
+                fprintf(stderr, "cache = malloc(%zu) falied in GTO_ft_aopair_drv\n",
+                        sizeof(double complex) * (gs[0] + gs[1] + gs[2]) * 3);
+        }
         if (eval_gz == NULL) {
                 eval_gz = GTO_Gv_general;
         }
@@ -1598,12 +1619,18 @@ void GTO_ft_fill_drv(int (*intor)(), FPtr_eval_gz eval_gz, void (*fill)(),
         if (intor != &GTO_ft_ovlp_cart && intor != &GTO_ft_ovlp_sph) {
                 eval_aopair = &GTO_aopair_lazy_contract;
         }
+        size_t di = GTOmax_shell_dim(ao_loc, shls_slice  , 1);
+        size_t dj = GTOmax_shell_dim(ao_loc, shls_slice+2, 1);
 
 #pragma omp parallel
 {
         int i, j, ij;
         double complex *buf = malloc(sizeof(double complex)
-                                     * NCTRMAX*NCTRMAX*comp*(size_t)nGv);
+                                     * di*dj*comp*(size_t)nGv);
+        if (buf == NULL) {
+                fprintf(stderr, "buf = malloc(%zu) falied in GTO_ft_fill_drv\n",
+                        di*dj*comp*(size_t)nGv);
+        }
 #pragma omp for schedule(dynamic)
         for (ij = 0; ij < nish*njsh; ij++) {
                 i = ij / njsh;

--- a/pyscf/lib/pbc/fill_ints_sr.c
+++ b/pyscf/lib/pbc/fill_ints_sr.c
@@ -31,8 +31,6 @@
 #define IMGBLK          80
 #define OF_CMPLX        2
 
-#define ABS(X)          ((X>0)?(X):(-X))
-
 int GTOmax_shell_dim(int *ao_loc, int *shls_slice, int ncenter);
 int GTOmax_cache_size(int (*intor)(), int *shls_slice, int ncenter,
                       int *atm, int natm, int *bas, int nbas, double *env);
@@ -157,7 +155,7 @@ static void _nr2c_k_fill(int (*intor)(), double complex *out,
     int iptrxyz, dijc, ISH, JSH, IJSH, i;
     JSH = refuniqshl_map[jsh-jsh0];
     double *ri, *rj, Rij2, Rij2_cut;
-    const double omega = ABS(env_loc[PTR_RANGE_OMEGA]);
+    const double omega = fabs(env_loc[PTR_RANGE_OMEGA]);
 // <<<<<<<<<
 
     shls[1] = jsh;
@@ -419,7 +417,7 @@ static void _nr3c_g(int (*intor)(), void (*fsort)(), double *out,
     double *cache = bufL + dijmc;
     double *pbuf;
 
-    const double omega = ABS(env_loc[PTR_RANGE_OMEGA]);
+    const double omega = fabs(env_loc[PTR_RANGE_OMEGA]);
 
     shls[0] = ish;
     shls[1] = jsh;
@@ -793,7 +791,7 @@ static void _nr3c_bvk_k(int (*intor)(), void (*fsort)(),
     shls[0] = ish;
     shls[1] = jsh;
 // >>>>>>>>>>
-    const double omega = ABS(env_loc[PTR_RANGE_OMEGA]);
+    const double omega = fabs(env_loc[PTR_RANGE_OMEGA]);
     int Ish, Jsh, IJsh, Ksh, idij, kiLj, kiLi;
     Ish = refuniqshl_map[ish];
     Jsh = refuniqshl_map[jsh-nbas];
@@ -1084,7 +1082,7 @@ static void _nr3c_k(int (*intor)(), void (*fsort)(),
     shls[0] = ish;
     shls[1] = jsh;
 // >>>>>>>>>>
-    const double omega = ABS(env_loc[PTR_RANGE_OMEGA]);
+    const double omega = fabs(env_loc[PTR_RANGE_OMEGA]);
     int Ish, Jsh, IJsh, Ksh, idij, kiLj, kiLjc, kiLi;
     Ish = refuniqshl_map[ish];
     Jsh = refuniqshl_map[jsh-nbas];
@@ -1483,7 +1481,7 @@ static void _nr3c_bvk_kk(int (*intor)(), void (*fsort)(),
     double *bufkk_r, *bufkk_i, *bufkL_r, *bufkL_i, *bufL, *pbuf, *cache;
     double *buf_rs, *buf_rs0, *pbuf_rs;
 
-    const double omega = ABS(env_loc[PTR_RANGE_OMEGA]);
+    const double omega = fabs(env_loc[PTR_RANGE_OMEGA]);
 
     shls[0] = ish;
     shls[1] = jsh;
@@ -1766,7 +1764,7 @@ static void _nr3c_kk(int (*intor)(), void (*fsort)(),
     shls[0] = ish;
     shls[1] = jsh;
 // >>>>>>>>>>
-    const double omega = ABS(env_loc[PTR_RANGE_OMEGA]);
+    const double omega = fabs(env_loc[PTR_RANGE_OMEGA]);
     int Ish, Jsh, IJsh, Ksh, idij;
     Ish = refuniqshl_map[ish];
     Jsh = refuniqshl_map[jsh-nbas];

--- a/pyscf/lib/pbc/ft_ao.c
+++ b/pyscf/lib/pbc/ft_ao.c
@@ -17,6 +17,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <complex.h>
 #include <assert.h>
 #include "config.h"
@@ -699,6 +700,10 @@ void PBC_ft_latsum_drv(int (*intor)(), void (*eval_gz)(), void (*fill)(),
         NPdcopy(env_loc, env, nenv);
         size_t count = nkpts + IMGBLK;
         double complex *buf = malloc(sizeof(double complex)*count*INTBUFMAX*comp+400);
+        if (buf == NULL) {
+                fprintf(stderr, "buf = malloc(%zu) falied in PBC_ft_latsum_drv\n",
+                        sizeof(double complex)*count*INTBUFMAX*comp+400);
+        }
 #pragma omp for schedule(dynamic)
         for (ij = 0; ij < nish*njsh; ij++) {
                 i = ij / njsh;
@@ -752,6 +757,10 @@ void PBC_ft_bvk_drv(int (*intor)(), void (*eval_gz)(), void (*fill)(),
         NPdcopy(env_loc, env, nenv);
         size_t count = nkpts + bvk_nimgs;
         double complex *buf = malloc(sizeof(double complex)*count*INTBUFMAX*comp+400);
+        if (buf == NULL) {
+                fprintf(stderr, "buf = malloc(%zu) falied in PBC_ft_bvk_drv\n",
+                        sizeof(double complex)*count*INTBUFMAX*comp+400);
+        }
 #pragma omp for schedule(dynamic)
         for (ij = 0; ij < nish*njsh; ij++) {
                 i = ij / njsh;

--- a/pyscf/pbc/df/df.py
+++ b/pyscf/pbc/df/df.py
@@ -196,7 +196,7 @@ def _make_j3c(mydf, cell, auxcell, kptij_lst, cderi_file):
     j2c = fused_cell.pbc_intor('int2c2e', hermi=0, kpts=uniq_kpts)
 
     max_memory = max(2000, mydf.max_memory - lib.current_memory()[0])
-    blksize = max(2048, int(max_memory*.5e6/16/fused_cell.nao_nr()))
+    blksize = max(2048, int(max_memory*.4e6/16/fused_cell.nao_nr()))
     log.debug2('max_memory %s (MB)  blocksize %s', max_memory, blksize)
     for k, kpt in enumerate(uniq_kpts):
         coulG = mydf.weighted_coulG(kpt, False, mesh)

--- a/pyscf/pbc/df/mdf.py
+++ b/pyscf/pbc/df/mdf.py
@@ -83,22 +83,28 @@ def _make_j3c(mydf, cell, auxcell, kptij_lst, cderi_file):
     # j2c ~ (-kpt_ji | kpt_ji)
     j2c = fused_cell.pbc_intor('int2c2e', hermi=0, kpts=uniq_kpts)
 
+    max_memory = max(2000, mydf.max_memory - lib.current_memory()[0])
+    blksize = max(2048, int(max_memory*.4e6/16/fused_cell.nao_nr()))
+    log.debug2('max_memory %s (MB)  blocksize %s', max_memory, blksize)
     for k, kpt in enumerate(uniq_kpts):
-        aoaux = ft_ao.ft_ao(fused_cell, Gv, None, b, gxyz, Gvbase, kpt).T
-        aoaux = fuse(aoaux)
-        coulG = mydf.weighted_coulG(kpt, False, mesh)
-        LkR = numpy.asarray(aoaux.real, order='C')
-        LkI = numpy.asarray(aoaux.imag, order='C')
-
         j2c_k = fuse(fuse(j2c[k]).T).T.copy()
         j2c_k = (j2c_k + j2c_k.conj().T) * .5
-        if is_zero(kpt):  # kpti == kptj
-            j2c_k -= lib.dot(LkR*coulG, LkR.T)
-            j2c_k -= lib.dot(LkI*coulG, LkI.T)
-        else:
-            # aoaux ~ kpt_ij, aoaux.conj() ~ kpt_kl
-            j2cR, j2cI = zdotCN(LkR*coulG, LkI*coulG, LkR.T, LkI.T)
-            j2c_k -= j2cR + j2cI * 1j
+
+        coulG = mydf.weighted_coulG(kpt, False, mesh)
+        for p0, p1 in lib.prange(0, ngrids, blksize):
+            aoaux = ft_ao.ft_ao(fused_cell, Gv[p0:p1], None, b, gxyz[p0:p1], Gvbase, kpt).T
+            aoaux = fuse(aoaux)
+            LkR = numpy.asarray(aoaux.real, order='C')
+            LkI = numpy.asarray(aoaux.imag, order='C')
+            aoaux = None
+
+            if is_zero(kpt):  # kpti == kptj
+                j2c_k -= lib.dot(LkR*coulG[p0:p1], LkR.T)
+                j2c_k -= lib.dot(LkI*coulG[p0:p1], LkI.T)
+            else:
+                # aoaux ~ kpt_ij, aoaux.conj() ~ kpt_kl
+                j2cR, j2cI = zdotCN(LkR*coulG[p0:p1], LkI*coulG[p0:p1], LkR.T, LkI.T)
+                j2c_k -= j2cR + j2cI * 1j
         fswap['j2c/%d'%k] = j2c_k
         aoaux = LkR = LkI = j2cR = j2cI = coulG = j2c_k = None
     j2c = None


### PR DESCRIPTION
The ft_ao code allocates a buffer too large to be fit into virtual memory. Improve the estimation of buffer size. Issue #1140 may be related.