### PR TITLE
fix_spin_ as dynamical class for SA-CASSCF gradient compatibility

### DIFF
--- a/pyscf/fci/addons.py
+++ b/pyscf/fci/addons.py
@@ -656,7 +656,7 @@ def fix_spin_(fciobj, shift=PENALTY, ss=None, **kwargs):
 
     if isinstance (fciobj, SpinPenaltyFCISolver):
         # recursion avoidance
-        fciobj.shift = shift
+        fciobj.ss_penalty = shift
         fciobj.ss_value = ss
         return fciobj
     ismodule = isinstance (fciobj, types.ModuleType)
@@ -686,7 +686,7 @@ def fix_spin_(fciobj, shift=PENALTY, ss=None, **kwargs):
             ci1 = -ss * tmp
             ci1 += self.contract_ss(tmp, norb, nelec).reshape(fcivec.shape)
             tmp = None
-        ci1 *= self.shift
+        ci1 *= self.ss_penalty
 
         ci0 = self.base_contract_2e (eri, fcivec, norb, nelec, link_index, **kwargs)
         ci1 += ci0.reshape(fcivec.shape)
@@ -694,7 +694,7 @@ def fix_spin_(fciobj, shift=PENALTY, ss=None, **kwargs):
 
     if ismodule:
         base_contract_2e = fciobj.contract_2e
