### PR TITLE
Bugfixes in vhf prescreening code

### DIFF
--- a/pyscf/lib/CMakeLists.txt
+++ b/pyscf/lib/CMakeLists.txt
@@ -166,7 +166,7 @@ if(NOT EXISTS "${PROJECT_SOURCE_DIR}/deps/include/cint.h")
 
   ExternalProject_Add(libcint
     GIT_REPOSITORY ${LIBCINT_GIT}
-    GIT_TAG v5.1.2
+    GIT_TAG v5.1.3
     PREFIX ${PROJECT_BINARY_DIR}/deps
     INSTALL_DIR ${PROJECT_SOURCE_DIR}/deps
     CMAKE_CACHE_ARGS

--- a/pyscf/lib/ao2mo/nr_ao2mo.c
+++ b/pyscf/lib/ao2mo/nr_ao2mo.c
@@ -1280,7 +1280,7 @@ void AO2MOnr_e1fill_drv(int (*intor)(), void (*fill)(), double *eri,
                                   klsh_start, klsh_count, 0, 0, 0, 0,
                                   ncomp, ao_loc, NULL, cintopt, vhfopt};
         int (*fprescreen)();
-        if (vhfopt) {
+        if (vhfopt != NULL) {
                 fprescreen = vhfopt->fprescreen;
         } else {
                 fprescreen = CVHFnoscreen;

--- a/pyscf/lib/ao2mo/r_ao2mo.c
+++ b/pyscf/lib/ao2mo/r_ao2mo.c
@@ -836,7 +836,7 @@ void AO2MOr_e1_drv(int (*intor)(), void (*fill)(),
         assert(eri_ao);
         int ish, kl;
         int (*fprescreen)();
-        if (vhfopt) {
+        if (vhfopt != NULL) {
                 fprescreen = vhfopt->fprescreen;
         } else {
                 fprescreen = CVHFnoscreen;

--- a/pyscf/lib/pbc/fill_ints_sr.c
+++ b/pyscf/lib/pbc/fill_ints_sr.c
@@ -1763,7 +1763,7 @@ static void _nr3c_kk(int (*intor)(), void (*fsort)(),
 
     shls[0] = ish;
     shls[1] = jsh;
-// >>>>>>>>>>
+
     const double omega = fabs(env_loc[PTR_RANGE_OMEGA]);
     int Ish, Jsh, IJsh, Ksh, idij;
     Ish = refuniqshl_map[ish];

--- a/pyscf/lib/pbc/grid_ao.c
+++ b/pyscf/lib/pbc/grid_ao.c
@@ -217,7 +217,7 @@ void PBCeval_cart_iter(FPtr_eval feval,  FPtr_exp fexp,
                 if (atm_imag_max[i] == ALL_IMAGES) {
                         atm_imag_max[i] = nimgs;
                 } else {
-                        atm_imag_max[i] = MIN(atm_imag_max, nimgs);
+                        atm_imag_max[i] = MIN(atm_imag_max[i], nimgs);
                 }
         }
 
@@ -337,7 +337,7 @@ void PBCeval_sph_iter(FPtr_eval feval,  FPtr_exp fexp,
                 if (atm_imag_max[i] == ALL_IMAGES) {
                         atm_imag_max[i] = nimgs;
                 } else {
-                        atm_imag_max[i] = MIN(atm_imag_max, nimgs);
+                        atm_imag_max[i] = MIN(atm_imag_max[i], nimgs);
                 }
         }
 

--- a/pyscf/lib/pbc/grid_ao.c
+++ b/pyscf/lib/pbc/grid_ao.c
@@ -251,7 +251,7 @@ void PBCeval_cart_iter(FPtr_eval feval,  FPtr_exp fexp,
                         aobufk[i] = 0;
                 }
                 for (iL0 = 0; iL0 < bas_nimgs; iL0+=IMGBLK) {
-                        iLcount = MIN(IMGBLK, nimgs - iL0);
+                        iLcount = MIN(IMGBLK, bas_nimgs - iL0);
 
                         count = 0;
                         for (iL = iL0; iL < iL0+iLcount; iL++) {
@@ -370,7 +370,7 @@ void PBCeval_sph_iter(FPtr_eval feval,  FPtr_exp fexp,
 
                 NPdset0(aobufk, ((size_t)nkpts2) * dimc);
                 for (iL0 = 0; iL0 < bas_nimgs; iL0+=IMGBLK) {
-                        iLcount = MIN(IMGBLK, nimgs - iL0);
+                        iLcount = MIN(IMGBLK, bas_nimgs - iL0);
 
                         count = 0;
                         for (iL = iL0; iL < iL0+iLcount; iL++) {

--- a/pyscf/lib/pbc/nr_direct.c
+++ b/pyscf/lib/pbc/nr_direct.c
@@ -709,7 +709,7 @@ void PBCVHFsetnr_direct_scf(CVHFOpt *opt, int (*intor)(), CINTOpt *cintopt,
 {
         /* This memory is released in void CVHFdel_optimizer, Don't know
          * why valgrind raises memory leak here */
-        if (opt->q_cond) {
+        if (opt->q_cond != NULL) {
                 free(opt->q_cond);
         }
         // nbas in the input arguments may different to opt->nbas.

--- a/pyscf/lib/pbc/optimizer.c
+++ b/pyscf/lib/pbc/optimizer.c
@@ -34,11 +34,11 @@ void PBCinit_optimizer(PBCOpt **opt, int *atm, int natm,
 void PBCdel_optimizer(PBCOpt **opt)
 {
         PBCOpt *opt0 = *opt;
-        if (!opt0) {
+        if (opt0 == NULL) {
                 return;
         }
 
-        if (!opt0->rrcut) {
+        if (opt0->rrcut != NULL) {
                 free(opt0->rrcut);
         }
         free(opt0);
@@ -53,7 +53,7 @@ int PBCnoscreen(int *shls, PBCOpt *opt, int *atm, int *bas, double *env)
 
 int PBCrcut_screen(int *shls, PBCOpt *opt, int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1; // no screen
         }
         const int ish = shls[0];
@@ -71,7 +71,7 @@ int PBCrcut_screen(int *shls, PBCOpt *opt, int *atm, int *bas, double *env)
 void PBCset_rcut_cond(PBCOpt *opt, double *rcut,
                       int *atm, int natm, int *bas, int nbas, double *env)
 {
-        if (opt->rrcut) {
+        if (opt->rrcut != NULL) {
                 free(opt->rrcut);
         }
         opt->rrcut = (double *)malloc(sizeof(double) * nbas);

--- a/pyscf/lib/vhf/hessian_screen.c
+++ b/pyscf/lib/vhf/hessian_screen.c
@@ -44,7 +44,7 @@ int int2e_spsp1spsp2_sph();
 int CVHFgrad_jk_prescreen(int *shls, CVHFOpt *opt,
                           int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1; // no screen
         }
         int i = shls[0];
@@ -71,7 +71,7 @@ void CVHFgrad_jk_direct_scf(CVHFOpt *opt, int (*intor)(), CINTOpt *cintopt,
                             int *ao_loc, int *atm, int natm,
                             int *bas, int nbas, double *env)
 {
-        if (opt->q_cond) {
+        if (opt->q_cond != NULL) {
                 free(opt->q_cond);
         }
         nbas = opt->nbas;
@@ -141,7 +141,7 @@ void CVHFgrad_jk_direct_scf(CVHFOpt *opt, int (*intor)(), CINTOpt *cintopt,
 void CVHFgrad_jk_direct_scf_dm(CVHFOpt *opt, double *dm, int nset, int *ao_loc,
                                int *atm, int natm, int *bas, int nbas, double *env)
 {
-        if (opt->dm_cond) {
+        if (opt->dm_cond != NULL) {
                 free(opt->dm_cond);
         }
         nbas = opt->nbas;
@@ -179,7 +179,7 @@ void CVHFgrad_jk_direct_scf_dm(CVHFOpt *opt, double *dm, int nset, int *ao_loc,
 int CVHFip1ip2_prescreen(int *shls, CVHFOpt *opt,
                          int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1; // no screen
         }
         int i = shls[0];
@@ -223,7 +223,7 @@ void CVHFip1ip2_direct_scf_dm(CVHFOpt *opt, double *dm, int nset, int *ao_loc,
 int CVHFipip1_prescreen(int *shls, CVHFOpt *opt,
                         int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1; // no screen
         }
         int i = shls[0];
@@ -251,7 +251,7 @@ void CVHFipip1_direct_scf(CVHFOpt *opt, int (*intor)(), CINTOpt *cintopt,
                           int *ao_loc, int *atm, int natm,
                           int *bas, int nbas, double *env)
 {
-        if (opt->q_cond) {
+        if (opt->q_cond != NULL) {
                 free(opt->q_cond);
         }
         nbas = opt->nbas;
@@ -345,7 +345,7 @@ void CVHFipip1_direct_scf_dm(CVHFOpt *opt, double *dm, int nset, int *ao_loc,
 int CVHFipvip1_prescreen(int *shls, CVHFOpt *opt,
                          int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1; // no screen
         }
         int i = shls[0];

--- a/pyscf/lib/vhf/nr_direct.h
+++ b/pyscf/lib/vhf/nr_direct.h
@@ -19,6 +19,8 @@
 #include "cint.h"
 #include "optimizer.h"
 
+#define AO_BLOCK_SIZE   32
+
 #define NOVALUE 0xffffffff
 
 typedef struct {

--- a/pyscf/lib/vhf/nr_sgx_direct.c
+++ b/pyscf/lib/vhf/nr_sgx_direct.c
@@ -96,7 +96,7 @@ int _max_cache_size_sgx(int (*intor)(), int *shls_slice, int ncenter,
 int SGXnr_pj_prescreen(int *shls, CVHFOpt *opt,
                        int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1;
         }
         int i = shls[0];
@@ -198,7 +198,7 @@ void SGXnr_direct_drv(int (*intor)(), void (*fdot)(), SGXJKOperator **jkop,
         }
 
         int (*fprescreen)();
-        if (vhfopt) {
+        if (vhfopt != NULL) {
                 fprescreen = vhfopt->fprescreen;
         } else {
                 fprescreen = CVHFnoscreen;
@@ -262,7 +262,7 @@ void SGXsetnr_direct_scf(CVHFOpt *opt, int (*intor)(), CINTOpt *cintopt,
                          int *ao_loc, int *atm, int natm,
                          int *bas, int nbas, double *env)
 {
-        if (opt->q_cond) {
+        if (opt->q_cond != NULL) {
                 free(opt->q_cond);
         }
         nbas = opt->nbas;
@@ -324,7 +324,7 @@ void SGXsetnr_direct_scf_dm(CVHFOpt *opt, double *dm, int nset, int *ao_loc,
                             int ngrids)
 {
         nbas = opt->nbas;
-        if (opt->dm_cond) {
+        if (opt->dm_cond != NULL) {
                 free(opt->dm_cond);
         }
         opt->dm_cond = (double *)malloc(sizeof(double) * nbas*ngrids);
@@ -353,7 +353,7 @@ void SGXsetnr_direct_scf_dm(CVHFOpt *opt, double *dm, int nset, int *ao_loc,
 int SGXnr_ovlp_prescreen(int *shls, CVHFOpt *opt,
                          int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1;
         }
         int i = shls[0];

--- a/pyscf/lib/vhf/optimizer.c
+++ b/pyscf/lib/vhf/optimizer.c
@@ -479,12 +479,12 @@ void CVHFsetnr_direct_scf_dm(CVHFOpt *opt, double *dm, int nset, int *ao_loc,
 // symmetrize dm_cond because nrs8_prescreen only tests the lower (or upper)
 // triangular part of dm_cond. Without the symmetrization, some integrals may be
 // incorrectly skipped.
-                                tmp = .5 * (fabs(pdm[i*nao+j]) + fabs(pdm[j*nao+i]));
+                                tmp = fabs(pdm[i*nao+j]) + fabs(pdm[j*nao+i]);
                                 dmax = MAX(dmax, tmp);
                         } }
                 }
-                opt->dm_cond[ish*nbas+jsh] = dmax;
-                opt->dm_cond[jsh*nbas+ish] = dmax;
+                opt->dm_cond[ish*nbas+jsh] = .5 * dmax;
+                opt->dm_cond[jsh*nbas+ish] = .5 * dmax;
         } }
 }
 

--- a/pyscf/lib/vhf/optimizer.c
+++ b/pyscf/lib/vhf/optimizer.c
@@ -21,7 +21,9 @@
 #include <assert.h>
 #include "cint.h"
 #include "cvhf.h"
+#include "fblas.h"
 #include "optimizer.h"
+#include "nr_direct.h"
 #include "np_helper/np_helper.h"
 #include "gto/gto.h"
 
@@ -46,14 +48,14 @@ void CVHFinit_optimizer(CVHFOpt **opt, int *atm, int natm,
 void CVHFdel_optimizer(CVHFOpt **opt)
 {
         CVHFOpt *opt0 = *opt;
-        if (!opt0) {
+        if (opt0 == NULL) {
                 return;
         }
 
-        if (!opt0->q_cond) {
+        if (opt0->q_cond != NULL) {
                 free(opt0->q_cond);
         }
-        if (!opt0->dm_cond) {
+        if (opt0->dm_cond != NULL) {
                 free(opt0->dm_cond);
         }
 
@@ -61,16 +63,14 @@ void CVHFdel_optimizer(CVHFOpt **opt)
         *opt = NULL;
 }
 
-int CVHFnoscreen(int *shls, CVHFOpt *opt,
-                 int *atm, int *bas, double *env)
+int CVHFnoscreen(int *shls, CVHFOpt *opt, int *atm, int *bas, double *env)
 {
         return 1;
 }
 
-int CVHFnr_schwarz_cond(int *shls, CVHFOpt *opt,
-                        int *atm, int *bas, double *env)
+int CVHFnr_schwarz_cond(int *shls, CVHFOpt *opt, int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1;
         }
         int i = shls[0];
@@ -87,10 +87,9 @@ int CVHFnr_schwarz_cond(int *shls, CVHFOpt *opt,
         return qijkl > opt->direct_scf_cutoff;
 }
 
-int CVHFnrs8_prescreen(int *shls, CVHFOpt *opt,
-                       int *atm, int *bas, double *env)
+int CVHFnrs8_prescreen(int *shls, CVHFOpt *opt, int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1; // no screen
         }
         int i = shls[0];
@@ -117,10 +116,9 @@ int CVHFnrs8_prescreen(int *shls, CVHFOpt *opt,
             || (  dm_cond[i*n+l]*qijkl > direct_scf_cutoff));
 }
 
-int CVHFnrs8_vj_prescreen(int *shls, CVHFOpt *opt,
-                          int *atm, int *bas, double *env)
+int CVHFnrs8_vj_prescreen(int *shls, CVHFOpt *opt, int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1; // no screen
         }
         int i = shls[0];
@@ -141,10 +139,9 @@ int CVHFnrs8_vj_prescreen(int *shls, CVHFOpt *opt,
             || (4*qijkl*opt->dm_cond[l*n+k] > direct_scf_cutoff));
 }
 
-int CVHFnrs8_vk_prescreen(int *shls, CVHFOpt *opt,
-                          int *atm, int *bas, double *env)
+int CVHFnrs8_vk_prescreen(int *shls, CVHFOpt *opt, int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1; // no screen
         }
         int i = shls[0];
@@ -169,6 +166,125 @@ int CVHFnrs8_vk_prescreen(int *shls, CVHFOpt *opt,
             || (  dm_cond[i*n+l]*qijkl > direct_scf_cutoff));
 }
 
+int CVHFnrs8_vj_prescreen_block(CVHFOpt *opt, int *ishls, int *jshls, int *kshls, int *lshls)
+{
+        int i0 = ishls[0];
+        int j0 = jshls[0];
+        int k0 = kshls[0];
+        int l0 = lshls[0];
+        int i1 = ishls[1];
+        int j1 = jshls[1];
+        int k1 = kshls[1];
+        int l1 = lshls[1];
+        int i, j, k, l;
+        size_t n = opt->nbas;
+        double *q_cond = opt->q_cond;
+        double *dm_cond = opt->dm_cond;
+        double direct_scf_cutoff = opt->direct_scf_cutoff;
+        double rho, cutoff;
+        rho = 0;
+        for (j = j0; j < j1; j++) {
+#pragma GCC ivdep
+        for (i = i0; i < i1; i++) {
+                rho += dm_cond[j*n+i] * q_cond[j*n+i];
+        } }
+
+        cutoff = 4 * direct_scf_cutoff / rho;
+        for (l = l0; l < l1; l++) {
+        for (k = k0; k < k1; k++) {
+                if (q_cond[l*n+k] > cutoff) {
+                        return 1;
+                }
+        } }
+
+        rho = 0;
+        for (l = l0; l < l1; l++) {
+#pragma GCC ivdep
+        for (k = k0; k < k1; k++) {
+                rho += dm_cond[l*n+k] * q_cond[l*n+k];
+        } }
+
+        cutoff = 4 * direct_scf_cutoff / rho;
+        for (j = j0; j < j1; j++) {
+        for (i = i0; i < i1; i++) {
+                if (q_cond[j*n+i] > cutoff) {
+                        return 1;
+                }
+        } }
+        return 0;
+}
+
+int CVHFnrs8_vk_prescreen_block(CVHFOpt *opt, int *ishls, int *jshls, int *kshls, int *lshls)
+{
+        const double D0 = 0;
+        const double D1 = 1;
+        const char TRANS_N = 'N';
+        const char TRANS_T = 'T';
+        int i0 = ishls[0];
+        int j0 = jshls[0];
+        int k0 = kshls[0];
+        int l0 = lshls[0];
+        int i1 = ishls[1];
+        int j1 = jshls[1];
+        int k1 = kshls[1];
+        int l1 = lshls[1];
+        int di = i1 - i0;
+        int dj = j1 - j0;
+        int dk = k1 - k0;
+        int dl = l1 - l0;
+        int i;
+        int nbas = opt->nbas;
+        size_t n = opt->nbas;
+        double *q_cond = opt->q_cond;
+        double *dm_cond = opt->dm_cond;
+        double direct_scf_cutoff = opt->direct_scf_cutoff;
+        assert(di < 128);
+        assert(dj < 128);
+        assert(dk < 128);
+        assert(dl < 128);
+        double buf1[128*128];
+        double buf2[128*128];
+
+        dgemm_(&TRANS_N, &TRANS_T, &di, &dk, &dj, &D1, q_cond+j0*n+i0, &nbas, dm_cond+j0*n+k0, &nbas, &D0, buf1, &di);
+        dgemm_(&TRANS_N, &TRANS_T, &dl, &di, &dk, &D1, q_cond+k0*n+l0, &nbas, buf1, &di, &D0, buf2, &dl);
+        for (i = 0; i < di * dl; i++) {
+                if (buf2[i] > direct_scf_cutoff) {
+                        return 1;
+                }
+        }
+
+        dgemm_(&TRANS_N, &TRANS_T, &di, &dl, &dj, &D1, q_cond+j0*n+i0, &nbas, dm_cond+j0*n+l0, &nbas, &D0, buf1, &di);
+        dgemm_(&TRANS_N, &TRANS_T, &dk, &di, &dl, &D1, q_cond+l0*n+k0, &nbas, buf1, &di, &D0, buf2, &dk);
+        for (i = 0; i < di * dk; i++) {
+                if (buf2[i] > direct_scf_cutoff) {
+                        return 1;
+                }
+        }
+
+        dgemm_(&TRANS_N, &TRANS_T, &dj, &dk, &di, &D1, q_cond+i0*n+j0, &nbas, dm_cond+i0*n+k0, &nbas, &D0, buf1, &dj);
+        dgemm_(&TRANS_N, &TRANS_T, &dl, &dj, &dk, &D1, q_cond+k0*n+l0, &nbas, buf1, &dj, &D0, buf2, &dl);
+        for (i = 0; i < dj * dl; i++) {
+                if (buf2[i] > direct_scf_cutoff) {
+                        return 1;
+                }
+        }
+
+        dgemm_(&TRANS_N, &TRANS_T, &dj, &dl, &di, &D1, q_cond+i0*n+j0, &nbas, dm_cond+i0*n+l0, &nbas, &D0, buf1, &dj);
+        dgemm_(&TRANS_N, &TRANS_T, &dk, &dj, &dl, &D1, q_cond+l0*n+k0, &nbas, buf1, &dj, &D0, buf2, &dk);
+        for (i = 0; i < dj * dk; i++) {
+                if (buf2[i] > direct_scf_cutoff) {
+                        return 1;
+                }
+        }
+        return 0;
+}
+
+int CVHFnrs8_prescreen_block(CVHFOpt *opt, int *ishls, int *jshls, int *kshls, int *lshls)
+{
+        return (CVHFnrs8_vj_prescreen_block(opt, ishls, jshls, kshls, lshls) ||
+                CVHFnrs8_vk_prescreen_block(opt, ishls, jshls, kshls, lshls));
+}
+
 // return flag to decide whether transpose01324
 int CVHFr_vknoscreen(int *shls, CVHFOpt *opt,
                      double **dms_cond, int n_dm, double *dm_atleast,
@@ -185,7 +301,7 @@ int CVHFr_vknoscreen(int *shls, CVHFOpt *opt,
 int CVHFnr3c2e_vj_pass1_prescreen(int *shls, CVHFOpt *opt,
                                int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1; // no screen
         }
         size_t n = opt->nbas;
@@ -208,7 +324,7 @@ int CVHFnr3c2e_vj_pass1_prescreen(int *shls, CVHFOpt *opt,
 int CVHFnr3c2e_vj_pass2_prescreen(int *shls, CVHFOpt *opt,
                                int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1; // no screen
         }
         size_t n = opt->nbas;
@@ -231,7 +347,7 @@ int CVHFnr3c2e_vj_pass2_prescreen(int *shls, CVHFOpt *opt,
 int CVHFnr3c2e_schwarz_cond(int *shls, CVHFOpt *opt,
                             int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1; // no screen
         }
         size_t n = opt->nbas;
@@ -266,7 +382,7 @@ void CVHFsetnr_direct_scf(CVHFOpt *opt, int (*intor)(), CINTOpt *cintopt,
 {
         /* This memory is released in void CVHFdel_optimizer, Don't know
          * why valgrind raises memory leak here */
-        if (opt->q_cond) {
+        if (opt->q_cond != NULL) {
                 free(opt->q_cond);
         }
         // nbas in the input arguments may different to opt->nbas.
@@ -330,7 +446,7 @@ void CVHFset_int2e_q_cond(int (*intor)(), CINTOpt *cintopt, double *q_cond,
 
 void CVHFset_q_cond(CVHFOpt *opt, double *q_cond, int len)
 {
-        if (opt->q_cond) {
+        if (opt->q_cond != NULL) {
                 free(opt->q_cond);
         }
         opt->q_cond = (double *)malloc(sizeof(double) * len);
@@ -340,7 +456,7 @@ void CVHFset_q_cond(CVHFOpt *opt, double *q_cond, int len)
 void CVHFsetnr_direct_scf_dm(CVHFOpt *opt, double *dm, int nset, int *ao_loc,
                              int *atm, int natm, int *bas, int nbas, double *env)
 {
-        if (opt->dm_cond) { // NOT reuse opt->dm_cond because nset may be diff in different call
+        if (opt->dm_cond != NULL) { // NOT reuse opt->dm_cond because nset may be diff in different call
                 free(opt->dm_cond);
         }
         // nbas in the input arguments may different to opt->nbas.
@@ -374,7 +490,7 @@ void CVHFsetnr_direct_scf_dm(CVHFOpt *opt, double *dm, int nset, int *ao_loc,
 
 void CVHFset_dm_cond(CVHFOpt *opt, double *dm_cond, int len)
 {
-        if (opt->dm_cond) {
+        if (opt->dm_cond != NULL) {
                 free(opt->dm_cond);
         }
         opt->dm_cond = (double *)malloc(sizeof(double) * len);

--- a/pyscf/lib/vhf/optimizer.c
+++ b/pyscf/lib/vhf/optimizer.c
@@ -189,13 +189,15 @@ int CVHFnrs8_vj_prescreen_block(CVHFOpt *opt, int *ishls, int *jshls, int *kshls
                 rho += dm_cond[j*n+i] * q_cond[j*n+i];
         } }
 
-        cutoff = 4 * direct_scf_cutoff / rho;
-        for (l = l0; l < l1; l++) {
-        for (k = k0; k < k1; k++) {
-                if (q_cond[l*n+k] > cutoff) {
-                        return 1;
-                }
-        } }
+        if (rho != 0) {
+                cutoff = 4 * direct_scf_cutoff / fabs(rho);
+                for (l = l0; l < l1; l++) {
+                for (k = k0; k < k1; k++) {
+                        if (q_cond[l*n+k] > cutoff) {
+                                return 1;
+                        }
+                } }
+        }
 
         rho = 0;
         for (l = l0; l < l1; l++) {
@@ -204,13 +206,15 @@ int CVHFnrs8_vj_prescreen_block(CVHFOpt *opt, int *ishls, int *jshls, int *kshls
                 rho += dm_cond[l*n+k] * q_cond[l*n+k];
         } }
 
-        cutoff = 4 * direct_scf_cutoff / rho;
-        for (j = j0; j < j1; j++) {
-        for (i = i0; i < i1; i++) {
-                if (q_cond[j*n+i] > cutoff) {
-                        return 1;
-                }
-        } }
+        if (rho != 0) {
+                cutoff = 4 * direct_scf_cutoff / fabs(rho);
+                for (j = j0; j < j1; j++) {
+                for (i = i0; i < i1; i++) {
+                        if (q_cond[j*n+i] > cutoff) {
+                                return 1;
+                        }
+                } }
+        }
         return 0;
 }
 

--- a/pyscf/lib/vhf/optimizer.h
+++ b/pyscf/lib/vhf/optimizer.h
@@ -37,12 +37,14 @@ void CVHFinit_optimizer(CVHFOpt **opt, int *atm, int natm,
 
 void CVHFdel_optimizer(CVHFOpt **opt);
 
-int CVHFnoscreen(int *shls, CVHFOpt *opt,
-                  int *atm, int *bas, double *env);
-int CVHFnr_schwarz_cond(int *shls, CVHFOpt *opt,
-                        int *atm, int *bas, double *env);
-int CVHFnrs8_prescreen(int *shls, CVHFOpt *opt,
-                       int *atm, int *bas, double *env);
+int CVHFnoscreen(int *shls, CVHFOpt *opt, int *atm, int *bas, double *env);
+int CVHFnr_schwarz_cond(int *shls, CVHFOpt *opt, int *atm, int *bas, double *env);
+int CVHFnrs8_prescreen(int *shls, CVHFOpt *opt, int *atm, int *bas, double *env);
+int CVHFnrs8_vj_prescreen(int *shls, CVHFOpt *opt, int *atm, int *bas, double *env);
+int CVHFnrs8_vk_prescreen(int *shls, CVHFOpt *opt, int *atm, int *bas, double *env);
+int CVHFnrs8_prescreen_block(CVHFOpt *opt, int *ishls, int *jshls, int *kshls, int *lshls);
+int CVHFnrs8_vj_prescreen_block(CVHFOpt *opt, int *ishls, int *jshls, int *kshls, int *lshls);
+int CVHFnrs8_vk_prescreen_block(CVHFOpt *opt, int *ishls, int *jshls, int *kshls, int *lshls);
 
 int CVHFr_vknoscreen(int *shls, CVHFOpt *opt,
                      double **dms_cond, int n_dm, double *dm_atleast,

--- a/pyscf/lib/vhf/r_direct_dot.c
+++ b/pyscf/lib/vhf/r_direct_dot.c
@@ -101,7 +101,7 @@ void CVHFrs1_ji_s1kl(double complex *eri,
                      int nao, int ncomp, int *shls, int *ao_loc, int *tao,
                      double *dm_cond, int nbas, double dm_atleast)
 {
-        if (dm_cond && DMCOND(1,0) < dm_atleast) { return; }
+        if (dm_cond != NULL && DMCOND(1,0) < dm_atleast) { return; }
         LOCIJKL;
         int INC1 = 1;
         char TRANST = 'T';
@@ -129,7 +129,7 @@ void CVHFrs1_lk_s1ij(double complex *eri,
                      int nao, int ncomp, int *shls, int *ao_loc, int *tao,
                      double *dm_cond, int nbas, double dm_atleast)
 {
-        if (dm_cond && DMCOND(3,2) < dm_atleast) { return; }
+        if (dm_cond != NULL && DMCOND(3,2) < dm_atleast) { return; }
         LOCIJKL;
         int INC1 = 1;
         char TRANSN = 'N';
@@ -157,7 +157,7 @@ void CVHFrs1_jk_s1il(double complex *eri,
                      int nao, int ncomp, int *shls, int *ao_loc, int *tao,
                      double *dm_cond, int nbas, double dm_atleast)
 {
-        if (dm_cond && DMCOND(1,2) < dm_atleast) { return; }
+        if (dm_cond != NULL && DMCOND(1,2) < dm_atleast) { return; }
         LOCIJKL;
         int INC1 = 1;
         char TRANSN = 'N';
@@ -186,7 +186,7 @@ void CVHFrs1_li_s1kj(double complex *eri,
                      int nao, int ncomp, int *shls, int *ao_loc, int *tao,
                      double *dm_cond, int nbas, double dm_atleast)
 {
-        if (dm_cond && DMCOND(3,0) < dm_atleast) { return; }
+        if (dm_cond != NULL && DMCOND(3,0) < dm_atleast) { return; }
         LOCIJKL;
         int INC1 = 1;
         char TRANST = 'T';
@@ -219,7 +219,7 @@ void CVHFrs2ij_ji_s1kl(double complex *eri,
                                 dm_cond, nbas, dm_atleast);
                 return;
         }
-        if (dm_cond && DMCOND(1,0)+DMCOND(0,1) < dm_atleast) { return; }
+        if (dm_cond != NULL && DMCOND(1,0)+DMCOND(0,1) < dm_atleast) { return; }
         LOCIJKL;
         int INC1 = 1;
         char TRANST = 'T';
@@ -263,7 +263,7 @@ void CVHFrs2ij_jk_s1il(double complex *eri,
         if (shls[0] == shls[1]) {
                 return;
         }
-        if (dm_cond && DMCOND(0,2) < dm_atleast) { return; }
+        if (dm_cond != NULL && DMCOND(0,2) < dm_atleast) { return; }
 
         LOCIJKL;
         int INC1 = 1;
@@ -299,7 +299,7 @@ void CVHFrs2ij_li_s1kj(double complex *eri,
         if (shls[0] == shls[1]) {
                 return;
         }
-        if (dm_cond && DMCOND(3,1) < dm_atleast) { return; }
+        if (dm_cond != NULL && DMCOND(3,1) < dm_atleast) { return; }
 
         LOCIJKL;
         int INC1 = 1;
@@ -344,7 +344,7 @@ void CVHFrs2kl_lk_s1ij(double complex *eri,
                                 dm_cond, nbas, dm_atleast);
                 return;
         }
-        if (dm_cond && DMCOND(2,3)+DMCOND(3,2) < dm_atleast) { return; }
+        if (dm_cond != NULL && DMCOND(2,3)+DMCOND(3,2) < dm_atleast) { return; }
 
         LOCIJKL;
         int INC1 = 1;
@@ -380,7 +380,7 @@ void CVHFrs2kl_jk_s1il(double complex *eri,
         if (shls[2] == shls[3]) {
                 return;
         }
-        if (dm_cond && DMCOND(1,3) < dm_atleast) { return; }
+        if (dm_cond != NULL && DMCOND(1,3) < dm_atleast) { return; }
 
         LOCIJKL;
         int INC1 = 1;
@@ -416,7 +416,7 @@ void CVHFrs2kl_li_s1kj(double complex *eri,
         if (shls[2] == shls[3]) {
                 return;
         }
-        if (dm_cond && DMCOND(2,0) < dm_atleast) { return; }
+        if (dm_cond != NULL && DMCOND(2,0) < dm_atleast) { return; }
 
         LOCIJKL;
         int INC1 = 1;
@@ -493,7 +493,7 @@ void CVHFrs4_jk_s1il(double complex *eri,
         int l, ic;
 
         // tjtikl
-        if (!dm_cond || DMCOND(0,2) > dm_atleast) {
+        if (dm_cond == NULL || DMCOND(0,2) > dm_atleast) {
                 CVHFtimerev_iT(sdm, dm, tao, istart, iend, kstart, kend, nao);
                 for (ic = 0; ic < ncomp; ic++) {
                         NPzset0(svk, djl);
@@ -511,7 +511,7 @@ void CVHFrs4_jk_s1il(double complex *eri,
         }
 
         // tjtitltk
-        if (!dm_cond || DMCOND(0,3) > dm_atleast) {
+        if (dm_cond == NULL || DMCOND(0,3) > dm_atleast) {
                 CVHFtimerev_blockT(sdm, dm, tao, istart, iend, lstart, lend, nao);
                 for (ic = 0; ic < ncomp; ic++) {
                         NPzset0(svk, djk);
@@ -559,7 +559,7 @@ void CVHFrs4_li_s1kj(double complex *eri,
         int l, ic;
 
         // tjtikl
-        if (!dm_cond || DMCOND(3,1) > dm_atleast) {
+        if (dm_cond == NULL || DMCOND(3,1) > dm_atleast) {
                 CVHFtimerev_j(sdm, dm, tao, lstart, lend, jstart, jend, nao);
                 for (ic = 0; ic < ncomp; ic++) {
                         NPzset0(svk, dik);
@@ -577,7 +577,7 @@ void CVHFrs4_li_s1kj(double complex *eri,
         }
 
         // tjtitltk
-        if (!dm_cond || DMCOND(2,1) > dm_atleast) {
+        if (dm_cond == NULL || DMCOND(2,1) > dm_atleast) {
                 CVHFtimerev_block(sdm, dm, tao, kstart, kend, jstart, jend,nao);
                 for (ic = 0; ic < ncomp; ic++) {
                         NPzset0(svk, dil);

--- a/pyscf/lib/vhf/r_direct_o1.c
+++ b/pyscf/lib/vhf/r_direct_o1.c
@@ -48,7 +48,7 @@
         double *cache = (double *)(buf + di * dj * dim * dim * ncomp); \
         int (*fprescreen)(); \
         int (*r_vkscreen)(); \
-        if (vhfopt) { \
+        if (vhfopt != NULL) { \
                 fprescreen = vhfopt->fprescreen; \
                 r_vkscreen = vhfopt->r_vkscreen; \
         } else { \

--- a/pyscf/lib/vhf/rkb_screen.c
+++ b/pyscf/lib/vhf/rkb_screen.c
@@ -39,7 +39,7 @@ int int2e_spsp1spsp2_spinor();
 int CVHFrkbllll_prescreen(int *shls, CVHFOpt *opt,
                           int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1; // no screen
         }
         int i = shls[0];
@@ -88,7 +88,7 @@ int CVHFrkbllll_vkscreen(int *shls, CVHFOpt *opt,
 int CVHFrkbssll_prescreen(int *shls, CVHFOpt *opt,
                           int *atm, int *bas, double *env)
 {
-        if (!opt) {
+        if (opt == NULL) {
                 return 1; // no screen
         }
         int i = shls[0];
@@ -192,7 +192,7 @@ void CVHFrkbllll_direct_scf(CVHFOpt *opt, int (*intor)(), CINTOpt *cintopt,
                             int *ao_loc, int *atm, int natm,
                             int *bas, int nbas, double *env)
 {
-        if (opt->q_cond) {
+        if (opt->q_cond != NULL) {
                 free(opt->q_cond);
         }
         opt->q_cond = (double *)malloc(sizeof(double) * nbas*nbas);
@@ -205,7 +205,7 @@ void CVHFrkbssss_direct_scf(CVHFOpt *opt, int (*intor)(), CINTOpt *cintopt,
                             int *ao_loc, int *atm, int natm,
                             int *bas, int nbas, double *env)
 {
-        if (opt->q_cond) {
+        if (opt->q_cond != NULL) {
                 free(opt->q_cond);
         }
         opt->q_cond = (double *)malloc(sizeof(double) * nbas*nbas);
@@ -219,7 +219,7 @@ void CVHFrkbssll_direct_scf(CVHFOpt *opt, int (*intor)(), CINTOpt *cintopt,
                             int *ao_loc, int *atm, int natm,
                             int *bas, int nbas, double *env)
 {
-        if (opt->q_cond) {
+        if (opt->q_cond != NULL) {
                 free(opt->q_cond);
         }
         opt->q_cond = (double *)malloc(sizeof(double) * nbas*nbas*2);
@@ -264,7 +264,7 @@ void CVHFrkbllll_direct_scf_dm(CVHFOpt *opt, double complex *dm, int nset,
                                int *ao_loc, int *atm, int natm,
                                int *bas, int nbas, double *env)
 {
-        if (opt->dm_cond) { // NOT reuse opt->dm_cond because nset may be diff in different call
+        if (opt->dm_cond != NULL) { // NOT reuse opt->dm_cond because nset may be diff in different call
                 free(opt->dm_cond);
         }
         opt->dm_cond = (double *)malloc(sizeof(double)*nbas*nbas*(1+nset));
@@ -278,7 +278,7 @@ void CVHFrkbssss_direct_scf_dm(CVHFOpt *opt, double complex *dm, int nset,
                                int *ao_loc, int *atm, int natm,
                                int *bas, int nbas, double *env)
 {
-        if (opt->dm_cond) {
+        if (opt->dm_cond != NULL) {
                 free(opt->dm_cond);
         }
         opt->dm_cond = (double *)malloc(sizeof(double)*nbas*nbas*(1+nset));
@@ -293,7 +293,7 @@ void CVHFrkbssll_direct_scf_dm(CVHFOpt *opt, double complex *dm, int nset,
                                int *ao_loc, int *atm, int natm,
                                int *bas, int nbas, double *env)
 {
-        if (opt->dm_cond) {
+        if (opt->dm_cond != NULL) {
                 free(opt->dm_cond);
         }
         if (nset < 4) {

--- a/pyscf/lib/vhf/rkb_screen.c
+++ b/pyscf/lib/vhf/rkb_screen.c
@@ -247,15 +247,15 @@ static void set_dmcond(double *dmcond, double *dmscond, double complex *dm,
                         pdm = dm + nao*nao*iset;
                         for (i = ao_loc[ish]; i < ao_loc[ish+1]; i++) {
                         for (j = ao_loc[jsh]; j < ao_loc[jsh+1]; j++) {
-                                tmp = .5 * (cabs(pdm[i*nao+j]) + cabs(pdm[j*nao+i]));
+                                tmp = cabs(pdm[i*nao+j]) + cabs(pdm[j*nao+i]);
                                 dmaxi = MAX(dmaxi, tmp);
                         } }
-                        dmscond[iset*nbas*nbas+ish*nbas+jsh] = dmaxi;
-                        dmscond[iset*nbas*nbas+jsh*nbas+ish] = dmaxi;
+                        dmscond[iset*nbas*nbas+ish*nbas+jsh] = .5 * dmaxi;
+                        dmscond[iset*nbas*nbas+jsh*nbas+ish] = .5 * dmaxi;
                         dmax = MAX(dmax, dmaxi);
                 }
-                dmcond[ish*nbas+jsh] = dmax;
-                dmcond[jsh*nbas+ish] = dmax;
+                dmcond[ish*nbas+jsh] = .5 * dmax;
+                dmcond[jsh*nbas+ish] = .5 * dmax;
         } }
 }
 

--- a/pyscf/pbc/cc/test/test_kgccsd.py
+++ b/pyscf/pbc/cc/test/test_kgccsd.py
@@ -671,7 +671,7 @@ class KnownValues(unittest.TestCase):
 
         #mymp = pbmp.KMP2(kmf)
         #ekmp2, _ = mymp.kernel()
-        #print("KMP2 corr energy (per unit cell) = ", ekmp2)
+        #print("KMP2 corr energy (per cell) = ", ekmp2)
 
         mycc = pbcc.KGCCSD(kmf)
         ekccsd, t1, t2 = mycc.kernel()
@@ -699,7 +699,7 @@ class KnownValues(unittest.TestCase):
 
         ##mysmp = pbmp.KMP2(mf)
         ##emp2, _ = mysmp.kernel()
-        ##print("MP2 corr energy (per unit cell) = ", emp2 / np.prod(nmp))
+        ##print("MP2 corr energy (per cell) = ", emp2 / np.prod(nmp))
 
         myscc = pbcc.KGCCSD(mf)
         eccsd, _, _ = myscc.kernel()
@@ -755,7 +755,7 @@ class KnownValues(unittest.TestCase):
 
         #mymp = pbmp.KMP2(kmf)
         #ekmp2, _ = mymp.kernel()
-        #print("KMP2 corr energy (per unit cell) = ", ekmp2)
+        #print("KMP2 corr energy (per cell) = ", ekmp2)
 
         # By not applying a level-shift, one gets a different initial CCSD answer.
         # One can check however that the t1/t2 from level-shifting are a solution
@@ -787,7 +787,7 @@ class KnownValues(unittest.TestCase):
 
         #mysmp = pbmp.KMP2(mf)
         #emp2, _ = mysmp.kernel()
-        #print("MP2 corr energy (per unit cell) = ", emp2 / np.prod(nmp))
+        #print("MP2 corr energy (per cell) = ", emp2 / np.prod(nmp))
 
         myscc = pbcc.KGCCSD(mf, frozen=[0, 1, 14, 15])
         eccsd, _, _ = myscc.kernel()

--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -999,7 +999,7 @@ def tot_electrons(cell, nkpts=1):
     '''
     if cell._nelectron is None:
         nelectron = cell.atom_charges().sum() * nkpts - cell.charge
-    else: # Custom cell.nelectron stands for num. electrons per unit cell
+    else: # Custom cell.nelectron stands for num. electrons per cell
         nelectron = cell._nelectron * nkpts
     # Round off to the nearest integer
     nelectron = int(nelectron+0.5)
@@ -1126,7 +1126,7 @@ class Cell(mole.Mole):
             nbeta = nalpha - self.spin
             if nalpha + nbeta != ne:
                 warnings.warn('Electron number %d and spin %d are not consistent '
-                              'in unit cell\n' % (ne, self.spin))
+                              'in cell\n' % (ne, self.spin))
             return nalpha, nbeta
 
     def __getattr__(self, key):
@@ -1198,7 +1198,7 @@ class Cell(mole.Mole):
 
         Kwargs:
             a : (3,3) ndarray
-                The real-space unit cell lattice vectors. Each row represents
+                The real-space cell lattice vectors. Each row represents
                 a lattice vector.
             mesh : (3,) ndarray of ints
                 The number of *positive* G-vectors along each direction.

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -213,7 +213,7 @@ energy_elec = mol_hf.energy_elec
 
 def dip_moment(cell, dm, unit='Debye', verbose=logger.NOTE,
                grids=None, rho=None, kpt=np.zeros(3), origin=None):
-    ''' Dipole moment in the unit cell (is it well defined)?
+    ''' Dipole moment in the cell (is it well defined)?
 
     Args:
          cell : an instance of :class:`Cell`
@@ -246,7 +246,7 @@ def dip_moment(cell, dm, unit='Debye', verbose=logger.NOTE,
     if origin is None:
         origin = _search_dipole_gauge_origin(cell, grids, rho, log)
 
-    # Move the unit cell to the position around the origin.
+    # Move the cell to the position around the origin.
     def shift_grids(r):
         r_frac = lib.dot(r - origin, b.T)
         # Grids on the boundary (r_frac == +/-0.5) of the new cell may lead to

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -359,7 +359,7 @@ def init_guess_by_chkfile(cell, chkfile_name, project=None, kpts=None):
 
 def dip_moment(cell, dm_kpts, unit='Debye', verbose=logger.NOTE,
                grids=None, rho=None, kpts=np.zeros((1,3))):
-    ''' Dipole moment in the unit cell (is it well defined)?
+    ''' Dipole moment in the cell (is it well defined)?
 
     Args:
          cell : an instance of :class:`Cell`

--- a/pyscf/pbc/scf/krohf.py
+++ b/pyscf/pbc/scf/krohf.py
@@ -290,7 +290,7 @@ class KROHF(khf.KRHF, pbcrohf.ROHF):
 
     def dump_flags(self, verbose=None):
         khf.KSCF.dump_flags(self, verbose)
-        logger.info(self, 'number of electrons per unit cell  '
+        logger.info(self, 'number of electrons per cell  '
                     'alpha = %d beta = %d', *self.nelec)
         return self
 

--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -357,7 +357,7 @@ def init_guess_by_chkfile(cell, chkfile_name, project=None, kpts=None):
 
 def dip_moment(cell, dm_kpts, unit='Debye', verbose=logger.NOTE,
                grids=None, rho=None, kpts=np.zeros((1,3))):
-    ''' Dipole moment in the unit cell.
+    ''' Dipole moment in the cell.
 
     Args:
          cell : an instance of :class:`Cell`
@@ -408,7 +408,7 @@ class KUHF(khf.KSCF, pbcuhf.UHF):
 
     def dump_flags(self, verbose=None):
         khf.KSCF.dump_flags(self, verbose)
-        logger.info(self, 'number of electrons per unit cell  '
+        logger.info(self, 'number of electrons per cell  '
                     'alpha = %d beta = %d', *self.nelec)
         return self
 

--- a/pyscf/pbc/scf/rohf.py
+++ b/pyscf/pbc/scf/rohf.py
@@ -71,7 +71,7 @@ class ROHF(pbchf.RHF, mol_rohf.ROHF):
 
     def dump_flags(self, verbose=None):
         pbchf.SCF.dump_flags(self, verbose)
-        logger.info(self, 'number of electrons per unit cell  '
+        logger.info(self, 'number of electrons per cell  '
                     'alpha = %d beta = %d', *self.nelec)
         return self
 

--- a/pyscf/pbc/scf/uhf.py
+++ b/pyscf/pbc/scf/uhf.py
@@ -89,7 +89,7 @@ def init_guess_by_chkfile(cell, chkfile_name, project=None, kpt=None):
 
 def dip_moment(cell, dm, unit='Debye', verbose=logger.NOTE,
                grids=None, rho=None, kpt=np.zeros(3)):
-    ''' Dipole moment in the unit cell.
+    ''' Dipole moment in the cell.
 
     Args:
          cell : an instance of :class:`Cell`
@@ -138,7 +138,7 @@ class UHF(pbchf.SCF, mol_uhf.UHF):
 
     def dump_flags(self, verbose=None):
         pbchf.SCF.dump_flags(self, verbose)
-        logger.info(self, 'number of electrons per unit cell  '
+        logger.info(self, 'number of electrons per cell  '
                     'alpha = %d beta = %d', *self.nelec)
         return self
 

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -633,7 +633,7 @@ def cutoff_to_mesh(a, cutoff):
 
     Args:
         a : (3,3) ndarray
-            The real-space unit cell lattice vectors. Each row represents a
+            The real-space cell lattice vectors. Each row represents a
             lattice vector.
         cutoff : float
             KE energy cutoff in a.u.


### PR DESCRIPTION
* Fix memory leaks bugs in vhf prescreening code and refactor prescreening code
* Fix a bug of lattice-sum range in pbc AO evaluation
* Optimize vhf prescreening performance
* Update libcint to v5.1.3
* Change the phrase "unit cell" to "cell" in various modules