### PR TITLE
Add CDERIArray class to load pbc.gdf tensor

### DIFF
--- a/pyscf/pbc/cc/kccsd_rhf.py
+++ b/pyscf/pbc/cc/kccsd_rhf.py
@@ -950,12 +950,12 @@ def _init_df_eris(cc, eris):
     dtype = np.result_type(dtype, *eris.mo_coeff)
     eris.Lpv = Lpv = np.empty((nkpts,nkpts), dtype=object)
 
-    with df._load3c(cc._scf.with_df._cderi, 'j3c') as fload:
+    with df.CDERIArray(cc._scf.with_df._cderi) as cderi_array:
         tao = []
         ao_loc = None
-        for ki, kpti in enumerate(kpts):
-            for kj, kptj in enumerate(kpts):
-                Lpq = np.asarray(fload(kpti, kptj))
+        for ki in range(nkpts):
+            for kj in range(nkpts):
+                Lpq = cderi_array[ki,kj]
 
                 mo = np.hstack((eris.mo_coeff[ki], eris.mo_coeff[kj][:, nocc:]))
                 mo = np.asarray(mo, dtype=dtype, order='F')

--- a/pyscf/pbc/cc/kccsd_uhf.py
+++ b/pyscf/pbc/cc/kccsd_uhf.py
@@ -1086,12 +1086,12 @@ def _make_df_eris(cc, mo_coeff=None):
 
     eris.Lpv = Lpv = np.empty((nkpts,nkpts), dtype=object)
     eris.LPV = LPV = np.empty((nkpts,nkpts), dtype=object)
-    with df._load3c(thisdf._cderi, 'j3c') as fload:
+    with df.CDERIArray(thisdf._cderi) as cderi_array:
         tao = []
         ao_loc = None
-        for ki, kpti in enumerate(kpts):
-            for kj, kptj in enumerate(kpts):
-                Lpq = np.asarray(fload(kpti, kptj))
+        for ki in range(nkpts):
+            for kj in range(nkpts):
+                Lpq = cderi_array[ki,kj]
 
                 mo_a = np.hstack((mo_kpts_a[ki], mo_kpts_a[kj][:,nocca:]))
                 mo_b = np.hstack((mo_kpts_b[ki], mo_kpts_b[kj][:,noccb:]))

--- a/pyscf/pbc/ci/kcis_rhf.py
+++ b/pyscf/pbc/ci/kcis_rhf.py
@@ -650,12 +650,12 @@ def _init_cis_df_eris(cis, eris):
 
     cput0 = (logger.process_clock(), logger.perf_counter())
 
-    with df._load3c(cis._scf.with_df._cderi, 'j3c') as fload:
+    with df.CDERIArray(cis._scf.with_df._cderi) as cderi_array:
         tao = []
         ao_loc = None
-        for ki, kpti in enumerate(kpts):
-            for kj, kptj in enumerate(kpts):
-                Lpq_ao = np.asarray(fload(kpti, kptj))
+        for ki in range(nkpts):
+            for kj in range(nkpts):
+                Lpq_ao = cderi_array[ki,kj]
 
                 mo = np.hstack((eris.mo_coeff[ki], eris.mo_coeff[kj]))
                 mo = np.asarray(mo, dtype=dtype, order='F')

--- a/pyscf/pbc/df/df.py
+++ b/pyscf/pbc/df/df.py
@@ -35,6 +35,7 @@ import ctypes
 import warnings
 import tempfile
 import contextlib
+import itertools
 import numpy
 import h5py
 import scipy.linalg
@@ -281,6 +282,14 @@ class GDF(lib.StreamObject, aft.AFTDFMixin):
         dfbuilder.linear_dep_threshold = self.linear_dep_threshold
         dfbuilder.make_j3c(cderi_file, j_only=self._j_only)
 
+    def cderi_array(self, label='j3c'):
+        '''
+        Returns CDERIArray object which provides numpy APIs to access cderi tensor.
+        '''
+        if self._cderi is None:
+            self.build()
+        return CDERIArray(self._cderi, label)
+
     def has_kpts(self, kpts):
         if kpts is None:
             return True
@@ -465,6 +474,99 @@ class GDF(lib.StreamObject, aft.AFTDFMixin):
 
 DF = GDF
 
