### PR TITLE
Fix VXCao_empty_blocks (fix issue #1191)

### DIFF
--- a/pyscf/dft/test/test_numint.py
+++ b/pyscf/dft/test/test_numint.py
@@ -150,7 +150,7 @@ class KnownValues(unittest.TestCase):
         mo_occ = numpy.ones(nao)
         mo_occ[-2:] = -1
         dm = numpy.einsum('pi,i,qi->pq', mo_coeff, mo_occ, mo_coeff)
-        
+
         rho0 = numpy.zeros((6,ngrids))
         rho0[0] = numpy.einsum('pi,ij,pj->p', ao[0], dm, ao[0].conj())
         rho0[1] = numpy.einsum('pi,ij,pj->p', ao[1], dm, ao[0].conj()) + numpy.einsum('pi,ij,pj->p', ao[0], dm, ao[1].conj())
@@ -164,7 +164,6 @@ class KnownValues(unittest.TestCase):
         rho0[5]+= numpy.einsum('pi,ij,pj->p', ao[3], dm, ao[3].conj())
         rho0[4]+= rho0[5]*2
         rho0[5] *= .5
-        return rho0
 
         ni = dft.numint.NumInt()
         rho1 = ni.eval_rho (mol, ao, dm, xctype='MGGA')

--- a/pyscf/lib/dft/nr_numint.c
+++ b/pyscf/lib/dft/nr_numint.c
@@ -41,13 +41,14 @@ int VXCao_empty_blocks(int8_t *empty, uint8_t *non0table, int *shls_slice,
         int has0 = 0;
         empty[box_id] = 1;
         for (bas_id = sh0; bas_id < sh1; bas_id++) {
-                empty[box_id] &= !non0table[bas_id];
                 if (ao_loc[bas_id] == bound) {
                         has0 |= empty[box_id];
                         box_id++;
                         bound += BOXSIZE;
                         empty[box_id] = 1;
-                } else if (ao_loc[bas_id] > bound) {
+                }
+                empty[box_id] &= !non0table[bas_id];
+                if (ao_loc[bas_id+1] > bound) {
                         has0 |= empty[box_id];
                         box_id++;
                         bound += BOXSIZE;

--- a/pyscf/lib/dft/test/test_libdft.py
+++ b/pyscf/lib/dft/test/test_libdft.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import unittest
+import ctypes
+import itertools
+import numpy
+from pyscf.dft.numint import libdft
+
+class KnownValues(unittest.TestCase):
+    def test_empty_blocks(self):
+        ao_loc = numpy.array([0,51,60,100,112,165,172], dtype=numpy.int32)
+
+        def get_empty_mask(non0tab_mask):
+            non0tab_mask = numpy.asarray(non0tab_mask, dtype=numpy.uint8)
+            shls_slice = (0, non0tab_mask.size)
+            empty_mask = numpy.empty(4, dtype=numpy.int8)
+            empty_mask[:] = -9
+            libdft.VXCao_empty_blocks(
+                empty_mask.ctypes.data_as(ctypes.c_void_p),
+                non0tab_mask.ctypes.data_as(ctypes.c_void_p),
+                (ctypes.c_int*2)(*shls_slice),
+                ao_loc.ctypes.data_as(ctypes.c_void_p))
+            return empty_mask.tolist()
+
+        def naive_emtpy_mask(non0tab_mask):
+            blksize = 56
+            ao_mask = numpy.zeros(ao_loc[-1], dtype=bool)
+            for k, (i0, i1) in enumerate(zip(ao_loc[:-1], ao_loc[1:])):
+                ao_mask[i0:i1] = non0tab_mask[k] == 1
+            valued = [m.any() for m in numpy.split(ao_mask, [56, 112, 168])]
+            empty_mask = ~numpy.array(valued)
+            return empty_mask.astype(numpy.int).tolist()
+
+        def check(non0tab_mask):
+            if get_empty_mask(non0tab_mask) != naive_emtpy_mask(non0tab_mask):
+                raise ValueError(non0tab_mask)
+
+        for mask in list(itertools.product([0, 1], repeat=6)):
+            check(mask)
+
+if __name__ == "__main__":
+    print("Test libdft")
+    unittest.main()


### PR DESCRIPTION
This PR fixes issue #1191 by correcting the algorithm in the `VXCao_empty_blocks` function, which previously would assign non0tab values for some shells to the wrong box for some systems. A unit test is also introduced in `pyscf.dft.test.test_numint` to test the new function; this test fails for the old version and passes for the new one.