### PR TITLE
fix example pbc/23-smearing

### DIFF
--- a/examples/pbc/23-smearing.py
+++ b/examples/pbc/23-smearing.py
@@ -20,7 +20,7 @@ cell.build()
 # SCF object
 #
 nks = [2,1,1]
-mf = scf.KRHF(cell, cell.make_kpts(nks))
+mf = scf.KRHF(cell, cell.make_kpts(nks)).density_fit()
 mf = scf.addons.smearing_(mf, sigma=.1, method='fermi')
 mf.kernel()
 print('Entropy = %s' % mf.entropy)
@@ -30,14 +30,17 @@ print('Zero temperature energy = %s' % ((mf.e_tot+mf.e_free)/2))
 #
 # The smearing method and parameters can be modified at runtime
 #
-mf = scf.addons.smearing_(scf.UHF(cell))
+#mf.sigma = .1
+#mf.method = 'gauss'
+#mf.max_cycle = 1
+#mf.kernel()
 mf.sigma = .1
-mf.method = 'gauss'
+mf.smearing_method = 'gauss'
 mf.max_cycle = 2
 mf.kernel()
 
 mf.sigma = .05
-mf.method = 'fermi'
+mf.smearing_method = 'fermi'
 mf.max_cycle = 50
 mf.kernel()
 

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -562,9 +562,8 @@ class SCF(mol_hf.SCF):
             logger.info(self, '    Total energy shift due to Ewald probe charge'
                         ' = -1/2 * Nelec*madelung = %.12g',
                         madelung*cell.nelectron * -.5)
-        if self.smearing_method is not None:
+        if getattr(self, 'smearing_method', None) is not None:
             logger.info(self, 'Smearing method = %s', self.smearing_method)
-            logger.info(self, '    sigma = %s', self.sigma)
         logger.info(self, 'DF object = %s', self.with_df)
         if not getattr(self.with_df, 'build', None):
             # .dump_flags() is called in pbc.df.build function

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -562,6 +562,9 @@ class SCF(mol_hf.SCF):
             logger.info(self, '    Total energy shift due to Ewald probe charge'
                         ' = -1/2 * Nelec*madelung = %.12g',
                         madelung*cell.nelectron * -.5)
+        if self.smearing_method is not None:
+            logger.info(self, 'Smearing method = %s', self.smearing_method)
+            logger.info(self, '    sigma = %s', self.sigma)
         logger.info(self, 'DF object = %s', self.with_df)
         if not getattr(self.with_df, 'build', None):
             # .dump_flags() is called in pbc.df.build function

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -527,9 +527,8 @@ class KSCF(pbchf.SCF):
             logger.info(self, '    Total energy shift due to Ewald probe charge'
                         ' = -1/2 * Nelec*madelung = %.12g',
                         madelung*nelectron * -.5)
-        if self.smearing_method is not None:
+        if getattr(self, 'smearing_method', None) is not None:
             logger.info(self, 'Smearing method = %s', self.smearing_method)
-            logger.info(self, '    sigma = %s', self.sigma)
         logger.info(self, 'DF object = %s', self.with_df)
         if not getattr(self.with_df, 'build', None):
             # .dump_flags() is called in pbc.df.build function

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -527,6 +527,9 @@ class KSCF(pbchf.SCF):
             logger.info(self, '    Total energy shift due to Ewald probe charge'
                         ' = -1/2 * Nelec*madelung = %.12g',
                         madelung*nelectron * -.5)
+        if self.smearing_method is not None:
+            logger.info(self, 'Smearing method = %s', self.smearing_method)
+            logger.info(self, '    sigma = %s', self.sigma)
         logger.info(self, 'DF object = %s', self.with_df)
         if not getattr(self.with_df, 'build', None):
             # .dump_flags() is called in pbc.df.build function


### PR DESCRIPTION
When modify smearing method at runtime, modify `mf.method` actually changes nothing. It should be `mf.smearing_method`. This can be checked by comparing entropy output by L33-36 (commented since it's wrong) and L37-40. Or, just dump the smearing method at dump_flags.