### PR TITLE
Linear dependency treatment for IAOs

### DIFF
--- a/pyscf/lo/iao.py
+++ b/pyscf/lo/iao.py
@@ -37,14 +37,23 @@ from pyscf.data.elements import is_ghost_atom
 #     vec_lowdin(iao_coeff, mol.intor('int1e_ovlp'))
 MINAO = getattr(__config__, 'lo_iao_minao', 'minao')
 
-def iao(mol, orbocc, minao=MINAO, kpts=None):
+def iao(mol, orbocc, minao=MINAO, kpts=None, lindep_threshold=1e-8):
     '''Intrinsic Atomic Orbitals. [Ref. JCTC, 9, 4834]
 
-    Args:
-        mol : the molecule or cell object
+    For large basis sets which are close to being linearly dependent,
+    the Cholesky decomposition can fail. In this case a canonical orthogonalization
+    with threshold `lindep_threshold` is used.
 
+    Args:
+        mol : molecule or cell object
         orbocc : 2D array
             occupied orbitals
+        minao : str, optional
+            reference basis set for IAOs
+        kpts : 2D ndarray, optional
+            k-points, for cell objects only
+        lindep_threshold : float, optional
+            threshold for canonical orthogonalization
 
     Returns:
         non-orthogonal IAO orbitals.  Orthogonalize them as C (C^T S C)^{-1/2},
@@ -54,20 +63,18 @@ def iao(mol, orbocc, minao=MINAO, kpts=None):
         >>> c = iao(mol, orbocc)
         >>> numpy.dot(c, orth.lowdin(reduce(numpy.dot, (c.T,s,c))))
     '''
-    if mol.has_ecp():
+    if mol.has_ecp() and minao == 'minao':
         logger.warn(mol, 'ECP/PP is used. MINAO is not a good reference AO basis in IAO.')
 
     pmol = reference_mol(mol, minao)
     # For PBC, we must use the pbc code for evaluating the integrals lest the
     # pbc conditions be ignored.
-    # DO NOT import pbcgto early and check whether mol is a cell object.
-    # "from pyscf.pbc import gto as pbcgto and isinstance(mol, pbcgto.Cell)"
-    # The code should work even pbc module is not availabe.
-    if getattr(mol, 'pbc_intor', None):  # cell object has pbc_intor method
+    has_pbc = getattr(mol, 'dimension', 0) > 1
+    if has_pbc:
         from pyscf.pbc import gto as pbcgto
-        s1 = numpy.asarray(mol.pbc_intor('int1e_ovlp', hermi=1, kpts=kpts))
-        s2 = numpy.asarray(pmol.pbc_intor('int1e_ovlp', hermi=1, kpts=kpts))
-        s12 = numpy.asarray(pbcgto.cell.intor_cross('int1e_ovlp', mol, pmol, kpts=kpts))
+        s1 = mol.pbc_intor('int1e_ovlp', hermi=1, kpts=kpts)
+        s2 = pmol.pbc_intor('int1e_ovlp', hermi=1, kpts=kpts)
+        s12 = pbcgto.cell.intor_cross('int1e_ovlp', mol, pmol, kpts=kpts)
     else:
         #s1 is the one electron overlap integrals (coulomb integrals)
         s1 = mol.intor_symmetric('int1e_ovlp')
@@ -76,37 +83,44 @@ def iao(mol, orbocc, minao=MINAO, kpts=None):
         #overlap integrals of the two molecules
         s12 = gto.mole.intor_cross('int1e_ovlp', mol, pmol)
 
-    if len(s1.shape) == 2:
+    def make_iaos(s1, s2, s12, mo):
+        """Make IAOs for a molecule or single k-point"""
         s21 = s12.conj().T
-        s1cd = scipy.linalg.cho_factor(s1)
+        # s2 is overlap in minimal reference basis and should never be singular:
         s2cd = scipy.linalg.cho_factor(s2)
-        p12 = scipy.linalg.cho_solve(s1cd, s12)
-        ctild = scipy.linalg.cho_solve(s2cd, numpy.dot(s21, orbocc))
-        ctild = scipy.linalg.cho_solve(s1cd, numpy.dot(s12, ctild))
+        ctild = scipy.linalg.cho_solve(s2cd, numpy.dot(s21, mo))
+        try:
+            s1cd = scipy.linalg.cho_factor(s1)
+            p12 = scipy.linalg.cho_solve(s1cd, s12)
+            ctild = scipy.linalg.cho_solve(s1cd, numpy.dot(s12, ctild))
+        # s1 can be singular in large basis sets: Use canonical orthogonalization in this case:
+        except numpy.linalg.LinAlgError:
+            se, sv = numpy.linalg.eigh(s1)
+            keep = (se >= lindep_threshold)
+            sinv = numpy.einsum("ai,i,bi->ab", sv[:,keep], 1/se[keep], sv[:,keep])
+            p12 = numpy.dot(sinv, s12)
+            ctild = numpy.dot(p12, ctild)
+        # If there are no occupied orbitals at this k-point, all but the first term will vanish:
+        if mo.shape[-1] == 0:
+            return p12
         ctild = vec_lowdin(ctild, s1)
-        ccs1 = reduce(numpy.dot, (orbocc, orbocc.conj().T, s1))
-        ccs2 = reduce(numpy.dot, (ctild, ctild.conj().T, s1))
+        ccs1 = numpy.linalg.multi_dot((mo, mo.conj().T, s1))
+        ccs2 = numpy.linalg.multi_dot((ctild, ctild.conj().T, s1))
         #a is the set of IAOs in the original basis
