### PR TITLE
Adds copy argument to cisdvec_to_amplitudes

### DIFF
--- a/pyscf/cc/eom_gccsd.py
+++ b/pyscf/cc/eom_gccsd.py
@@ -240,7 +240,7 @@ class EOMIP(eom_rccsd.EOMIP):
     def vector_size(self):
         nocc = self.nocc
         nvir = self.nmo - nocc
-        return nocc + nocc*(nocc-1)/2*nvir
+        return nocc + nocc*(nocc-1)//2*nvir
 
     def make_imds(self, eris=None):
         imds = _IMDS(self._cc, eris)

--- a/pyscf/cc/test/test_eom_gccsd.py
+++ b/pyscf/cc/test/test_eom_gccsd.py
@@ -185,6 +185,27 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(mycc1.t1-r1).max(), 0, 14)
         self.assertAlmostEqual(abs(mycc1.t2-r2).max(), 0, 14)
 
+    def test_vector_to_amplitudes_overwritten(self):
+        mol = gto.M()
+        mycc = scf.GHF(mol).apply(cc.GCCSD)
+        nelec = (3,3)
+        nocc, nvir = nelec[0]*2, 4
+        nmo = nocc + nvir
+        mycc.nocc = nocc
+        mycc.nmo = nmo
+        def check_overwritten(method):
+            vec = numpy.zeros(method.vector_size())
+            vec_orig = vec.copy()
+            t1, t2 = method.vector_to_amplitudes(vec)
+            t1[:] = 1
+            t2[:] = 1
+            self.assertAlmostEqual(abs(vec - vec_orig).max(), 0, 15)
+
+        check_overwritten(mycc)
+        check_overwritten(mycc.EOMIP())
+        check_overwritten(mycc.EOMEA())
+        check_overwritten(mycc.EOMEE())
+
     def test_ip_matvec(self):
         numpy.random.seed(12)
         r1 = numpy.random.random((nocc))-.9 + numpy.random.random((nocc))*.2j
@@ -309,4 +330,3 @@ class KnownValues(unittest.TestCase):
 if __name__ == "__main__":
     print("Tests for EOM GCCSD")
     unittest.main()
-

--- a/pyscf/cc/test/test_eom_rccsd.py
+++ b/pyscf/cc/test/test_eom_rccsd.py
@@ -244,6 +244,32 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(mycc1.t1-t1).sum(), 0, 9)
         self.assertAlmostEqual(abs(mycc1.t2-t2).sum(), 0, 9)
 
+    def test_vector_to_amplitudes_overwritten(self):
+        mol = gto.M()
+        mycc = scf.RHF(mol).apply(cc.RCCSD)
+        nelec = (3,3)
+        nocc, nvir = nelec[0], 4
+        nmo = nocc + nvir
+        mycc.nocc = nocc
+        mycc.nmo = nmo
+        def check_overwritten(method):
+            vec = numpy.zeros(method.vector_size())
+            vec_orig = vec.copy()
+            ts = method.vector_to_amplitudes(vec)
+            for ti in ts:
+                if isinstance(ti, numpy.ndarray):
+                    ti[:] = 1
+                else:
+                    for t in ti:
+                        t[:] = 1
+            self.assertAlmostEqual(abs(vec - vec_orig).max(), 0, 15)
+
+        check_overwritten(mycc)
+        check_overwritten(mycc.EOMIP())
+        check_overwritten(mycc.EOMEA())
+        check_overwritten(mycc.EOMEESinglet())
+        check_overwritten(mycc.EOMEETriplet())
+
     def test_eomee_ccsd_matvec_singlet(self):
         numpy.random.seed(10)
         r1 = numpy.random.random((no,nv)) - .9
@@ -876,4 +902,3 @@ class KnownValues(unittest.TestCase):
 if __name__ == "__main__":
     print("Tests for EOM RCCSD")
     unittest.main()
-

--- a/pyscf/cc/test/test_eom_uccsd.py
+++ b/pyscf/cc/test/test_eom_uccsd.py
@@ -306,8 +306,33 @@ class KnownValues(unittest.TestCase):
         v1 = eomsf.amplitudes_to_vector(r1, r2)
         self.assertAlmostEqual(abs(v-v1).max(), 0, 12)
 
