### PR TITLE
Try to use original axes if pointgroup is inputed, add axes logging

### DIFF
--- a/pyscf/fci/test/test_spin0_symm.py
+++ b/pyscf/fci/test/test_spin0_symm.py
@@ -60,11 +60,11 @@ class KnownValues(unittest.TestCase):
         ci1 = fci.addons.symmetrize_wfn(ci0, norb, nelec, orbsym, wfnsym=1)
         ci1 = cis.contract_2e(g2e, ci1, norb, nelec, wfnsym=1)
         self.assertAlmostEqual(numpy.linalg.norm(ci1), 82.571087072474697, 9)
-        ci1 = fci.addons.symmetrize_wfn(ci0, norb, nelec, orbsym, wfnsym=2)
-        ci1 = cis.contract_2e(g2e, ci1, norb, nelec, wfnsym=2)
-        self.assertAlmostEqual(numpy.linalg.norm(ci1), 82.257163492625622, 9)
         ci1 = fci.addons.symmetrize_wfn(ci0, norb, nelec, orbsym, wfnsym=3)
         ci1 = cis.contract_2e(g2e, ci1, norb, nelec, wfnsym=3)
+        self.assertAlmostEqual(numpy.linalg.norm(ci1), 82.257163492625622, 9)
+        ci1 = fci.addons.symmetrize_wfn(ci0, norb, nelec, orbsym, wfnsym=2)
+        ci1 = cis.contract_2e(g2e, ci1, norb, nelec, wfnsym=2)
         self.assertAlmostEqual(numpy.linalg.norm(ci1), 81.010497935954916, 9)
 
     def test_kernel(self):

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2433,19 +2433,18 @@ class Mole(lib.StreamObject):
         if isinstance(self.symmetry, (str, unicode)):
             self.symmetry = str(symm.std_symb(self.symmetry))
             try:
-                try:
-                    groupname0, axes0 = symm.as_subgroup(self.topgroup, np.eye(3),
-                                                         self.symmetry)
-                    self.groupname, axes = groupname0, axes0
-                except PointGroupSymmetryError:
-                    logger.info(self, 'Unable to to identify input symmetry using original axes.\n'
-                                'Different symmetry axes will be used.')
-                self.groupname, axes = symm.as_subgroup(self.topgroup, axes,
+                self.groupname, axes = symm.as_subgroup(self.topgroup, np.eye(3),
                                                         self.symmetry)
             except PointGroupSymmetryError:
-                raise PointGroupSymmetryError(
-                    'Unable to identify input symmetry %s. Try symmetry="%s"' %
-                    (self.symmetry, self.topgroup))
+                logger.warn(self, 'Unable to to identify input symmetry using original axes.\n'
+                            'Different symmetry axes will be used.')
+                try:
+                    self.groupname, axes = symm.as_subgroup(self.topgroup, axes,
+                                                            self.symmetry)
+                except PointGroupSymmetryError as e:
+                    raise PointGroupSymmetryError(
+                        'Unable to identify input symmetry %s. Try symmetry="%s"' %
+                        (self.symmetry, self.topgroup)) from e
         else:
             self.groupname, axes = symm.as_subgroup(self.topgroup, axes,
                                                     self.symmetry_subgroup)

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2433,6 +2433,13 @@ class Mole(lib.StreamObject):
         if isinstance(self.symmetry, (str, unicode)):
             self.symmetry = str(symm.std_symb(self.symmetry))
             try:
+                try:
+                    groupname0, axes0 = symm.as_subgroup(self.topgroup, np.eye(3),
+                                                         self.symmetry)
+                    self.groupname, axes = groupname0, axes0
+                except PointGroupSymmetryError:
+                    logger.info(self, 'Unable to to identify input symmetry using original axes.\n'
+                                'Different symmetry axes will be used.')
                 self.groupname, axes = symm.as_subgroup(self.topgroup, axes,
                                                         self.symmetry)
             except PointGroupSymmetryError:
@@ -2621,6 +2628,10 @@ class Mole(lib.StreamObject):
                 else:
                     logger.info(self, 'point group symmetry = %s, use subgroup %s',
                                 self.topgroup, self.groupname)
+                logger.info(self, "symmetry origin: %s", self._symm_orig)
+                logger.info(self, "symmetry axis x: %s", self._symm_axes[0])
+                logger.info(self, "symmetry axis y: %s", self._symm_axes[1])
+                logger.info(self, "symmetry axis z: %s", self._symm_axes[2])
                 for ir in range(self.symm_orb.__len__()):
                     logger.info(self, 'num. orbitals of irrep %s = %d',
                                 self.irrep_name[ir], self.symm_orb[ir].shape[1])

--- a/pyscf/scf/test/test_ghf.py
+++ b/pyscf/scf/test/test_ghf.py
@@ -243,7 +243,7 @@ class KnownValues(unittest.TestCase):
     def test_get_occ(self):
         mf1 = copy.copy(mfsym)
         mf1.irrep_nelec = {}
-        mf1.irrep_nelec['B2'] = 1
+        mf1.irrep_nelec['B1'] = 1
         occ = mf1.get_occ(mf.mo_energy, mf.mo_coeff+0j)
         self.assertAlmostEqual(lib.fp(occ), 0.49368251542877073, 9)
         mf1.irrep_nelec['A2'] = 5


### PR DESCRIPTION
If one inputs the point group together with proper axes framework, these axes should be used. In the current implementation the program searches for symmetry from scratch.