-        a = (p12 + reduce(numpy.dot, (ccs1, ccs2, p12)) * 2
+        a = (p12 + 2*numpy.linalg.multi_dot((ccs1, ccs2, p12))
              - numpy.dot(ccs1, p12) - numpy.dot(ccs2, p12))
-    else: # k point sampling
-        s21 = numpy.swapaxes(s12, -1, -2).conj()
-        nkpts = len(kpts)
-        a = numpy.zeros((nkpts, s1.shape[-1], s2.shape[-1]), dtype=numpy.complex128)
-        for k in range(nkpts):
-            # ZHC NOTE check the case, at some kpts, there is no occupied MO.
-            s1cd_k = scipy.linalg.cho_factor(s1[k])
-            s2cd_k = scipy.linalg.cho_factor(s2[k])
-            p12_k = scipy.linalg.cho_solve(s1cd_k, s12[k])
-            ctild_k = scipy.linalg.cho_solve(s2cd_k, numpy.dot(s21[k], orbocc[k]))
-            ctild_k = scipy.linalg.cho_solve(s1cd_k, numpy.dot(s12[k], ctild_k))
-            ctild_k = vec_lowdin(ctild_k, s1[k])
-            ccs1_k = reduce(numpy.dot, (orbocc[k], orbocc[k].conj().T, s1[k]))
-            ccs2_k = reduce(numpy.dot, (ctild_k, ctild_k.conj().T, s1[k]))
-            #a is the set of IAOs in the original basis
-            a[k] = (p12_k + reduce(numpy.dot, (ccs1_k, ccs2_k, p12_k)) * 2
-                    - numpy.dot(ccs1_k, p12_k) - numpy.dot(ccs2_k, p12_k))
-    return a
+        return a
+
+    # Molecules and Gamma-point only solids
+    if s1[0].ndim == 1:
+        iaos = make_iaos(s1, s2, s12, orbocc)
+    # Solid with multiple k-points
+    else:
+        iaos = []
+        for k in range(len(kpts)):
+            iaos.append(make_iaos(s1[k], s2[k], s12[k], orbocc[k]))
+        iaos = numpy.asarray(iaos)
+    return iaos
 
 def reference_mol(mol, minao=MINAO):
     '''Create a molecule which uses reference minimal basis'''

--- a/pyscf/lo/iao.py
+++ b/pyscf/lo/iao.py
@@ -69,7 +69,7 @@ def iao(mol, orbocc, minao=MINAO, kpts=None, lindep_threshold=1e-8):
     pmol = reference_mol(mol, minao)
     # For PBC, we must use the pbc code for evaluating the integrals lest the
     # pbc conditions be ignored.
-    has_pbc = getattr(mol, 'dimension', 0) > 1
+    has_pbc = getattr(mol, 'dimension', 0) > 0
     if has_pbc:
         from pyscf.pbc import gto as pbcgto
         s1 = mol.pbc_intor('int1e_ovlp', hermi=1, kpts=kpts)

--- a/pyscf/lo/iao.py
+++ b/pyscf/lo/iao.py
@@ -95,10 +95,8 @@ def iao(mol, orbocc, minao=MINAO, kpts=None, lindep_threshold=1e-8):
             ctild = scipy.linalg.cho_solve(s1cd, numpy.dot(s12, ctild))
         # s1 can be singular in large basis sets: Use canonical orthogonalization in this case:
         except numpy.linalg.LinAlgError:
-            se, sv = numpy.linalg.eigh(s1)
-            keep = (se >= lindep_threshold)
-            sinv = numpy.einsum("ai,i,bi->ab", sv[:,keep], 1/se[keep], sv[:,keep])
-            p12 = numpy.dot(sinv, s12)
+            x = scf.addons.canonical_orth_(s1, lindep_threshold)
+            p12 = numpy.linalg.multi_dot((x, x.T, s12))
             ctild = numpy.dot(p12, ctild)
         # If there are no occupied orbitals at this k-point, all but the first term will vanish:
         if mo.shape[-1] == 0:

--- a/pyscf/lo/iao.py
+++ b/pyscf/lo/iao.py
@@ -96,7 +96,7 @@ def iao(mol, orbocc, minao=MINAO, kpts=None, lindep_threshold=1e-8):
         # s1 can be singular in large basis sets: Use canonical orthogonalization in this case:
         except numpy.linalg.LinAlgError:
             x = scf.addons.canonical_orth_(s1, lindep_threshold)
-            p12 = numpy.linalg.multi_dot((x, x.T, s12))
+            p12 = numpy.linalg.multi_dot((x, x.conj().T, s12))
             ctild = numpy.dot(p12, ctild)
         # If there are no occupied orbitals at this k-point, all but the first term will vanish:
         if mo.shape[-1] == 0:


### PR DESCRIPTION
I'm frequently using IAOs and encountered two problems with the current code:

1) For large basis sets, where the AO overlap is (numerically) singular, the Cholesky decomposition of this overlap matrix will fail; this is especially common in solids. In cases where the CD fails, I added a backup inversion, a la canonical orthogonalization, i.e. removing (almost) linearly dependent eigenvectors according to some threshold `lindep_threshold`
[I actually think options for linear-dependency treatment, such as method and threshold, should be attached to the `mole`/`cell` object, as it crops up in multiple locations, but this is another discussion].
 
 2) If at some k-point (or in one spin channel, for a 1e-system), there are not occupied orbitals, the call to `vec_lowdin` will fail
 (there are no orbitals to orthogonalize). I added an early return to deal with this case.
 
Lastly, the IAO construction for molecules and for solids at a given k-point is the same; previously the code was just copied,
 with a k-point loop in the case for solids, but to reduce code duplication I put it into a function, which is being looped over for k-points.
 
 