-        self = SpinPenaltyMod (shift=shift, ss_value=ss_value,
+        self = SpinPenaltyMod (ss_penalty=shift, ss_value=ss_value,
                                contract_ss=fciobj.contract_ss,
                                base_contract_2e=base_contract_2e)
         from functools import partial
@@ -710,7 +710,7 @@ def fix_spin_(fciobj, shift=PENALTY, ss=None, **kwargs):
             self.base = copy.copy (fcibase)
             self.__dict__.update (fcibase.__dict__)
             self.ss_value = ss_value
-            self.shift = shift
+            self.ss_penalty = shift
             self.davidson_only = self.base.davidson_only = True
 
         def base_contract_2e (self, *args, **kwargs):

--- a/pyscf/fci/addons.py
+++ b/pyscf/fci/addons.py
@@ -711,13 +711,14 @@ def fix_spin_(fciobj, shift=PENALTY, ss=None, **kwargs):
             self.__dict__.update (fcibase.__dict__)
             self.ss_value = ss_value
             self.ss_penalty = shift
+            keys = set (('ss_value', 'ss_penalty', 'base'))
+            self._keys = self._keys.union (keys)
             self.davidson_only = self.base.davidson_only = True
 
         def base_contract_2e (self, *args, **kwargs):
             return self.base.__class__.contract_2e (self, *args, **kwargs)
 
     FCISolver.contract_2e = contract_2e
-    mol = getattr (fciobj, 'mol', None)
     new_fciobj = FCISolver (fciobj)
     fciobj.__class__ = new_fciobj.__class__
     fciobj.__dict__.update (new_fciobj.__dict__)

--- a/pyscf/fci/addons.py
+++ b/pyscf/fci/addons.py
@@ -694,7 +694,7 @@ def fix_spin_(fciobj, shift=PENALTY, ss=None, **kwargs):
 
     if ismodule:
         base_contract_2e = fciobj.contract_2e
-        self = SpinPenaltyMod (shift=shift, ss_value=ss_value, 
+        self = SpinPenaltyMod (shift=shift, ss_value=ss_value,
                                contract_ss=fciobj.contract_ss,
                                base_contract_2e=base_contract_2e)
         from functools import partial

--- a/pyscf/fci/addons.py
+++ b/pyscf/fci/addons.py
@@ -618,6 +618,13 @@ def overlap(bra, ket, norb, nelec, s=None):
         bra = transform_ci_for_orbital_rotation(bra, norb, nelec, s)
     return numpy.dot(bra.ravel().conj(), ket.ravel())
 
+class SpinPenaltyFCISolver ():
+    pass
+class SpinPenaltyMod ():
+    def __init__(self,**kwargs):
+        self.__dict__.update (kwargs)
+
+
 def fix_spin_(fciobj, shift=PENALTY, ss=None, **kwargs):
     r'''If FCI solver cannot stay on spin eigenfunction, this function can
     add a shift to the states which have wrong spin.
@@ -639,6 +646,7 @@ def fix_spin_(fciobj, shift=PENALTY, ss=None, **kwargs):
             A modified FCI object based on fciobj.
     '''
     import types
+
     if 'ss_value' in kwargs:
         sys.stderr.write('fix_spin_: kwarg "ss_value" will be removed in future release. '
                          'It was replaced by "ss"\n')
@@ -646,40 +654,77 @@ def fix_spin_(fciobj, shift=PENALTY, ss=None, **kwargs):
     else:
         ss_value = ss
 
-    if (not isinstance(fciobj, types.ModuleType)
-        and 'contract_2e' in getattr(fciobj, '__dict__', {})):
+    if isinstance (fciobj, SpinPenaltyFCISolver):
+        # recursion avoidance
+        fciobj.shift = shift
+        fciobj.ss_value = ss
+        return fciobj
+    ismodule = isinstance (fciobj, types.ModuleType)
+
+    if (not ismodule and 'contract_2e' in getattr(fciobj, '__dict__', {})):
         del fciobj.contract_2e  # To avoid initialize twice
-    old_contract_2e = fciobj.contract_2e
-    def contract_2e(eri, fcivec, norb, nelec, link_index=None, **kwargs):
+
+    def contract_2e(self, eri, fcivec, norb, nelec, link_index=None, **kwargs):
         if isinstance(nelec, (int, numpy.number)):
             sz = (nelec % 2) * .5
         else:
             sz = abs(nelec[0]-nelec[1]) * .5
-        if ss_value is None:
+        if self.ss_value is None:
             ss = sz*(sz+1)
         else:
-            ss = ss_value
+            ss = self.ss_value
 
         if ss < sz*(sz+1)+.1:
             # (S^2-ss)|Psi> to shift state other than the lowest state
-            ci1 = fciobj.contract_ss(fcivec, norb, nelec).reshape(fcivec.shape)
+            ci1 = self.contract_ss(fcivec, norb, nelec).reshape(fcivec.shape)
             ci1 -= ss * fcivec
         else:
             # (S^2-ss)^2|Psi> to shift states except the given spin.
             # It still relies on the quality of initial guess
-            tmp = fciobj.contract_ss(fcivec, norb, nelec).reshape(fcivec.shape)
+            tmp = self.contract_ss(fcivec, norb, nelec).reshape(fcivec.shape)
             tmp -= ss * fcivec
             ci1 = -ss * tmp
-            ci1 += fciobj.contract_ss(tmp, norb, nelec).reshape(fcivec.shape)
+            ci1 += self.contract_ss(tmp, norb, nelec).reshape(fcivec.shape)
             tmp = None
-        ci1 *= shift
+        ci1 *= self.shift
 
-        ci0 = old_contract_2e(eri, fcivec, norb, nelec, link_index, **kwargs)
+        ci0 = self.base_contract_2e (eri, fcivec, norb, nelec, link_index, **kwargs)
         ci1 += ci0.reshape(fcivec.shape)
         return ci1
 
-    fciobj.davidson_only = True
-    fciobj.contract_2e = contract_2e
+    if ismodule:
+        base_contract_2e = fciobj.contract_2e
+        self = SpinPenaltyMod (shift=shift, ss_value=ss_value, 
+                               contract_ss=fciobj.contract_ss,
+                               base_contract_2e=base_contract_2e)
+        from functools import partial
+        fciobj.davidson_only = True
+        fciobj.contract_2e = partial (contract_2e, self)
+        return fciobj
+    else:
+        fciobj_class = fciobj.__class__
+
+    class FCISolver (fciobj_class, SpinPenaltyFCISolver):
+
+        def __init__(self, mol=None):
+            self.ss_value = ss_value
+            self.shift = shift
+            self.base = copy.copy (fciobj)
+            fciobj_class.__init__(self, mol=mol)
+
+        def base_contract_2e (self, *args, **kwargs):
+            return self.base.contract_2e (*args, **kwargs)
+
+    FCISolver.contract_2e = contract_2e
+    mol = getattr (fciobj, 'mol', None)
+    new_fciobj = FCISolver (mol)
+    new_fciobj.ss_value = ss_value
+    new_fciobj.shift = shift
+    new_fciobj.__dict__.update (new_fciobj.base.__dict__)
+    new_fciobj.davidson_only = True
+    new_fciobj.base.davidson_only = True
+    fciobj.__class__ = new_fciobj.__class__
+    fciobj.__dict__.update (new_fciobj.__dict__)
     return fciobj
 def fix_spin(fciobj, shift=.1, ss=None):
     return fix_spin_(copy.copy(fciobj), shift, ss)

--- a/pyscf/fci/addons.py
+++ b/pyscf/fci/addons.py
@@ -706,23 +706,19 @@ def fix_spin_(fciobj, shift=PENALTY, ss=None, **kwargs):
 
     class FCISolver (fciobj_class, SpinPenaltyFCISolver):
 
-        def __init__(self, mol=None):
+        def __init__(self, fcibase):
+            self.base = copy.copy (fcibase)
+            self.__dict__.update (fcibase.__dict__)
             self.ss_value = ss_value
             self.shift = shift
-            self.base = copy.copy (fciobj)
-            fciobj_class.__init__(self, mol=mol)
+            self.davidson_only = self.base.davidson_only = True
 
         def base_contract_2e (self, *args, **kwargs):
-            return self.base.contract_2e (*args, **kwargs)
+            return self.base.__class__.contract_2e (self, *args, **kwargs)
 
     FCISolver.contract_2e = contract_2e
     mol = getattr (fciobj, 'mol', None)
-    new_fciobj = FCISolver (mol)
-    new_fciobj.ss_value = ss_value
-    new_fciobj.shift = shift
-    new_fciobj.__dict__.update (new_fciobj.base.__dict__)
-    new_fciobj.davidson_only = True
-    new_fciobj.base.davidson_only = True
+    new_fciobj = FCISolver (fciobj)
     fciobj.__class__ = new_fciobj.__class__
     fciobj.__dict__.update (new_fciobj.__dict__)
     return fciobj

--- a/pyscf/grad/test/test_casscf.py
+++ b/pyscf/grad/test/test_casscf.py
@@ -173,6 +173,36 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(de_0[1,2], (e1_0-e2_0)/0.002*lib.param.BOHR, 4)
         self.assertAlmostEqual(de_1[1,2], (e1_1-e2_1)/0.002*lib.param.BOHR, 4)
 
+    def test_state_average_scanner_spin_penalty(self):
+        mc = mcscf.CASSCF(mf, 4, 4)
+        mc.conv_tol = 1e-10 # B/c high sensitivity in the numerical test
+        mc.fcisolver.conv_tol = 1e-10
+        mc.fix_spin_(ss=0)
+        gs = mc.state_average_([0.5, 0.5]).nuc_grad_method().as_scanner()
+        e_avg, de_avg = gs(mol)
+        e_0, de_0 = gs(mol, state=0)
+        e_1, de_1 = gs(mol, state=1)
+        mcs = gs.base
+        pmol = mol.copy()
+        mcs(pmol.set_geom_('N 0 0 0; N 0 0 1.201; H 1 1 0; H 1 1 1.2'))
+        e1_avg = mcs.e_average
+        e1_0 = mcs.e_states[0]
+        e1_1 = mcs.e_states[1]
+        mcs(pmol.set_geom_('N 0 0 0; N 0 0 1.199; H 1 1 0; H 1 1 1.2'))
+        e2_avg = mcs.e_average
+        e2_0 = mcs.e_states[0]
+        e2_1 = mcs.e_states[1]
+
+        self.assertAlmostEqual(e_avg, -1.0832566212162700e+02, 6)
+        self.assertAlmostEqual(lib.fp(de_avg), -1.0250043630625633e-01, 4)
+        self.assertAlmostEqual(e_0, -1.0837262409318993e+02, 6)
+        self.assertAlmostEqual(lib.fp(de_0), -1.5002188382934722e-01, 5)
+        self.assertAlmostEqual(e_1, -1.0827870015006400e+02, 6)
+        self.assertAlmostEqual(lib.fp(de_1), -5.4978564096385588e-02, 4)
+        self.assertAlmostEqual(de_avg[1,2], (e1_avg-e2_avg)/0.002*lib.param.BOHR, 4)
+        self.assertAlmostEqual(de_0[1,2], (e1_0-e2_0)/0.002*lib.param.BOHR, 4)
+        self.assertAlmostEqual(de_1[1,2], (e1_1-e2_1)/0.002*lib.param.BOHR, 4)
+
     def test_state_average_mix_scanner(self):
         mc = mcscf.CASSCF(mf, 4, 4)
         mc.conv_tol = 1e-10 # B/c high sensitivity in the numerical test

--- a/pyscf/mcscf/addons.py
+++ b/pyscf/mcscf/addons.py
@@ -868,6 +868,9 @@ def state_average(casscf, weights=(0.5,0.5), wfnsym=None):
             self.weights = weights
             self.wfnsym = wfnsym
             self.e_states = [None]
+            # MRH 09/09/2022: I turned the _base_class property into an
+            # attribute to prevent conflict with fix_spin_ dynamic class
+            self._base_class = fcibase_class
             keys = set (('weights','e_states','_base_class'))
             self._keys = self._keys.union (keys)
 
@@ -878,11 +881,6 @@ def state_average(casscf, weights=(0.5,0.5), wfnsym=None):
             log.info('State-average over %d states with weights %s',
                      len(self.weights), self.weights)
             return self
-
-        @property
-        def _base_class (self):
-            ''' for convenience; this is equal to fcibase_class '''
-            return self.__class__.__bases__[0]
 
         def kernel(self, h1, h2, norb, nelec, ci0=None, **kwargs):
             if 'nroots' not in kwargs:


### PR DESCRIPTION
This addresses an issue I brought up at the conference in July (#1371). The spin penalty FCI method implemented by the "fix_spin_" function was not compatible with state-averaged CASSCF nuclear gradients, because the change to the Hamiltonian is only applied to the contract_2e function, not to the preconditioner obtained with make_hdiag; and anyway the spin penalty method isn't really applicable to the linear response problem we need to solve in order to get the SA-CASSCF gradients. However, because fix_spin_ was implemented as a "monkey patch" where the "ss" and "shift" arguments go out of scope as soon as the function returns, it is not straightforward to undo this "fix". This PR turns fix_spin_ into a dynamic class definition to which the target S2 eigenvalue and the penalty parameter as well as a copy of the "fciobj" are attached as arguments, allowing them to be changed or pulled out later on. This allows SA-CASSCF nuclear gradients to work transparently, and a unit test is added to this effect. A branch in the function preserves the old behavior when fix_spin_ is called with fciobj as a module function, rather than an FCISolver instance (used in test_spin_op.py at least).