### PR TITLE
Fixes cisd.tn_addrs_signs for impossible excitations

### DIFF
--- a/pyscf/ci/cisd.py
+++ b/pyscf/ci/cisd.py
@@ -270,10 +270,13 @@ def tn_addrs_signs(norb, nelec, n_excite):
     '''Compute the FCI strings (address) for CIS n-excitation amplitudes and
     the signs of the coefficients when transferring the reference from physics
     vacuum to HF vacuum.
+
+    If the excitation level is not compatible with the number of
+    electrons and holes, empty lists are returned for the addresses and signs.
     '''
-    if n_excite > nelec:
-        print("Warning: Not enough occupied orbitals to excite.")
-        return [0], [0]
+    # Not enough electrons or holes for excitation; return empty lists.
+    if n_excite > min(nelec, norb-nelec):
+        return [], []
     nocc = nelec
 
     hole_strs = cistring.gen_strings4orblist(range(nocc), nocc - n_excite)


### PR DESCRIPTION
The function `tn_addrs_signs` in `cisd.py` returns the address of the HF determinant, i.e. `[0]`, for excitations > nelec, which should be considered a bug. This fix returns empty lists instead. Empty lists are also returned if the excitation is impossible because there are not enough holes available, i.e. `n_excite > norb-nelec`.

I also took the liberty to remove the printing of a warning in this case - I think it should be perfectly fine to ask for a list of all, say, fourfold excitations in a two-electron sytems (the answer being the empty set) without resulting in excessive writing to stdout.