### PR TITLE
enable gamma-point TDDFT

### DIFF
--- a/examples/pbc/22-k_points_tddft.py
+++ b/examples/pbc/22-k_points_tddft.py
@@ -45,6 +45,19 @@ mf.kernel()
 td = tdscf.TDA(mf)
 td.kernel()
 
+#
+# Gamma-point RKS
+#
+ks = scf.RKS(cell)
+ks.run()
+
+td = tdscf.KTDDFT(ks)
+td.nstates = 5
+td.verbose = 5
+print(td.kernel()[0] * 27.2114)
+print(td.oscillator_strength())
+
+
 # TODO:
 #kpt = cell.get_abs_kpts([0.25, 0.25, 0.25])
 #mf = scf.RHF(cell, kpt=kpt)

--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -813,7 +813,7 @@ def nr_sap_vxc(ni, mol, grids, max_memory=2000, verbose=None):
     atom_charges = mol.atom_charges()
     eps = numpy.finfo(float).eps
 
-    for ao, mask, weight, coords in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
+    for ao, mask, weight, coords in ni.block_loop(mol, grids, nao, ao_deriv, max_memory=max_memory):
         aow = numpy.ndarray(ao.shape, order='F', buffer=aow)
         vxc = numpy.ndarray(coords.shape[0], buffer=vxcw)
         vxc.fill(0.0)
