### PR TITLE
Adding CMake Option to Build qcint 

### DIFF
--- a/pyscf/lib/CMakeLists.txt
+++ b/pyscf/lib/CMakeLists.txt
@@ -140,11 +140,20 @@ set(CXX_LINK_TEMPLATE "<CMAKE_CXX_COMPILER> <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LA
 include(ExternalProject)
 option(BUILD_LIBCINT "Using libcint for analytical gaussian integral" ON)
 option(WITH_F12 "Compling F12 integrals" ON)
+option(USE_QCINT "Using the qcint library (optimized for x86-64) for gaussian integral evaluation" OFF)
+
 if(BUILD_LIBCINT)
 if(NOT EXISTS "${PROJECT_SOURCE_DIR}/deps/include/cint.h")
+  set(LIBCINT_GIT https://github.com/sunqm/libcint.git) # libcint is a portable, cross-platform implementation
+  if (USE_QCINT)
+    set(LIBCINT_GIT https://github.com/sunqm/qcint.git) # qcint is an optimized implementation for x86-64 architecture
+    if(NOT BUILD_MARCH_NATIVE)
+      message(WARNING "The BUILD_MARCH_NATIVE option is not specified! qcint may not compile unless you explicitly pass compiler flags that turn on vectorization!")    
+    endif()
+  endif()
+
   ExternalProject_Add(libcint
-    GIT_REPOSITORY https://github.com/sunqm/libcint.git # libcint is a portable, cross-platform implementation
-    # GIT_REPOSITORY https://github.com/sunqm/qcint.git # qcint is an optimized implementation for x86-64 architecture
+    GIT_REPOSITORY ${LIBCINT_GIT}
     GIT_TAG v5.1.0
     PREFIX ${PROJECT_BINARY_DIR}/deps
     INSTALL_DIR ${PROJECT_SOURCE_DIR}/deps


### PR DESCRIPTION
## Summary
This PR adds the cmake option to build `qcint` instead of vanilla `libcint`. Users can specify from the command line like this:

```
cmake -B build -DUSE_QCINT=ON
```

When users specify `USE_QCINT=ON` and _do not_ define `BUILD_MARCH_NATIVE`, they are warned that `qcint` may fail to compile, which happens when `CMAKE_C_FLAGS` doesn't contain any flags anything to turn vectorization on. This problem was behind #1173.

## Next Steps
This is a somewhat loose check. If users specify `CMAKE_C_FLAGS=-O3`, but not `BUILD_MARCH_NATIVE`, then the warning is unnecessary. At the same time, I think it would complicate `CMakeLists.txt` to try to check all ways that users could turn on vectorization. Do other people have thoughts on this?