### PR TITLE
Add low-level interface to Basis Set Exchange

### DIFF
--- a/pyscf/df/addons.py
+++ b/pyscf/df/addons.py
@@ -23,6 +23,7 @@ from pyscf.lib import logger
 from pyscf import gto
 from pyscf import ao2mo
 from pyscf.data import elements
+from pyscf.lib.exceptions import BasisNotFoundError
 from pyscf import __config__
 
 DFBASIS = getattr(__config__, 'df_addons_aug_etb_beta', 'weigend')
@@ -169,10 +170,16 @@ def make_auxbasis(mol, mp2fit=False):
                     auxb = DEFAULT_AUXBASIS[balias][1]
                 else:
                     auxb = DEFAULT_AUXBASIS[balias][0]
-                if auxb is not None and gto.basis.load(auxb, k):
-                    auxbasis[k] = auxb
-                    logger.info(mol, 'Default auxbasis %s is used for %s %s',
-                                auxb, k, _basis[k])
+                if auxb is not None:
+                    try:
+                        # Test if basis auxb for element k is available
+                        gto.basis.load(auxb, k)
+                    except BasisNotFoundError:
+                        pass
+                    else:
+                        auxbasis[k] = auxb
+                        logger.info(mol, 'Default auxbasis %s is used for %s %s',
+                                    auxb, k, _basis[k])
 
     if len(auxbasis) != len(_basis):
         # Some AO basis not found in DEFAULT_AUXBASIS

--- a/pyscf/df/test/test_addons.py
+++ b/pyscf/df/test/test_addons.py
@@ -82,4 +82,3 @@ class KnownValues(unittest.TestCase):
 if __name__ == "__main__":
     print("Full Tests for df.addons")
     unittest.main()
-

--- a/pyscf/gto/basis/bse.py
+++ b/pyscf/gto/basis/bse.py
@@ -1,0 +1,106 @@
+'''
+Conversion from the Basis Set Exchange format to PySCF format
+
+17 Nov 2021 Susi Lehtola
+'''
+
+from basis_set_exchange import lut, manip, sort
+
+
+def _orbital_basis(basis):
+    '''Extracts the orbital basis from the BSE format in PySCF format'''
+
+    r = {}
+
+    basis = manip.make_general(basis, False, True)
+    basis = sort.sort_basis(basis, False)
+
+    # Elements for which we have electron basis
+    electron_elements = [k for k, v in basis['elements'].items() if 'electron_shells' in v]
+
+    # Electron Basis
+    if electron_elements:
+        for z in electron_elements:
+            data = basis['elements'][z]
+
+            sym = lut.element_sym_from_Z(z, True)
+
+            # List of shells
+            atom_shells = []
+            for shell in data['electron_shells']:
+                exponents = shell['exponents']
+                coefficients = shell['coefficients']
+                ncontr = len(coefficients)
+                nprim = len(exponents)
+                am = shell['angular_momentum']
+                assert len(am) == 1
+
+                shell_data = [am[0]]
+                for iprim in range(nprim):
+                    row = [float(coefficients[ic][iprim]) for ic in range(ncontr)]
+                    row.insert(0, float(exponents[iprim]))
+                    shell_data.append(row)
+                atom_shells.append(shell_data)
+            r[sym] = atom_shells
+
+    return r
+
+
+def _ecp_basis(basis):
+    '''Extracts the ECP from the BSE format in PySCF format'''
+
+    r = {}
+
+    basis = manip.make_general(basis, False, True)
+    basis = sort.sort_basis(basis, False)
+
+    # Elements for which we have ECP
+    ecp_elements = [k for k, v in basis['elements'].items() if 'ecp_potentials' in v]
+
+    # Electron Basis
+    if ecp_elements:
+        for z in ecp_elements:
+            data = basis['elements'][z]
+            sym = lut.element_sym_from_Z(z, True)
+            max_ecp_am = max([x['angular_momentum'][0] for x in data['ecp_potentials']])
+            max_ecp_amchar = lut.amint_to_char([max_ecp_am], hij=True)
+
+            # Sort lowest->highest
+            ecp_list = sorted(data['ecp_potentials'], key=lambda x: x['angular_momentum'])
+
+            # List of ECP
+            atom_ecp = [data['ecp_electrons'], []]
+            for ir, pot in enumerate(ecp_list):
+                rexponents = pot['r_exponents']
+                gexponents = pot['gaussian_exponents']
+                coefficients = pot['coefficients']
+                am = pot['angular_momentum']
+                nprim = len(rexponents)
+
+                shell_data = [am[0], []]
+                # PySCF wants the data in order of rexp=0, 1, 2, ..
+                for rexpval in range(max(rexponents) + 1):
+                    rcontr = []
+                    for i in range(nprim):
+                        if rexponents[i] == rexpval:
+                            rcontr.append([float(gexponents[i]), float(coefficients[0][i])])
+                    shell_data[1].append(rcontr)
+                atom_ecp[1].append(shell_data)
+            r[sym] = atom_ecp
+
+    return r
+
+if __name__ == '__main__':
+    from basis_set_exchange import api
+    o631gbas = api.get_basis('6-31g', elements='O')
+    print('O 6-31G basis, BSE format\n{}'.format(o631gbas))
+    o631gorb = _orbital_basis(o631gbas)
+    print('O 6-31G orbital basis, PySCF format\n{}'.format(o631gorb))
+    print('')
+
+    nalanl2dzbas = api.get_basis('lanl2dz', elements='Na')
+    print('Na LANL2DZ basis, BSE format\n{}'.format(nalanl2dzbas))
+    nalanl2dzorb = _orbital_basis(nalanl2dzbas)
+    print('Na LANL2DZ orbital basis, PySCF format\n{}'.format(nalanl2dzorb))
+    nalanl2dzecp = _ecp_basis(nalanl2dzbas)
+    print('Na LANL2DZ ECP basis, PySCF format\n{}'.format(nalanl2dzecp))

