### PR TITLE
Fixes inconsistent energy between k-RCCSD and k-UCCSD

### DIFF
--- a/pyscf/cc/ccsd.py
+++ b/pyscf/cc/ccsd.py
@@ -979,7 +979,7 @@ http://sunqm.net/pyscf/code-rule.html#api-rules for the details of API conventio
 
     @property
     def e_tot(self):
-        return (self.e_hf or self._scf.e_tot) + self.e_corr
+        return self.e_hf + self.e_corr
 
     @property
     def nocc(self):

--- a/pyscf/pbc/cc/kccsd_rhf.py
+++ b/pyscf/pbc/cc/kccsd_rhf.py
@@ -608,6 +608,11 @@ class RCCSD(pyscf.cc.ccsd.CCSD):
             # eris = self.ao2mo()
             eris = self.ao2mo(self.mo_coeff)
         self.eris = eris
+
+        self.e_hf = getattr(eris, 'e_hf', None)
+        if self.e_hf is None:
+            self.e_hf = self._scf.e_tot
+
         if mbpt2:
             self.e_corr, self.t1, self.t2 = self.init_amps(eris)
             return self.e_corr, self.t1, self.t2


### PR DESCRIPTION
There is an inconsistency in energy between k-RCCSD and k-UCCSD, which is due to the divergent exact exchange correction of the mean field energy. More generally, I think this will also affect k-RCCSD calculation on top of non-converged HF mean-fields, such as LDA - the main issue is that the k-RCCSD kernel, opposed to all other CCSD kernels, does *not* set the attribute `e_hf`,
and the `e_tot` property thus falls back to using `self._scf.e_tot` as the mean-field energy.

The inconsistency between k-RCCSD and k-UCCSD then arises hence `self._scf.e_tot` by default includes the exxdiv correction,
whereas `eris.e_hf` does not, since the HF potential is build without this correction in the `_common_init_` of the ERIs.
For k-RCCSD@LDA the issue will likely be even worse, since E_LDA will be very different from E_HF[DM_LDA]. 

This fix will make ensure that k-RCCSD behaves like k-UCCSD (and also agrees with the Gamma-point pbc.ccsd classes, for Gamma-point only calculations. The code I used to verify this is attached below.


There is still another, related question, which is if we should not use the exxdiv correction for the HF energy part of the CCSD total energy by default (but not for the `eris.fock`, used in the CCSD eqs. and correlation energy, of course).
I think there is some justification for this, as exxdiv accelerates convergence to the thermodynamic limit, and combining a HF energy with exxdiv with a CCSD correlation energy without exxdiv is similar to combining, say, a E(HF) on a 6x6x6 k-point grid with a E(corr) calculated on a 3x3x3 grid - a somewhat common approach to converge energetics.
One big benefit of this would be that `ccsd.e_tot = hf.e_tot + ccsd.e_corr` will be true again (for converged HF calculations), as most users would expect.

[example.py.txt](https://github.com/pyscf/pyscf/files/9193487/example.py.txt)