+class CDERIArray:
+    '''
+    Provide numpy APIs to access cderi tensor. This object can be viewed as an
+    5-dimension array [kpt-i, kpt-j, aux-index, ao-i, ao-j]
+    '''
+
+    def __init__(self, data_group, label='j3c'):
+        self._data_is_h5obj = isinstance(data_group, h5py.Group)
+        if not self._data_is_h5obj:
+            data_group = h5py.File(data_group, 'r')
+        self.data_group = data_group
+        if 'kpts' not in data_group:
+            raise RuntimeError('cderi data not generated or format incompatible')
+
+        aosym = data_group['aosym'][()]
+        if isinstance(aosym, bytes):
+            aosym = aosym.decode()
+        self.aosym = aosym
+        self.j3c = data_group[label]
+        self.kpts = data_group['kpts'][:]
+        self.nkpts = self.kpts.shape[0]
+        nao_pair = sum(dat.shape[1] for dat in self.j3c['0'].values())
+        nao = int(nao_pair ** .5)
+        if nao ** 2 == nao_pair:  # s
+            self.nao = nao
+        else:
+            self.nao = int((nao_pair * 2)**.5)
+        self.naux = self.j3c['0/0'].shape[0]
+
+    def __del__(self):
+        if not self._data_is_h5obj:
+            self.data_group.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        if not self._data_is_h5obj:
+            self.data_group.close()
+
+    def __getitem__(self, slices):
+        if isinstance(slices, tuple):
+            ns = len(slices)
+            if ns < 2:
+                # patch (:) to slices
+                slices = slices + (range(self.nkpts),) * (2 - ns)
+
+            k_slices = slices[:2]
+            a_slices = slices[2:]
+            if isinstance(k_slices[0], int) and isinstance(k_slices[1], int):
+                return self._load_one(k_slices[0], k_slices[1], ())
+        else:
+            k_slices = slices
+            a_slices = ()
+        out = numpy.empty((self.nkpts, self.nkpts), dtype=object)
+        out[k_slices] = True
+
+        for ki, kj in numpy.argwhere(out):
+            out[ki,kj] = self._load_one(ki, kj, a_slices)
+        return out[k_slices]
+
+    def _load_one(self, ki, kj, slices):
+        kikj = ki * self.nkpts + kj
+        kjki = kj * self.nkpts + ki
+        if self.aosym == 's1' or kikj == kjki:
+            dat = self.j3c[str(kikj)]
+            nsegs = len(dat)
+            out = numpy.hstack([dat[str(i)][slices] for i in range(nsegs)])
+        elif self.aosym == 's2':
+            dat_ij = self.j3c[str(kikj)]
+            dat_ji = self.j3c[str(kjki)]
+            tril = numpy.hstack([dat_ij[str(i)][slices] for i in range(len(dat_ij))])
+            triu = numpy.hstack([dat_ji[str(i)][slices] for i in range(len(dat_ji))])
+            assert tril.dtype == numpy.complex128
+            naux = self.naux
+            nao = self.nao
+            out = numpy.empty((naux, nao*nao), dtype=tril.dtype)
+            libpbc.PBCunpack_tril_triu(out.ctypes.data_as(ctypes.c_void_p),
+                                       tril.ctypes.data_as(ctypes.c_void_p),
+                                       triu.ctypes.data_as(ctypes.c_void_p),
+                                       ctypes.c_int(naux), ctypes.c_int(nao))
+        return out
+
+    def load(self, kpti, kptj):
+        ki = member(kpti, self.kpts)
+        kj = member(kptj, self.kpts)
+        if len(ki) == 0 or len(kj) == 0:
+            raise RuntimeError(f'CDERI for kpts ({kpti}, {kptj}) not found')
+        return self._load_one(ki[0], kj[0], ())
+
+    def __array__(self):
+        '''Create a numpy array'''
+        return self[:]
 
 class _load3c:
     #'''Read cderi from old version pyscf (<= 2.0)'''
@@ -534,14 +636,20 @@ class _load3c:
         if self.data_version == 'v2':
             kpts = self.kptij_lst
             nkpts = len(kpts)
-            ki = member(kpti, kpts)
-            kj = member(kptj, kpts)
-            if len(ki) == 0 or len(kj) == 0:
-                raise RuntimeError(f'CDERI {self.label} for kpts ({kpti}, {kptj}) is '
-                                   'not initialized.')
+            if (isinstance(kpti, (int, numpy.integer)) and
+                isinstance(kptj, (int, numpy.integer))):
+                ki = kpti
+                kj = kptj
+            else:
+                ki = member(kpti, kpts)
+                kj = member(kptj, kpts)
+                if len(ki) == 0 or len(kj) == 0:
+                    raise RuntimeError(f'CDERI {self.label} for kpts ({kpti}, {kptj}) is '
+                                       'not initialized.')
 