--- a/pyscf/gto/basis/bse.py
+++ b/pyscf/gto/basis/bse.py
@@ -18,6 +18,9 @@ def _orbital_basis(basis):
     # Elements for which we have electron basis
     electron_elements = [k for k, v in basis['elements'].items() if 'electron_shells' in v]
 
+    # List of references in the used basis
+    reference_list = []
+
     # Electron Basis
     if electron_elements:
         for z in electron_elements:
@@ -43,7 +46,13 @@ def _orbital_basis(basis):
                 atom_shells.append(shell_data)
             r[sym] = atom_shells
 
-    return r
+            # Collect the literature references
+            for ref in data['references']:
+                for key in ref['reference_keys']:
+                    if key not in reference_list:
+                        reference_list.append(key)
+
+    return r, reference_list
 
 
 def _ecp_basis(basis):
@@ -90,17 +99,40 @@ def _ecp_basis(basis):
 
     return r
 
+def _print_basis_information(basis):
+    name = basis['name']
+    version = basis['version']
+    revision_description = basis['revision_description']
+    revision_date = basis['revision_date']
+    print('{} basis set, version {}'.format(name, version))
+    print('Last revised on {}'.format(revision_date))
+    print('Revision description: {}'.format(revision_description))
+
 if __name__ == '__main__':
-    from basis_set_exchange import api
+    from basis_set_exchange import api, references
+
+    # Get reference data
+    reference_data = api.get_reference_data()
+    #print(references)
+
     o631gbas = api.get_basis('6-31g', elements='O')
-    print('O 6-31G basis, BSE format\n{}'.format(o631gbas))
-    o631gorb = _orbital_basis(o631gbas)
+    #print('O 6-31G basis, BSE format\n{}'.format(o631gbas))
+    _print_basis_information(o631gbas)
+    o631gorb, o631gref = _orbital_basis(o631gbas)
     print('O 6-31G orbital basis, PySCF format\n{}'.format(o631gorb))
+    print('Literature references')
+    for ref in o631gref:
+        print(references.reference_text(ref, reference_data[ref]))
     print('')
 
     nalanl2dzbas = api.get_basis('lanl2dz', elements='Na')
-    print('Na LANL2DZ basis, BSE format\n{}'.format(nalanl2dzbas))
-    nalanl2dzorb = _orbital_basis(nalanl2dzbas)
+    #print('Na LANL2DZ basis, BSE format\n{}'.format(nalanl2dzbas))
+    _print_basis_information(nalanl2dzbas)
+    nalanl2dzorb, nalanl2dzref = _orbital_basis(nalanl2dzbas)
     print('Na LANL2DZ orbital basis, PySCF format\n{}'.format(nalanl2dzorb))
     nalanl2dzecp = _ecp_basis(nalanl2dzbas)
     print('Na LANL2DZ ECP basis, PySCF format\n{}'.format(nalanl2dzecp))
+    print('Literature references')
+    for ref in nalanl2dzref:
+        print(references.reference_text(ref, reference_data[ref]))
+    print('')

