### PR TITLE
Add aarch64 support in test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,39 @@ jobs:
         uses: codecov/codecov-action@v1.0.13
         with:
           token: ${{secrets.CODECOV_TOKEN}}
+  
+  linux-build-aarch64:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        pyver: [cp37-cp37m, cp38-cp38, cp39-cp39]
+    env:
+      img: quay.io/pypa/manylinux2014_aarch64
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v2
+      - name: Build Wheel
+        run: |
+            docker run --rm -v ${{ github.workspace }}:/src/pyscf:rw --workdir=/src/pyscf ${{ env.img }} \
+            bash -exc '/opt/python/${{ matrix.pyver }}/bin/pip install --upgrade pip setuptools && \
+            /opt/python/${{ matrix.pyver }}/bin/pip install "numpy!=1.16,!=1.17" "scipy!=1.5" h5py pytest pytest-cov pytest-timer pyberny geometric && \
+            yum install -y epel-release && \
+            yum-config-manager --enable epel && \
+            yum install -y openblas-devel gcc cmake curl && \
+            cd ./pyscf/lib && curl -o deps.tar.gz -L "https://github.com/kkyusuke/pyscf-build-deps/blob/master/pyscf-2.1a-aarch64-deps.tar.gz?raw=true"  && \
+            tar xzf deps.tar.gz && \
+            mkdir build && cd build && \
+            cmake -DBUILD_LIBXC=OFF -DBUILD_XCFUN=OFF -DBUILD_LIBCINT=OFF .. && \
+            make -j2 && cd .. && rm -Rf build && cd ../.. && \
+            export OMP_NUM_THREADS=1 && export PYTHONPATH=$(pwd):$PYTHONPATH && \
+            echo 'pbc_tools_pbc_fft_engine = "NUMPY"' > .pyscf_conf.py && \
+            echo "dftd3_DFTD3PATH = './pyscf/lib/deps/lib'" >> .pyscf_conf.py && \
+            echo "scf_hf_SCF_mute_chkfile = True" >> .pyscf_conf.py && \
+            ulimit -s 20000 && /opt/python/${{ matrix.pyver }}/bin/pytest pyscf/ --ignore=pyscf/adc --ignore=pyscf/pbc/df --ignore=pyscf/pbc/cc -s -c setup.cfg --cov-report xml --cov-report term --cov-config .coveragerc --cov pyscf'
 
   macos-build:
     runs-on: macos-latest


### PR DESCRIPTION
The code supports build & testing in CI. Please find the discussion in #1277.
Please note the following items.
* Python 3.6 is excluded, because pip failed to solve the dependency.
* pyscf/adc, pyscf/pbc/df and pyscf/pbc/cc are ignored in pytest, according to the advice.