+    def test_vector_to_amplitudes_overwritten(self):
+        mol = gto.M()
+        mycc = scf.UHF(mol).apply(cc.UCCSD)
+        nelec = (3,3)
+        nocc = nelec
+        nmo = (5, 5)
+        mycc.nocc = nocc
+        mycc.nmo = nmo
+        def check_overwritten(method):
+            vec = numpy.zeros(method.vector_size())
+            vec_orig = vec.copy()
+            ts = method.vector_to_amplitudes(vec)
+            for ti in ts:
+                if isinstance(ti, numpy.ndarray):
+                    ti[:] = 1
+                else:
+                    for t in ti:
+                        t[:] = 1
+            self.assertAlmostEqual(abs(vec - vec_orig).max(), 0, 15)
+
+        check_overwritten(mycc)
+        check_overwritten(mycc.EOMIP())
+        check_overwritten(mycc.EOMEA())
+        check_overwritten(mycc.EOMEESpinKeep())
+        check_overwritten(mycc.EOMEESpinFlip())
+
 
 if __name__ == "__main__":
     print("Tests for UCCSD")
     unittest.main()
-

--- a/pyscf/cc/test/test_gccsd.py
+++ b/pyscf/cc/test/test_gccsd.py
@@ -473,4 +473,3 @@ class KnownValues(unittest.TestCase):
 if __name__ == "__main__":
     print("Tests for GCCSD")
     unittest.main()
-

--- a/pyscf/cc/test/test_rccsd.py
+++ b/pyscf/cc/test/test_rccsd.py
@@ -202,6 +202,21 @@ class KnownValues(unittest.TestCase):
         vec1 = mycc.amplitudes_to_vector(r1, r2)
         self.assertAlmostEqual(abs(vec-vec1).max(), 0, 14)
 
+    def test_vector_to_amplitudes_overwritten(self):
+        mol = gto.M()
+        mycc = scf.RHF(mol).apply(cc.CCSD)
+        nelec = (3,3)
+        nocc, nvir = nelec[0], 4
+        nmo = nocc + nvir
+        mycc.nocc = nocc
+        mycc.nmo = nmo
+        vec = numpy.zeros(mycc.vector_size())
+        vec_orig = vec.copy()
+        t1, t2 = mycc.vector_to_amplitudes(vec)
+        t1[:] = 1
+        t2[:] = 1
+        self.assertAlmostEqual(abs(vec - vec_orig).max(), 0, 15)
+
     def test_vector_size(self):
         self.assertEqual(mycc.vector_size(), 860)
 

--- a/pyscf/cc/test/test_uccsd.py
+++ b/pyscf/cc/test/test_uccsd.py
@@ -432,6 +432,26 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(t2[1]-myucc.t2[1]).max(), 0, 12)
         self.assertAlmostEqual(abs(t2[2]-myucc.t2[2]).max(), 0, 12)
 
+    def test_vector_to_amplitudes_overwritten(self):
+        mol = gto.M()
+        mycc = scf.UHF(mol).apply(cc.UCCSD)
+        nelec = (3, 3)
+        nocc = nelec
+        nmo = (5, 5)
+        mycc.nocc = nocc
+        mycc.nmo = nmo
+        vec = numpy.zeros(mycc.vector_size())
+        vec_orig = vec.copy()
+        t1, t2 = mycc.vector_to_amplitudes(vec)
+        t1a, t1b = t1
+        t2aa, t2ab, t2bb = t2
+        t1a[:] = 1
+        t1b[:] = 1
+        t2aa[:] = 1
+        t2ab[:] = 1
+        t2bb[:] = 1
+        self.assertAlmostEqual(abs(vec - vec_orig).max(), 0, 15)
+
     def test_vector_size(self):
         self.assertEqual(myucc.vector_size(), 2240)
 
@@ -708,4 +728,3 @@ class KnownValues(unittest.TestCase):
 if __name__ == "__main__":
     print("Full Tests for UCCSD")
     unittest.main()
-

