### PR TITLE
bug fix for LRC hybrid DFT with exxdiv = 'ewald'

### DIFF
--- a/pyscf/pbc/df/test/test_mdf_jk.py
+++ b/pyscf/pbc/df/test/test_mdf_jk.py
@@ -309,7 +309,7 @@ class KnownValues(unittest.TestCase):
         vj2, vk2 = pbcdf.MDF(cell, kpts).get_jk(dm, hermi=0, kpts=kpts, omega=0.3, exxdiv='ewald')
         vj3, vk3 = pbcdf.AFTDF(cell, kpts).get_jk(dm, hermi=0, kpts=kpts, omega=0.3, exxdiv='ewald')
         self.assertAlmostEqual(lib.fp(vj0), 0.007500219791944259, 9)
-        self.assertAlmostEqual(lib.fp(vk0), 0.0007724337759304424+0.00018842136513478529j, 9)
+        self.assertAlmostEqual(lib.fp(vk0), 0.13969453408250163-0.009249150979351648j, 9)
         self.assertAlmostEqual(abs(vj0-vj1).max(), 0, 8)
         self.assertAlmostEqual(abs(vj0-vj2).max(), 0, 8)
         self.assertAlmostEqual(abs(vj0-vj3).max(), 0, 8)

--- a/pyscf/pbc/dft/test/test_krks.py
+++ b/pyscf/pbc/dft/test/test_krks.py
@@ -116,17 +116,18 @@ class KnownValues(unittest.TestCase):
         e1 = mf.scf()
         self.assertAlmostEqual(e1, -11.353643583707452, 8)
 
-    def test_rsh_df(self):
+    def test_rsh_fft(self):
         mf = pbcdft.KRKS(cell)
         mf.xc = 'camb3lyp'
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.3032261128220544, 7)
+        self.assertAlmostEqual(mf.e_tot, -2.4745140703871877, 7)
 
+    def test_rsh_df(self):
         mf = pbcdft.KRKS(cell).density_fit()
         mf.xc = 'camb3lyp'
         mf.omega = .15
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.3987656490734555, 7)
+        self.assertAlmostEqual(mf.e_tot, -2.4766238116030683, 7)
 
 # TODO: test the reset method of pbcdft.KRKS, pbcdft.RKS whether the reset
 # methods of all subsequent objects are called

