### PR TITLE
Fix compilation error in combination to qcint

### DIFF
--- a/pyscf/lib/CMakeLists.txt
+++ b/pyscf/lib/CMakeLists.txt
@@ -46,6 +46,11 @@ if (BUILD_MARCH_NATIVE)
       set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-math-errno")
     endif()
   endif()
+else()
+  if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+    # Avoids error "‘SIMDD’ undeclared here (not in a function)" in the qcint two-electron integral interface
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse3")
+  endif()
 endif()
 
 


### PR DESCRIPTION
When compiling PySCF against the system version of qcint, I get several errors
```
In file included from /home/work/pyscf/pyscf/lib/gto/fill_int2c.c:22:
/usr/include/cint.h:253:9: error: ‘SIMDD’ undeclared here (not in a function)
  253 |         ALIGNMM double ai[SIMDD];
      |         ^~~~~~~
make[2]: *** [gto/CMakeFiles/cgto.dir/build.make:76: gto/CMakeFiles/cgto.dir/fill_int2c.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /home/work/pyscf/pyscf/lib/gto/fill_nr_3c.c:22:
/usr/include/cint.h:253:9: error: ‘SIMDD’ undeclared here (not in a function)
  253 |         ALIGNMM double ai[SIMDD];
      |         ^~~~~~~
make[2]: *** [gto/CMakeFiles/cgto.dir/build.make:90: gto/CMakeFiles/cgto.dir/fill_nr_3c.c.o] Error 1
In file included from /home/work/pyscf/pyscf/lib/gto/fill_r_3c.c:23:
/usr/include/cint.h:253:9: error: ‘SIMDD’ undeclared here (not in a function)
  253 |         ALIGNMM double ai[SIMDD];
      |         ^~~~~~~
In file included from /home/work/pyscf/pyscf/lib/gto/fill_int2e.c:22:
/usr/include/cint.h:253:9: error: ‘SIMDD’ undeclared here (not in a function)
  253 |         ALIGNMM double ai[SIMDD];
      |         ^~~~~~~
make[2]: *** [gto/CMakeFiles/cgto.dir/build.make:104: gto/CMakeFiles/cgto.dir/fill_r_3c.c.o] Error 1
make[2]: *** [gto/CMakeFiles/cgto.dir/build.make:118: gto/CMakeFiles/cgto.dir/fill_int2e.c.o] Error 1
In file included from /home/work/pyscf/pyscf/lib/gto/fill_r_4c.c:23:
/usr/include/cint.h:253:9: error: ‘SIMDD’ undeclared here (not in a function)
  253 |         ALIGNMM double ai[SIMDD];
      |         ^~~~~~~
make[2]: *** [gto/CMakeFiles/cgto.dir/build.make:132: gto/CMakeFiles/cgto.dir/fill_r_4c.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:290: gto/CMakeFiles/cgto.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```
The problem arises when native instructions are not enabled. The fix is to add the `-msse3` flag.