--- a/pyscf/cc/uccsd_slow.py
+++ b/pyscf/cc/uccsd_slow.py
@@ -167,19 +167,19 @@ class UCCSD(ccsd.CCSD):
     def nip(self):
         nocc = self.nocc
         nvir = self.nmo - nocc
-        self._nip = nocc + nocc*(nocc-1)/2*nvir
+        self._nip = nocc + nocc*(nocc-1)//2*nvir
         return self._nip
 
     def nea(self):
         nocc = self.nocc
         nvir = self.nmo - nocc
-        self._nea = nvir + nocc*nvir*(nvir-1)/2
+        self._nea = nvir + nocc*nvir*(nvir-1)//2
         return self._nea
 
     def nee(self):
         nocc = self.nocc
         nvir = self.nmo - nocc
-        self._nee = nocc*nvir + nocc*(nocc-1)/2*nvir*(nvir-1)/2
+        self._nee = nocc*nvir + nocc*(nocc-1)//2*nvir*(nvir-1)//2
         return self._nee
 
     def ipccsd_matvec(self, vector):
@@ -253,7 +253,7 @@ class UCCSD(ccsd.CCSD):
     def amplitudes_to_vector_ip(self,r1,r2):
         nocc = self.nocc
         nvir = self.nmo - nocc
-        size = nocc + nocc*(nocc-1)/2*nvir
+        size = nocc + nocc*(nocc-1)//2*nvir
         vector = np.zeros(size, r1.dtype)
         vector[:nocc] = r1.copy()
         index = nocc
@@ -338,7 +338,7 @@ class UCCSD(ccsd.CCSD):
     def amplitudes_to_vector_ea(self,r1,r2):
         nocc = self.nocc
         nvir = self.nmo - nocc
-        size = nvir + nvir*(nvir-1)/2*nocc
+        size = nvir + nvir*(nvir-1)//2*nocc
         vector = np.zeros(size, r1.dtype)
         vector[:nvir] = r1.copy()
         index = nvir
@@ -450,7 +450,7 @@ class UCCSD(ccsd.CCSD):
     def amplitudes_to_vector_ee(self,r1,r2):
         nocc = self.nocc
         nvir = self.nmo - nocc
-        size = nocc*nvir + nocc*(nocc-1)/2*nvir*(nvir-1)/2
+        size = nocc*nvir + nocc*(nocc-1)//2*nvir*(nvir-1)//2
         vector = np.zeros(size, r1.dtype)
         vector[:nocc*nvir] = r1.copy().reshape(nocc*nvir)
         index = nocc*nvir

--- a/pyscf/ci/cisd.py
+++ b/pyscf/ci/cisd.py
@@ -170,7 +170,7 @@ def contract(myci, civec, eris):
     nocc = myci.nocc
     nmo = myci.nmo
     nvir = nmo - nocc
-    c0, c1, c2 = myci.cisdvec_to_amplitudes(civec, nmo, nocc)
+    c0, c1, c2 = myci.cisdvec_to_amplitudes(civec, nmo, nocc, copy=False)
 
     t2 = myci._add_vvvv(c2, eris, t2sym='jiba')
     t2 *= .5  # due to t2+t2.transpose(1,0,3,2) in the end
@@ -243,11 +243,12 @@ def contract(myci, civec, eris):
 def amplitudes_to_cisdvec(c0, c1, c2):
     return numpy.hstack((c0, c1.ravel(), c2.ravel()))
 
-def cisdvec_to_amplitudes(civec, nmo, nocc):
+def cisdvec_to_amplitudes(civec, nmo, nocc, copy=True):
     nvir = nmo - nocc
     c0 = civec[0]
-    c1 = civec[1:nocc*nvir+1].reshape(nocc,nvir)
-    c2 = civec[nocc*nvir+1:].reshape(nocc,nocc,nvir,nvir)
+    cp = lambda x: (x.copy() if copy else x)
+    c1 = cp(civec[1:nocc*nvir+1].reshape(nocc,nvir))
+    c2 = cp(civec[nocc*nvir+1:].reshape(nocc,nocc,nvir,nvir))
     return c0, c1, c2
 
 def dot(v1, v2, nmo, nocc):