@@ -894,7 +894,7 @@ def nr_rks(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
 
     def block_loop(ao_deriv):
         for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
+                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory=max_memory):
             for i in range(nset):
                 rho = make_rho(i, ao, mask, xctype)
                 exc, vxc = ni.eval_xc(xc_code, rho, spin=0,
@@ -933,7 +933,7 @@ def nr_rks(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
         vvweight=numpy.empty([nset,0])
         vvcoords=numpy.empty([nset,0,3])
         for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
+                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory=max_memory):
             rhotmp = numpy.empty([0,4,weight.size])
             weighttmp = numpy.empty([0,weight.size])
             coordstmp = numpy.empty([0,weight.size,3])
@@ -949,7 +949,7 @@ def nr_rks(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
             vvcoords=numpy.concatenate((vvcoords,coordstmp),axis=1)
             rhotmp = weighttmp = coordstmp = None
         for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
+                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory=max_memory):
             aow = numpy.ndarray(ao[0].shape, order='F', buffer=aow)
             for i in range(nset):
                 rho = make_rho(i, ao, mask, 'GGA')
@@ -1049,7 +1049,7 @@ def nr_uks(ni, mol, grids, xc_code, dms, relativity=0, hermi=1,
 
     def block_loop(ao_deriv):
         for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
+                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory=max_memory):
             for i in range(nset):
                 rho_a = make_rhoa(i, ao, mask, xctype)
                 rho_b = make_rhob(i, ao, mask, xctype)
@@ -1196,7 +1196,7 @@ def nr_rks_fxc(ni, mol, grids, xc_code, dm0, dms, relativity=0, hermi=0,
         p1 = 0
         _rho0 = None
         for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
+                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory=max_memory):
             p0, p1 = p1, p1 + weight.size
             if rho0 is not None:
                 if xctype == 'LDA':
@@ -1301,7 +1301,7 @@ def nr_rks_fxc_st(ni, mol, grids, xc_code, dm0, dms_alpha, relativity=0, singlet
         aow = None
         p1 = 0
         for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
+                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory=max_memory):
             p0, p1 = p1, p1 + weight.size
             if fxc is None:
                 if rho0 is None:
@@ -1332,7 +1332,7 @@ def nr_rks_fxc_st(ni, mol, grids, xc_code, dm0, dms_alpha, relativity=0, singlet
         aow = None
         p1 = 0
         for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
+                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory=max_memory):
             p0, p1 = p1, p1 + weight.size
             if rho0 is None:
                 rhoa = make_rho0a(0, ao, mask, xctype)
@@ -1388,7 +1388,7 @@ def nr_rks_fxc_st(ni, mol, grids, xc_code, dm0, dms_alpha, relativity=0, singlet
         aow = None
         p1 = 0
         for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
+                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory=max_memory):
             p0, p1 = p1, p1 + weight.size
             if rho0 is None:
                 rhoa = make_rho0a(0, ao, mask, xctype)
@@ -1643,7 +1643,7 @@ def nr_uks_fxc(ni, mol, grids, xc_code, dm0, dms, relativity=0, hermi=0,
         p1 = 0
         rho0a = rho0b = None
         for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
+                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory=max_memory):
             p0, p1 = p1, p1 + weight.size
             if rho0 is not None:
                 if xctype == 'LDA':
@@ -2469,7 +2469,7 @@ def cache_xc_kernel(ni, mol, grids, xc_code, mo_coeff, mo_occ, spin=0,
         rhoa = []
         rhob = []
         for ao, mask, weight, coords \
-                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory):
+                in ni.block_loop(mol, grids, nao, ao_deriv, max_memory=max_memory):
             rhoa.append(ni.eval_rho2(mol, ao, mo_coeff[0], mo_occ[0], mask, xctype))
             rhob.append(ni.eval_rho2(mol, ao, mo_coeff[1], mo_occ[1], mask, xctype))
         rho = (numpy.hstack(rhoa), numpy.hstack(rhob))
@@ -2485,7 +2485,7 @@ def get_rho(ni, mol, dm, grids, max_memory=2000):
     rho = numpy.empty(grids.weights.size)
     p1 = 0
     for ao, mask, weight, coords \
-            in ni.block_loop(mol, grids, nao, 0, max_memory):
+            in ni.block_loop(mol, grids, nao, 0, max_memory=max_memory):
         p0, p1 = p1, p1 + weight.size
         rho[p0:p1] = make_rho(0, ao, mask, 'LDA')
     return rho

--- a/pyscf/pbc/dft/numint.py
+++ b/pyscf/pbc/dft/numint.py
@@ -694,11 +694,11 @@ def nr_rks_fxc_st(ni, cell, grids, xc_code, dm0, dms_alpha, relativity=0, single
                 vmat[i] += ni._vxc_mat(cell, ao_k1, wv, mask, xctype,
                                        shls_slice, ao_loc, hermi)
 
+        vmat = numpy.stack(vmat)
         # For only real orbitals, K_{ia,bj} = K_{ia,jb}. It simplifies
         # [(\nabla mu) nu + mu (\nabla nu)] * fxc_jb = ((\nabla mu) nu f_jb) + h.c.
         if hermi == 1:
             vmat = vmat + vmat.conj().swapaxes(-2,-1)
-        vmat = numpy.stack(vmat)
         if nset == 1:
             vmat = vmat.reshape(dms_alpha.shape)
     else:

--- a/pyscf/pbc/scf/_response_functions.py
+++ b/pyscf/pbc/scf/_response_functions.py
@@ -203,7 +203,7 @@ krohf.KROHF.gen_response = _gen_uhf_response
 from pyscf.pbc.scf import hf, uhf, rohf, ghf
 
 def _gen_rhf_response_gam(mf, mo_coeff=None, mo_occ=None,
-                      singlet=None, hermi=0, max_memory=None):
+                          singlet=None, hermi=0, max_memory=None):
     from pyscf.pbc.dft import numint, multigrid
     assert isinstance(mf, hf.RHF)
 
@@ -304,7 +304,7 @@ def _gen_rhf_response_gam(mf, mo_coeff=None, mo_occ=None,
     return vind
 
 def _gen_uhf_response_gam(mf, mo_coeff=None, mo_occ=None,
-                      with_j=True, hermi=0, max_memory=None):
+                          with_j=True, hermi=0, max_memory=None):
     from pyscf.pbc.dft import multigrid
     assert isinstance(mf, (uhf.UHF, rohf.ROHF))
 
@@ -366,7 +366,7 @@ def _gen_uhf_response_gam(mf, mo_coeff=None, mo_occ=None,
     return vind
 
 def _gen_ghf_response_gam(mf, mo_coeff=None, mo_occ=None,
-                      with_j=True, hermi=0, max_memory=None):
+                          with_j=True, hermi=0, max_memory=None):
     '''Generate a function to compute the product of KGHF response function and
     KGHF density matrices.
     '''

--- a/pyscf/pbc/scf/_response_functions.py
+++ b/pyscf/pbc/scf/_response_functions.py
@@ -17,7 +17,7 @@
 #
 
 '''
-Generate KSCF response functions
+Generate PBC (K)SCF response functions
 '''
 
 import numpy
@@ -199,4 +199,182 @@ khf.KRHF.gen_response = _gen_rhf_response
 kuhf.KUHF.gen_response = _gen_uhf_response
 kghf.KGHF.gen_response = _gen_ghf_response
 krohf.KROHF.gen_response = _gen_uhf_response
+
+from pyscf.pbc.scf import hf, uhf, rohf, ghf
+
+def _gen_rhf_response_gam(mf, mo_coeff=None, mo_occ=None,
+                      singlet=None, hermi=0, max_memory=None):
+    from pyscf.pbc.dft import numint, multigrid
+    assert isinstance(mf, hf.RHF)
+
+    if mo_coeff is None: mo_coeff = mf.mo_coeff
+    if mo_occ is None: mo_occ = mf.mo_occ
+    cell = mf.cell
+    kpt = mf.kpt
+    if isinstance(mf, khf.pbchf.KohnShamDFT):
+        ni = mf._numint
+        ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
+
+        omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=cell.spin)
+        hybrid = abs(hyb) > 1e-10
+        if abs(omega) > 1e-10:  # For range separated Coulomb
+            raise NotImplementedError
+
+        if not hybrid and isinstance(mf.with_df, multigrid.MultiGridFFTDF):
+            dm0 = mf.make_rdm1(mo_coeff, mo_occ)
+            return multigrid._gen_rhf_response(mf, dm0, singlet, hermi)
+
+        if singlet is None:  # for newton solver
+            rho0, vxc, fxc = ni.cache_xc_kernel(cell, mf.grids, mf.xc, mo_coeff,
+                                                mo_occ, 0, kpt)
+        else:
+            if isinstance(mo_occ, numpy.ndarray):
+                mo_occ = mo_occ*.5
+            else:
+                mo_occ = [x*.5 for x in mo_occ]
+            rho0, vxc, fxc = ni.cache_xc_kernel(cell, mf.grids, mf.xc,
+                                                [mo_coeff]*2, [mo_occ]*2,
+                                                spin=1, kpts=kpt)
+        dm0 = None #mf.make_rdm1(mo_coeff, mo_occ)
+
+        if max_memory is None:
+            mem_now = lib.current_memory()[0]
+            max_memory = max(2000, mf.max_memory*.8-mem_now)
+
+        if singlet is None:  # Without specify singlet, general case
+            def vind(dm1):
+                # The singlet hessian
+                if hermi == 2:
+                    v1 = numpy.zeros_like(dm1)
+                else:
+                    v1 = ni.nr_rks_fxc(cell, mf.grids, mf.xc, dm0, dm1, 0, hermi,
+                                       rho0, vxc, fxc, kpt, max_memory=max_memory)
+                if hybrid:
+                    if hermi != 2:
+                        vj, vk = mf.get_jk(cell, dm1, hermi=hermi, kpt=kpt)
+                        v1 += vj - .5 * hyb * vk
+                    else:
+                        v1 -= .5 * hyb * mf.get_k(cell, dm1, hermi=hermi, kpt=kpt)
+                elif hermi != 2:
+                    v1 += mf.get_j(cell, dm1, hermi=hermi, kpt=kpt)
+                return v1
+
+        elif singlet:
+            def vind(dm1):
+                if hermi == 2:
+                    v1 = numpy.zeros_like(dm1)
+                else:
+                    # nr_rks_fxc_st requires alpha of dm1
+                    v1 = numint.nr_rks_fxc_st(ni, cell, mf.grids, mf.xc, dm0, dm1, 0,
+                                              True, rho0, vxc, fxc, kpt,
+                                              max_memory=max_memory)
+                    v1 *= .5
+                if hybrid:
+                    if hermi != 2:
+                        vj, vk = mf.get_jk(cell, dm1, hermi=hermi, kpt=kpt)
+                        v1 += vj - .5 * hyb * vk
+                    else:
+                        v1 -= .5 * hyb * mf.get_k(cell, dm1, hermi=hermi, kpt=kpt)
+                elif hermi != 2:
+                    v1 += mf.get_j(cell, dm1, hermi=hermi, kpt=kpt)
+                return v1
+        else:  # triplet
+            def vind(dm1):
+                if hermi == 2:
+                    v1 = numpy.zeros_like(dm1)
+                else:
+                    # nr_rks_fxc_st requires alpha of dm1
+                    v1 = numint.nr_rks_fxc_st(ni, cell, mf.grids, mf.xc, dm0, dm1, 0,
+                                              False, rho0, vxc, fxc, kpt,
+                                              max_memory=max_memory)
+                    v1 *= .5
+                if hybrid:
+                    v1 += -.5 * hyb * mf.get_k(cell, dm1, hermi=hermi, kpt=kpt)
+                return v1
+
+    else:  # HF
+        if (singlet is None or singlet) and hermi != 2:
+            def vind(dm1):
+                vj, vk = mf.get_jk(cell, dm1, hermi=hermi, kpt=kpt)
+                return vj - .5 * vk
+        else:
+            def vind(dm1):
+                return -.5 * mf.get_k(cell, dm1, hermi=hermi, kpt=kpt)
+
+    return vind
+
+def _gen_uhf_response_gam(mf, mo_coeff=None, mo_occ=None,
+                      with_j=True, hermi=0, max_memory=None):
+    from pyscf.pbc.dft import multigrid
+    assert isinstance(mf, (uhf.UHF, rohf.ROHF))
+
+    if mo_coeff is None: mo_coeff = mf.mo_coeff
+    if mo_occ is None: mo_occ = mf.mo_occ
+    cell = mf.cell
+    kpt = mf.kpt
+    if isinstance(mf, khf.pbchf.KohnShamDFT):
+        ni = mf._numint
+        ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
+
+        omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=cell.spin)
+        hybrid = abs(hyb) > 1e-10
+        if abs(omega) > 1e-10:  # For range separated Coulomb
+            raise NotImplementedError
+
+        if not hybrid and isinstance(mf.with_df, multigrid.MultiGridFFTDF):
+            dm0 = mf.make_rdm1(mo_coeff, mo_occ)
+            return multigrid._gen_uhf_response(mf, dm0, with_j, hermi)
+
+        rho0, vxc, fxc = ni.cache_xc_kernel(cell, mf.grids, mf.xc,
+                                            mo_coeff, mo_occ, 1, kpt)
+        #dm0 =(numpy.dot(mo_coeff[0]*mo_occ[0], mo_coeff[0].conj().T),
+        #      numpy.dot(mo_coeff[1]*mo_occ[1], mo_coeff[1].conj().T))
+        dm0 = None
+
+        if max_memory is None:
+            mem_now = lib.current_memory()[0]
+            max_memory = max(2000, mf.max_memory*.8-mem_now)
+
+        def vind(dm1):
+            if hermi == 2:
+                v1 = numpy.zeros_like(dm1)
+            else:
+                v1 = ni.nr_uks_fxc(cell, mf.grids, mf.xc, dm0, dm1, 0, hermi,
+                                   rho0, vxc, fxc, kpt, max_memory=max_memory)
+            if not hybrid:
+                if with_j:
+                    vj = mf.get_j(cell, dm1, hermi=hermi, kpt=kpt)
+                    v1 += vj[0] + vj[1]
+            else:
+                if with_j:
+                    vj, vk = mf.get_jk(cell, dm1, hermi=hermi, kpt=kpt)
+                    v1 += vj[0] + vj[1] - vk * hyb
+                else:
+                    v1 -= hyb * mf.get_k(cell, dm1, hermi=hermi, kpt=kpt)
+            return v1
+
+    elif with_j:
+        def vind(dm1):
+            vj, vk = mf.get_jk(cell, dm1, hermi=hermi, kpt=kpt)
+            v1 = vj[0] + vj[1] - vk
+            return v1
+
+    else:
+        def vind(dm1):
+            return -mf.get_k(cell, dm1, hermi=hermi, kpt=kpt)
+
+    return vind
+
+def _gen_ghf_response_gam(mf, mo_coeff=None, mo_occ=None,
+                      with_j=True, hermi=0, max_memory=None):
+    '''Generate a function to compute the product of KGHF response function and
+    KGHF density matrices.
+    '''
+    raise NotImplementedError
+
+
+hf.RHF.gen_response = _gen_rhf_response_gam
+uhf.UHF.gen_response = _gen_uhf_response_gam
+ghf.GHF.gen_response = _gen_ghf_response_gam
+rohf.ROHF.gen_response = _gen_uhf_response_gam
 


### PR DESCRIPTION
Currently, calling TDDFT on gamma-point RKS will trigger error. The main reason is that in this case non-PBC tdscf is used and it assumes pbc.RKS has a response function (compatible with pbc.dft.numint) , but it has not.
After implementing this, it looks like calling TDDFT on pbc.RKS gives the same result as pbc.KRKS with 1 k-point. 
Also, with this routine, td.oscillator_strength() can be called directly.

Tests and side-effect-check have not been fully considered yet.