### PR TITLE
Solve problem using symmetry with unconventional basis sets

### DIFF
--- a/pyscf/symm/basis.py
+++ b/pyscf/symm/basis.py
@@ -324,6 +324,8 @@ def so3_symm_adapted_basis(mol, gpname, orig=0, coordinates=None):
     irrep_names = []
     for l in range(lmax+1):
         bas_idx = mol._bas[:,gto.ANG_OF] == l
+        if sum(bas_idx) == 0: # Skip any unused angular momentum channels
+            continue
         cs = [coeff[:,p0:p1]
               for p0, p1 in zip(ao_loc[:-1][bas_idx], ao_loc[1:][bas_idx])]
         c_groups = numpy.hstack(cs).reshape(nao, -1, l*2+1)


### PR DESCRIPTION
At the moment, PySCF fails to run with unconventional basis sets when symmetry is enabled. Test case: hydrogen atom with P functions from HGBSP1-9 basis set
```
import pyscf

mol = pyscf.M(
    atom = 'H',
    basis = {'H' : pyscf.gto.load('''
H    P
      4.9729544510e+01       1.0
H    P
      2.6899149919e+01       1.0
H    P
      1.4549987809e+01       1.0
H    P
      7.8702169357e+00       1.0
H    P
      4.2570698634e+00       1.0
H    P
      2.3026866946e+00       1.0
H    P
      1.2455435743e+00       1.0
H    P
      6.7372552203e-01       1.0
H    P
      3.6442408633e-01       1.0
H    P
      1.9712020749e-01       1.0
H    P
      1.0662406153e-01       1.0
H    P
      5.7673896760e-02       1.0
H    P
      3.1196320229e-02       1.0
H    P
      1.6874365190e-02       1.0
H    P
      9.1274931936e-03       1.0
''', 'H')},
    symmetry = True,
    spin = 1,
    verbose = 4
)

method = pyscf.scf.UHF(mol)
method.init_guess = '1e'
method.kernel()
```
With these changes, the code runs and returns the SCF energy -0.124999998288299 which is in excellent agreement with the theoretical value -0.125. Without the change, PySCF crashes.