@@ -325,7 +326,7 @@ def to_fcivec(cisdvec, norb, nelec, frozen=None):
     nocc = numpy.count_nonzero(~frozen_mask[:neleca])
     nmo = norb - nfroz
     nvir = nmo - nocc
-    c0, c1, c2 = cisdvec_to_amplitudes(cisdvec, nmo, nocc)
+    c0, c1, c2 = cisdvec_to_amplitudes(cisdvec, nmo, nocc, copy=False)
     t1addr, t1sign = tn_addrs_signs(nmo, nocc, 1)
 
     na = cistring.num_strings(nmo, nocc)
@@ -414,8 +415,8 @@ def overlap(cibra, ciket, nmo, nocc, s=None):
 
     nvir = nmo - nocc
     nov = nocc * nvir
-    bra0, bra1, bra2 = cisdvec_to_amplitudes(cibra, nmo, nocc)
-    ket0, ket1, ket2 = cisdvec_to_amplitudes(ciket, nmo, nocc)
+    bra0, bra1, bra2 = cisdvec_to_amplitudes(cibra, nmo, nocc, copy=False)
+    ket0, ket1, ket2 = cisdvec_to_amplitudes(ciket, nmo, nocc, copy=False)
 
 # Sort the ket orbitals to make the orbitals in bra one-one mapt to orbitals
 # in ket.
@@ -595,7 +596,7 @@ def make_rdm2(myci, civec=None, nmo=None, nocc=None, ao_repr=False):
                                ao_repr=ao_repr)
 
 def _gamma1_intermediates(myci, civec, nmo, nocc):
-    c0, c1, c2 = myci.cisdvec_to_amplitudes(civec, nmo, nocc)
+    c0, c1, c2 = myci.cisdvec_to_amplitudes(civec, nmo, nocc, copy=False)
     dvo = c0.conj() * c1.T
     dvo += numpy.einsum('jb,ijab->ai', c1.conj(), c2) * 2
     dvo -= numpy.einsum('jb,ijba->ai', c1.conj(), c2)
@@ -621,7 +622,7 @@ def _gamma2_outcore(myci, civec, nmo, nocc, h5fobj, compress_vvvv=False):
     nmo = myci.nmo
     nvir = nmo - nocc
     nvir_pair = nvir * (nvir+1) // 2
-    c0, c1, c2 = myci.cisdvec_to_amplitudes(civec, nmo, nocc)
+    c0, c1, c2 = myci.cisdvec_to_amplitudes(civec, nmo, nocc, copy=False)
 
     h5fobj['dovov'] = (2*c0*c2.conj().transpose(0,2,1,3) -
                        c0*c2.conj().transpose(1,2,0,3))
