### PR TITLE
Make spin_square work for a custom fcisolver in UCASCI/UCASSCF

### DIFF
--- a/pyscf/fci/spin_op.py
+++ b/pyscf/fci/spin_op.py
@@ -109,13 +109,17 @@ def spin_square_general(dm1a, dm1b, dm2aa, dm2ab, dm2bb, mo_coeff, ovlp=1):
     return ss, multip
 
 @lib.with_doc(spin_square_general.__doc__)
-def spin_square(fcivec, norb, nelec, mo_coeff=None, ovlp=1):
-    from pyscf.fci import direct_spin1
+def spin_square(fcivec, norb, nelec, mo_coeff=None, ovlp=1, fcisolver=None):
     if mo_coeff is None:
         mo_coeff = (numpy.eye(norb),) * 2
-
-    (dm1a, dm1b), (dm2aa, dm2ab, dm2bb) = \
+    
+    if fcisolver is None:
+        from pyscf.fci import direct_spin1
+        (dm1a, dm1b), (dm2aa, dm2ab, dm2bb) = \
             direct_spin1.make_rdm12s(fcivec, norb, nelec)
+    else:
+        (dm1a, dm1b), (dm2aa, dm2ab, dm2bb) = \
+            fcisolver.make_rdm12s(fcivec, norb, nelec)
 
     return spin_square_general(dm1a, dm1b, dm2aa, dm2ab, dm2bb, mo_coeff, ovlp)
 

--- a/pyscf/fci/spin_op.py
+++ b/pyscf/fci/spin_op.py
@@ -112,7 +112,7 @@ def spin_square_general(dm1a, dm1b, dm2aa, dm2ab, dm2bb, mo_coeff, ovlp=1):
 def spin_square(fcivec, norb, nelec, mo_coeff=None, ovlp=1, fcisolver=None):
     if mo_coeff is None:
         mo_coeff = (numpy.eye(norb),) * 2
-    
+
     if fcisolver is None:
         from pyscf.fci import direct_spin1
         (dm1a, dm1b), (dm2aa, dm2ab, dm2bb) = \

--- a/pyscf/mcscf/ucasci.py
+++ b/pyscf/mcscf/ucasci.py
@@ -296,13 +296,13 @@ class UCASCI(casci.CASCI):
             ss_core = self._scf.spin_square(mocore, ovlp_ao)
             if isinstance(self.e_cas, (float, numpy.number)):
                 ss = fci.spin_op.spin_square(self.ci, self.ncas, self.nelecas,
-                                             mocas, ovlp_ao)
+                                             mocas, ovlp_ao, self.fcisolver)
                 log.note('UCASCI E = %.15g  E(CI) = %.15g  S^2 = %.7f',
                          self.e_tot, self.e_cas, ss[0]+ss_core[0])
             else:
                 for i, e in enumerate(self.e_cas):
                     ss = fci.spin_op.spin_square(self.ci[i], self.ncas, self.nelecas,
-                                                 mocas, ovlp_ao)
+                                                 mocas, ovlp_ao, self.fcisolver)
                     log.note('UCASCI root %d  E = %.15g  E(CI) = %.15g  S^2 = %.7f',
                              i, self.e_tot[i], e, ss[0]+ss_core[0])
         else:


### PR DESCRIPTION
The current implementation of ``fci.spin_op.spin_square`` restricts the ``fcisolver`` in ``mcscf.ucasci`` to be ``fci.direct_spin1`` (or its subclass). The following change will allow supporting a custom fcisolver (such as the non-spin-adapted DMRG solver) with UCASCI and UCASSCF.