### PR TITLE
Ensure deterministic result from pyscf.lib.einsum

### DIFF
--- a/pyscf/lib/numpy_helper.py
+++ b/pyscf/lib/numpy_helper.py
@@ -157,6 +157,7 @@ def _contract(subscripts, *tensors, **kwargs):
     idxBt = list(idxB)
     inner_shape = 1
     insert_B_loc = 0
+    shared_idxAB = sorted(list(shared_idxAB))
     for n in shared_idxAB:
         if rangeA[n] != rangeB[n]:
             err = ('ERROR: In index string %s, the range of index %s is '


### PR DESCRIPTION
Due to the usage of sets in `pyscf.lib.contract`, `pyscf.lib.einsum` is non-deterministic even when running on a single thread, unlike `np.einsum`. Minimal example below, fixed by this PR. 

```
from pyscf import lib
import numpy as np
np.random.seed(1)

a = np.random.random((10, 10, 10, 10))
b = np.random.random((10, 10, 10, 10))

for einsum in [np.einsum, lib.einsum]:
    res = einsum("xijk,yijk->xy", a, b)
    print("%.32f" % lib.fp(res))
```

Thanks to @obackhouse.