### PR TITLE
Fix cmake error in aarch64

### DIFF
--- a/pyscf/lib/CMakeLists.txt
+++ b/pyscf/lib/CMakeLists.txt
@@ -48,8 +48,12 @@ if (BUILD_MARCH_NATIVE)
   endif()
 else()
   if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
-    # Avoids error "‘SIMDD’ undeclared here (not in a function)" in the qcint two-electron integral interface
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse3")
+    include(CheckCCompilerFlag)
+    CHECK_C_COMPILER_FLAG("-msse3" COMPILER_SUPPORTS_SSE3)
+    if(COMPILER_SUPPORTS_SSE3)
+      # Avoids error "‘SIMDD’ undeclared here (not in a function)" in the qcint two-electron integral interface
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse3")
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
Build failed in AArch64, due to the change in #1275 that assume all CPU supports SSE3.
This fix adds another if-statement to avoid the error.

(This will help fix build problem in #1277.)