-            ki = ki[0]
-            kj = kj[0]
+                ki = ki[0]
+                kj = kj[0]
+
             key = f'{self.label}/{ki * nkpts + kj}'
             if key not in self.feri:
                 if self.ignore_key_error:

--- a/pyscf/pbc/df/test/test_rsdf_builder.py
+++ b/pyscf/pbc/df/test/test_rsdf_builder.py
@@ -157,14 +157,15 @@ class KnownValues(unittest.TestCase):
             self.assertAlmostEqual(lib.fp(v_s2[2*nkpts+2]), 1.2630074629589676+0j, 8)
 
             dfbuilder.make_j3c(tmpf.name, aosym='s1')
-            for ki in range(nkpts):
-                for kj in range(nkpts):
-                    v1 = load(tmpf.name, kpts[[ki, kj]])
-                    if ki == kj:
-                        v2 = lib.unpack_tril(v_s2[ki*nkpts+kj]).reshape(v1.shape)
-                        self.assertAlmostEqual(abs(v1 - v2).max(), 0, 9)
-                    else:
-                        self.assertAlmostEqual(abs(v1 - v_s2[ki*nkpts+kj]).max(), 0, 9)
+            with df.CDERIArray(tmpf.name) as cderi_array:
+                for ki in range(nkpts):
+                    for kj in range(nkpts):
+                        v1 = cderi_array[ki, kj]
+                        if ki == kj:
+                            v2 = lib.unpack_tril(v_s2[ki*nkpts+kj]).reshape(v1.shape)
+                            self.assertAlmostEqual(abs(v1 - v2).max(), 0, 9)
+                        else:
+                            self.assertAlmostEqual(abs(v1 - v_s2[ki*nkpts+kj]).max(), 0, 9)
 
     def test_make_j3c_j_only(self):
         dfbuilder = rsdf_builder._RSGDFBuilder(cell, auxcell, kpts).build()
@@ -327,14 +328,16 @@ class KnownValues(unittest.TestCase):
             self.assertAlmostEqual(lib.fp(v_s2[2*nkpts+2]), 0.8297008206216369+0j, 8)
 
             dfbuilder.make_j3c(tmpf.name, aosym='s1')
+            with df.CDERIArray(tmpf.name) as cderi_array:
+                v_s1 = cderi_array[:]
             for ki in range(nkpts):
                 for kj in range(nkpts):
-                    v1 = load(tmpf.name, kpts[[ki, kj]])
+                    v1 = v_s1[ki,kj]
                     if ki == kj:
                         v2 = lib.unpack_tril(v_s2[ki*nkpts+kj]).reshape(v1.shape)
-                        self.assertAlmostEqual(abs(v1 - v2).max(), 0, 8)
+                        self.assertAlmostEqual(abs(v1 - v2).max(), 0, 9)
                     else:
-                        self.assertAlmostEqual(abs(v1 - v_s2[ki*nkpts+kj]).max(), 0, 8)
+                        self.assertAlmostEqual(abs(v1 - v_s2[ki*nkpts+kj]).max(), 0, 9)
 
     def test_make_j3c_j_only_sr(self):
         dfbuilder = rsdf_builder._RSGDFBuilder(cell_sr, auxcell_sr, kpts).build()

--- a/pyscf/pbc/mp/kmp2.py
+++ b/pyscf/pbc/mp/kmp2.py
@@ -198,12 +198,12 @@ def _init_mp_df_eris(mp):
     bra_end = nocc
     ket_start = nmo+nocc
     ket_end = ket_start + nvir
-    with df._load3c(mp._scf.with_df._cderi, 'j3c') as fload:
+    with df.CDERIArray(mp._scf.with_df._cderi) as cderi_array:
         tao = []
         ao_loc = None
-        for ki, kpti in enumerate(kpts):
-            for kj, kptj in enumerate(kpts):
-                Lpq_ao = np.asarray(fload(kpti, kptj))
+        for ki in range(nkpts):
+            for kj in range(nkpts):
+                Lpq_ao = cderi_array[ki,kj]
 
                 mo = np.hstack((mo_coeff[ki], mo_coeff[kj]))
                 mo = np.asarray(mo, dtype=dtype, order='F')


### PR DESCRIPTION
The CDERIArray class provides an numpy.ndarray-like abstract to read pbc GDF tensor.
```
cderi_array = pbc.df.df.CDERIArray(cderi_file)
ki = 0
kj = 1
# specific tensor at k-point (0,1)
cderi_array[ki, kj]
# tensors at all k-points
cderi_array[:]
```