### PR TITLE
Fix typos

### DIFF
--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2669,7 +2669,7 @@ class Mole(lib.StreamObject):
     set_common_origin_ = set_common_orig  # for backward compatibility
 
     def with_common_origin(self, coord):
-        '''Retuen a temporary mol context which has the rquired common origin.
+        '''Return a temporary mol context which has the rquired common origin.
         The required common origin has no effects out of the temporary context.
         See also :func:`mol.set_common_origin`
 
@@ -2698,7 +2698,7 @@ class Mole(lib.StreamObject):
     set_rinv_origin_ = set_rinv_orig  # for backward compatibility
 
     def with_rinv_origin(self, coord):
-        '''Retuen a temporary mol context which has the rquired origin of 1/r
+        '''Return a temporary mol context which has the rquired origin of 1/r
         operator.  The required origin has no effects out of the temporary
         context.  See also :func:`mol.set_rinv_origin`
 
@@ -2733,7 +2733,7 @@ class Mole(lib.StreamObject):
     omega = omega.setter(set_range_coulomb)
 
     def with_range_coulomb(self, omega):
-        '''Retuen a temporary mol context which sets the required parameter
+        '''Return a temporary mol context which sets the required parameter
         omega for range-separated Coulomb operator.
         If omega = None, return the context for regular Coulomb integrals.
         See also :func:`mol.set_range_coulomb`
@@ -2747,13 +2747,13 @@ class Mole(lib.StreamObject):
         return self._TemporaryMoleContext(self.set_range_coulomb, (omega,), (omega0,))
 
     def with_long_range_coulomb(self, omega):
-        '''Retuen a temporary mol context for long-range part of
+        '''Return a temporary mol context for long-range part of
         range-separated Coulomb operator.
         '''
         return self.with_range_coulomb(abs(omega))
 
     def with_short_range_coulomb(self, omega):
-        '''Retuen a temporary mol context for short-range part of
+        '''Return a temporary mol context for short-range part of
         range-separated Coulomb operator.
         '''
         return self.with_range_coulomb(-abs(omega))
@@ -2794,7 +2794,7 @@ class Mole(lib.StreamObject):
     set_rinv_zeta_ = set_rinv_zeta  # for backward compatibility
 
     def with_rinv_zeta(self, zeta):
-        '''Retuen a temporary mol context which has the rquired Gaussian charge
+        '''Return a temporary mol context which has the rquired Gaussian charge
         distribution placed at "rinv_origin": rho(r) = Norm * exp(-zeta * r^2).
         See also :func:`mol.set_rinv_zeta`
 
@@ -2807,7 +2807,7 @@ class Mole(lib.StreamObject):
         return self._TemporaryMoleContext(self.set_rinv_zeta, (zeta,), (zeta0,))
 
     def with_rinv_at_nucleus(self, atm_id):
-        '''Retuen a temporary mol context in which the rinv operator (1/r) is
+        '''Return a temporary mol context in which the rinv operator (1/r) is
         treated like the Coulomb potential of a Gaussian charge distribution
         rho(r) = Norm * exp(-zeta * r^2) at the place of the input atm_id.
 
@@ -2833,7 +2833,7 @@ class Mole(lib.StreamObject):
     with_rinv_as_nucleus = with_rinv_at_nucleus  # For backward compatibility
 
     def with_integral_screen(self, threshold):
-        '''Retuen a temporary mol context which has the rquired integral
+        '''Return a temporary mol context which has the rquired integral
         screen threshold
         '''
         expcutoff0 = self._env[PTR_EXPCUTOFF]


### PR DESCRIPTION
Fixes a few typos found in mole.py ("Retuen" -> "Return").