@@ -712,8 +713,8 @@ def trans_rdm1(myci, cibra, ciket, nmo=None, nocc=None):
     '''
     if nmo is None: nmo = myci.nmo
     if nocc is None: nocc = myci.nocc
-    c0bra, c1bra, c2bra = myci.cisdvec_to_amplitudes(cibra, nmo, nocc)
-    c0ket, c1ket, c2ket = myci.cisdvec_to_amplitudes(ciket, nmo, nocc)
+    c0bra, c1bra, c2bra = myci.cisdvec_to_amplitudes(cibra, nmo, nocc, copy=False)
+    c0ket, c1ket, c2ket = myci.cisdvec_to_amplitudes(ciket, nmo, nocc, copy=False)
 
     dvo = c0bra.conj() * c1ket.T
     dvo += numpy.einsum('jb,ijab->ai', c1bra.conj(), c2ket) * 2
@@ -1111,10 +1112,10 @@ class CISD(lib.StreamObject):
     def amplitudes_to_cisdvec(self, c0, c1, c2):
         return amplitudes_to_cisdvec(c0, c1, c2)
 
-    def cisdvec_to_amplitudes(self, civec, nmo=None, nocc=None):
+    def cisdvec_to_amplitudes(self, civec, nmo=None, nocc=None, copy=True):
         if nmo is None: nmo = self.nmo
         if nocc is None: nocc = self.nocc
-        return cisdvec_to_amplitudes(civec, nmo, nocc)
+        return cisdvec_to_amplitudes(civec, nmo, nocc, copy=copy)
 
     def density_fit(self):
         raise NotImplementedError

--- a/pyscf/ci/test/test_cisd.py
+++ b/pyscf/ci/test/test_cisd.py
@@ -399,6 +399,21 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(myci.mol is mol1)
         self.assertTrue(myci._scf.mol is mol1)
 
+    def test_cisdvec_to_amplitudes_overwritten(self):
+        mol = gto.M()
+        myci = scf.RHF(mol).apply(ci.CISD)
+        nelec = (3,3)
+        nocc, nvir = nelec[0], 4
+        nmo = nocc + nvir
+        myci.nocc = nocc
+        myci.nmo = nmo
+        vec = numpy.zeros(myci.vector_size())
+        vec_orig = vec.copy()
+        c0, c1, c2 = myci.cisdvec_to_amplitudes(vec)
+        c1[:] = 1
+        c2[:] = 1
+        self.assertAlmostEqual(abs(vec - vec_orig).max(), 0, 15)
+
 
 def t1_strs_ref(norb, nelec):
     nocc = nelec

--- a/pyscf/ci/test/test_gcisd.py
+++ b/pyscf/ci/test/test_gcisd.py
@@ -636,9 +636,22 @@ class KnownValues(unittest.TestCase):
         check_frozen([10])
         check_frozen([10,3])
 
+    def test_cisdvec_to_amplitudes_overwritten(self):
+        mol = gto.M()
+        myci = scf.GHF(mol).apply(ci.GCISD)
+        nelec = (3,3)
+        nocc, nvir = sum(nelec), 4
+        nmo = nocc + nvir
+        myci.nocc = nocc
+        myci.nmo = nmo
+        vec = numpy.zeros(myci.vector_size())
+        vec_orig = vec.copy()
+        c0, c1, c2 = myci.cisdvec_to_amplitudes(vec)
+        c1[:] = 1
+        c2[:] = 1
+        self.assertAlmostEqual(abs(vec - vec_orig).max(), 0, 15)
+
 
 if __name__ == "__main__":
     print("Full Tests for GCISD")
     unittest.main()
-
-

--- a/pyscf/ci/test/test_ucisd.py
+++ b/pyscf/ci/test/test_ucisd.py
@@ -285,8 +285,27 @@ class KnownValues(unittest.TestCase):
         s1 = ucisd.overlap(cibra, ciket, nmo, nocc, (s_mo, s_mo))
         self.assertAlmostEqual(s1, s0, 9)
 
+    def test_cisdvec_to_amplitudes_overwritten(self):
+        mol = gto.M()
+        myci = scf.UHF(mol).apply(ci.UCISD)
+        nelec = (3, 3)
+        nocc = nelec
+        nmo = (5, 5)
+        myci.nocc = nocc
+        myci.nmo = nmo
+        vec = numpy.zeros(myci.vector_size())
+        vec_orig = vec.copy()
+        c0, t1, t2 = myci.cisdvec_to_amplitudes(vec)
+        t1a, t1b = t1
+        t2aa, t2ab, t2bb = t2
+        t1a[:] = 1
+        t1b[:] = 1
+        t2aa[:] = 1
+        t2ab[:] = 1
+        t2bb[:] = 1
+        self.assertAlmostEqual(abs(vec - vec_orig).max(), 0, 15)
+
 
 if __name__ == "__main__":
     print("Full Tests for UCISD")
     unittest.main()
-


### PR DESCRIPTION
`cisdvec_to_amplitudes` in the CISD, UCISD, and GCISD return the wave function in terms of C0, C1, and C2 amplitudes.

Modifying the returned arrays has inconsistent effects:
C0 is always a float and as such immutable
C1 is a view into underlying `civec` - modifying the returned C1 amplitudes will also modify the underlying `civec`
C2 can be a view or an unpacked new array, so modifying these amplitudes may or may not have side effects

I think `cisdvec_to_amplitudes` should always return copies by default, which can be modified without side effects.
I thus added a keyword argument `copy` with default value `True`. Existing code, which does not modify the amplitudes, can be called with `copy=False`, to avoid unnecessary copying.
