### PR TITLE
remove unnecessary and faulty get_e_hf

### DIFF
--- a/pyscf/cc/rccsd_slow.py
+++ b/pyscf/cc/rccsd_slow.py
@@ -218,7 +218,6 @@ class RCCSD(ccsd.CCSD):
 
     energy = energy
     update_amps = update_amps
-    get_e_hf = ccsd.get_e_hf
 
     def nip(self):
         nocc = self.nocc


### PR DESCRIPTION
remove get_e_hf assignment which is not only unnecessary but it also fails to find the function correctly