--- a/pyscf/gto/basis/bse.py
+++ b/pyscf/gto/basis/bse.py
@@ -4,7 +4,10 @@ Conversion from the Basis Set Exchange format to PySCF format
 17 Nov 2021 Susi Lehtola
 '''
 
-from basis_set_exchange import lut, manip, sort
+try:
+    from basis_set_exchange import lut, manip, sort
+except ImportError:
+    basis_set_exchange = None
 
 
 def _orbital_basis(basis):
@@ -71,8 +74,6 @@ def _ecp_basis(basis):
         for z in ecp_elements:
             data = basis['elements'][z]
             sym = lut.element_sym_from_Z(z, True)
-            max_ecp_am = max([x['angular_momentum'][0] for x in data['ecp_potentials']])
-            max_ecp_amchar = lut.amint_to_char([max_ecp_am], hij=True)
 
             # Sort lowest->highest
             ecp_list = sorted(data['ecp_potentials'], key=lambda x: x['angular_momentum'])

--- a/pyscf/gto/basis/parse_gaussian.py
+++ b/pyscf/gto/basis/parse_gaussian.py
@@ -109,6 +109,8 @@ def _parse(raw_basis, optimize=True):
     basis_sorted = []
     for l in range(MAXL):
         basis_sorted.extend([b for b in basis_add if b[0] == l])
+    if not basis_sorted:
+        raise BasisNotFoundError(f'Basis data not found in "{raw_basis}"')
 
     if optimize:
         basis_sorted = optimize_contraction(basis_sorted)

--- a/pyscf/gto/basis/parse_gaussian.py
+++ b/pyscf/gto/basis/parse_gaussian.py
@@ -28,6 +28,7 @@ try:
 except ImportError:
     optimize_contraction = lambda basis: basis
     remove_zero = lambda basis: basis
+from pyscf.lib.exceptions import BasisNotFoundError
 
 MAXL = 12
 SPDF = 'SPDFGHIJKLMN'

--- a/pyscf/gto/basis/parse_nwchem.py
+++ b/pyscf/gto/basis/parse_nwchem.py
@@ -136,6 +136,8 @@ def _parse(raw_basis, optimize=True):
             else:
                 current_basis.append(dat)
     basis_sorted = [b for bs in basis_parsed for b in bs]
+    if not basis_sorted:
+        raise BasisNotFoundError(f'Basis data not found in string "{raw_basis}"')
 
     if optimize:
         basis_sorted = optimize_contraction(basis_sorted)

--- a/pyscf/gto/basis/parse_nwchem.py
+++ b/pyscf/gto/basis/parse_nwchem.py
@@ -212,7 +212,7 @@ def _parse_ecp(raw_ecp):
     for l in range(-1, MAXL):
         bsort.extend([b for b in ecp_add if b[0] == l])
     if not bsort:
-        raise BasisNotFoundError(f'ECP data not found in "{raw_basis}"')
+        raise BasisNotFoundError(f'ECP data not found in "{raw_ecp}"')
     return [nelec, bsort]
 
 def load_ecp(basisfile, symb):

--- a/pyscf/gto/basis/parse_nwchem.py
+++ b/pyscf/gto/basis/parse_nwchem.py
@@ -137,7 +137,7 @@ def _parse(raw_basis, optimize=True):
                 current_basis.append(dat)
     basis_sorted = [b for bs in basis_parsed for b in bs]
     if not basis_sorted:
-        raise BasisNotFoundError(f'Basis data not found in string "{raw_basis}"')
+        raise BasisNotFoundError(f'Basis data not found in "{raw_basis}"')
 
     if optimize:
         basis_sorted = optimize_contraction(basis_sorted)
@@ -207,11 +207,13 @@ def _parse_ecp(raw_ecp):
 
     if nelec is None:
         return []
-    else:
-        bsort = []
-        for l in range(-1, MAXL):
-            bsort.extend([b for b in ecp_add if b[0] == l])
-        return [nelec, bsort]
+
+    bsort = []
+    for l in range(-1, MAXL):
+        bsort.extend([b for b in ecp_add if b[0] == l])
+    if not bsort:
+        raise BasisNotFoundError(f'ECP data not found in "{raw_basis}"')
+    return [nelec, bsort]
 
 def load_ecp(basisfile, symb):
     return _parse_ecp(search_ecp(basisfile, symb))

--- a/pyscf/gto/test/test_basis_parser.py
+++ b/pyscf/gto/test/test_basis_parser.py
@@ -36,9 +36,8 @@ class KnownValues(unittest.TestCase):
         self.assertRaises(KeyError, gto.basis._parse_pople_basis, '631g++', 'C')
 
     def test_basis_load(self):
-        self.assertEqual(gto.basis.load(__file__, 'H'), [])
+        self.assertRaises(BasisNotFoundError, gto.basis.load, __file__, 'H')
         self.assertRaises(BasisNotFoundError, gto.basis.load, 'abas', 'H')
-        #self.assertRaises(BasisNotFoundError, gto.basis.load(__file__, 'C'), [])
 
         self.assertEqual(len(gto.basis.load('631++g**', 'C')), 8)
         self.assertEqual(len(gto.basis.load('ccpcvdz', 'C')), 7)

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ EXTRAS = {
     'cppe': ['cppe'],
     'pyqmc': ['pyqmc'],
     'mcfun': ['mcfun>=0.2.1'],
+    'bse': ['basis-set-exchange'],
 }
 EXTRAS['all'] = [p for extras in EXTRAS.values() for p in extras]
 # extras which should not be installed by "all" components


### PR DESCRIPTION
Partial solution to #898: these routines parse the JSON type data that `basis_set_exchange.api.get_basis` returns.