### PR TITLE
Adds _make_df_eris_outcore to UCCSD

### DIFF
--- a/pyscf/cc/__init__.py
+++ b/pyscf/cc/__init__.py
@@ -124,7 +124,9 @@ def UCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
         mf = scf.addons.convert_to_uhf(mf)
 
     if getattr(mf, 'with_df', None):
-        raise NotImplementedError('DF-UCCSD')
+        # TODO: DF-UCCSD with memory-efficient particle-particle ladder,
+        # similar to dfccsd.RCCSD
+        return uccsd.UCCSD(mf, frozen, mo_coeff, mo_occ)
     else:
         return uccsd.UCCSD(mf, frozen, mo_coeff, mo_occ)
 UCCSD.__doc__ = uccsd.UCCSD.__doc__
@@ -145,9 +147,9 @@ GCCSD.__doc__ = gccsd.GCCSD.__doc__
 
 def QCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     if isinstance(mf, scf.uhf.UHF):
-        raise NotImplementedError 
+        raise NotImplementedError
     elif isinstance(mf, scf.ghf.GHF):
-        raise NotImplementedError 
+        raise NotImplementedError
     else:
         return RQCISD(mf, frozen, mo_coeff, mo_occ)
 QCISD.__doc__ = qcisd.QCISD.__doc__
@@ -165,13 +167,13 @@ def RQCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
         lib.logger.warn(mf, 'RQCISD method does not support ROHF method. ROHF object '
                         'is converted to UHF object and UQCISD method is called.')
         mf = scf.addons.convert_to_uhf(mf)
-        raise NotImplementedError 
+        raise NotImplementedError
 
     if isinstance(mf, newton_ah._CIAH_SOSCF) or not isinstance(mf, scf.hf.RHF):
         mf = scf.addons.convert_to_rhf(mf)
 
     elif numpy.iscomplexobj(mo_coeff) or numpy.iscomplexobj(mf.mo_coeff):
-        raise NotImplementedError 
+        raise NotImplementedError
 
     else:
         return qcisd.QCISD(mf, frozen, mo_coeff, mo_occ)

--- a/pyscf/cc/test/test_uccsd.py
+++ b/pyscf/cc/test/test_uccsd.py
@@ -67,10 +67,16 @@ def tearDownModule():
     del mol, rhf, mf, myucc, mol_s2, mf_s2, eris
 
 class KnownValues(unittest.TestCase):
-#    def test_with_df(self):
-#        mf = scf.UHF(mol).density_fit(auxbasis='weigend').run()
-#        mycc = cc.UCCSD(mf).run()
-#        self.assertAlmostEqual(mycc.e_tot, -76.118403942938741, 7)
+
+    def test_with_df_s0(self):
+        mf = scf.UHF(mol).density_fit(auxbasis='weigend').run()
+        mycc = cc.UCCSD(mf).run()
+        self.assertAlmostEqual(mycc.e_tot, -76.118403942938741, 7)
+
+    def test_with_df_s2(self):
+        mf = scf.UHF(mol_s2).density_fit(auxbasis='weigend').run()
+        mycc = cc.UCCSD(mf).run()
+        self.assertAlmostEqual(mycc.e_tot, -75.83360033370676, 7)
 
     def test_ERIS(self):
         ucc1 = cc.UCCSD(mf)


### PR DESCRIPTION
I added an outcore AO->MO routine for UCCSD + DF, which I thought would be useful to add to master.

The implementation was tested in two limits (examples below):
1) spin-symmetric solution of H2O@cc-pVDZ, comparing RCCSD+DF vs UCCSD+DF, which leads to a difference of ~1e-10 in the correlation energy
2) The radical NO2, comparing non-DF UCCSD/cc-pVDZ  with UCCSD/cc-pVDZ+DF(aug-cc-pV5Z-ri), which leads to a difference of ~2e-6, which I guess is reasonable for the remaining DF error?

[test_1.py.txt](https://github.com/pyscf/pyscf/files/7848058/test_1.py.txt)
[test_2.py.txt](https://github.com/pyscf/pyscf/files/7848067/test_2.py.txt)