--- a/pyscf/pbc/dft/test/test_kuks.py
+++ b/pyscf/pbc/dft/test/test_kuks.py
@@ -65,17 +65,18 @@ C, 0.8917,  2.6751,  2.6751'''
         e1 = mf.scf()
         self.assertAlmostEqual(e1, -45.42583489512954, 8)
 
-    def test_rsh_df(self):
+    def test_rsh_fft(self):
         mf = pbcdft.KUKS(cell)
         mf.xc = 'camb3lyp'
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.3032261128220544, 7)
+        self.assertAlmostEqual(mf.e_tot, -2.4745140703871877, 7)
 
+    def test_rsh_df(self):
         mf = pbcdft.KUKS(cell).density_fit()
         mf.xc = 'camb3lyp'
         mf.omega = .15
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.3987656490734555, 7)
+        self.assertAlmostEqual(mf.e_tot, -2.4766238116030683, 7)
 
 
 if __name__ == '__main__':

--- a/pyscf/pbc/dft/test/test_rks.py
+++ b/pyscf/pbc/dft/test/test_rks.py
@@ -197,6 +197,30 @@ class KnownValues(unittest.TestCase):
         mf1.kernel()
         self.assertAlmostEqual(mf1.e_tot, mf.e_tot, 4)
 
+    def test_rsh_0d_ewald(self):
+        L = 4.
+        cell = pbcgto.Cell()
+        cell.verbose = 0
+        cell.a = np.eye(3)*L
+        cell.atom =[['He' , ( L/2+0., L/2+0. ,   L/2+1.)],]
+        cell.basis = {'He': [[0, (4.0, 1.0)], [0, (1.0, 1.0)]]}
+        cell.dimension = 0
+        cell.mesh = [60]*3
+        cell.build()
+        mf = pbcdft.RKS(cell).density_fit()
+        mf.xc = 'camb3lyp'
+        mf.omega = '0.7'
+        mf.exxdiv = 'ewald'
+        mf.kernel()
+        self.assertAlmostEqual(mf.e_tot, -2.4836186361124617, 7)
+
+        mol = cell.to_mol()
+        mf1 = mol.RKS().density_fit()
+        mf1.xc = 'camb3lyp'
+        mf1.omega = '0.7'
+        mf1.kernel()
+        self.assertAlmostEqual(mf1.e_tot, mf.e_tot, 4)
+
 if __name__ == '__main__':
     print("Full Tests for pbc.dft.rks")
     unittest.main()

--- a/pyscf/pbc/dft/test/test_rks.py
+++ b/pyscf/pbc/dft/test/test_rks.py
@@ -139,31 +139,31 @@ class KnownValues(unittest.TestCase):
         mf = pbcdft.RKS(cell)
         mf.xc = 'camb3lyp'
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.3032261128220544, 7)
+        self.assertAlmostEqual(mf.e_tot, -2.4745140703871877, 7)
 
         mf.omega = .15
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.3987595548455523, 7)
+        self.assertAlmostEqual(mf.e_tot, -2.476617717375184, 7)
 
     def test_custom_rsh_df(self):
         mf = pbcdft.RKS(cell).density_fit()
         mf.xc = 'camb3lyp'
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.303232164939132, 7)
+        self.assertAlmostEqual(mf.e_tot, -2.474520122522153, 7)
 
         mf.omega = .15
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.3987656490734555, 7)
+        self.assertAlmostEqual(mf.e_tot, -2.4766238116030683, 7)
 
     def test_rsh_mdf(self):
         mf = pbcdft.RKS(cell).mix_density_fit()
         mf.xc = 'camb3lyp'
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.303225896642264, 7)
+        self.assertAlmostEqual(mf.e_tot, -2.4745138538438827, 7)
 
         mf.omega = .15
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.398759319488945, 7)
+        self.assertAlmostEqual(mf.e_tot, -2.4766174820185456, 7)
 
     def test_rsh_aft_high_cost(self):
         from pyscf.pbc.df.aft import AFTDF
@@ -171,7 +171,7 @@ class KnownValues(unittest.TestCase):
         mf.with_df = AFTDF(cell)
         mf.xc = 'camb3lyp'
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.303226113014942, 7)
+        self.assertAlmostEqual(mf.e_tot, -2.4745140705800446, 7)
 
     def test_rsh_0d(self):
         L = 4.

--- a/pyscf/pbc/dft/test/test_uks.py
+++ b/pyscf/pbc/dft/test/test_uks.py
@@ -66,17 +66,18 @@ class KnownValues(unittest.TestCase):
         mf.xc = 'lda,vwn'
         self.assertAlmostEqual(mf.scf(), -7.6162130840535092, 8)
 
-    def test_rsh_df(self):
+    def test_rsh_fft(self):
         mf = pbcdft.UKS(cell)
         mf.xc = 'camb3lyp'
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.3032261128220544, 7)
+        self.assertAlmostEqual(mf.e_tot, -2.4745140703871877, 7)
 
+    def test_rsh_df(self):
         mf = pbcdft.UKS(cell).density_fit()
         mf.xc = 'camb3lyp'
         mf.omega = .15
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.3987656490734555, 7)
+        self.assertAlmostEqual(mf.e_tot, -2.4766238116030683, 7)
 
 
 if __name__ == '__main__':

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -461,7 +461,7 @@ def madelung(cell, kpts):
         Gv, Gvbase, weights = ecell.get_Gv_weights(ecell.mesh)
         coulG = get_coulG(ecell, Gv=Gv)
         ZSI = np.einsum("i,ij->j", ecell.atom_charges(), ecell.get_SI(Gv))
-        return -np.einsum('i,i,i->', ZSI.conj(), ZSI, coulG*weights).real
+        return 2*cell.omega/np.pi**0.5-np.einsum('i,i,i->', ZSI.conj(), ZSI, coulG*weights).real
 
 
 def get_monkhorst_pack_size(cell, kpts):


### PR DESCRIPTION
For a STO-3G H2 molecule in a cubic box of length `a0`, the PBC DFT energy with `exxdiv='ewald'` for the wb97x LRC hybrid functional does not converge to that from a molecular calculation (see column `old Epbc` vs `Emol`).
| a0 (Ang)  |  old Epbc  |   new Epbc  |   Emol   |
| ----------|-----------|-------------|--------|
| 10             | -0.87429950  |  -1.15942760 |  |
| 20             | -0.87299382 | -1.15812192   |  |
| 1/a0^3 extrap | -0.87280729 | -1.15793540  | -1.15793625 |

The problem is found to be the `madelung` function in `pbc/tool/pbc.py` giving an incorrect correction to the long-range exchange matrix. The change in this PR fixes this (see column `new Epbc` in the table above).

A test function `test_rsh_0d_ewald` is added to `pbc/dft/test_rsk.py`. The reference values for other tests in the same file that use a LRC hybrid functional and `exxdiv='ewald'` are updated as well (the new reference values are much closer to the molecular result in all cases).

Thanks to @tberkel and @verena-neufeld for helping identify the problem and the fix.