### PR TITLE
Add compiler option for ARM

### DIFF
--- a/pyscf/lib/CMakeLists.txt
+++ b/pyscf/lib/CMakeLists.txt
@@ -29,7 +29,7 @@ if (CMAKE_COMPILER_IS_GNUCC) # Does it skip the link flag on old OsX?
     set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-as-needed")
   endif()
 endif()
-set(CMAKE_C_FLAGS "-Wall ${CMAKE_C_FLAGS}")
+set(CMAKE_C_FLAGS "-Wall -fsigned-char ${CMAKE_C_FLAGS}")
 
 option(BUILD_MARCH_NATIVE "gcc flag -march=native" off)
 if (BUILD_MARCH_NATIVE)


### PR DESCRIPTION
PySCF tries to support aarch64 (ARM) architecture as in #1226, but it has a numerical problem and most tests fail #1123. 

The root cause of this problem is from C codes in lib directory which use `char`.  C language's char is implementation dependent, and ARM's gcc regards it as `unsinged char`. PySCF codes assume char as `signed char`.

I suggest to add compiler option `-fsigned-char` so that ARM's gcc also behave in the same way.