### PR TITLE
Adds make_rdm2 to RHF and UHF

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,20 @@
 [flake8]
 # https://flake8.pycqa.org/en/2.5.5/warnings.html#error-codes
-ignore = E127, E129, E201, E202, E203, E225, E226, E231, E241, E261, E262, \
-         E265, E266, E301, E302, E303, E305, E401, E701, W391, W504, C901, \
-         F401, E228, E126, W503, E731, E211, E221, E222, E741, E251, E402, \
-         E306
+ignore = \
+        # Indentation:
+        E126, E127, E128, E129, \
+        # Whitespaces:
+        E201, E202, E203, E211, E221, E222, E225, E226, E228, E231, E241, \
+        E251, \
+        # Comments:
+        E261, E262, E265, E266, \
+        # Blank lines:
+        E301, E302, E303, E305, E306, \
+        # Imports:
+        E401, E402, \
+        # Other:
+        E701, E731, E741, \
+        F401, C901, W391, W503, W504
 
 exclude = test, .git, __pycache__, build, dist, __init__.py .eggs, *.egg
 max-line-length = 120

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -669,6 +669,8 @@ def make_rdm1(mo_coeff, mo_occ, **kwargs):
             Orbital coefficients. Each column is one orbital.
         mo_occ : 1D ndarray
             Occupancy
+    Returns:
+        One-particle density matrix, 2D ndarray
     '''
     mocc = mo_coeff[:,mo_occ>0]
 # DO NOT make tag_array for dm1 here because this DM array may be modified and
@@ -677,6 +679,21 @@ def make_rdm1(mo_coeff, mo_occ, **kwargs):
 # array and modifications to DM array may be ignored.
     return numpy.dot(mocc*mo_occ[mo_occ>0], mocc.conj().T)
 
+def make_rdm2(mo_coeff, mo_occ, **kwargs):
+    '''Two-particle density matrix in AO representation
+
+    Args:
+        mo_coeff : 2D ndarray
+            Orbital coefficients. Each column is one orbital.
+        mo_occ : 1D ndarray
+            Occupancy
+    Returns:
+        Two-particle density matrix, 4D ndarray
+    '''
+    dm1 = make_rdm1(mo_coeff, mo_occ, **kwargs)
+    dm2 = (numpy.einsum('ij,kl->ijkl', dm1, dm1)
+         - numpy.einsum('ij,kl->iklj', dm1, dm1)/2)
+    return dm2
 
 ################################################
 # for general DM
@@ -1624,6 +1641,12 @@ class SCF(lib.StreamObject):
         if mo_occ is None: mo_occ = self.mo_occ
         if mo_coeff is None: mo_coeff = self.mo_coeff
         return make_rdm1(mo_coeff, mo_occ, **kwargs)
+
+    @lib.with_doc(make_rdm2.__doc__)
+    def make_rdm2(self, mo_coeff=None, mo_occ=None, **kwargs):
+        if mo_occ is None: mo_occ = self.mo_occ
+        if mo_coeff is None: mo_coeff = self.mo_coeff
+        return make_rdm2(mo_coeff, mo_occ, **kwargs)
 
     energy_elec = energy_elec
     energy_tot = energy_tot

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -692,7 +692,7 @@ def make_rdm2(mo_coeff, mo_occ, **kwargs):
     '''
     dm1 = make_rdm1(mo_coeff, mo_occ, **kwargs)
     dm2 = (numpy.einsum('ij,kl->ijkl', dm1, dm1)
-         - numpy.einsum('ij,kl->iklj', dm1, dm1)/2)
+           - numpy.einsum('ij,kl->iklj', dm1, dm1)/2)
     return dm2
 
 ################################################

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -692,7 +692,7 @@ def make_rdm2(mo_coeff, mo_occ, **kwargs):
     '''
     dm1 = make_rdm1(mo_coeff, mo_occ, **kwargs)
     dm2 = (numpy.einsum('ij,kl->ijkl', dm1, dm1)
-           - numpy.einsum('ij,kl->iklj', dm1, dm1)/2)
+         - numpy.einsum('ij,kl->iklj', dm1, dm1)/2)
     return dm2
 
 ################################################

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -164,9 +164,9 @@ def make_rdm2(mo_coeff, mo_occ):
     '''
     dm1a, dm1b = make_rdm1(mo_coeff, mo_occ)
     dm2aa = (numpy.einsum('ij,kl->ijkl', dm1a, dm1a)
-             - numpy.einsum('ij,kl->iklj', dm1a, dm1a))
+           - numpy.einsum('ij,kl->iklj', dm1a, dm1a))
     dm2bb = (numpy.einsum('ij,kl->ijkl', dm1b, dm1b)
-             - numpy.einsum('ij,kl->iklj', dm1b, dm1b))
+           - numpy.einsum('ij,kl->iklj', dm1b, dm1b))
     dm2ab = numpy.einsum('ij,kl->ijkl', dm1a, dm1b)
     return dm2aa, dm2ab, dm2bb
 

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -164,9 +164,9 @@ def make_rdm2(mo_coeff, mo_occ):
     '''
     dm1a, dm1b = make_rdm1(mo_coeff, mo_occ)
     dm2aa = (numpy.einsum('ij,kl->ijkl', dm1a, dm1a)
-           - numpy.einsum('ij,kl->iklj', dm1a, dm1a))
+             - numpy.einsum('ij,kl->iklj', dm1a, dm1a))
     dm2bb = (numpy.einsum('ij,kl->ijkl', dm1b, dm1b)
-           - numpy.einsum('ij,kl->iklj', dm1b, dm1b))
+             - numpy.einsum('ij,kl->iklj', dm1b, dm1b))
     dm2ab = numpy.einsum('ij,kl->ijkl', dm1a, dm1b)
     return dm2aa, dm2ab, dm2bb
 


### PR DESCRIPTION
Mean-field 2-RDMs factorize into products of the 1-RDM, so typically we don't care to build them,
but sometimes I find it useful to have them at hand to quickly compare to correlated results, etc.
For this reason I suggest to add `make_rdm2` methods to the SCF classes. 