### PR TITLE
Fix for projecting the dm to a larger basis set in PBC systems using from_chk() and init_guess

### DIFF
--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -328,8 +328,7 @@ def init_guess_by_chkfile(cell, chkfile_name, project=None, kpts=None):
     if kpts.shape == chk_kpts.shape and np.allclose(kpts, chk_kpts):
         def makedm(mos, occs):
             moa, mob = mos
-            mos =([fproj(mo, None) for mo in moa],
-                  [fproj(mo, None) for mo in mob])
+            mos = (fproj(moa, kpts), fproj(mob, kpts))
             return make_rdm1(mos, occs)
     else:
         def makedm(mos, occs):


### PR DESCRIPTION
Following from an issue #1317 I created earlier about `mf.from_chk()` failing to read the density matrix produced from a smaller basis set into the mean field object with a larger basis set in periodic systems (the same for `mf.init_guess` method), @hebrewsnabla provided a solution to fix this bug, as described in https://github.com/pyscf/pyscf/issues/1317#issuecomment-1176276629.