### PR TITLE
Enable molecular nuc grad with DF ERIs for ROHF, ROKS, CASSCF, SA-CASSCF

### DIFF
--- a/pyscf/df/df_jk.py
+++ b/pyscf/df/df_jk.py
@@ -151,12 +151,17 @@ def density_fit(mf, auxbasis=None, with_df=None, only_dfj=False):
 # 2. A hook to register DF specific methods, such as nuc_grad_method.
 class _DFHF(object):
     def nuc_grad_method(self):
-        from pyscf.df.grad import rhf, uhf, rks, uks
-        if isinstance(self, (scf.uhf.UHF, scf.rohf.ROHF)):
+        from pyscf.df.grad import rhf, rohf, uhf, rks, roks, uks
+        if isinstance(self, scf.uhf.UHF):
             if isinstance(self, scf.hf.KohnShamDFT):
                 return uks.Gradients(self)
             else:
                 return uhf.Gradients(self)
+        elif isinstance(self, scf.rohf.ROHF):
+            if isinstance(self, scf.hf.KohnShamDFT):
+                return roks.Gradients(self)
+            else:
+                return rohf.Gradients(self)
         elif isinstance(self, scf.rhf.RHF):
             if isinstance(self, scf.hf.KohnShamDFT):
                 return rks.Gradients(self)

--- a/pyscf/df/grad/casdm2_util.py
+++ b/pyscf/df/grad/casdm2_util.py
@@ -1,0 +1,574 @@
+#!/usr/bin/env python
+# Copyright 2014-2022 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: MRH <mrhermes@uchicago.edu>
+#
+
+import numpy as np
+from scipy import linalg
+from pyscf import gto
+from pyscf import lib
+from pyscf import scf
+from pyscf import df
+from pyscf import mcscf
+from pyscf.ao2mo import _ao2mo
+from pyscf.grad.rhf import GradientsMixin
+from pyscf.df.grad.rhf import _int3c_wrapper
+from pyscf.ao2mo.outcore import balance_partition
+from pyscf.ao2mo.incore import _conc_mos
+from pyscf import __config__
+from functools import reduce
+
+def get_int3c_mo (mol, auxmol, mo_coeff, compact=getattr(__config__, 'df_df_DF_ao2mo_compact', True), max_memory=None):
+    ''' Evaluate (P|uv) c_ui c_vj -> (P|ij)
+
+    Args:
+        mol: gto.Mole
+        auxmol: gto.Mole, contains auxbasis
+        mo_coeff: ndarray, list, or tuple containing MO coefficients
+            if two ndarrays mo_coeff = (mo0, mo1) are provided, mo0 and mo1 are
+            used for the two AO dimensions
+
+    Kwargs:
+        compact: bool
+            If true, will return only unique ERIs along the two MO dimensions.
+            Does nothing if mo_coeff contains two different sets of orbitals.
+        max_memory: int
+            Maximum memory consumption in MB
+
+    Returns:
+        int3c: ndarray of shape (naux, nmo0, nmo1) or (naux, nmo*(nmo+1)//2) '''
+
+    nao, naux, nbas, nauxbas = mol.nao, auxmol.nao, mol.nbas, auxmol.nbas
+    npair = nao * (nao + 1) // 2
+    if max_memory is None: max_memory = mol.max_memory
+
+    # Separate mo_coeff
+    if isinstance (mo_coeff, np.ndarray) and mo_coeff.ndim == 2:
+        mo0 = mo1 = mo_coeff
+    else:
+        mo0, mo1 = mo_coeff[0], mo_coeff[1]
+    nmo0, nmo1 = mo0.shape[-1], mo1.shape[-1]
+    mosym, nmo_pair, mo_conc, mo_slice = _conc_mos(mo0, mo1, compact=compact)
+
+    # (P|uv) -> (P|ij)
+    get_int3c = _int3c_wrapper(mol, auxmol, 'int3c2e', 's2ij')
+    int3c = np.zeros ((naux, nmo_pair), dtype=mo0.dtype)
+    max_memory -= lib.current_memory()[0]    
+    blksize = int (min (max (max_memory * 1e6 / 8 / (npair*2), 20), 240))
+    aux_loc = auxmol.ao_loc
+    aux_ranges = balance_partition(aux_loc, blksize)
+    for shl0, shl1, nL in aux_ranges:
+        int3c_ao = get_int3c ((0, nbas, 0, nbas, shl0, shl1))  # (uv|P)
+        p0, p1 = aux_loc[shl0], aux_loc[shl1]
+        int3c_ao = int3c_ao.T # is apparently stored f-contiguous but in the actual memory order I need, so just transpose
+        int3c[p0:p1] = _ao2mo.nr_e2(int3c_ao, mo_conc, mo_slice, aosym='s2', mosym=mosym, out=int3c[p0:p1])
+        int3c_ao = None
+
+    # Shape and return
+    if 's1' in mosym: int3c = int3c.reshape (naux, nmo0, nmo1)
+    return int3c
+
+def solve_df_rdm2 (mc_or_mc_grad, mo_cas=None, ci=None, casdm2=None):
+    ''' Solve (P|Q)d_Qij = (P|kl)d_ijkl for d_Qij in the MO basis.
+
+    Args:
+        mc_or_mc_grad: DF-MCSCF energy or gradients method object.
+
+    Kwargs:
+        mo_cas: ndarray, tuple, or list containing active mo coefficients.
+            if two ndarrays mo_cas = (mo0, mo1) are provided, mo0 and mo1 are
+            assumed to correspond to casdm2's LAST two dimensions in that order,
+            regardless of len (ci) or len (casdm2).
+            (This will facilitate SA-CASSCF gradients at some point. Note the
+            difference from grad_elec_dferi!)
+        ci: ndarray, tuple, or list containing CI coefficients in mo_cas basis.
+            Not used if casdm2 is provided.
+        casdm2: ndarray, tuple, or list containing rdm2 in mo_cas basis.
+            Computed by mc_or_mc_grad.fcisolver.make_rdm12 (ci,...) if omitted.
+        compact: bool
+            If true, tries to return d_Pqr in lower-triangular form if possible
+        
+    Returns:
+        dfcasdm2: ndarray or list containing 3-center 2RDM, d_Pqr, where P is
+            auxbasis index and q, r are mo_cas basis indices. '''
+
+    # Initialize mol and auxmol
+    mol = mc_or_mc_grad.mol
+    if isinstance (mc_or_mc_grad, GradientsMixin):
+        mc = mc_or_mc_grad.base
+    else:
+        mc = mc_or_mc_grad
+    auxmol = mc.with_df.auxmol
+    if auxmol is None:
+        auxmol = df.addons.make_auxmol(mc.with_df.mol, mc.with_df.auxbasis)
+    naux = auxmol.nao
+    ncore, ncas, nelecas = mc.ncore, mc.ncas, mc.nelecas
+    nocc = ncore + ncas
+
+    # Initialize casdm2, mo_cas, and nset
+    if mo_cas is None: mo_cas = mc.mo_coeff[:,ncore:nocc]
+    if ci is None: ci = mc.ci
+    if casdm2 is None: casdm2 = mc.fcisolver.make_rdm12 (ci, ncas, nelecas)
+    if np.asarray (casdm2).ndim == 4: casdm2 = [casdm2]
+    nset = len (casdm2)
+
+    # (P|Q) and (P|ij)
+    int2c = linalg.cho_factor(auxmol.intor('int2c2e', aosym='s1'))
+    int3c = get_int3c_mo (mol, auxmol, mo_cas, compact=True, max_memory=mc_or_mc_grad.max_memory)
+
+    # Solve (P|Q) d_Qij = (P|kl) d_ijkl
+    dfcasdm2 = []
+    for dm2 in casdm2:
+        nmo = tuple (dm2.shape) # make sure it copies
+        if int3c.ndim == 2:
+            # I'm not going to use the memory-efficient version because this is meant to be small
+            nmo_pair = nmo[2] * (nmo[2] + 1) // 2
+            dm2 = dm2.copy ().reshape ((-1, nmo[2], nmo[3]))
+            dm2 += dm2.transpose (0,2,1)
+            diag_idx = np.arange(nmo[-1])
+            diag_idx = diag_idx * (diag_idx+1) // 2 + diag_idx
+            dm2 = lib.pack_tril (np.ascontiguousarray (dm2))
+            dm2[:,diag_idx] *= 0.5
+        elif int3c.ndim == 3:
+            nmo_pair = nmo[2] * nmo[3]
+            int3c = int3c.reshape (naux, nmo_pair)
+        else:
+            raise RuntimeError ('int3c.shape = {}'.format (int3c.shape))
+        dm2 = dm2.reshape (nmo[0]*nmo[1], nmo_pair).T
+        int3c_dm2 = np.dot (int3c, dm2)
+        dfcasdm2.append (linalg.cho_solve (int2c, int3c_dm2).reshape (naux, nmo[0], nmo[1]))
+
+    return dfcasdm2
+
+def solve_df_eri (mc_or_mc_grad, mo_cas=None, compact=True):
+    ''' Solve (P|Q) g_Qij = (P|ij) for g_Qij using MOs i,j. I mean this should be a basic function but whatever. '''
+
+    # Initialize mol and auxmol
+    mol = mc_or_mc_grad.mol
+    if isinstance (mc_or_mc_grad, GradientsMixin):
+        mc = mc_or_mc_grad.base
+    else:
+        mc = mc_or_mc_grad
+    auxmol = mc.with_df.auxmol
+    if auxmol is None:
+        auxmol = df.addons.make_auxmol(mc.with_df.mol, mc.with_df.auxbasis)
+    nao, naux, nbas, nauxbas = mol.nao, auxmol.nao, mol.nbas, auxmol.nbas
+    npair = nao * (nao + 1) // 2
+    ncore, ncas = mc.ncore, mc.ncas 
+    nocc = ncore + ncas
+    if mo_cas is None: mo_cas = mc.mo_coeff[:,ncore:nocc]
+    if isinstance (mo_cas, np.ndarray) and mo_cas.ndim == 2:
+        nmo = (mo_cas.shape[1], mo_cas.shape[1])
+    else:
+        nmo = (mo_cas[0].shape[1], mo_cas[1].shape[1])
+
+    # (P|Q) and (P|ij)
+    int2c = linalg.cho_factor(auxmol.intor('int2c2e', aosym='s1'))
+    int3c = get_int3c_mo (mol, auxmol, mo_cas, compact=compact, max_memory=mc_or_mc_grad.max_memory)
+
+    # Solve (P|Q) g_Qij = (P|ij)
+    dferi = linalg.cho_solve (int2c, int3c)
+    if int3c.ndim == 2:
+        dferi = dferi.reshape (naux, -1)
+    else:
+        dferi = dferi.reshape (naux, nmo[0], nmo[1])
+    return dferi
+
+
+def energy_elec_dferi (mc, mo_cas=None, ci=None, dfcasdm2=None, casdm2=None):
+    ''' Evaluate E2 = (P|ij) d_Pij / 2, where d_Pij is the DF-2rdm obtained by solve_df_rdm2.
+    For testing purposes. Note that the only index permutation this function understands
+    is (P|ij) = (P|ji) if i and j span the same range of MOs. The caller has to handle everything
+    else, including, for instance, multiplication by 2 if a nonsymmetric slice of the 2RDM is used.
+
+    Args:
+        mc: MC-SCF energy method object
+
+    Kwargs:
+        mo_cas: ndarray, list, or tuple containing active-space MO coefficients
+            If a tuple of length 2, the same pair of MO sets are assumed to apply to
+            the internally-contracted and externally-contracted indices of the DF-2rdm:
+            (P|Q)d_Qij = (P|kl)d_ijkl -> (P|Q)d_Qij = (P|ij)d_ijij
+            If a tuple of length 4, the 4 MO sets are applied to ijkl above in that order
+            (first two external, last two internal).
+        ci: ndarray, tuple, or list containing CI coefficients in mo_cas basis.
+            Not used if dfcasdm2 is provided.
+        dfcasdm2: ndarray, tuple, or list containing DF-2rdm in mo_cas basis.
+            Computed by solve_df_rdm2 if omitted.
+        casdm2: ndarray, tuple, or list containing rdm2 in mo_cas basis.
+            Computed by mc_or_mc_grad.fcisolver.make_rdm12 (ci,...) if omitted.
+
+    Returns:
+        energy: list
+            List of energies corresponding to the dfcasdm2s,
+            E = (P|ij) d_Pij / 2 = (P|ij) (P|Q)^-1 (Q|kl) d_ijkl / 2
+    '''
+    if isinstance (mc, GradientsMixin): mc = mc.base
+    if mo_cas is None:
+        ncore = mc.ncore
+        nocc = ncore + mc.ncas
+        mo_cas = mc.mo_coeff[:,ncore:nocc]
+    if isinstance (mo_cas, np.ndarray) and mo_cas.ndim == 2:
+        mo_cas = (mo_cas,)*4
+    elif len (mo_cas) == 2:
+        mo_cas = (mo_cas[0], mo_cas[1], mo_cas[0], mo_cas[1])
+    elif len (mo_cas) == 4:
+        mo_cas = tuple (mo_cas)
+    else:
+        raise RuntimeError ('Invalid shape of np.asarray (mo_cas): {}'.format (mo_cas.shape))
+    nmo = [mo.shape[1] for mo in mo_cas]
+    if ci is None: ci = mc.ci
+    if dfcasdm2 is None: dfcasdm2 = solve_df_rdm2 (mc, mo_cas=mo_cas[2:], ci=ci, casdm2=casdm2)
+    int3c = get_int3c_mo (mc.mol, mc.with_df.auxmol, mo_cas[:2], compact=True, max_memory=mc.max_memory)
+    symm = (int3c.ndim == 2)
+    int3c = np.ravel (int3c)
+    energy = []
+    for dm2 in dfcasdm2:
+        naux = mc.with_df.auxmol.nao
+        if symm:
+            nmo_pair = nmo[0] * (nmo[0] + 1) // 2
+            dm2 += dm2.transpose (0,2,1)
+            diag_idx = np.arange(nmo[1])
+            diag_idx = diag_idx * (diag_idx+1) // 2 + diag_idx
+            dm2 = lib.pack_tril (np.ascontiguousarray (dm2))
+            dm2[:,diag_idx] *= 0.5
+        else:
+            nmo_pair = nmo[0] * nmo[1]
+        energy.append (np.dot (int3c, dm2.ravel ()) / 2)
+
+    return energy
+
+def gfock_dferi (mc, mo_cas=None, ci=None, dfcasdm2=None, casdm2=None, max_memory=None, ao_basis=True):
+    ''' Evaluate F_ij = (P|ik) d_Pjk - this was a giant reinvention of the wheel that didn't need
+    to happen because with_df._cderi is plenty good enough to calculate gfock. Oh well.
+
+    Args:
+        mc_grad: MC-SCF gradients method object
+
+    Kwargs:
+        mc_cas: ndarray, list, or tuple containing active-space MO coefficients
+            If a tuple of length 2, the same pair of MO sets are assumed to apply to
+            the internally-contracted and externally-contracted indices of the DF-2rdm:
+            (P|Q)d_Qij = (P|kl)d_ijkl -> (P|Q)d_Qij = (P|ij)d_ijij
+            If a tuple of length 4, the 4 MO sets are applied to ijkl above in that order
+            (first two external, last two internal).
+        ci: ndarray, tuple, or list containing CI coefficients in mo_cas basis.
+            Not used if dfcasdm2 is provided.
+        dfcasdm2: ndarray, tuple, or list containing DF-2rdm in mo_cas basis.
+            Computed by solve_df_rdm2 if omitted.
+        casdm2: ndarray, tuple, or list containing rdm2 in mo_cas basis.
+            Computed by mc_grad.fcisolver.make_rdm12 (ci,...) if omitted.
+        max_memory: int
+            Maximum memory usage in MB
+        ao_basis: bool
+            If true, return gfock in AO basis
+
+    Returns:
+        gfock: ndarray of shape (nset, nmo[0], nmo[1]) or (nset, nao, nao)
+
+    '''
+    if isinstance (mc, GradientsMixin): mc = mc.base
+    if mo_cas is None:
+        ncore = mc.ncore
+        nocc = ncore + mc.ncas
+        mo_cas = mc.mo_coeff[:,ncore:nocc]
+    if isinstance (mo_cas, np.ndarray) and mo_cas.ndim == 2:
+        mo_cas = (mo_cas,)*4
+    elif len (mo_cas) == 2:
+        mo_cas = (mo_cas[0], mo_cas[1], mo_cas[0], mo_cas[1])
+    elif len (mo_cas) == 4:
+        mo_cas = tuple (mo_cas)
+    else:
+        raise RuntimeError ('Invalid shape of np.asarray (mo_cas): {}'.format (mo_cas.shape))
+    nmo = [mo.shape[1] for mo in mo_cas]
+    if ci is None: ci = mc.ci
+    if dfcasdm2 is None: dfcasdm2 = solve_df_rdm2 (mc, mo_cas=mo_cas[2:], ci=ci, casdm2=casdm2)
+    dfcasdm2 = np.asarray (dfcasdm2)
+    int3c = get_int3c_mo (mc.mol, mc.with_df.auxmol, mo_cas[:2], compact=False, max_memory=max_memory)
+    assert (int3c.ndim == 3)
+    gfock = np.einsum ('pik,npkj->nij', int3c, dfcasdm2)
+    if ao_basis: gfock = np.einsum ('ui,nij,vj->nuv', mo_cas[0], gfock, mo_cas[2].conjugate ())
+    return gfock
+
+def grad_elec_auxresponse_dferi (mc_grad, mo_cas=None, ci=None, dfcasdm2=None, casdm2=None, atmlst=None, max_memory=None, dferi=None, incl_2c=True):
+    ''' Evaluate the [(P'|ij) + (P'|Q) g_Qij] d_Pij contribution to the electronic gradient, where d_Pij is
+    the DF-2RDM obtained by solve_df_rdm2 and g_Qij solves (P|Q) g_Qij = (P|ij). The caller must symmetrize
+    if necessary (i.e., (P|Q) d_Qij = (P|kl) d_ijkl <-> (P|Q) d_Qkl = (P|ij) d_ijkl in order to get at Q').
+    Args:
+        mc_grad: MC-SCF gradients method object
+
+    Kwargs:
+        mc_cas: ndarray, list, or tuple containing active-space MO coefficients
+            If a tuple of length 2, the same pair of MO sets are assumed to apply to
+            the internally-contracted and externally-contracted indices of the DF-2rdm:
+            (P|Q)d_Qij = (P|kl)d_ijkl -> (P|Q)d_Qij = (P|ij)d_ijij
+            If a tuple of length 4, the 4 MO sets are applied to ijkl above in that order
+            (first two external, last two internal).
+        ci: ndarray, tuple, or list containing CI coefficients in mo_cas basis.
+            Not used if dfcasdm2 is provided.
+        dfcasdm2: ndarray, tuple, or list containing DF-2rdm in mo_cas basis.
+            Computed by solve_df_rdm2 if omitted.
+        casdm2: ndarray, tuple, or list containing rdm2 in mo_cas basis.
+            Computed by mc_grad.fcisolver.make_rdm12 (ci,...) if omitted.
+        atmlst: list of integers
+            List of nonfrozen atoms, as in grad_elec functions.
+            Defaults to list (range (mol.natm))
+        max_memory: int
+            Maximum memory usage in MB
+        dferi: ndarray containing g_Pij for optional precalculation
+        incl_2c: bool
+            If False, omit the terms depending on (P'|Q)
+
+    Returns:
+        dE: list of ndarray of shape (len (atmlst), 3) '''
+
+    if isinstance (mc_grad, GradientsMixin):
+        mc = mc_grad.base
+    else:
+        mc = mc_grad
+    mol = mc_grad.mol
+    auxmol = mc.with_df.auxmol
+    ncore, ncas, nao, naux, nbas = mc.ncore, mc.ncas, mol.nao, auxmol.nao, mol.nbas
+    nocc = ncore + ncas
+    npair = nao * (nao + 1) // 2
+    if mo_cas is None: mo_cas = mc.mo_coeff[:,ncore:nocc]
+    if max_memory is None: max_memory = mc.max_memory
+    if isinstance (mo_cas, np.ndarray) and mo_cas.ndim == 2:
+        mo_cas = (mo_cas,)*4
+    elif len (mo_cas) == 2:
+        mo_cas = (mo_cas[0], mo_cas[1], mo_cas[0], mo_cas[1])
+    elif len (mo_cas) == 4:
+        mo_cas = tuple (mo_cas)
+    else:
+        raise RuntimeError ('Invalid shape of np.asarray (mo_cas): {}'.format (mo_cas.shape))
+    nmo = [mo.shape[1] for mo in mo_cas]
+    if atmlst is None: atmlst = list (range (mol.natm))
+    if ci is None: ci = mc.ci
+    if dfcasdm2 is None: dfcasdm2 = solve_df_rdm2 (mc, mo_cas=mo_cas[2:], ci=ci, casdm2=casdm2) # d_Pij = (P|Q)^{-1} (Q|kl) d_ijkl
+    nset = len (dfcasdm2)
+    dE = np.zeros ((nset, naux, 3))
+    dfcasdm2 = np.array (dfcasdm2)
+
+    # Shape dfcasdm2
+    mosym, nmo_pair, mo_conc, mo_slice = _conc_mos(mo_cas[0], mo_cas[1], compact=True)
+    if 's2' in mosym:
+        assert (nmo[0] == nmo[1]), 'How did I get {} with nmo[0] = {} and nmo[1] = {}'.format (mosym, nmo[0], nmo[1])
+        dfcasdm2 = dfcasdm2.reshape (nset*naux, nmo[0], nmo[1])
+        dfcasdm2 += dfcasdm2.transpose (0,2,1)
+        diag_idx = np.arange(nmo[0])
+        diag_idx = diag_idx * (diag_idx+1) // 2 + diag_idx
+        dfcasdm2 = lib.pack_tril (np.ascontiguousarray (dfcasdm2))
+        dfcasdm2[:,diag_idx] *= 0.5
+    dfcasdm2 = dfcasdm2.reshape (nset, naux, nmo_pair)
+
+    # Do 2c part. Assume memory is no object
+    if incl_2c: 
+        int2c = auxmol.intor('int2c2e_ip1')
+        if (dferi is None): dferi = solve_df_eri (mc, mo_cas=mo_cas[:2]).reshape (naux, nmo_pair) # g_Pij = (P|Q)^{-1} (Q|ij)
+        int3c = np.dot (int2c, dferi) # (P'|Q) g_Qij
+        dE += lib.einsum ('npi,xpi->npx', dfcasdm2, int3c) # d_Pij (P'|Q) g_Qij
+        int2c = int3c = dferi = None
+
+    # Set up 3c part
+    get_int3c = _int3c_wrapper(mol, auxmol, 'int3c2e_ip2', 's2ij')
+    max_memory -= lib.current_memory()[0]  
+    blklen = 6*npair
+    blksize = int (min (max (max_memory * 1e6 / 8 / blklen, 20), 240))
+    aux_loc = auxmol.ao_loc
+    aux_ranges = balance_partition(aux_loc, blksize)
+
+    # Iterate over auxbasis range and do 3c part
+    for shl0, shl1, nL in aux_ranges:
+        p0, p1 = aux_loc[shl0], aux_loc[shl1]
+        int3c = get_int3c ((0, nbas, 0, nbas, shl0, shl1))  # (uv|P'); shape = (3,npair,p1-p0)
+        int3c = np.ascontiguousarray (int3c.transpose (0,2,1).reshape (3*(p1-p0), npair))
+        int3c = _ao2mo.nr_e2(int3c, mo_conc, mo_slice, aosym='s2', mosym=mosym)
+        int3c = int3c.reshape (3,p1-p0,nmo_pair)
+        int3c = np.ascontiguousarray (int3c)
+        dE[:,p0:p1,:] -= lib.einsum ('npi,xpi->npx', dfcasdm2[:,p0:p1,:], int3c)
+
+    # Ravel to atoms
+    auxslices = auxmol.aoslice_by_atom ()
+    dE = np.array ([dE[:,p0:p1].sum (axis=1) for p0, p1 in auxslices[:,2:]]).transpose (1,0,2)
+    return np.ascontiguousarray (dE)
+    
+def grad_elec_dferi (mc_grad, mo_cas=None, ci=None, dfcasdm2=None, casdm2=None, atmlst=None, max_memory=None):
+    ''' Evaluate the (P|i'j) d_Pij contribution to the electronic gradient, where d_Pij is the
+    DF-2RDM obtained by solve_df_rdm2. The caller must symmetrize (i.e., [(P|i'j) + (P|ij')] d_Pij / 2)
+    if necessary. 
+
+    Args:
+        mc_grad: MC-SCF gradients method object
+
+    Kwargs:
+        mc_cas: ndarray, list, or tuple containing active-space MO coefficients
+            If a tuple of length 2, the same pair of MO sets are assumed to apply to
+            the internally-contracted and externally-contracted indices of the DF-2rdm:
+            (P|Q)d_Qij = (P|kl)d_ijkl -> (P|Q)d_Qij = (P|ij)d_ijij
+            If a tuple of length 4, the 4 MO sets are applied to ijkl above in that order
+            (first two external, last two internal).
+        ci: ndarray, tuple, or list containing CI coefficients in mo_cas basis.
+            Not used if dfcasdm2 is provided.
+        dfcasdm2: ndarray, tuple, or list containing DF-2rdm in mo_cas basis.
+            Computed by solve_df_rdm2 if omitted.
+        casdm2: ndarray, tuple, or list containing rdm2 in mo_cas basis.
+            Computed by mc_grad.fcisolver.make_rdm12 (ci,...) if omitted.
+        atmlst: list of integers
+            List of nonfrozen atoms, as in grad_elec functions.
+            Defaults to list (range (mol.natm))
+        max_memory: int
+            Maximum memory usage in MB
+
+    Returns:
+        dE: ndarray of shape (len (dfcasdm2), len (atmlst), 3) '''
+    if isinstance (mc_grad, GradientsMixin):
+        mc = mc_grad.base
+    else:
+        mc = mc_grad
+    mol = mc_grad.mol
+    auxmol = mc.with_df.auxmol
+    ncore, ncas, nao, naux, nbas = mc.ncore, mc.ncas, mol.nao, auxmol.nao, mol.nbas
+    nocc = ncore + ncas
+    if mo_cas is None: mo_cas = mc.mo_coeff[:,ncore:nocc]
+    if max_memory is None: max_memory = mc_grad.max_memory
+    if isinstance (mo_cas, np.ndarray) and mo_cas.ndim == 2:
+        mo_cas = (mo_cas,)*4
+    elif len (mo_cas) == 2:
+        mo_cas = (mo_cas[0], mo_cas[1], mo_cas[0], mo_cas[1])
+    elif len (mo_cas) == 4:
+        mo_cas = tuple (mo_cas)
+    else:
+        raise RuntimeError ('Invalid shape of np.asarray (mo_cas): {}'.format (mo_cas.shape))
+    nmo = [mo.shape[1] for mo in mo_cas]
+    if atmlst is None: atmlst = list (range (mol.natm))
+    if ci is None: ci = mc.ci
+    if dfcasdm2 is None: dfcasdm2 = solve_df_rdm2 (mc, mo_cas=mo_cas[2:], ci=ci, casdm2=casdm2) # d_Pij
+    nset = len (dfcasdm2)
+    dE = np.zeros ((nset, nao, 3))
+    dfcasdm2 = np.array (dfcasdm2)
+
+    # Set up (P|u'v) calculation
+    get_int3c = _int3c_wrapper(mol, auxmol, 'int3c2e_ip1', 's1')
+    max_memory -= lib.current_memory()[0]  
+    blklen = nao*((3*nao) + (3*nmo[1]) + (nset*nmo[1]))
+    blksize = int (min (max (max_memory * 1e6 / 8 / blklen, 20), 240))
+    aux_loc = auxmol.ao_loc
+    aux_ranges = balance_partition(aux_loc, blksize)
+
+    # Iterate over auxbasis range
+    for shl0, shl1, nL in aux_ranges:
+        p0, p1 = aux_loc[shl0], aux_loc[shl1]
+        int3c = get_int3c ((0, nbas, 0, nbas, shl0, shl1))  # (u'v|P); shape = (3,nao,nao,p1-p0)
+        intbuf = lib.einsum ('xuvp,vj->xupj', int3c, mo_cas[1])
+        dm2buf = lib.einsum ('ui,npij->nupj', mo_cas[0], dfcasdm2[:,p0:p1,:,:])
+        dE -= np.einsum ('nupj,xupj->nux', dm2buf, intbuf) 
+        intbuf = dm2buf = None
+        intbuf = lib.einsum ('xuvp,vj->xupj', int3c, mo_cas[0])
+        dm2buf = lib.einsum ('uj,npij->nupi', mo_cas[1], dfcasdm2[:,p0:p1,:,:])
+        dE -= np.einsum ('nupj,xupj->nux', dm2buf, intbuf) 
+        intbuf = dm2buf = int3c = None
+
+    aoslices = mol.aoslice_by_atom ()
+    dE = np.array ([dE[:,p0:p1].sum (axis=1) for p0, p1 in aoslices[:,2:]]).transpose (1,0,2)
+    return np.ascontiguousarray (dE)
+
+if __name__ == '__main__':
+    from pyscf.tools import molden
+    from pyscf.lib import logger, param
+    h2co_casscf66_631g_xyz = '''C  0.534004  0.000000  0.000000
+    O -0.676110  0.000000  0.000000
+    H  1.102430  0.000000  0.920125
+    H  1.102430  0.000000 -0.920125'''
+    mol = gto.M (atom = h2co_casscf66_631g_xyz, basis = '6-31g', symmetry = False, verbose = logger.INFO, output = 'h2co_casscf66_631g_grad.log')
+    mf = scf.RHF (mol).density_fit (auxbasis = df.aug_etb (mol)).run ()
+    mc = mcscf.CASSCF (mf, 11, 16)
+    mc.conv_tol = 1e-10
+    mc.kernel ()
+
+    ncore, ncas = mc.ncore, mc.ncas
+    nocc = ncore + ncas
+    nmo = mc.mo_coeff.shape[-1]
+    mo_cas = mc.mo_coeff[:,ncore:nocc]
+    casdm1, casdm2 = mc.fcisolver.make_rdm12 (mc.ci, mc.ncas, mc.nelecas)
+    eri_cas = mc.with_df.ao2mo (mo_cas, compact=False).reshape ((ncas,)*4)
+
+    # Full energy
+    e2_ref = np.dot (casdm2.ravel (), eri_cas.ravel ()) / 2
+    e2_test = energy_elec_dferi (mc, mo_cas=mo_cas, casdm2=casdm2)[0]
+    e2_err = e2_test - e2_ref
+    print ("Testing full energy calculation: e2_test - e2_ref = {:13.6e} - {:13.6e} = {:13.6e}".format (e2_test, e2_ref, e2_err))
+
+    # 2-RDM slices (see: SA-CASSCF gradients)
+    eri_cas_sl = eri_cas[0:2,1:3,0:4,1:6]
+    casdm2_sl = casdm2[0:2,1:3,0:4,1:6]
+    mo_cas_sl = (mo_cas[:,0:2], mo_cas[:,1:3], mo_cas[:,0:4], mo_cas[:,1:6]) 
+    e2_ref = np.dot (casdm2_sl.ravel (), eri_cas_sl.ravel ())
+    e2_test = energy_elec_dferi (mc, mo_cas=mo_cas_sl, casdm2=casdm2_sl)[0] * 2
+    e2_err = e2_test - e2_ref
+    print ("Testing slice calculation: e2_test - e2_ref = {:13.6e} - {:13.6e} = {:13.6e}".format (e2_test, e2_ref, e2_err))
+
+    # 2-RDM slice complex conjugate
+    casdm2_sl = casdm2[1:3,0:2,1:6,0:4]
+    eri_cas_sl = eri_cas[1:3,0:2,1:6,0:4]
+    mo_cas_sl = (mo_cas[:,1:3], mo_cas[:,0:2], mo_cas[:,1:6], mo_cas[:,0:4]) 
+    e2_test = np.dot (casdm2_sl.ravel (), eri_cas_sl.ravel ())
+    e2_err = e2_test - e2_ref
+    print ("Testing slice c.c. ERI: e2_test - e2_ref = {:13.6e} - {:13.6e} = {:13.6e}".format (e2_test, e2_ref, e2_err))
+    e2_test = energy_elec_dferi (mc, mo_cas=mo_cas_sl, casdm2=casdm2_sl)[0] * 2
+    print ("Testing slice c.c. DFERI: e2_test - e2_ref = {:13.6e} - {:13.6e} = {:13.6e}".format (e2_test, e2_ref, e2_err))
+    
+    # 2-RDM slice electron interchange
+    casdm2_sl = casdm2[0:4,1:6,0:2,1:3]
+    eri_cas_sl = eri_cas[0:4,1:6,0:2,1:3]
+    mo_cas_sl = (mo_cas[:,0:4], mo_cas[:,1:6], mo_cas[:,0:2], mo_cas[:,1:3]) 
+    e2_test = np.dot (casdm2_sl.ravel (), eri_cas_sl.ravel ())
+    e2_err = e2_test - e2_ref
+    print ("Testing slice 1<->2 ERI: e2_test - e2_ref = {:13.6e} - {:13.6e} = {:13.6e}".format (e2_test, e2_ref, e2_err))
+    e2_test = energy_elec_dferi (mc, mo_cas=mo_cas_sl, casdm2=casdm2_sl)[0] * 2
+    print ("Testing slice 1<->2 DFERI: e2_test - e2_ref = {:13.6e} - {:13.6e} = {:13.6e}".format (e2_test, e2_ref, e2_err))
+
+    mc_grad_conv = mcscf.CASSCF (scf.RHF (mol).run (), 11, 16)
+    mc_grad_conv.conv_tol = 1e-10
+    mc_grad_conv = mc_grad_conv.run ().nuc_grad_method ()
+    dm1 = mc.make_rdm1 ()
+    hcore_deriv = mc_grad_conv.hcore_generator (mol)
+    dE_conv = mc_grad_conv.kernel ()
+    ###
+    dE_nuc = mc_grad_conv.grad_nuc (atmlst=list (range (mol.natm)))
+    dE_hcore = np.stack ([np.dot (hcore_deriv (iatm).reshape (3,-1), dm1.ravel ()) for iatm in range (mol.natm)], axis=0)
+    dE_ao = grad_elec_dferi (mc, mo_cas=mo_cas, casdm2=casdm2)
+    dE_aux = grad_elec_auxresponse_dferi (mc, mo_cas=mo_cas, casdm2=casdm2)
+    h1 = reduce (np.dot, (mc.mo_coeff.conjugate ().T, mc.get_hcore (), mo_cas))
+    gfock = np.zeros ((nmo,nmo), dtype=mc.mo_coeff.dtype)
+    gfock[:,:nocc] += np.dot (h1, casdm1)
+    gfock[:,:nocc] += np.squeeze (gfock_dferi (mc, mo_cas=(mc.mo_coeff, mo_cas, mo_cas, mo_cas), casdm2=casdm2, ao_basis=False))
+    gfock = (gfock + gfock.T) / 2
+    gfock = reduce (np.dot, (mc.mo_coeff, gfock, mc.mo_coeff.conjugate ().T))
+    dE_renorm = np.einsum ('xij,ij->xi', mc_grad_conv.get_ovlp (mol), gfock)
+    aoslices = mol.aoslice_by_atom ()
+    dE_renorm = -2*np.array ([dE_renorm[:,p0:p1].sum (axis=1) for p0, p1 in aoslices[:,2:]])
+    dE = dE_ao + dE_aux + dE_nuc + dE_hcore + dE_renorm
+    ###
+    #from pyscf.grad.numeric import Gradients as NumGrad
+    #mc_numgrad = NumGrad (mc)
+    #dE_num = mc_numgrad.kernel ()
+    print ('Putative analytical DF-CASSCF gradient:\n', dE)
+    print ('Numerical DF-CASSCF gradient:\n', dE_num)
+    print ('Analytical CASSCF gradient:\n', dE_conv)
+    #print ('DF-CASSCF analytical-numerical disagreement:\n', dE-dE_num)
+    print ('Analytical DF-CASSCF - CASSCF disagreement:\n', dE-dE_conv)
+
+

--- a/pyscf/df/grad/casdm2_util.py
+++ b/pyscf/df/grad/casdm2_util.py
@@ -164,8 +164,7 @@ def solve_df_eri (mc_or_mc_grad, mo_cas=None, compact=True):
     auxmol = mc.with_df.auxmol
     if auxmol is None:
         auxmol = df.addons.make_auxmol(mc.with_df.mol, mc.with_df.auxbasis)
-    nao, naux = mol.nao, auxmol.nao
-    ncore, ncas = mc.ncore, mc.ncas
+    naux, ncore, ncas = auxmol.nao, mc.ncore, mc.ncas
     nocc = ncore + ncas
     if mo_cas is None: mo_cas = mc.mo_coeff[:,ncore:nocc]
     if isinstance (mo_cas, np.ndarray) and mo_cas.ndim == 2:
@@ -528,7 +527,7 @@ if __name__ == '__main__':
     e2_test = energy_elec_dferi (mc, mo_cas=mo_cas_sl, casdm2=casdm2_sl)[0] * 2
     print ("Testing slice c.c. DFERI: e2_test - e2_ref = {:13.6e} - {:13.6e} = {:13.6e}".format (
            e2_test, e2_ref, e2_err))
-    
+
     # 2-RDM slice electron interchange
     casdm2_sl = casdm2[0:4,1:6,0:2,1:3]
     eri_cas_sl = eri_cas[0:4,1:6,0:2,1:3]

--- a/pyscf/df/grad/casscf.py
+++ b/pyscf/df/grad/casscf.py
@@ -186,7 +186,7 @@ class Gradients(casci_grad.Gradients):
         if mol is None: mol = self.mol
         if dm is None: dm = self.base.make_rdm1()
         cpu0 = (logger.process_clock(), logger.perf_counter())
-        vj, vk = dfrhf_grad.get_jk(self, mol, dm, ishf=False)
+        vj, vk = dfrhf_grad.get_jk(self, mol, dm)
         logger.timer(self, 'vj and vk', *cpu0)
         return vj, vk
 

--- a/pyscf/df/grad/casscf.py
+++ b/pyscf/df/grad/casscf.py
@@ -55,13 +55,11 @@ def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
     time0 = logger.process_clock(), logger.perf_counter()
     log = logger.new_logger(mc_grad, verbose)
     mol = mc_grad.mol
-    auxmol = with_df.auxmol
     ncore = mc.ncore
     ncas = mc.ncas
     nocc = ncore + ncas
     nelecas = mc.nelecas
     nao, nmo = mo_coeff.shape
-    nao_pair = nao * (nao+1) // 2
 
     # Necessary kludge because gfock isn't zero in occ-virt space in SA-CASSCf
     # Among many other potential applications!
@@ -104,7 +102,7 @@ def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
     if atmlst is None:
         atmlst = range(mol.natm)
     aoslices = mol.aoslice_by_atom()
-    de = grad_elec_dferi (mc_grad, mo_cas=mo_cas, dfcasdm2=dfcasdm2, atmlst=atmlst, 
+    de = grad_elec_dferi (mc_grad, mo_cas=mo_cas, dfcasdm2=dfcasdm2, atmlst=atmlst,
         max_memory=mc_grad.max_memory)[0]
     if mc_grad.auxbasis_response:
         de_aux = vj.aux - vk.aux * .5

--- a/pyscf/df/grad/casscf.py
+++ b/pyscf/df/grad/casscf.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python
+# Copyright 2014-2022 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Qiming Sun <osirpt.sun@gmail.com>
+#
+
+'''
+CASSCF analytical nuclear gradients
+
+Ref.
+J. Comput. Chem., 5, 589
+
+MRH: copied from pyscf.grad.casscf.py on 12/07/2019
+Contains my modifications for SA-CASSCF gradients
+1. Generalized Fock has nonzero i->a and u->a
+2. Memory footprint for differentiated eris bugfix
+'''
+
+import inspect
+import time
+from functools import reduce
+from itertools import product
+import numpy
+from scipy import linalg
+from pyscf import lib
+from pyscf import ao2mo
+from pyscf.lib import logger
+from pyscf.grad import casci as casci_grad
+from pyscf.grad import rhf as rhf_grad
+from pyscf.grad.mp2 import _shell_prange
+from pyscf.df.grad import rhf as dfrhf_grad
+from pyscf.df.grad.casdm2_util import solve_df_rdm2,\
+    grad_elec_dferi, grad_elec_auxresponse_dferi
+
+def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
+    mc = mc_grad.base
+    with_df = mc.with_df
+    if mo_coeff is None: mo_coeff = mc.mo_coeff
+    if ci is None: ci = mc.ci
+    if mc.frozen is not None:
+        raise NotImplementedError
+
+    time0 = logger.process_clock(), logger.perf_counter()
+    log = logger.new_logger(mc_grad, verbose)
+    mol = mc_grad.mol
+    auxmol = with_df.auxmol
+    ncore = mc.ncore
+    ncas = mc.ncas
+    nocc = ncore + ncas
+    nelecas = mc.nelecas
+    nao, nmo = mo_coeff.shape
+    nao_pair = nao * (nao+1) // 2
+
+    # Necessary kludge because gfock isn't zero in occ-virt space in SA-CASSCf
+    # Among many other potential applications!
+    if hasattr (mc, '_tag_gfock_ov_nonzero'):
+        if mc._tag_gfock_ov_nonzero:
+            nocc = nmo
+
+    mo_occ = mo_coeff[:,:nocc]
+    mo_core = mo_coeff[:,:ncore]
+    mo_cas = mo_coeff[:,ncore:ncore+ncas]
+
+    casdm1, casdm2 = mc.fcisolver.make_rdm12(ci, ncas, nelecas)
+
+# gfock = Generalized Fock, Adv. Chem. Phys., 69, 63
+    dm_core = numpy.dot(mo_core, mo_core.T) * 2
+    dm_cas = reduce(numpy.dot, (mo_cas, casdm1, mo_cas.T))
+    # MRH flag: this is one of my kludges
+    # It would be better to just pass the ERIS object used in orbital optimization
+    # But I am too lazy at the moment
+    aapa = with_df.ao2mo ((mo_cas, mo_cas, mo_occ, mo_cas), compact=False)
+    aapa = aapa.reshape(ncas,ncas,nocc,ncas)
+    vj, vk = mc._scf.get_jk(mol, (dm_core, dm_cas))
+    h1 = mc.get_hcore()
+    vhf_c = vj[0] - vk[0] * .5
+    vhf_a = vj[1] - vk[1] * .5
+    gfock = numpy.zeros ((nocc, nocc))
+    gfock[:,:ncore] = reduce(numpy.dot, (mo_occ.T, h1 + vhf_c + vhf_a, mo_core)) * 2
+    gfock[:,ncore:ncore+ncas] = reduce(numpy.dot, (mo_occ.T, h1 + vhf_c, mo_cas, casdm1))
+    gfock[:,ncore:ncore+ncas] += numpy.einsum('uviw,vuwt->it', aapa, casdm2)
+    dme0 = reduce(numpy.dot, (mo_occ, (gfock+gfock.T)*.5, mo_occ.T))
+    aapa = vj = vk = vhf_c = vhf_a = h1 = gfock = None
+
+    dm1 = dm_core + dm_cas
+    vj, vk = mc_grad.get_jk(mol, (dm_core, dm_cas))
+    vhf1c, vhf1a = vj - vk * .5
+    hcore_deriv = mc_grad.hcore_generator(mol)
+    s1 = mc_grad.get_ovlp(mol)
+
+    dfcasdm2 = casdm2 = solve_df_rdm2 (mc_grad, mo_cas=mo_cas, casdm2=casdm2)
+    if atmlst is None:
+        atmlst = range(mol.natm)
+    aoslices = mol.aoslice_by_atom()
+    de = grad_elec_dferi (mc_grad, mo_cas=mo_cas, dfcasdm2=dfcasdm2, atmlst=atmlst, 
+        max_memory=mc_grad.max_memory)[0]
+    if mc_grad.auxbasis_response:
+        de_aux = vj.aux - vk.aux * .5
+        de_aux = de_aux.sum ((0,1)) - de_aux[1,1]
+        de_aux += grad_elec_auxresponse_dferi (mc_grad, mo_cas=mo_cas, dfcasdm2=dfcasdm2,
+            atmlst=atmlst, max_memory=mc_grad.max_memory)[0]
+        de += de_aux
+    dfcasdm2 = casdm2 = None
+
+    for k, ia in enumerate(atmlst):
+        shl0, shl1, p0, p1 = aoslices[ia]
+        h1ao = hcore_deriv(ia)
+        de[k] += numpy.einsum('xij,ij->x', h1ao, dm1)
+        de[k] -= numpy.einsum('xij,ij->x', s1[:,p0:p1], dme0[p0:p1]) * 2
+        de[k] += numpy.einsum('xij,ij->x', vhf1c[:,p0:p1], dm1[p0:p1]) * 2
+        de[k] += numpy.einsum('xij,ij->x', vhf1a[:,p0:p1], dm_core[p0:p1]) * 2
+
+    log.timer('CASSCF nuclear gradients', *time0)
+    return de
+
+def as_scanner(mcscf_grad):
+    '''Generating a nuclear gradients scanner/solver (for geometry optimizer).
+
+    The returned solver is a function. This function requires one argument
+    "mol" as input and returns energy and first order nuclear derivatives.
+
+    The solver will automatically use the results of last calculation as the
+    initial guess of the new calculation.  All parameters assigned in the
+    nuc-grad object and SCF object (DIIS, conv_tol, max_memory etc) are
+    automatically applied in the solver.
+
+    Note scanner has side effects.  It may change many underlying objects
+    (_scf, with_df, with_x2c, ...) during calculation.
+
+    Examples:
+
+    >>> from pyscf import gto, scf, mcscf
+    >>> mol = gto.M(atom='N 0 0 0; N 0 0 1.1', verbose=0)
+    >>> mc_grad_scanner = mcscf.CASSCF(scf.RHF(mol), 4, 4).nuc_grad_method().as_scanner()
+    >>> etot, grad = mc_grad_scanner(gto.M(atom='N 0 0 0; N 0 0 1.1'))
+    >>> etot, grad = mc_grad_scanner(gto.M(atom='N 0 0 0; N 0 0 1.5'))
+    '''
+    from pyscf import gto
+    from pyscf.mcscf.addons import StateAverageMCSCFSolver
+    if isinstance(mcscf_grad, lib.GradScanner):
+        return mcscf_grad
+
+    logger.info(mcscf_grad, 'Create scanner for %s', mcscf_grad.__class__)
+
+    class CASSCF_GradScanner(mcscf_grad.__class__, lib.GradScanner):
+        def __init__(self, g):
+            lib.GradScanner.__init__(self, g)
+        def __call__(self, mol_or_geom, **kwargs):
+            if isinstance(mol_or_geom, gto.Mole):
+                mol = mol_or_geom
+            else:
+                mol = self.mol.set_geom_(mol_or_geom, inplace=False)
+
+            mc_scanner = self.base
+            e_tot = mc_scanner(mol)
+            if isinstance(mc_scanner, StateAverageMCSCFSolver):
+                e_tot = mc_scanner.e_average
+
+            self.mol = mol
+            de = self.kernel(**kwargs)
+            return e_tot, de
+    return CASSCF_GradScanner(mcscf_grad)
+
+
+class Gradients(casci_grad.Gradients):
+    '''Non-relativistic restricted Hartree-Fock gradients'''
+
+    def __init__(self, mc):
+        self.with_df = mc.with_df
+        self.auxbasis_response = True
+        casci_grad.Gradients.__init__(self, mc)
+
+    grad_elec = grad_elec
+
+    def get_jk (self, mol=None, dm=None, hermi=0):
+        if mol is None: mol = self.mol
+        if dm is None: dm = self.base.make_rdm1()
+        cpu0 = (logger.process_clock(), logger.perf_counter())
+        vj, vk = dfrhf_grad.get_jk(self, mol, dm, ishf=False)
+        logger.timer(self, 'vj and vk', *cpu0)
+        return vj, vk
+
+    def kernel (self, mo_coeff=None, ci=None, atmlst=None, verbose=None):
+        log = logger.new_logger(self, verbose)
+        if atmlst is None:
+            atmlst = self.atmlst
+        else:
+            self.atmlst = atmlst
+
+        if self.verbose >= logger.WARN:
+            self.check_sanity()
+        if self.verbose >= logger.INFO:
+            self.dump_flags()
+
+        de = self.grad_elec(mo_coeff, ci, atmlst, log)
+        self.de = de = de + self.grad_nuc(atmlst=atmlst)
+        if self.mol.symmetry:
+            self.de = self.symmetrize(self.de, atmlst)
+        self._finalize()
+        return self.de
+
+    def _finalize(self):
+        if self.verbose >= logger.NOTE:
+            logger.note(self, '--------------- %s gradients ---------------',
+                        self.base.__class__.__name__)
+            self._write(self.mol, self.de, self.atmlst)
+            logger.note(self, '----------------------------------------------')
+
+    as_scanner = as_scanner
+
+Grad = Gradients
+
+#from pyscf import mcscf
+#mcscf.mc1step.CASSCF.Gradients = lib.class_as_method(Gradients)
+
+
+if __name__ == '__main__':
+    from pyscf import gto
+    from pyscf import scf
+    from pyscf import mcscf
+    from pyscf import df
+    #from pyscf.grad import numeric
+
+    mol = gto.Mole()
+    mol.atom = 'N 0 0 0; N 0 0 1.2; H 1 1 0; H 1 1 1.2'
+    mol.basis = '631g'
+    mol.build()
+    aux = df.aug_etb (mol)
+    mf = scf.RHF(mol).density_fit (auxbasis=aux).run()
+    mc = mcscf.CASSCF(mf, 4, 4).run()
+    mc.conv_tol = 1e-10
+    de = Gradients (mc).kernel()
+    #de_num = numeric.Gradients (mc).kernel ()
+    #print(lib.finger(de) - 0.019602220578635747)
+    #print(lib.finger(de) - lib.finger (de_num))
+
+    mol = gto.Mole()
+    mol.verbose = 0
+    mol.atom = 'N 0 0 0; N 0 0 1.2'
+    mol.basis = 'sto3g'
+    mol.build()
+    mf = scf.RHF(mol).density_fit (auxbasis=aux).run()
+    mc = mcscf.CASSCF(mf, 4, 4)
+    mc.conv_tol = 1e-10
+    mc.kernel ()
+    de = Gradients (mc).kernel()
+
+    mcs = mc.as_scanner()
+    mol.set_geom_('N 0 0 0; N 0 0 1.201')
+    e1 = mcs(mol)
+    mol.set_geom_('N 0 0 0; N 0 0 1.199')
+    e2 = mcs(mol)
+    print(de[1,2], (e1-e2)/0.002*lib.param.BOHR)

--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -405,7 +405,7 @@ def _cho_solve_rhojk (mf_grad, mol, auxmol, orbol, orbor):
     class get_rhok_class (object):
         def __init__(self, my_f):
             self.f_rhok = my_f
-        def __call__(set_id, p0, p1):
+        def __call__(self, set_id, p0, p1):
             buf = numpy.empty((p1-p0,nocc[set_id],nao))
             col1 = 0
             for istep in range(nsteps):

--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -38,10 +38,10 @@ from functools import reduce
 from itertools import product
 from pyscf.ao2mo import _ao2mo
 
-def get_jk(mf_grad, mol=None, dm=None, hermi=0, with_j=True, with_k=True, ishf=True):
+def get_jk(mf_grad, mol=None, dm=None, hermi=0, with_j=True, with_k=True):
     assert (with_j or with_k)
     if not with_k:
-        return get_j (mf_grad, mol=mol, dm=dm, hermi=hermi, ishf=ishf), None
+        return get_j (mf_grad, mol=mol, dm=dm, hermi=hermi), None
     t0 = (logger.process_clock (), logger.perf_counter ())
     if mol is None: mol = mf_grad.mol
     if dm is None: dm = mf_grad.base.make_rdm1()
@@ -199,7 +199,7 @@ def get_jk(mf_grad, mol=None, dm=None, hermi=0, with_j=True, with_k=True, ishf=T
     if with_j: return vj, vk
     else: return None, vk
 
-def get_j(mf_grad, mol=None, dm=None, hermi=0, ishf=True):
+def get_j(mf_grad, mol=None, dm=None, hermi=0):
     if mol is None: mol = mf_grad.mol
     if dm is None: dm = mf_grad.base.make_rdm1()
     t0 = (logger.process_clock (), logger.perf_counter ())
@@ -431,15 +431,11 @@ class Gradients(rhf_grad.Gradients):
 
     get_jk = get_jk
 
-    # Setting ishf=False as the default in get_j and get_k is literally
-    # just a convenience thing for MRH on 09/01/2021. A different philosophy
-    # is probably needed here.
+    def get_j(self, mol=None, dm=None, hermi=0):
+        return self.get_jk(mol, dm, with_k=False)[0]
 
-    def get_j(self, mol=None, dm=None, hermi=0, ishf=False):
-        return self.get_jk(mol, dm, with_k=False, ishf=False)[0]
-
-    def get_k(self, mol=None, dm=None, hermi=0, ishf=False):
-        return self.get_jk(mol, dm, with_j=False, ishf=False)[1]
+    def get_k(self, mol=None, dm=None, hermi=0):
+        return self.get_jk(mol, dm, with_j=False)[1]
 
     def get_veff(self, mol=None, dm=None):
         vj, vk = self.get_jk(mol, dm)

--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -214,7 +214,6 @@ def get_j(mf_grad, mol=None, dm=None, hermi=0, ishf=True):
     auxmol = with_df.auxmol
     if auxmol is None:
         auxmol = df.addons.make_auxmol(with_df.mol, with_df.auxbasis)
-    ao_loc = mol.ao_loc
     nbas = mol.nbas
 
     get_int3c_s2 = _int3c_wrapper(mol, auxmol, 'int3c2e', 's2ij')

--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -402,14 +402,18 @@ def _cho_solve_rhojk (mf_grad, mol, auxmol, orbol, orbor):
     rhoj = scipy.linalg.cho_solve(int2c, rhoj.T).T
     int2c = None
     t1 = logger.timer_debug1 (mf_grad, 'df grad vj and vk AO (P|Q) D_Q = (P|mn) D_mn solve', *t1)
-    def get_rhok(set_id, p0, p1):
-        buf = numpy.empty((p1-p0,nocc[set_id],nao))
-        col1 = 0
-        for istep in range(nsteps):
-            dat = f_rhok['%s/%s'%(set_id,istep)][p0:p1]
-            col0, col1 = col1, col1 + dat.shape[1]
-            buf[:p1-p0,:,col0:col1] = dat.transpose(0,2,1)
-        return buf
+    class get_rhok_class (object):
+        def __init__(self, my_f):
+            self.f_rhok = my_f
+        def __call__(set_id, p0, p1):
+            buf = numpy.empty((p1-p0,nocc[set_id],nao))
+            col1 = 0
+            for istep in range(nsteps):
+                dat = self.f_rhok['%s/%s'%(set_id,istep)][p0:p1]
+                col0, col1 = col1, col1 + dat.shape[1]
+                buf[:p1-p0,:,col0:col1] = dat.transpose(0,2,1)
+            return buf
+    get_rhok = get_rhok_class (f_rhok)
     return rhoj, get_rhok
 
 

--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -309,9 +309,7 @@ def _decompose_rdm1 (mf_grad, mol, dm, ishf=True):
 
     Kwargs:
         ishf : Logical
-            If True and dm lacks tags mo_coeff (eigenvectors)
-            or mo_occ (eigenvalues), these are taken from attributes
-            of mf_grad.base instead
+            Unused
 
     Returns:
         orbol : list of ndarrays of shape (nao,*)
@@ -326,15 +324,6 @@ def _decompose_rdm1 (mf_grad, mol, dm, ishf=True):
     if hasattr (dm, 'mo_coeff') and hasattr (dm, 'mo_occ'):
         mo_coeff = dm.mo_coeff
         mo_occ = dm.mo_occ
-    elif ishf:
-        mo_coeff = mf_grad.base.mo_coeff
-        mo_occ = mf_grad.base.mo_occ
-        if isinstance (mf_grad.base, scf.rohf.ROHF):
-            mo_coeff = numpy.vstack((mo_coeff,mo_coeff))
-            mo_occa = numpy.array(mo_occ> 0, dtype=numpy.double)
-            mo_occb = numpy.array(mo_occ==2, dtype=numpy.double)
-            assert(mo_occa.sum() + mo_occb.sum() == mo_occ.sum())
-            mo_occ = numpy.vstack((mo_occa, mo_occb))
     else:
         s0 = mol.intor ('int1e_ovlp')
         mo_occ = []

--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -22,8 +22,9 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-
+import time
 import numpy
+import ctypes
 import scipy.linalg
 from pyscf import gto
 from pyscf import lib
@@ -33,14 +34,181 @@ from pyscf.ao2mo.outcore import balance_partition
 from pyscf.gto.moleintor import getints, make_cintopt
 from pyscf.lib import logger
 from pyscf.grad import rhf as rhf_grad
+from functools import reduce
+from itertools import product
+from pyscf.ao2mo import _ao2mo
 
-
-def get_jk(mf_grad, mol=None, dm=None, hermi=0, with_j=True, with_k=True):
+def get_jk(mf_grad, mol=None, dm=None, hermi=0, with_j=True, with_k=True, ishf=True):
+    assert (with_j or with_k)
+    if not with_k:
+        return get_j (mf_grad, mol=mol, dm=dm, hermi=hermi, ishf=ishf), None
+    t0 = (logger.process_clock (), logger.perf_counter ())
     if mol is None: mol = mf_grad.mol
-    #if dm is None: dm = mf_grad.base.make_rdm1()
-    #TODO: dm has to be the SCF density matrix in this version.  dm should be
-    # extended to any 1-particle density matrix
-    dm = mf_grad.base.make_rdm1()
+    if dm is None: dm = mf_grad.base.make_rdm1()
+    with_df = mf_grad.base.with_df
+    auxmol = with_df.auxmol
+    if auxmol is None:
+        auxmol = df.addons.make_auxmol(with_df.mol, with_df.auxbasis)
+    ao_loc = mol.ao_loc
+    nbas, nao = mol.nbas, mol.nao
+    aux_loc = auxmol.ao_loc
+    nauxbas, naux = auxmol.nbas, auxmol.nao
+
+    # Density matrix preprocessing
+    dms = numpy.asarray(dm)
+    out_shape = dms.shape[:-2] + (3,) + dms.shape[-2:]
+    dms = dms.reshape(-1,nao,nao)
+    nset = dms.shape[0]
+
+    # For j
+    idx = numpy.arange(nao)
+    idx = idx * (idx+1) // 2 + idx
+    dm_tril = dms + dms.transpose(0,2,1)
+    dm_tril = lib.pack_tril(dm_tril)
+    dm_tril[:,idx] *= .5
+
+    # For k
+    orbol, orbor = _decompose_rdm1 (mf_grad, mol, dm, ishf=ishf)
+    nocc = [o.shape[-1] for o in orbor]
+
+    # Coulomb: (P|Q) D_Q = (P|uv) D_uv for D_Q ("rhoj")
+    # Exchange: (P|Q) D_Qui = (P|uv) C_vi n_i for D_Qui ("rhok") 
+    rhoj, get_rhok = _cho_solve_rhojk (mf_grad, mol, auxmol, orbol, orbor)
+
+    # (d/dX i,j|P)
+    t1 = (logger.process_clock (), logger.perf_counter ())
+    vj = numpy.zeros((nset,3,nao,nao))
+    vk = numpy.zeros((nset,3,nao,nao))
+    get_int3c_ip1 = _int3c_wrapper(mol, auxmol, 'int3c2e_ip1', 's1')
+    max_memory = mf_grad.max_memory - lib.current_memory()[0]
+    blksize = int(min(max(max_memory * .5e6/8 / (nao**2*3), 20), naux, 240))
+    ao_ranges = balance_partition(aux_loc, blksize)
+    fmmm = _ao2mo.libao2mo.AO2MOmmm_bra_nr_s1 # MO output index slower than AO output index; input AOs are asymmetric
+    fdrv = _ao2mo.libao2mo.AO2MOnr_e2_drv # comp and aux indices are slower
+    ftrans = _ao2mo.libao2mo.AO2MOtranse2_nr_s1 # input is not tril_packed
+    null = lib.c_null_ptr() 
+    t2 = t1
+    for shl0, shl1, nL in ao_ranges:
+        int3c = get_int3c_ip1((0, nbas, 0, nbas, shl0, shl1)).transpose (0,3,2,1)  # (P|mn'), row-major order
+        t2 = logger.timer_debug1 (mf_grad, "df grad intor (P|mn')", *t2)
+        p0, p1 = aux_loc[shl0], aux_loc[shl1]
+        for i in range(nset):
+            # MRH 05/21/2020: De-vectorize this because array contiguity -> multithread efficiency
+            vj[i,0] += numpy.dot (rhoj[i,p0:p1], int3c[0].reshape (p1-p0, -1)).reshape (nao, nao).T
+            vj[i,1] += numpy.dot (rhoj[i,p0:p1], int3c[1].reshape (p1-p0, -1)).reshape (nao, nao).T
+            vj[i,2] += numpy.dot (rhoj[i,p0:p1], int3c[2].reshape (p1-p0, -1)).reshape (nao, nao).T
+            t2 = logger.timer_debug1 (mf_grad, "df grad einsum rho_P (P|mn') rho_P", *t2)
+            tmp = numpy.empty ((3,p1-p0,nocc[i],nao), dtype=orbol[0].dtype) 
+            fdrv(ftrans, fmmm, # lib.einsum ('xpmn,mi->xpin', int3c, orbol[i])
+                 tmp.ctypes.data_as(ctypes.c_void_p),
+                 int3c.ctypes.data_as(ctypes.c_void_p),
+                 orbol[i].ctypes.data_as(ctypes.c_void_p),
+                 ctypes.c_int (3*(p1-p0)), ctypes.c_int (nao),
+                 (ctypes.c_int*4)(0, nocc[i], 0, nao),
+                 null, ctypes.c_int(0))
+            t2 = logger.timer_debug1 (mf_grad, "df grad einsum (P|mn') u_mi = dg_Pin", *t2)
+            rhok = get_rhok (i, p0, p1)
+            vk[i] += lib.einsum('xpoi,pok->xik', tmp, rhok)
+            t2 = logger.timer_debug1 (mf_grad, "df grad einsum D_Pim dg_Pin = v_ij", *t2)
+            rhok = tmp = None
+        int3c = None
+    t1 = logger.timer_debug1 (mf_grad, 'df grad vj and vk AO (P|mn) D_P eval', *t1)
+
+    if not mf_grad.auxbasis_response:
+        vj = -vj.reshape(out_shape)
+        vk = -vk.reshape(out_shape)
+        logger.timer (mf_grad, 'df grad vj and vk', *t0)
+        if with_j: return vj, vk
+        else: return None, vk
+
+    ####### BEGIN AUXBASIS PART #######
+
+    # ao2mo the final AO index of rhok and store in "rhok_oo":
+    # dPiu C_uj -> dPij. *Not* symmetric i<->j: "i" has an occupancy
+    # factor and "j" must not.
+    max_memory = mf_grad.max_memory - lib.current_memory()[0]
+    blksize = int(min(max(max_memory * .5e6/8 / (nao*max (nocc)), 20), naux))
+    rhok_oo = []
+    for i, j in product (range (nset), repeat=2):
+        tmp = numpy.empty ((naux,nocc[i],nocc[j]))
+        for p0, p1 in lib.prange(0, naux, blksize):
+            rhok = get_rhok (i, p0, p1).reshape ((p1-p0)*nocc[i], nao)
+            tmp[p0:p1] = lib.dot (rhok, orbol[j]).reshape (p1-p0, nocc[i], nocc[j])
+        rhok_oo.append(tmp)
+        rhok = tmp = None
+    t1 = logger.timer_debug1 (mf_grad, 'df grad vj and vk aux d_Pim u_mj = d_Pij eval', *t1)
+
+    vjaux = numpy.zeros((nset,nset,3,naux))
+    vkaux = numpy.zeros((nset,nset,3,naux))
+    # (i,j|d/dX P)
+    t2 = t1
+    get_int3c_ip2 = _int3c_wrapper(mol, auxmol, 'int3c2e_ip2', 's2ij')
+    fmmm = _ao2mo.libao2mo.AO2MOmmm_bra_nr_s2 # MO output index slower than AO output index; input AOs are symmetric
+    fdrv = _ao2mo.libao2mo.AO2MOnr_e2_drv # comp and aux indices are slower
+    ftrans = _ao2mo.libao2mo.AO2MOtranse2_nr_s2 # input is tril_packed
+    null = lib.c_null_ptr() 
+    for shl0, shl1, nL in ao_ranges:
+        int3c = get_int3c_ip2((0, nbas, 0, nbas, shl0, shl1))  # (i,j|P)
+        t2 = logger.timer_debug1 (mf_grad, "df grad intor (P'|mn)", *t2)
+        p0, p1 = aux_loc[shl0], aux_loc[shl1]
+        drhoj = lib.dot (int3c.transpose (0,2,1).reshape (3*(p1-p0), -1),
+            dm_tril.T).reshape (3, p1-p0, -1) # xpij,mij->xpm
+        vjaux[:,:,:,p0:p1] = lib.einsum ('xpm,np->mnxp', drhoj, rhoj[:,p0:p1])
+        t2 = logger.timer_debug1 (mf_grad, "df grad vj aux (P'|mn) eval", *t2)
+        # MRH, 09/19/2022: This is a different order of operations than PySCF v2.1.0. There,
+        #                  the dense matrix rhok_oo is transformed into the larger AO basis.
+        #                  Here, the sparse matrix int3c is transformed into the smaller MO
+        #                  basis. The latter approach is obviously more performant.
+        for i in range (nset):
+            assert (orbol[i].flags.f_contiguous), '{} {}'.format (orbol[i].shape, orbol[i].strides)
+            buf = numpy.empty ((3, p1-p0, nocc[i], nao), dtype=orbol[i].dtype) 
+            fdrv(ftrans, fmmm, # lib.einsum ('pmn,ni->pim', int3c, orbol[i])
+                 buf.ctypes.data_as(ctypes.c_void_p),
+                 int3c.ctypes.data_as(ctypes.c_void_p),
+                 orbol[i].ctypes.data_as(ctypes.c_void_p),
+                 ctypes.c_int (3*(p1-p0)), ctypes.c_int (nao),
+                 (ctypes.c_int*4)(0, nocc[i], 0, nao),
+                 null, ctypes.c_int(0))
+            for j in range (nset): # lib.einsum ('pim,mj->pij', buf, orbor[j])
+                assert (orbor[j].flags.f_contiguous), '{} {}'.format (orbor[j].shape, orbor[j].strides)
+                int3c_ij = lib.dot (buf.reshape (-1, nao), orbor[j])
+                int3c_ij = int3c_ij.reshape (3, p1-p0, nocc[i], nocc[j])
+                rhok_oo_ij = rhok_oo[(i*nset)+j][p0:p1]
+                vkaux[i,j,:,p0:p1] += lib.einsum('xpij,pij->xp', int3c_ij,
+                                                 rhok_oo_ij)
+        t2 = logger.timer_debug1 (mf_grad, "df grad vk aux (P'|mn) eval", *t2)
+    int3c = tmp = None
+    t1 = logger.timer_debug1 (mf_grad, "df grad vj and vk aux (P'|mn) eval", *t1)
+
+    # (d/dX P|Q)
+    int2c_e1 = auxmol.intor('int2c2e_ip1')
+    vjaux -= lib.einsum('xpq,mp,nq->mnxp', int2c_e1, rhoj, rhoj)
+    for i, j in product (range (nset), repeat=2):
+        k = (i*nset) + j
+        l = (j*nset) + i
+        tmp = lib.einsum('pij,qji->pq', rhok_oo[k], rhok_oo[l])
+        vkaux[i,j] -= lib.einsum('xpq,pq->xp', int2c_e1, tmp)
+    t1 = logger.timer_debug1 (mf_grad, "df grad vj and vk aux (P'|Q) eval", *t1)
+
+    auxslices = auxmol.aoslice_by_atom()
+    vjaux = numpy.array ([-vjaux[:,:,:,p0:p1].sum(axis=3) for p0, p1 in auxslices[:,2:]])
+    vkaux = numpy.array ([-vkaux[:,:,:,p0:p1].sum(axis=3) for p0, p1 in auxslices[:,2:]])
+    if ishf:
+        vjaux = vjaux.sum ((1,2))
+        vkaux = numpy.trace (vkaux, axis1=1, axis2=2)
+    else:
+        vjaux = numpy.ascontiguousarray (vjaux.transpose (1,2,0,3))
+        vkaux = numpy.ascontiguousarray (vkaux.transpose (1,2,0,3))
+    vj = lib.tag_array(-vj.reshape(out_shape), aux=numpy.array(vjaux))
+    vk = lib.tag_array(-vk.reshape(out_shape), aux=numpy.array(vkaux))
+    logger.timer (mf_grad, 'df grad vj and vk', *t0)
+    if with_j: return vj, vk
+    else: return None, vk
+
+def get_j(mf_grad, mol=None, dm=None, hermi=0, ishf=True):
+    if mol is None: mol = mf_grad.mol
+    if dm is None: dm = mf_grad.base.make_rdm1()
+    t0 = (logger.process_clock (), logger.perf_counter ())
 
     with_df = mf_grad.base.with_df
     auxmol = with_df.auxmol
@@ -48,9 +216,7 @@ def get_jk(mf_grad, mol=None, dm=None, hermi=0, with_j=True, with_k=True):
         auxmol = df.addons.make_auxmol(with_df.mol, with_df.auxbasis)
     ao_loc = mol.ao_loc
     nbas = mol.nbas
-    nauxbas = auxmol.nbas
 
-    get_int3c_s1 = _int3c_wrapper(mol, auxmol, 'int3c2e', 's1')
     get_int3c_s2 = _int3c_wrapper(mol, auxmol, 'int3c2e', 's2ij')
     get_int3c_ip1 = _int3c_wrapper(mol, auxmol, 'int3c2e_ip1', 's1')
     get_int3c_ip2 = _int3c_wrapper(mol, auxmol, 'int3c2e_ip2', 's2ij')
@@ -62,172 +228,66 @@ def get_jk(mf_grad, mol=None, dm=None, hermi=0, with_j=True, with_k=True):
     dms = dms.reshape(-1,nao,nao)
     nset = dms.shape[0]
 
-    auxslices = auxmol.aoslice_by_atom()
+    idx = numpy.arange(nao)
+    idx = idx * (idx+1) // 2 + idx
+    dm_tril = dms + dms.transpose(0,2,1)
+    dm_tril = lib.pack_tril(dm_tril)
+    dm_tril[:,idx] *= .5
+
     aux_loc = auxmol.ao_loc
     max_memory = mf_grad.max_memory - lib.current_memory()[0]
     blksize = int(min(max(max_memory * .5e6/8 / (nao**2*3), 20), naux, 240))
     ao_ranges = balance_partition(aux_loc, blksize)
 
-    if not with_k:
-        idx = numpy.arange(nao)
-        dm_tril = dms + dms.transpose(0,2,1)
-        dm_tril[:,idx,idx] *= .5
-        dm_tril = lib.pack_tril(dm_tril)
-
-        # (i,j|P)
-        rhoj = numpy.empty((nset,naux))
-        for shl0, shl1, nL in ao_ranges:
-            int3c = get_int3c_s2((0, nbas, 0, nbas, shl0, shl1))  # (i,j|P)
-            p0, p1 = aux_loc[shl0], aux_loc[shl1]
-            rhoj[:,p0:p1] = numpy.einsum('wp,nw->np', int3c, dm_tril)
-            int3c = None
-
-        # (P|Q)
-        int2c = auxmol.intor('int2c2e', aosym='s1')
-        rhoj = scipy.linalg.solve(int2c, rhoj.T, sym_pos=True).T
-        int2c = None
-
-        # (d/dX i,j|P)
-        vj = numpy.zeros((nset,3,nao,nao))
-        for shl0, shl1, nL in ao_ranges:
-            int3c = get_int3c_ip1((0, nbas, 0, nbas, shl0, shl1))  # (i,j|P)
-            p0, p1 = aux_loc[shl0], aux_loc[shl1]
-            vj += numpy.einsum('xijp,np->nxij', int3c, rhoj[:,p0:p1])
-            int3c = None
-
-        if mf_grad.auxbasis_response:
-            # (i,j|d/dX P)
-            vjaux = numpy.empty((3,naux))
-            for shl0, shl1, nL in ao_ranges:
-                int3c = get_int3c_ip2((0, nbas, 0, nbas, shl0, shl1))  # (i,j|P)
-                p0, p1 = aux_loc[shl0], aux_loc[shl1]
-                vjaux[:,p0:p1] = numpy.einsum('xwp,mw,np->xp',
-                                              int3c, dm_tril, rhoj[:,p0:p1])
-                int3c = None
-
-            # (d/dX P|Q)
-            int2c_e1 = auxmol.intor('int2c2e_ip1', aosym='s1')
-            vjaux -= numpy.einsum('xpq,mp,nq->xp', int2c_e1, rhoj, rhoj)
-
-            vjaux = [-vjaux[:,p0:p1].sum(axis=1) for p0, p1 in auxslices[:,2:]]
-            vj = lib.tag_array(-vj.reshape(out_shape), aux=numpy.array(vjaux))
-        else:
-            vj = -vj.reshape(out_shape)
-        return vj, None
-
-    mo_coeff = mf_grad.base.mo_coeff
-    mo_occ = mf_grad.base.mo_occ
-    nmo = mo_occ.shape[-1]
-    if isinstance(mf_grad.base, scf.rohf.ROHF):
-        mo_coeff = numpy.vstack((mo_coeff,mo_coeff))
-        mo_occa = numpy.array(mo_occ> 0, dtype=numpy.double)
-        mo_occb = numpy.array(mo_occ==2, dtype=numpy.double)
-        assert (mo_occa.sum() + mo_occb.sum() == mo_occ.sum())
-        mo_occ = numpy.vstack((mo_occa, mo_occb))
-
-    mo_coeff = numpy.asarray(mo_coeff).reshape(-1,nao,nmo)
-    mo_occ   = numpy.asarray(mo_occ).reshape(-1,nmo)
-    rhoj = numpy.zeros((nset,naux))
-    f_rhok = lib.H5TmpFile()
-    orbo = []
-    for i in range(nset):
-        c = numpy.einsum('pi,i->pi', mo_coeff[i][:,mo_occ[i]>0],
-                         numpy.sqrt(mo_occ[i][mo_occ[i]>0]))
-        nocc = c.shape[1]
-        orbo.append(c)
+    # (i,j|P)
+    rhoj = numpy.empty((nset,naux))
+    for shl0, shl1, nL in ao_ranges:
+        int3c = get_int3c_s2((0, nbas, 0, nbas, shl0, shl1))  # (i,j|P)
+        p0, p1 = aux_loc[shl0], aux_loc[shl1]
+        rhoj[:,p0:p1] = lib.einsum('wp,nw->np', int3c, dm_tril)
+        int3c = None
 
     # (P|Q)
-    int2c = scipy.linalg.cho_factor(auxmol.intor('int2c2e', aosym='s1'))
-
-    max_memory = mf_grad.max_memory - lib.current_memory()[0]
-    blksize = max_memory * .5e6/8 / (naux*nao)
-    mol_ao_ranges = balance_partition(ao_loc, blksize)
-    nsteps = len(mol_ao_ranges)
-    for istep, (shl0, shl1, nd) in enumerate(mol_ao_ranges):
-        int3c = get_int3c_s1((0, nbas, shl0, shl1, 0, nauxbas))
-        p0, p1 = ao_loc[shl0], ao_loc[shl1]
-        rhoj += numpy.einsum('nlk,klp->np', dms[:,p0:p1], int3c)
-        for i in range(nset):
-            v = lib.einsum('ko,klp->plo', orbo[i], int3c)
-            v = scipy.linalg.cho_solve(int2c, v.reshape(naux,-1))
-            f_rhok['%s/%s'%(i,istep)] = v.reshape(naux,p1-p0,-1)
-        int3c = v = None
-
-    rhoj = scipy.linalg.cho_solve(int2c, rhoj.T).T
+    int2c = auxmol.intor('int2c2e', aosym='s1')
+    rhoj = scipy.linalg.solve(int2c, rhoj.T, sym_pos=True).T
     int2c = None
 
-    def load(set_id, p0, p1):
-        nocc = orbo[set_id].shape[1]
-        buf = numpy.empty((p1-p0,nocc,nao))
-        col1 = 0
-        for istep in range(nsteps):
-            dat = f_rhok['%s/%s'%(set_id,istep)][p0:p1]
-            col0, col1 = col1, col1 + dat.shape[1]
-            buf[:p1-p0,:,col0:col1] = dat.transpose(0,2,1)
-        return buf
-
-    vj = numpy.zeros((nset,3,nao,nao))
-    vk = numpy.zeros((nset,3,nao,nao))
     # (d/dX i,j|P)
+    vj = numpy.zeros((nset,3,nao,nao))
     for shl0, shl1, nL in ao_ranges:
         int3c = get_int3c_ip1((0, nbas, 0, nbas, shl0, shl1))  # (i,j|P)
         p0, p1 = aux_loc[shl0], aux_loc[shl1]
-        vj += numpy.einsum('xijp,np->nxij', int3c, rhoj[:,p0:p1])
-        for i in range(nset):
-            tmp = lib.einsum('xijp,jo->xipo', int3c, orbo[i])
-            rhok = load(i, p0, p1)
-            vk[i] += lib.einsum('xipo,pok->xik', tmp, rhok)
-            tmp = rhok = None
+        vj += lib.einsum('xijp,np->nxij', int3c, rhoj[:,p0:p1])
         int3c = None
 
-    max_memory = mf_grad.max_memory - lib.current_memory()[0]
-    blksize = int(min(max(max_memory * .5e6/8 / (nao*nocc), 20), naux))
-    rhok_oo = []
-    for i in range(nset):
-        nocc = orbo[i].shape[1]
-        tmp = numpy.empty((naux,nocc,nocc))
-        for p0, p1 in lib.prange(0, naux, blksize):
-            rhok = load(i, p0, p1)
-            tmp[p0:p1] = lib.einsum('pok,kr->por', rhok, orbo[i])
-        rhok_oo.append(tmp)
-        rhok = tmp = None
-
     if mf_grad.auxbasis_response:
-        vjaux = numpy.zeros((3,naux))
-        vkaux = numpy.zeros((3,naux))
         # (i,j|d/dX P)
+        vjaux = numpy.empty((nset,nset,3,naux))
         for shl0, shl1, nL in ao_ranges:
             int3c = get_int3c_ip2((0, nbas, 0, nbas, shl0, shl1))  # (i,j|P)
             p0, p1 = aux_loc[shl0], aux_loc[shl1]
-            int3c = int3c.transpose(0,2,1).reshape(3*(p1-p0),-1)
-            int3c = lib.unpack_tril(int3c)
-            int3c = int3c.reshape(3,p1-p0,nao,nao)
-            vjaux[:,p0:p1] = numpy.einsum('xpij,mji,np->xp',
-                                          int3c, dms, rhoj[:,p0:p1])
-            for i in range(nset):
-                tmp = rhok_oo[i][p0:p1]
-                tmp = lib.einsum('por,ir->pio', tmp, orbo[i])
-                tmp = lib.einsum('pio,jo->pij', tmp, orbo[i])
-                vkaux[:,p0:p1] += lib.einsum('xpij,pij->xp', int3c, tmp)
-        int3c = tmp = None
+            vjaux[:,:,:,p0:p1] = lib.einsum('xwp,mw,np->mnxp',
+                                          int3c, dm_tril, rhoj[:,p0:p1])
+            int3c = None
 
         # (d/dX P|Q)
-        int2c_e1 = auxmol.intor('int2c2e_ip1')
-        vjaux -= numpy.einsum('xpq,mp,nq->xp', int2c_e1, rhoj, rhoj)
-        for i in range(nset):
-            tmp = lib.einsum('pij,qij->pq', rhok_oo[i], rhok_oo[i])
-            vkaux -= numpy.einsum('xpq,pq->xp', int2c_e1, tmp)
+        int2c_e1 = auxmol.intor('int2c2e_ip1', aosym='s1')
+        vjaux -= lib.einsum('xpq,mp,nq->mnxp', int2c_e1, rhoj, rhoj)
 
-        vjaux = [-vjaux[:,p0:p1].sum(axis=1) for p0, p1 in auxslices[:,2:]]
-        vkaux = [-vkaux[:,p0:p1].sum(axis=1) for p0, p1 in auxslices[:,2:]]
+        auxslices = auxmol.aoslice_by_atom()
+        vjaux = numpy.array ([-vjaux[:,:,:,p0:p1].sum(axis=3) for p0, p1 in auxslices[:,2:]])
+        if ishf:
+            vjaux = vjaux.sum ((1,2))
+        else:
+            vjaux = numpy.ascontiguousarray (vjaux.transpose (1,2,0,3))
         vj = lib.tag_array(-vj.reshape(out_shape), aux=numpy.array(vjaux))
-        vk = lib.tag_array(-vk.reshape(out_shape), aux=numpy.array(vkaux))
     else:
         vj = -vj.reshape(out_shape)
-        vk = -vk.reshape(out_shape)
-    return vj, vk
+    logger.timer (mf_grad, 'df vj', *t0)
+    return vj
 
 def _int3c_wrapper(mol, auxmol, intor, aosym):
+    ''' Convenience wrapper for getints '''
     nbas = mol.nbas
     pmol = mol + auxmol
     intor = mol._add_suffix(intor)
@@ -241,6 +301,151 @@ def _int3c_wrapper(mol, auxmol, intor, aosym):
                        aosym=aosym, cintopt=opt)
     return get_int3c
 
+def _decompose_rdm1 (mf_grad, mol, dm, ishf=True):
+    '''Decompose dms as U.Vh, where 
+    U = orbol = eigenvectors
+    V = orbor = U * eigenvalues
+
+    Args:
+        mf_grad : instance of :class:`Gradients`
+        mol : instance of :class:`gto.Mole`
+        dm : ndarray or sequence of ndarrays of shape (nao,nao)
+            Density matrices
+
+    Kwargs:
+        ishf : Logical
+            If True and dm lacks tags mo_coeff (eigenvectors)
+            or mo_occ (eigenvalues), these are taken from attributes
+            of mf_grad.base instead
+
+    Returns:
+        orbol : list of ndarrays of shape (nao,*)
+            Contains non-null eigenvectors of density matrix
+        orbor : list of ndarrays of shape (nao,*)
+            Contains orbol * eigenvalues (occupancies)
+    '''
+    # TODO: get rid of ishf and tag dm in the caller instead
+    nao = mol.nao
+    dms = numpy.asarray(dm).reshape (-1,nao,nao)
+    nset = dms.shape[0]
+    if hasattr (dm, 'mo_coeff') and hasattr (dm, 'mo_occ'):
+        mo_coeff = dm.mo_coeff
+        mo_occ = dm.mo_occ
+    elif ishf:
+        mo_coeff = mf_grad.base.mo_coeff
+        mo_occ = mf_grad.base.mo_occ
+        if isinstance (mf_grad.base, scf.rohf.ROHF): 
+            mo_coeff = numpy.vstack((mo_coeff,mo_coeff))
+            mo_occa = numpy.array(mo_occ> 0, dtype=numpy.double)
+            mo_occb = numpy.array(mo_occ==2, dtype=numpy.double)
+            assert(mo_occa.sum() + mo_occb.sum() == mo_occ.sum())
+            mo_occ = numpy.vstack((mo_occa, mo_occb))
+    else:
+        s0 = mol.intor ('int1e_ovlp')
+        mo_occ = []
+        mo_coeff = []
+        for dm in dms:
+            sdms = reduce (lib.dot, (s0, dm, s0))
+            n, c = scipy.linalg.eigh (sdms, b=s0)
+            mo_occ.append (n)
+            mo_coeff.append (c)
+        mo_occ = numpy.stack (mo_occ, axis=0)
+    nmo = mo_occ.shape[-1]
+
+    mo_coeff = numpy.asarray(mo_coeff).reshape(-1,nao,nmo)
+    mo_occ   = numpy.asarray(mo_occ).reshape(-1,nmo)
+    orbor = []
+    orbol = []
+    orbor_stack = numpy.zeros ((nao,0), dtype=mo_coeff.dtype, order='F')
+    orbol_stack = numpy.zeros ((nao,0), dtype=mo_coeff.dtype, order='F')
+    offs = 0
+    for i in range(nset):
+        idx = numpy.abs (mo_occ[i])>1e-8
+        nocc = numpy.count_nonzero (idx)
+        c = mo_coeff[i][:,idx]
+        orbol_stack = numpy.append (orbol_stack, c, axis=1)
+        orbol.append (orbol_stack[:,offs:offs+nocc])
+        cn = lib.einsum('pi,i->pi', c, mo_occ[i][idx])
+        orbor_stack = numpy.append (orbor_stack, cn, axis=1)
+        orbor.append (orbor_stack[:,offs:offs+nocc])
+        offs += nocc
+
+    # For Coulomb
+    return orbol, orbor
+
+def _cho_solve_rhojk (mf_grad, mol, auxmol, orbol, orbor):
+    ''' Solve
+
+    (P|Q) dQ = (P|uv) D_uv
+    (P|Q) dQiu = (P|uv) C_vi n_i
+
+    for dQ ('rhoj') and dQui ('rhok'), where D_uv = C_ui n_i C_vi* is
+    a density matrix.
+
+    Args:
+        mf_grad : instance of :class:`Gradients`
+        mol : instance of :class:`gto.Mole`
+        auxmol : instance of :class:`gto.Mole`
+        orbol : list of length nset of ndarrays of shape (nao,*)
+            Contains non-null eigenvectors of density matrices. See
+            docstring for _decompose_1rdm.
+        orbor : list of length nset of ndarrays of shape (nao,*)
+            Contains orbol multiplied by eigenvalues. See docstring for
+            _decompose_1rdm.
+
+    Returns:
+        rhoj : ndarray of shape (nset, naux)
+            Aux-basis densities
+        get_rhok : callable taking 3 integers (i,j,k), i,j<naux, k<nset
+            Returns C-contiguous ndarray of shape
+            (k-j,orbol[i].shape[1],nao) which contains a mixed-basis
+            density matrix
+    '''
+
+    nset = len (orbol)
+    nao, naux = mol.nao, auxmol.nao
+    nbas, nauxbas = mol.nbas, auxmol.nbas
+    ao_loc = mol.ao_loc
+    nocc = [o.shape[-1] for o in orbor]
+
+    int2c = scipy.linalg.cho_factor(auxmol.intor('int2c2e', aosym='s1'))
+    get_int3c_s1 = _int3c_wrapper(mol, auxmol, 'int3c2e', 's1')
+    rhoj = numpy.zeros((nset,naux))
+    f_rhok = lib.H5TmpFile()
+    t1 = (logger.process_clock (), logger.perf_counter ())
+    max_memory = mf_grad.max_memory - lib.current_memory()[0]
+    blksize = max_memory * .5e6/8 / (naux*nao)
+    mol_ao_ranges = balance_partition(ao_loc, blksize)
+    nsteps = len(mol_ao_ranges)
+    t2 = t1
+    for istep, (shl0, shl1, nd) in enumerate(mol_ao_ranges):
+        int3c = get_int3c_s1((0, nbas, shl0, shl1, 0, nauxbas))
+        t2 = logger.timer_debug1 (mf_grad, 'df grad intor (P|mn)', *t2)
+        p0, p1 = ao_loc[shl0], ao_loc[shl1]
+        for i in range(nset):
+            # MRH 05/21/2020: De-vectorize this because array contiguity -> multithread efficiency
+            v = lib.dot(int3c.reshape (nao, -1, order='F').T, orbor[i]).reshape (naux, (p1-p0)*nocc[i])
+            t2 = logger.timer_debug1 (mf_grad, 'df grad einsum (P|mn) u_ni N_i = v_Pmi', *t2)
+            rhoj[i] += numpy.dot (v, orbol[i][p0:p1].ravel ())
+            t2 = logger.timer_debug1 (mf_grad, 'df grad einsum v_Pmi u_mi = rho_P', *t2)
+            v = scipy.linalg.cho_solve(int2c, v)
+            t2 = logger.timer_debug1 (mf_grad, 'df grad cho_solve (P|Q) D_Qmi = v_Pmi', *t2)
+            f_rhok['%s/%s'%(i,istep)] = v.reshape(naux,p1-p0,-1)
+            t2 = logger.timer_debug1 (mf_grad, 'df grad cache D_Pmi (m <-> i transpose upon retrieval)', *t2)
+        int3c = v = None
+    rhoj = scipy.linalg.cho_solve(int2c, rhoj.T).T
+    int2c = None
+    t1 = logger.timer_debug1 (mf_grad, 'df grad vj and vk AO (P|Q) D_Q = (P|mn) D_mn solve', *t1)
+    def get_rhok(set_id, p0, p1):
+        buf = numpy.empty((p1-p0,nocc[set_id],nao))
+        col1 = 0
+        for istep in range(nsteps):
+            dat = f_rhok['%s/%s'%(set_id,istep)][p0:p1]
+            col0, col1 = col1, col1 + dat.shape[1]
+            buf[:p1-p0,:,col0:col1] = dat.transpose(0,2,1)
+        return buf
+    return rhoj, get_rhok
+
 
 class Gradients(rhf_grad.Gradients):
     '''Restricted density-fitting Hartree-Fock gradients'''
@@ -252,11 +457,15 @@ class Gradients(rhf_grad.Gradients):
 
     get_jk = get_jk
 
-    def get_j(self, mol=None, dm=None, hermi=0):
-        return self.get_jk(mol, dm, with_k=False)[0]
+    # Setting ishf=False as the default in get_j and get_k is literally
+    # just a convenience thing for MRH on 09/01/2021. A different philosophy
+    # is probably needed here.
 
-    def get_k(self, mol=None, dm=None, hermi=0):
-        return self.get_jk(mol, dm, with_j=False)[1]
+    def get_j(self, mol=None, dm=None, hermi=0, ishf=False):
+        return self.get_jk(mol, dm, with_k=False, ishf=False)[0]
+
+    def get_k(self, mol=None, dm=None, hermi=0, ishf=False):
+        return self.get_jk(mol, dm, with_j=False, ishf=False)[1]
 
     def get_veff(self, mol=None, dm=None):
         vj, vk = self.get_jk(mol, dm)
@@ -274,7 +483,6 @@ class Gradients(rhf_grad.Gradients):
             return 0
 
 Grad = Gradients
-
 
 if __name__ == '__main__':
     mol = gto.Mole()

--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -330,21 +330,13 @@ def _decompose_rdm1 (mf_grad, mol, dm):
     mo_occ   = numpy.asarray(mo_occ).reshape(-1,nmo)
     orbor = []
     orbol = []
-    orbor_stack = numpy.zeros ((nao,0), dtype=mo_coeff.dtype, order='F')
-    orbol_stack = numpy.zeros ((nao,0), dtype=mo_coeff.dtype, order='F')
-    offs = 0
     for i in range(nset):
         idx = numpy.abs (mo_occ[i])>1e-8
-        nocc = numpy.count_nonzero (idx)
         c = mo_coeff[i][:,idx]
-        orbol_stack = numpy.append (orbol_stack, c, axis=1)
-        orbol.append (orbol_stack[:,offs:offs+nocc])
+        orbol.append (numpy.asfortranarray (c))
         cn = lib.einsum('pi,i->pi', c, mo_occ[i][idx])
-        orbor_stack = numpy.append (orbor_stack, cn, axis=1)
-        orbor.append (orbor_stack[:,offs:offs+nocc])
-        offs += nocc
+        orbor.append (numpy.asfortranarray (cn))
 
-    # For Coulomb
     return orbol, orbor
 
 def _cho_solve_rhojk (mf_grad, mol, auxmol, orbol, orbor):

--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -160,7 +160,6 @@ def get_jk(mf_grad, mol=None, dm=None, hermi=0, with_j=True, with_k=True, ishf=T
         #                  Here, the sparse matrix int3c is transformed into the smaller MO
         #                  basis. The latter approach is obviously more performant.
         for i in range (nset):
-            assert (orbol[i].flags.f_contiguous), '{} {}'.format (orbol[i].shape, orbol[i].strides)
             buf = numpy.empty ((3, p1-p0, nocc[i], nao), dtype=orbol[i].dtype) 
             fdrv(ftrans, fmmm, # lib.einsum ('pmn,ni->pim', int3c, orbol[i])
                  buf.ctypes.data_as(ctypes.c_void_p),

--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -169,7 +169,6 @@ def get_jk(mf_grad, mol=None, dm=None, hermi=0, with_j=True, with_k=True, ishf=T
                  (ctypes.c_int*4)(0, nocc[i], 0, nao),
                  null, ctypes.c_int(0))
             for j in range (nset): # lib.einsum ('pim,mj->pij', buf, orbor[j])
-                assert (orbor[j].flags.f_contiguous), '{} {}'.format (orbor[j].shape, orbor[j].strides)
                 int3c_ij = lib.dot (buf.reshape (-1, nao), orbor[j])
                 int3c_ij = int3c_ij.reshape (3, p1-p0, nocc[i], nocc[j])
                 rhok_oo_ij = rhok_oo[(i*nset)+j][p0:p1]

--- a/pyscf/df/grad/rks.py
+++ b/pyscf/df/grad/rks.py
@@ -67,7 +67,7 @@ def get_veff(ks_grad, mol=None, dm=None):
         vj = ks_grad.get_j(mol, dm)
         vxc += vj
         if ks_grad.auxbasis_response:
-            e1_aux = vj.aux
+            e1_aux = vj.aux.sum ((0,1))
     else:
         vj, vk = ks_grad.get_jk(mol, dm)
         if ks_grad.auxbasis_response:
@@ -81,7 +81,7 @@ def get_veff(ks_grad, mol=None, dm=None):
                 vk_aux += vk_lr.aux * (alpha - hyb)
         vxc += vj - vk * .5
         if ks_grad.auxbasis_response:
-            e1_aux = vj.aux - vk_aux * .5
+            e1_aux = (vj.aux - vk.aux * .5).sum ((0,1))
 
     if ks_grad.auxbasis_response:
         logger.debug1(ks_grad, 'sum(auxbasis response) %s', e1_aux.sum(axis=0))

--- a/pyscf/df/grad/rks.py
+++ b/pyscf/df/grad/rks.py
@@ -72,7 +72,7 @@ def get_veff(ks_grad, mol=None, dm=None):
         vj, vk = ks_grad.get_jk(mol, dm)
         if ks_grad.auxbasis_response:
             vk_aux = vk.aux * hyb
-        vk *= hyb
+        vk[:] *= hyb # Don't erase the .aux tags!
         if abs(omega) > 1e-10:  # For range separated Coulomb operator
             raise NotImplementedError
             vk_lr = ks_grad.get_k(mol, dm, omega=omega)

--- a/pyscf/df/grad/rohf.py
+++ b/pyscf/df/grad/rohf.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+#
+
+from pyscf.df.grad import uhf
+from pyscf.grad import rohf
+
+class Gradients (uhf.Gradients):
+    make_rdm1e = rohf.make_rdm1e
+
+Grad = Gradients
+
+

--- a/pyscf/df/grad/rohf.py
+++ b/pyscf/df/grad/rohf.py
@@ -6,6 +6,7 @@ from pyscf.grad import rohf
 
 class Gradients (uhf.Gradients):
     make_rdm1e = rohf.make_rdm1e
+    _tag_rdm1 = rohf._tag_rdm1
 
 Grad = Gradients
 

--- a/pyscf/df/grad/roks.py
+++ b/pyscf/df/grad/roks.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+#
+
+from pyscf.df.grad import uks
+from pyscf.grad import rohf
+
+class Gradients (uks.Gradients):
+    make_rdm1e = rohf.make_rdm1e
+
+Grad = Gradients
+
+

--- a/pyscf/df/grad/roks.py
+++ b/pyscf/df/grad/roks.py
@@ -6,6 +6,7 @@ from pyscf.grad import rohf
 
 class Gradients (uks.Gradients):
     make_rdm1e = rohf.make_rdm1e
+    _tag_rdm1 = rohf._tag_rdm1
 
 Grad = Gradients
 

--- a/pyscf/df/grad/sacasscf.py
+++ b/pyscf/df/grad/sacasscf.py
@@ -352,20 +352,6 @@ class Gradients (sacasscf_grad.Gradients):
         self.auxbasis_response = True
         sacasscf_grad.Gradients.__init__(self, mc, state=state)
 
-    def make_fcasscf_sa (self, casscf_attr={}, fcisolver_attr={}):
-        ''' Make a fake SA-CASSCF object to get around weird inheritance conflicts '''
-        # Fix me for state_average_mix!
-        fcasscf = sacasscf_grad.Gradients.make_fcasscf_sa (self, casscf_attr=casscf_attr,
-                                                           fcisolver_attr=fcisolver_attr)
-        class fcasscf_monkeypatch (fcasscf.__class__):
-            def __init__(self, my_fcas):
-                self.__dict__.update (fcasscf.__dict__)
-            def _base_class (self, my_scf, my_ncas, my_nelecas, **kwargs):
-                return fcasscf.__class__.__bases__[0] ()
-        return fcasscf_monkeypatch (fcasscf)
-        # Matt: do NOT let THIS ^^ godawful bullshit remain in your code by the time you make a pull request!!!
-        # Fix the problem in pyscf.mcscf.newton_casscf or pyscf.mcscf.df instead!
-
     def kernel (self, **kwargs):
         mf_grad = kwargs['mf_grad'] if 'mf_grad' in kwargs else None
         if mf_grad is None: kwargs['mf_grad'] = dfrhf_grad.Gradients (self.base._scf)

--- a/pyscf/df/grad/sacasscf.py
+++ b/pyscf/df/grad/sacasscf.py
@@ -35,7 +35,8 @@ from functools import reduce
 from scipy import linalg
 from pyscf.df.grad.casdm2_util import solve_df_rdm2, grad_elec_dferi, grad_elec_auxresponse_dferi
 
-def Lorb_dot_dgorb_dx (Lorb, mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=None, eris=None, verbose=None, auxbasis_response=True):
+def Lorb_dot_dgorb_dx (Lorb, mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=None, eris=None, verbose=None,
+                       auxbasis_response=True):
     ''' Modification of pyscf.grad.casscf.kernel to compute instead the orbital
     Lagrange term nuclear gradient (sum_pq Lorb_pq d2_Ecas/d_lambda d_kpq)
     This involves removing nuclear-nuclear terms and making the substitution
@@ -60,9 +61,7 @@ def Lorb_dot_dgorb_dx (Lorb, mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=No
     nocc = ncore + ncas
     nelecas = mc.nelecas
     nao, nmo = mo_coeff.shape
-    nao_pair = nao * (nao+1) // 2
 
-    mo_occ = mo_coeff[:,:nocc]
     mo_core = mo_coeff[:,:ncore]
     mo_cas = mo_coeff[:,ncore:nocc]
 
@@ -136,7 +135,7 @@ def Lorb_dot_dgorb_dx (Lorb, mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=No
     vhf1c, vhf1a, vhf1cL, vhf1aL = list (vj - vk * 0.5)
     if auxbasis_response:
         de_aux = vj.aux - 0.5 * vk.aux
-                #      D.T     +    T.D
+        #              D.T     +    T.D
         de_aux = ((de_aux[0,2] + de_aux[2,0]) # core-core
                 + (de_aux[0,3] + de_aux[2,1]) # core-active
                 + (de_aux[1,2] + de_aux[3,0])) # active-core
@@ -155,11 +154,14 @@ def Lorb_dot_dgorb_dx (Lorb, mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=No
     dfcasdm2  = solve_df_rdm2 (mc, mo_cas=(mo_cas, moL_cas), casdm2=casdm2)
     de_eri += grad_elec_dferi (mc, mo_cas=mo_cas, dfcasdm2=dfcasdm2, atmlst=atmlst, max_memory=mc.max_memory)[0]
     if auxbasis_response:
-        de_aux += grad_elec_auxresponse_dferi (mc, mo_cas=mo_cas, dfcasdm2=dfcasdm2, atmlst=atmlst, max_memory=mc.max_memory)[0]
-    dfcasdm2  = solve_df_rdm2 (mc, mo_cas=mo_cas, casdm2=casdm2) 
-    de_eri += grad_elec_dferi (mc, mo_cas=(mo_cas, moL_cas), dfcasdm2=dfcasdm2, atmlst=atmlst, max_memory=mc.max_memory)[0]
+        de_aux += grad_elec_auxresponse_dferi (mc, mo_cas=mo_cas, dfcasdm2=dfcasdm2, atmlst=atmlst,
+                                               max_memory=mc.max_memory)[0]
+    dfcasdm2  = solve_df_rdm2 (mc, mo_cas=mo_cas, casdm2=casdm2)
+    de_eri += grad_elec_dferi (mc, mo_cas=(mo_cas, moL_cas), dfcasdm2=dfcasdm2, atmlst=atmlst,
+                               max_memory=mc.max_memory)[0]
     if auxbasis_response:
-        de_aux += grad_elec_auxresponse_dferi (mc, mo_cas=(mo_cas, moL_cas), dfcasdm2=dfcasdm2, atmlst=atmlst, max_memory=mc.max_memory)[0]
+        de_aux += grad_elec_auxresponse_dferi (mc, mo_cas=(mo_cas, moL_cas), dfcasdm2=dfcasdm2, atmlst=atmlst,
+                                               max_memory=mc.max_memory)[0]
     dfcasdm2 = casdm2 = None
 
     for k, ia in enumerate(atmlst):
@@ -189,7 +191,8 @@ def Lorb_dot_dgorb_dx (Lorb, mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=No
 
     return de
 
-def Lci_dot_dgci_dx (Lci, weights, mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=None, eris=None, verbose=None, auxbasis_response=True):
+def Lci_dot_dgci_dx (Lci, weights, mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=None, eris=None, verbose=None,
+                     auxbasis_response=True):
     ''' Modification of pyscf.grad.casscf.kernel to compute instead the CI
     Lagrange term nuclear gradient (sum_IJ Lci_IJ d2_Ecas/d_lambda d_PIJ)
     This involves removing all core-core and nuclear-nuclear terms and making the substitution
@@ -209,8 +212,6 @@ def Lci_dot_dgci_dx (Lci, weights, mc, mo_coeff=None, ci=None, atmlst=None, mf_g
     nocc = ncore + ncas
     nelecas = mc.nelecas
     nao, nmo = mo_coeff.shape
-    nao_pair = nao * (nao+1) // 2
-    nroots = len (ci)
 
     mo_occ = mo_coeff[:,:nocc]
     mo_core = mo_coeff[:,:ncore]
@@ -341,7 +342,7 @@ def as_scanner(mcscf_grad, state=None):
                 kwargs['state'] = self.state
             de = self.kernel(**kwargs)
             return e_tot, de
-            
+
     return CASSCF_GradScanner(mcscf_grad)
 
 
@@ -354,7 +355,8 @@ class Gradients (sacasscf_grad.Gradients):
     def make_fcasscf_sa (self, casscf_attr={}, fcisolver_attr={}):
         ''' Make a fake SA-CASSCF object to get around weird inheritance conflicts '''
         # Fix me for state_average_mix!
-        fcasscf = sacasscf_grad.Gradients.make_fcasscf_sa (self, casscf_attr=casscf_attr, fcisolver_attr=fcisolver_attr)
+        fcasscf = sacasscf_grad.Gradients.make_fcasscf_sa (self, casscf_attr=casscf_attr,
+                                                           fcisolver_attr=fcisolver_attr)
         class fcasscf_monkeypatch (fcasscf.__class__):
             def __init__(self, my_fcas):
                 self.__dict__.update (fcasscf.__dict__)
@@ -377,4 +379,3 @@ class Gradients (sacasscf_grad.Gradients):
     def get_LdotJnuc (self, Lvec, **kwargs):
         with lib.temporary_env (sacasscf_grad, Lci_dot_dgci_dx=Lci_dot_dgci_dx, Lorb_dot_dgorb_dx=Lorb_dot_dgorb_dx):
             return sacasscf_grad.Gradients.get_LdotJnuc (self, Lvec, **kwargs)
-

--- a/pyscf/df/grad/sacasscf.py
+++ b/pyscf/df/grad/sacasscf.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python
+# Copyright 2014-2022 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Qiming Sun <osirpt.sun@gmail.com>
+#
+
+from pyscf import mcscf, lib, ao2mo
+from pyscf.grad import lagrange
+from pyscf.grad import rhf as rhf_grad
+from pyscf.grad import sacasscf as sacasscf_grad
+from pyscf.grad import casscf as casscf_grad
+from pyscf.grad.mp2 import _shell_prange
+from pyscf.mcscf import mc1step, mc1step_symm, newton_casscf
+from pyscf.mcscf.addons import StateAverageMCSCFSolver
+from pyscf.df.grad import casscf as dfcasscf_grad
+from pyscf.df.grad import rhf as dfrhf_grad
+from pyscf.fci.direct_spin1 import _unpack_nelec
+from pyscf.fci.spin_op import spin_square0
+from pyscf.fci import cistring
+import numpy as np
+import copy, time, gc
+from functools import reduce
+from scipy import linalg
+from pyscf.df.grad.casdm2_util import solve_df_rdm2, grad_elec_dferi, grad_elec_auxresponse_dferi
+
+def Lorb_dot_dgorb_dx (Lorb, mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=None, eris=None, verbose=None, auxbasis_response=True):
+    ''' Modification of pyscf.grad.casscf.kernel to compute instead the orbital
+    Lagrange term nuclear gradient (sum_pq Lorb_pq d2_Ecas/d_lambda d_kpq)
+    This involves removing nuclear-nuclear terms and making the substitution
+    (D_[p]q + D_p[q]) -> D_pq
+    (d_[p]qrs + d_pq[r]s + d_p[q]rs + d_pqr[s]) -> d_pqrs
+    Where [] around an index implies contraction with Lorb from the left, so that the external index
+    (regardless of whether the index on the rdm is bra or ket) is always the first index of Lorb. '''
+
+    # dmo = smoT.dao.smo
+    # dao = mo.dmo.moT
+    t0 = (lib.logger.process_clock (), lib.logger.perf_counter ())
+
+    if mo_coeff is None: mo_coeff = mc.mo_coeff
+    if ci is None: ci = mc.ci
+    if mf_grad is None: mf_grad = dfrhf_grad.Gradients (mc._scf)
+    if mc.frozen is not None:
+        raise NotImplementedError
+
+    mol = mc.mol
+    ncore = mc.ncore
+    ncas = mc.ncas
+    nocc = ncore + ncas
+    nelecas = mc.nelecas
+    nao, nmo = mo_coeff.shape
+    nao_pair = nao * (nao+1) // 2
+
+    mo_occ = mo_coeff[:,:nocc]
+    mo_core = mo_coeff[:,:ncore]
+    mo_cas = mo_coeff[:,ncore:nocc]
+
+    # MRH: new 'effective' MO coefficients including contraction from the Lagrange multipliers
+    moL_coeff = np.dot (mo_coeff, Lorb)
+    s0_inv = np.dot (mo_coeff,  mo_coeff.T)
+    moL_core = moL_coeff[:,:ncore]
+    moL_cas = moL_coeff[:,ncore:nocc]
+
+    # MRH: these SHOULD be state-averaged! Use the actual sacasscf object!
+    casdm1, casdm2 = mc.fcisolver.make_rdm12(ci, ncas, nelecas)
+
+    # gfock = Generalized Fock, Adv. Chem. Phys., 69, 63
+    # MRH: each index exactly once!
+    dm_core = np.dot(mo_core, mo_core.T) * 2
+    dm_cas = reduce(np.dot, (mo_cas, casdm1, mo_cas.T))
+    # MRH: new density matrix terms
+    dmL_core = np.dot(moL_core, mo_core.T) * 2
+    dmL_cas = reduce(np.dot, (moL_cas, casdm1, mo_cas.T))
+    dmL_core += dmL_core.T
+    dmL_cas += dmL_cas.T
+    dm1 = dm_core + dm_cas
+    dm1L = dmL_core + dmL_cas
+    # MRH: end new density matrix terms
+    # MRH: wrap the integral instead of the density matrix. I THINK the sign is the same!
+    # mo sets 0 and 2 should be transposed, 1 and 3 should be not transposed; this will lead to correct sign
+    # Except I can't do this for the external index, because the external index is contracted to ovlp matrix,
+    # not the 2RDM
+    aapa = np.zeros ((ncas, ncas, nmo, ncas), dtype=dm_cas.dtype)
+    aapaL = np.zeros ((ncas, ncas, nmo, ncas), dtype=dm_cas.dtype)
+    for i in range (nmo):
+        jbuf = eris.ppaa[i]
+        kbuf = eris.papa[i]
+        aapa[:,:,i,:] = jbuf[ncore:nocc,:,:].transpose (1,2,0)
+        aapaL[:,:,i,:] += np.tensordot (jbuf, Lorb[:,ncore:nocc], axes=((0),(0)))
+        kbuf = np.tensordot (kbuf, Lorb[:,ncore:nocc], axes=((1),(0))).transpose (1,2,0)
+        aapaL[:,:,i,:] += kbuf + kbuf.transpose (1,0,2)
+    # MRH: new vhf terms
+    vj, vk   = mc._scf.get_jk(mol, (dm_core,  dm_cas))
+    vjL, vkL = mc._scf.get_jk(mol, (dmL_core, dmL_cas))
+    h1 = mc.get_hcore()
+    vhf_c = vj[0] - vk[0] * .5
+    vhf_a = vj[1] - vk[1] * .5
+    vhfL_c = vjL[0] - vkL[0] * .5
+    vhfL_a = vjL[1] - vkL[1] * .5
+    # MRH: I rewrote this Feff calculation completely, double-check it
+    gfock  = np.dot (h1, dm1L) # h1e
+    gfock += np.dot ((vhf_c + vhf_a), dmL_core) # core-core and active-core, 2nd 1RDM linked
+    gfock += np.dot ((vhfL_c + vhfL_a), dm_core) # core-core and active-core, 1st 1RDM linked
+    gfock += np.dot (vhfL_c, dm_cas) # core-active, 1st 1RDM linked
+    gfock += np.dot (vhf_c, dmL_cas) # core-active, 2nd 1RDM linked
+    gfock  = np.dot (s0_inv, gfock) # Definition of quantity is in MO's; going (AO->MO->AO) incurs an inverse ovlp
+    gfock += reduce (np.dot, (mo_coeff, np.einsum('uviw,uvtw->it', aapaL, casdm2), mo_cas.T)) # active-active
+    # MRH: I have to contract this external 2RDM index explicitly on the 2RDM but fortunately I can do so here
+    gfock += reduce (np.dot, (mo_coeff, np.einsum('uviw,vuwt->it', aapa, casdm2), moL_cas.T))
+    # MRH: As of 04/18/2019, the two-body part of this is including aapaL is definitely, unambiguously correct
+    dme0 = (gfock+gfock.T)/2 # This transpose is for the overlap matrix later on
+    aapa = vj = vk = vhf_c = vhf_a = None
+
+    if atmlst is None:
+        atmlst = list (range(mol.natm))
+    aoslices = mol.aoslice_by_atom()
+    de_hcore = np.zeros((len(atmlst),3))
+    de_renorm = np.zeros((len(atmlst),3))
+    de_eri = np.zeros((len(atmlst),3))
+    de_aux = np.zeros((len(atmlst),3))
+    de = np.zeros((len(atmlst),3))
+
+    #vhf1c, vhf1a, vhf1cL, vhf1aL = mf_grad.get_veff(mol, (dm_core, dm_cas, dmL_core, dmL_cas))
+    vj, vk = mf_grad.get_jk (mol, (dm_core, dm_cas, dmL_core, dmL_cas), ishf=False)
+    vhf1c, vhf1a, vhf1cL, vhf1aL = list (vj - vk * 0.5)
+    if auxbasis_response:
+        de_aux = vj.aux - 0.5 * vk.aux
+                #      D.T     +    T.D
+        de_aux = ((de_aux[0,2] + de_aux[2,0]) # core-core
+                + (de_aux[0,3] + de_aux[2,1]) # core-active
+                + (de_aux[1,2] + de_aux[3,0])) # active-core
+    vj = vk = None
+    hcore_deriv = mf_grad.hcore_generator(mol)
+    s1 = mf_grad.get_ovlp(mol)
+
+
+    t0 = lib.logger.timer (mc, 'SA-CASSCF Lorb_dot_dgorb 1-electron part', *t0)
+
+    # I am trying to contract the eris with a notional casdm2 which has four separate terms.
+    casdm2 += casdm2.transpose (1,0,3,2) # Now I should only need 2 separate terms...
+    # The bare 3-center eris and the auxbasis derivatives are always symmetric wrt AOs
+    # grad_elec_dferi is explicitly symmetrized wrt AOs.
+    # If this fails I can always debug it by kludging ncore, ncas -> 0, nmo
+    dfcasdm2  = solve_df_rdm2 (mc, mo_cas=(mo_cas, moL_cas), casdm2=casdm2)
+    de_eri += grad_elec_dferi (mc, mo_cas=mo_cas, dfcasdm2=dfcasdm2, atmlst=atmlst, max_memory=mc.max_memory)[0]
+    if auxbasis_response:
+        de_aux += grad_elec_auxresponse_dferi (mc, mo_cas=mo_cas, dfcasdm2=dfcasdm2, atmlst=atmlst, max_memory=mc.max_memory)[0]
+    dfcasdm2  = solve_df_rdm2 (mc, mo_cas=mo_cas, casdm2=casdm2) 
+    de_eri += grad_elec_dferi (mc, mo_cas=(mo_cas, moL_cas), dfcasdm2=dfcasdm2, atmlst=atmlst, max_memory=mc.max_memory)[0]
+    if auxbasis_response:
+        de_aux += grad_elec_auxresponse_dferi (mc, mo_cas=(mo_cas, moL_cas), dfcasdm2=dfcasdm2, atmlst=atmlst, max_memory=mc.max_memory)[0]
+    dfcasdm2 = casdm2 = None
+
+    for k, ia in enumerate(atmlst):
+        shl0, shl1, p0, p1 = aoslices[ia]
+        h1ao = hcore_deriv(ia)
+        # MRH: h1e and Feff terms
+        de_hcore[k] += np.einsum('xij,ij->x', h1ao, dm1L)
+        de_renorm[k] -= np.einsum('xij,ij->x', s1[:,p0:p1], dme0[p0:p1]) * 2
+        # MRH: core-core and core-active 2RDM terms
+        de_eri[k] += np.einsum('xij,ij->x', vhf1c[:,p0:p1], dm1L[p0:p1]) * 2
+        de_eri[k] += np.einsum('xij,ij->x', vhf1cL[:,p0:p1], dm1[p0:p1]) * 2
+        # MRH: active-core 2RDM terms
+        de_eri[k] += np.einsum('xij,ij->x', vhf1a[:,p0:p1], dmL_core[p0:p1]) * 2
+        de_eri[k] += np.einsum('xij,ij->x', vhf1aL[:,p0:p1], dm_core[p0:p1]) * 2
+
+    # MRH: deleted the nuclear-nuclear part to avoid double-counting
+    # lesson learned from debugging - mol.intor computes -1 * the derivative and only
+    # for one index
+    # on the other hand, mf_grad.hcore_generator computes the actual derivative of
+    # h1 for both indices and with the correct sign
+
+    lib.logger.debug (mc, "Orb lagrange hcore component:\n{}".format (de_hcore))
+    lib.logger.debug (mc, "Orb lagrange renorm component:\n{}".format (de_renorm))
+    lib.logger.debug (mc, "Orb lagrange eri component:\n{}".format (de_eri))
+    lib.logger.debug (mc, "Orb lagrange aux component:\n{}".format (de_aux))
+    de = de_hcore + de_renorm + de_eri + de_aux
+
+    return de
+
+def Lci_dot_dgci_dx (Lci, weights, mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=None, eris=None, verbose=None, auxbasis_response=True):
+    ''' Modification of pyscf.grad.casscf.kernel to compute instead the CI
+    Lagrange term nuclear gradient (sum_IJ Lci_IJ d2_Ecas/d_lambda d_PIJ)
+    This involves removing all core-core and nuclear-nuclear terms and making the substitution
+    sum_I w_I<L_I|p'q|I> + c.c. -> <0|p'q|0>
+    sum_I w_I<L_I|p'r'sq|I> + c.c. -> <0|p'r'sq|0>
+    The active-core terms (sum_I w_I<L_I|x'iyi|I>, sum_I w_I <L_I|x'iiy|I>, c.c.) must be retained.'''
+    if mo_coeff is None: mo_coeff = mc.mo_coeff
+    if ci is None: ci = mc.ci
+    if mf_grad is None: mf_grad = dfrhf_grad.Gradients (mc._scf)
+    if mc.frozen is not None:
+        raise NotImplementedError
+
+    t0 = (lib.logger.process_clock (), lib.logger.perf_counter ())
+    mol = mc.mol
+    ncore = mc.ncore
+    ncas = mc.ncas
+    nocc = ncore + ncas
+    nelecas = mc.nelecas
+    nao, nmo = mo_coeff.shape
+    nao_pair = nao * (nao+1) // 2
+    nroots = len (ci)
+
+    mo_occ = mo_coeff[:,:nocc]
+    mo_core = mo_coeff[:,:ncore]
+    mo_cas = mo_coeff[:,ncore:nocc]
+
+    # MRH: TDMs + c.c. instead of RDMs; 06/30/2020: new interface in mcscf.addons makes this much more transparent
+    casdm1, casdm2 = mc.fcisolver.trans_rdm12 (Lci, ci, ncas, nelecas)
+    casdm1 += casdm1.transpose (1,0)
+    casdm2 += casdm2.transpose (1,0,3,2)
+
+# gfock = Generalized Fock, Adv. Chem. Phys., 69, 63
+    dm_core = np.dot(mo_core, mo_core.T) * 2
+    dm_cas = reduce(np.dot, (mo_cas, casdm1, mo_cas.T))
+    aapa = np.zeros ((ncas, ncas, nmo, ncas), dtype=dm_cas.dtype)
+    for i in range (nmo):
+        aapa[:,:,i,:] = eris.ppaa[i][ncore:nocc,:,:].transpose (1,2,0)
+    vj, vk = mc._scf.get_jk(mol, (dm_core, dm_cas))
+    h1 = mc.get_hcore()
+    vhf_c = vj[0] - vk[0] * .5
+    vhf_a = vj[1] - vk[1] * .5
+    # MRH: delete h1 + vhf_c from the first line below (core and core-core stuff)
+    # Also extend gfock to span the whole space
+    gfock = np.zeros_like (dm_cas)
+    gfock[:,:nocc]   = reduce(np.dot, (mo_coeff.T, vhf_a, mo_occ)) * 2
+    gfock[:,ncore:nocc]  = reduce(np.dot, (mo_coeff.T, h1 + vhf_c, mo_cas, casdm1))
+    gfock[:,ncore:nocc] += np.einsum('uvpw,vuwt->pt', aapa, casdm2)
+    dme0 = reduce(np.dot, (mo_coeff, (gfock+gfock.T)*.5, mo_coeff.T))
+    aapa = vj = vk = vhf_c = vhf_a = h1 = gfock = None
+
+    if atmlst is None:
+        atmlst = range(mol.natm)
+    aoslices = mol.aoslice_by_atom()
+    de_hcore = np.zeros((len(atmlst),3))
+    de_renorm = np.zeros((len(atmlst),3))
+    de_eri = np.zeros((len(atmlst),3))
+    de_aux = np.zeros((len(atmlst),3))
+    de = np.zeros((len(atmlst),3))
+
+    #vhf1c, vhf1a = mf_grad.get_veff(mol, (dm_core, dm_cas))
+    vj, vk = mf_grad.get_jk (mol, (dm_core, dm_cas), ishf=False)
+    if auxbasis_response:
+        de_aux = vj.aux - 0.5 * vk.aux
+        de_aux = de_aux[0,1] + de_aux[1,0]
+        # ^ de_aux[0,0] not included b/c this is CAS lagrange multipliers
+    vhf1c, vhf1a = list (vj - vk * 0.5)
+    vj = vk = None
+    hcore_deriv = mf_grad.hcore_generator(mol)
+    s1 = mf_grad.get_ovlp(mol)
+
+    dfcasdm2 = casdm2 = solve_df_rdm2 (mc, mo_cas=mo_cas, casdm2=casdm2)
+    de_eri = grad_elec_dferi (mc, mo_cas=mo_cas, dfcasdm2=dfcasdm2, atmlst=atmlst,
+        max_memory=mc.max_memory)[0]
+    if auxbasis_response:
+        de_aux += grad_elec_auxresponse_dferi (mc, mo_cas=mo_cas, dfcasdm2=dfcasdm2,
+            atmlst=atmlst, max_memory=mc.max_memory)[0]
+    dfcasdm2 = casdm2 = None
+
+    t0 = lib.logger.timer (mc, 'SA-CASSCF Lci_dot_dgci 1-electron part', *t0)
+
+    for k, ia in enumerate(atmlst):
+        shl0, shl1, p0, p1 = aoslices[ia]
+        h1ao = hcore_deriv(ia)
+        # MRH: dm1 -> dm_cas in the line below
+        de_hcore[k] += np.einsum('xij,ij->x', h1ao, dm_cas)
+        de_renorm[k] -= np.einsum('xij,ij->x', s1[:,p0:p1], dme0[p0:p1]) * 2
+        # MRH: dm1 -> dm_cas in the line below. Also eliminate core-core terms
+        de_eri[k] += np.einsum('xij,ij->x', vhf1c[:,p0:p1], dm_cas[p0:p1]) * 2
+        de_eri[k] += np.einsum('xij,ij->x', vhf1a[:,p0:p1], dm_core[p0:p1]) * 2
+
+    lib.logger.debug (mc, "CI lagrange hcore component:\n{}".format (de_hcore))
+    lib.logger.debug (mc, "CI lagrange renorm component:\n{}".format (de_renorm))
+    lib.logger.debug (mc, "CI lagrange eri component:\n{}".format (de_eri))
+    lib.logger.debug (mc, "CI lagrange aux component:\n{}".format (de_aux))
+    de = de_hcore + de_renorm + de_eri + de_aux
+    return de
+
+def as_scanner(mcscf_grad, state=None):
+    '''Generating a nuclear gradients scanner/solver (for geometry optimizer).
+
+    The returned solver is a function. This function requires one argument
+    "mol" as input and returns energy and first order nuclear derivatives.
+
+    The solver will automatically use the results of last calculation as the
+    initial guess of the new calculation.  All parameters assigned in the
+    nuc-grad object and SCF object (DIIS, conv_tol, max_memory etc) are
+    automatically applied in the solver.
+
+    Note scanner has side effects.  It may change many underlying objects
+    (_scf, with_df, with_x2c, ...) during calculation.
+
+    Examples:
+
+    >>> from pyscf import gto, scf, mcscf
+    >>> mol = gto.M(atom='N 0 0 0; N 0 0 1.1', verbose=0)
+    >>> mc_grad_scanner = mcscf.CASSCF(scf.RHF(mol), 4, 4).nuc_grad_method().as_scanner()
+    >>> etot, grad = mc_grad_scanner(gto.M(atom='N 0 0 0; N 0 0 1.1'))
+    >>> etot, grad = mc_grad_scanner(gto.M(atom='N 0 0 0; N 0 0 1.5'))
+    '''
+    from pyscf import gto
+    if isinstance(mcscf_grad, lib.GradScanner):
+        return mcscf_grad
+
+    if state is None and (not hasattr (mcscf_grad, 'state') or (mcscf_grad.state is None)):
+        return dfcasscf_grad.as_scanner (mcscf_grad)
+
+    lib.logger.info(mcscf_grad, 'Create scanner for %s', mcscf_grad.__class__)
+
+    class CASSCF_GradScanner(mcscf_grad.__class__, lib.GradScanner):
+        def __init__(self, g):
+            lib.GradScanner.__init__(self, g)
+            if state is None:
+                self.state = g.state
+            else:
+                self.state = state
+        def __call__(self, mol_or_geom, **kwargs):
+            if isinstance(mol_or_geom, gto.Mole):
+                mol = mol_or_geom
+            else:
+                mol = self.mol.set_geom_(mol_or_geom, inplace=False)
+
+            mc_scanner = self.base
+            e_tot = mc_scanner(mol)
+            if hasattr (mc_scanner, 'e_mcscf'): self.e_mcscf = mc_scanner.e_mcscf
+            #if isinstance (e_tot, (list, tuple, np.ndarray)): e_tot = e_tot[self.state]
+            if hasattr (mc_scanner, 'e_states'): e_tot = mc_scanner.e_states[self.state]
+            self.mol = mol
+            if not ('state' in kwargs):
+                kwargs['state'] = self.state
+            de = self.kernel(**kwargs)
+            return e_tot, de
+            
+    return CASSCF_GradScanner(mcscf_grad)
+
+
+class Gradients (sacasscf_grad.Gradients):
+
+    def __init__(self, mc, state=None):
+        self.auxbasis_response = True
+        sacasscf_grad.Gradients.__init__(self, mc, state=state)
+
+    def make_fcasscf_sa (self, casscf_attr={}, fcisolver_attr={}):
+        ''' Make a fake SA-CASSCF object to get around weird inheritance conflicts '''
+        # Fix me for state_average_mix!
+        fcasscf = sacasscf_grad.Gradients.make_fcasscf_sa (self, casscf_attr=casscf_attr, fcisolver_attr=fcisolver_attr)
+        class fcasscf_monkeypatch (fcasscf.__class__):
+            def __init__(self, my_fcas):
+                self.__dict__.update (fcasscf.__dict__)
+            def _base_class (self, my_scf, my_ncas, my_nelecas, **kwargs):
+                return fcasscf.__class__.__bases__[0] ()
+        return fcasscf_monkeypatch (fcasscf)
+        # Matt: do NOT let THIS ^^ godawful bullshit remain in your code by the time you make a pull request!!!
+        # Fix the problem in pyscf.mcscf.newton_casscf or pyscf.mcscf.df instead!
+
+    def kernel (self, **kwargs):
+        mf_grad = kwargs['mf_grad'] if 'mf_grad' in kwargs else None
+        if mf_grad is None: kwargs['mf_grad'] = dfrhf_grad.Gradients (self.base._scf)
+        # The below only works because dfcasscf_grad is NOT a child of casscf_grad
+        # For instance, I can't monkeypatch rhf_grad this way b/c dfrhf_grad refers to rhf_grad
+        # Maybe it should be, in which case I will have to change this
+        # But on the other hand maybe it can be even simpler?
+        with lib.temporary_env (casscf_grad, Gradients=dfcasscf_grad.Gradients):
+            return sacasscf_grad.Gradients.kernel (self, **kwargs)
+
+    def get_LdotJnuc (self, Lvec, **kwargs):
+        with lib.temporary_env (sacasscf_grad, Lci_dot_dgci_dx=Lci_dot_dgci_dx, Lorb_dot_dgorb_dx=Lorb_dot_dgorb_dx):
+            return sacasscf_grad.Gradients.get_LdotJnuc (self, Lvec, **kwargs)
+

--- a/pyscf/df/grad/sacasscf.py
+++ b/pyscf/df/grad/sacasscf.py
@@ -131,7 +131,7 @@ def Lorb_dot_dgorb_dx (Lorb, mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=No
     de = np.zeros((len(atmlst),3))
 
     #vhf1c, vhf1a, vhf1cL, vhf1aL = mf_grad.get_veff(mol, (dm_core, dm_cas, dmL_core, dmL_cas))
-    vj, vk = mf_grad.get_jk (mol, (dm_core, dm_cas, dmL_core, dmL_cas), ishf=False)
+    vj, vk = mf_grad.get_jk (mol, (dm_core, dm_cas, dmL_core, dmL_cas))
     vhf1c, vhf1a, vhf1cL, vhf1aL = list (vj - vk * 0.5)
     if auxbasis_response:
         de_aux = vj.aux - 0.5 * vk.aux
@@ -251,7 +251,7 @@ def Lci_dot_dgci_dx (Lci, weights, mc, mo_coeff=None, ci=None, atmlst=None, mf_g
     de = np.zeros((len(atmlst),3))
 
     #vhf1c, vhf1a = mf_grad.get_veff(mol, (dm_core, dm_cas))
-    vj, vk = mf_grad.get_jk (mol, (dm_core, dm_cas), ishf=False)
+    vj, vk = mf_grad.get_jk (mol, (dm_core, dm_cas))
     if auxbasis_response:
         de_aux = vj.aux - 0.5 * vk.aux
         de_aux = de_aux[0,1] + de_aux[1,0]

--- a/pyscf/df/grad/uhf.py
+++ b/pyscf/df/grad/uhf.py
@@ -22,7 +22,7 @@
 # Author: Qiming Sun <osirpt.sun@gmail.com>
 #
 
-
+import numpy
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf.grad import uhf as uhf_grad
@@ -49,7 +49,8 @@ class Gradients(uhf_grad.Gradients):
         vj, vk = self.get_jk(mol, dm)
         vhf = vj[0]+vj[1] - vk
         if self.auxbasis_response:
-            e1_aux = vj.aux - vk.aux
+            e1_aux = vj.aux.sum ((0,1))
+            e1_aux -= numpy.trace (vk.aux, axis1=0, axis2=1)
             logger.debug1(self, 'sum(auxbasis response) %s', e1_aux.sum(axis=0))
             vhf = lib.tag_array(vhf, aux=e1_aux)
         return vhf

--- a/pyscf/df/grad/uks.py
+++ b/pyscf/df/grad/uks.py
@@ -23,7 +23,7 @@
 #
 
 
-
+import numpy
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf.grad import uks as uks_grad
@@ -68,7 +68,7 @@ def get_veff(ks_grad, mol=None, dm=None):
         vj = ks_grad.get_j(mol, dm)
         vxc += vj[0] + vj[1]
         if ks_grad.auxbasis_response:
-            e1_aux = vj.aux
+            e1_aux = vj.aux.sum ((0,1))
     else:
         vj, vk = ks_grad.get_jk(mol, dm)
         if ks_grad.auxbasis_response:
@@ -82,7 +82,8 @@ def get_veff(ks_grad, mol=None, dm=None):
                 vk_aux += vk_lr.aux * (alpha - hyb)
         vxc += vj[0] + vj[1] - vk
         if ks_grad.auxbasis_response:
-            e1_aux = vj.aux - vk_aux
+            e1_aux = vj.aux.sum ((0,1))
+            e1_aux -= numpy.trace (vk_aux, axis1=0, axis2=1)
 
     if ks_grad.auxbasis_response:
         logger.debug1(ks_grad, 'sum(auxbasis response) %s', e1_aux.sum(axis=0))

--- a/pyscf/grad/rhf.py
+++ b/pyscf/grad/rhf.py
@@ -46,6 +46,7 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     hcore_deriv = mf_grad.hcore_generator(mol)
     s1 = mf_grad.get_ovlp(mol)
     dm0 = mf.make_rdm1(mo_coeff, mo_occ)
+    dm0 = mf_grad._tag_rdm1 (dm0, mo_coeff, mo_occ)
 
     t0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Computing Gradients of NR-HF Coulomb repulsion')
@@ -410,6 +411,10 @@ class GradientsMixin(lib.StreamObject):
 
     as_scanner = as_scanner
 
+    def _tag_rdm1 (self, dm, mo_coeff, mo_occ):
+        '''Tagging is necessary in DF subclass. Tagged arrays need
+        to be split into alpha,beta in DF-ROHF subclass'''
+        return lib.tag_array (dm, mo_coeff=mo_coeff, mo_occ=mo_occ)
 
 class Gradients(GradientsMixin):
     '''Non-relativistic restricted Hartree-Fock gradients'''

--- a/pyscf/grad/rohf.py
+++ b/pyscf/grad/rohf.py
@@ -38,6 +38,14 @@ def make_rdm1e(mf_grad, mo_energy, mo_coeff, mo_occ):
     rdm1e_b = reduce(numpy.dot, (mocc_b, mocc_b.conj().T, fb, mocc_b, mocc_b.conj().T))
     return numpy.array((rdm1e_a, rdm1e_b))
 
+def _tag_rdm1 (self, dm, mo_coeff, mo_occ):
+    mo_coeff = numpy.stack ((mo_coeff,mo_coeff), axis=0)
+    mo_occa = numpy.array (mo_occ>0, dtype=numpy.double)
+    mo_occb = numpy.array (mo_occ==2, dtype=numpy.double)
+    assert (mo_occa.sum () + mo_occb.sum () == mo_occ.sum())
+    mo_occ = numpy.vstack ((mo_occa,mo_occb))
+    return lib.tag_array (dm, mo_coeff=mo_coeff, mo_occ=mo_occ)
+
 class Gradients(rhf_grad.Gradients):
     '''Non-relativistic restricted open-shell Hartree-Fock gradients
     '''
@@ -47,6 +55,8 @@ class Gradients(rhf_grad.Gradients):
     make_rdm1e = make_rdm1e
 
     grad_elec = uhf_grad.grad_elec
+
+    _tag_rdm1 = _tag_rdm1
 
 Grad = Gradients
 

--- a/pyscf/grad/roks.py
+++ b/pyscf/grad/roks.py
@@ -38,6 +38,8 @@ class Gradients(rks_grad.Gradients):
 
     grad_elec = uhf_grad.grad_elec
 
+    _tag_rdm1 = rohf_grad._tag_rdm1
+
 Grad = Gradients
 
 from pyscf import dft

--- a/pyscf/grad/test/test_casscf.py
+++ b/pyscf/grad/test/test_casscf.py
@@ -18,6 +18,8 @@ from pyscf.grad import rhf as rhf_grad
 from pyscf.grad import casscf as casscf_grad
 from pyscf.grad.mp2 import _shell_prange
 from pyscf.fci.addons import fix_spin_
+from pyscf.df.grad import casscf as dfcasscf_grad
+from pyscf.df.grad import sacasscf as dfsacasscf_grad
 
 def grad_elec(mc, mf_grad):
     mf = mf_grad.base
@@ -80,7 +82,7 @@ def grad_elec(mc, mf_grad):
     return de
 
 def setUpModule():
-    global mol, mf
+    global mol, mf, mf_df
     mol = gto.Mole()
     mol.atom = 'N 0 0 0; N 0 0 1.2; H 1 1 0; H 1 1 1.2'
     mol.verbose = 5
@@ -88,6 +90,7 @@ def setUpModule():
     mol.symmetry = False
     mol.build()
     mf = scf.RHF(mol).run(conv_tol=1e-12)
+    mf_df = mf.density_fit ().run ()
 
 def tearDownModule():
     global mol, mf
@@ -103,6 +106,17 @@ class KnownValues(unittest.TestCase):
         g1ref = grad_elec(mc, mf.nuc_grad_method())
         g1ref += rhf_grad.grad_nuc(mol)
         self.assertAlmostEqual(abs(g1-g1ref).max(), 0, 7)
+
+        mcs = mc.as_scanner()
+        pmol = mol.copy()
+        e1 = mcs(pmol.set_geom_('N 0 0 0; N 0 0 1.201; H 1 1 0; H 1 1 1.2'))
+        e2 = mcs(pmol.set_geom_('N 0 0 0; N 0 0 1.199; H 1 1 0; H 1 1 1.2'))
+        self.assertAlmostEqual(g1[1,2], (e1-e2)/0.002*lib.param.BOHR, 4)
+
+    def test_df_casscf_grad(self):
+        mc = mcscf.CASSCF(mf_df, 4, 4).run()
+        g1 = dfcasscf_grad.Gradients(mc).kernel()
+        self.assertAlmostEqual(lib.fp(g1), -0.06511650686095324, 6)
 
         mcs = mc.as_scanner()
         pmol = mol.copy()
@@ -169,6 +183,36 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(lib.fp(de_0), -6.398928175384316e-02, 5)
         self.assertAlmostEqual(e_1, -1.083774262088640e+02, 6)
         self.assertAlmostEqual(lib.fp(de_1), -1.428890918624837e-01, 4)
+        self.assertAlmostEqual(de_avg[1,2], (e1_avg-e2_avg)/0.002*lib.param.BOHR, 4)
+        self.assertAlmostEqual(de_0[1,2], (e1_0-e2_0)/0.002*lib.param.BOHR, 4)
+        self.assertAlmostEqual(de_1[1,2], (e1_1-e2_1)/0.002*lib.param.BOHR, 4)
+
+    def test_df_state_average_scanner(self):
+        mc = mcscf.CASSCF(mf_df, 4, 4)
+        mc.conv_tol = 1e-10 # B/c high sensitivity in the numerical test
+        mc.fcisolver.conv_tol = 1e-10
+        gs = dfsacasscf_grad.Gradients (mc.state_average_([0.5, 0.5]))
+        gs = gs.as_scanner ()
+        e_avg, de_avg = gs(mol)
+        e_0, de_0 = gs(mol, state=0)
+        e_1, de_1 = gs(mol, state=1)
+        mcs = gs.base
+        pmol = mol.copy()
+        mcs(pmol.set_geom_('N 0 0 0; N 0 0 1.201; H 1 1 0; H 1 1 1.2'))
+        e1_avg = mcs.e_average
+        e1_0 = mcs.e_states[0]
+        e1_1 = mcs.e_states[1]
+        mcs(pmol.set_geom_('N 0 0 0; N 0 0 1.199; H 1 1 0; H 1 1 1.2'))
+        e2_avg = mcs.e_average
+        e2_0 = mcs.e_states[0]
+        e2_1 = mcs.e_states[1]
+
+        #self.assertAlmostEqual(e_avg, -1.083838462140703e+02, 6)
+        #self.assertAlmostEqual(lib.fp(de_avg), -1.034340877615413e-01, 4)
+        #self.assertAlmostEqual(e_0, -1.083902662192770e+02, 6)
+        #self.assertAlmostEqual(lib.fp(de_0), -6.398928175384316e-02, 5)
+        #self.assertAlmostEqual(e_1, -1.083774262088640e+02, 6)
+        #self.assertAlmostEqual(lib.fp(de_1), -1.428890918624837e-01, 4)
         self.assertAlmostEqual(de_avg[1,2], (e1_avg-e2_avg)/0.002*lib.param.BOHR, 4)
         self.assertAlmostEqual(de_0[1,2], (e1_0-e2_0)/0.002*lib.param.BOHR, 4)
         self.assertAlmostEqual(de_1[1,2], (e1_1-e2_1)/0.002*lib.param.BOHR, 4)

--- a/pyscf/grad/test/test_casscf.py
+++ b/pyscf/grad/test/test_casscf.py
@@ -191,8 +191,7 @@ class KnownValues(unittest.TestCase):
         mc = mcscf.CASSCF(mf_df, 4, 4)
         mc.conv_tol = 1e-10 # B/c high sensitivity in the numerical test
         mc.fcisolver.conv_tol = 1e-10
-        gs = dfsacasscf_grad.Gradients (mc.state_average_([0.5, 0.5]))
-        gs = gs.as_scanner ()
+        gs = mc.state_average_([0.5, 0.5]).nuc_grad_method().as_scanner()
         e_avg, de_avg = gs(mol)
         e_0, de_0 = gs(mol, state=0)
         e_1, de_1 = gs(mol, state=1)

--- a/pyscf/grad/test/test_rhf.py
+++ b/pyscf/grad/test/test_rhf.py
@@ -141,8 +141,8 @@ class KnownValues(unittest.TestCase):
         mf = scf.RHF(mol).density_fit ()
         mf.conv_tol = 1e-14
         e0 = mf.kernel()
-        g = grad.RHF(mf).kernel(atmlst=range(mol.natm))
-        self.assertAlmostEqual(lib.fp(g), 0.005513248517864607, 6)
+        g = mf.nuc_grad_method ().kernel(atmlst=range(mol.natm))
+        self.assertAlmostEqual(lib.fp(g), 0.005516675903099752, 6)
 
         mf_scanner = mf.as_scanner()
         pmol = mol.copy()

--- a/pyscf/grad/test/test_rhf.py
+++ b/pyscf/grad/test/test_rhf.py
@@ -57,6 +57,16 @@ class KnownValues(unittest.TestCase):
         e2 = mfs('O  0.  0.  0.001; H  0.  -0.757  0.587; H  0.  0.757   0.587')
         self.assertAlmostEqual(g[0,2], (e2-e1)/0.002*lib.param.BOHR, 5)
 
+    def test_df_rhf_grad(self):
+        g_scan = scf.RHF(mol).density_fit ().nuc_grad_method().as_scanner()
+        g = g_scan(mol)[1]
+        self.assertAlmostEqual(lib.fp(g), 0.005516638190188906, 7)
+
+        mfs = g_scan.base.as_scanner()
+        e1 = mfs('O  0.  0. -0.001; H  0.  -0.757  0.587; H  0.  0.757   0.587')
+        e2 = mfs('O  0.  0.  0.001; H  0.  -0.757  0.587; H  0.  0.757   0.587')
+        self.assertAlmostEqual(g[0,2], (e2-e1)/0.002*lib.param.BOHR, 5)
+
     def test_x2c_rhf_grad(self):
         h2o = gto.Mole()
         h2o.verbose = 0
@@ -108,6 +118,31 @@ class KnownValues(unittest.TestCase):
         e0 = mf.kernel()
         g = grad.RHF(mf).kernel(atmlst=range(mol.natm))
         self.assertAlmostEqual(lib.fp(g), 0.0055115512502467556, 6)
+
+        mf_scanner = mf.as_scanner()
+        pmol = mol.copy()
+        e1 = mf_scanner(pmol.set_geom_('O  0. 0. 0.0001; 1  0. -0.757 0.587; 1  0. 0.757 0.587'))
+        e2 = mf_scanner(pmol.set_geom_('O  0. 0. -.0001; 1  0. -0.757 0.587; 1  0. 0.757 0.587'))
+        self.assertAlmostEqual(g[0,2], (e1-e2)/2e-4*lib.param.BOHR, 5)
+
+        #e1 = mf_scanner(pmol.set_geom_('O  0.  1e-5 0.; 1  0. -0.757 0.587; 1  0. 0.757 0.587'))
+        #e2 = mf_scanner(pmol.set_geom_('O  0. -1e-5 0.; 1  0. -0.757 0.587; 1  0. 0.757 0.587'))
+        #self.assertAlmostEqual(g[0,1], (e1-e2)/2e-5*lib.param.BOHR, 5)
+
+        #e1 = mf_scanner(pmol.set_geom_('O  0. 0. 0.; 1  0. -0.7571 0.587; 1  0. 0.757 0.587'))
+        #e2 = mf_scanner(pmol.set_geom_('O  0. 0. 0.; 1  0. -0.7569 0.587; 1  0. 0.757 0.587'))
+        #self.assertAlmostEqual(g[1,1], (e2-e1)/2e-4*lib.param.BOHR, 5)
+
+        #e1 = mf_scanner(pmol.set_geom_('O  0. 0. 0.; 1  0. -0.757 0.5871; 1  0. 0.757 0.587'))
+        #e2 = mf_scanner(pmol.set_geom_('O  0. 0. 0.; 1  0. -0.757 0.5869; 1  0. 0.757 0.587'))
+        #self.assertAlmostEqual(g[1,2], (e1-e2)/2e-4*lib.param.BOHR, 5)
+
+    def test_finite_diff_df_rhf_grad(self):
+        mf = scf.RHF(mol).density_fit ()
+        mf.conv_tol = 1e-14
+        e0 = mf.kernel()
+        g = grad.RHF(mf).kernel(atmlst=range(mol.natm))
+        self.assertAlmostEqual(lib.fp(g), 0.005513248517864607, 6)
 
         mf_scanner = mf.as_scanner()
         pmol = mol.copy()

--- a/pyscf/grad/test/test_rks.py
+++ b/pyscf/grad/test/test_rks.py
@@ -190,6 +190,17 @@ class KnownValues(unittest.TestCase):
         e2 = mf_scanner(mol1.set_geom_('O  0. 0. -.0001; 1  0. -0.757 0.587; 1  0. 0.757 0.587'))
         self.assertAlmostEqual(g[0,2], (e1-e2)/2e-4*lib.param.BOHR, 6)
 
+    def test_finite_diff_df_rks_grad(self):
+        mf1 = mf.density_fit ().run ()
+        g = mf1.nuc_grad_method ().set (grid_response=True).kernel ()
+        self.assertAlmostEqual(lib.fp(g), -0.04990623577718451, 6)
+
+        mol1 = mol.copy()
+        mf_scanner = mf1.as_scanner()
+        e1 = mf_scanner(mol1.set_geom_('O  0. 0. 0.0001; 1  0. -0.757 0.587; 1  0. 0.757 0.587'))
+        e2 = mf_scanner(mol1.set_geom_('O  0. 0. -.0001; 1  0. -0.757 0.587; 1  0. 0.757 0.587'))
+        self.assertAlmostEqual(g[0,2], (e1-e2)/2e-4*lib.param.BOHR, 6)
+
     def test_rks_grad_lda(self):
         mol_hf = gto.Mole()
         mol_hf.atom = [

--- a/pyscf/grad/test/test_rohf.py
+++ b/pyscf/grad/test/test_rohf.py
@@ -109,6 +109,75 @@ H              0.99207379    1.16253558   -0.88226569
 H             -0.43459905    0.65805058   -0.00861418''')
         self.assertAlmostEqual(g[2,1], (e2-e1)/2e-4*lib.param.BOHR, 7)
 
+    def test_finite_diff_df_rohf_grad(self):
+        mf = scf.ROHF(mol).density_fit ()
+        mf.conv_tol = 1e-14
+        e0 = mf.kernel()
+        mf_grad = mf.nuc_grad_method ()
+        ### BEGIN DEBUGGING ###
+        # from pyscf.grad.rohf import make_rdm1e
+        # from functools import partial
+        # mf_grad.make_rdm1e = partial (make_rdm1e, mf_grad)
+        ### END DEBUGGING ###
+        g = mf_grad.kernel()
+        mf_scanner = mf.as_scanner()
+
+        e1 = mf_scanner('''O    0.   0.       0.
+                        H     0.8  0.3      0.2
+                        H    0.   -0.758   0.587
+                        H    0.   0.757    0.587''')
+        e2 = mf_scanner('''O    0.   0.       0.
+                        H     0.8  0.3      0.2
+                        H    0.   -0.756   0.587
+                        H    0.   0.757    0.587''')
+        self.assertAlmostEqual(g[2,1], (e2-e1)/2e-3*lib.param.BOHR, 5)
+
+        e1 = mf_scanner('''O    0.   0.       0.
+                        H     0.8  0.3      0.2
+                        H    0.   -0.7571  0.587
+                        H    0.   0.757    0.587''')
+        e2 = mf_scanner('''O    0.   0.       0.
+                        H     0.8  0.3      0.2
+                        H    0.   -0.7569 0.587
+                        H    0.   0.757    0.587''')
+        self.assertAlmostEqual(g[2,1], (e2-e1)/2e-4*lib.param.BOHR, 7)
+
+        mf = scf.ROHF(mol1).density_fit ()
+        mf.conv_tol = 1e-14
+        e0 = mf.kernel()
+        mf_grad = mf.nuc_grad_method ()
+        ### BEGIN DEBUGGING ###
+        # from pyscf.grad.rohf import make_rdm1e
+        # from functools import partial
+        # mf_grad.make_rdm1e = partial (make_rdm1e, mf_grad)
+        ### END DEBUGGING ###
+        g = mf_grad.kernel()
+        mf_scanner = mf.as_scanner()
+
+        e1 = mf_scanner('''
+C              0.63540095    0.65803739   -0.00861418
+H              0.99205538   -0.35077261   -0.00861418
+H              0.99207379    1.16143558   -0.88226569
+H             -0.43459905    0.65805058   -0.00861418''')
+        e2 = mf_scanner('''
+C              0.63540095    0.65803739   -0.00861418
+H              0.99205538   -0.35077261   -0.00861418
+H              0.99207379    1.16343558   -0.88226569
+H             -0.43459905    0.65805058   -0.00861418''')
+        self.assertAlmostEqual(g[2,1], (e2-e1)/2e-3*lib.param.BOHR, 5)
+
+        e1 = mf_scanner('''
+C              0.63540095    0.65803739   -0.00861418
+H              0.99205538   -0.35077261   -0.00861418
+H              0.99207379    1.16233558   -0.88226569
+H             -0.43459905    0.65805058   -0.00861418''')
+        e2 = mf_scanner('''
+C              0.63540095    0.65803739   -0.00861418
+H              0.99205538   -0.35077261   -0.00861418
+H              0.99207379    1.16253558   -0.88226569
+H             -0.43459905    0.65805058   -0.00861418''')
+        self.assertAlmostEqual(g[2,1], (e2-e1)/2e-4*lib.param.BOHR, 7)
+
     def test_rohf_grad_same_to_rhf_grad(self):
         mol = gto.Mole()
         mol.atom = [

--- a/pyscf/grad/test/test_rohf.py
+++ b/pyscf/grad/test/test_rohf.py
@@ -114,11 +114,6 @@ H             -0.43459905    0.65805058   -0.00861418''')
         mf.conv_tol = 1e-14
         e0 = mf.kernel()
         mf_grad = mf.nuc_grad_method ()
-        ### BEGIN DEBUGGING ###
-        # from pyscf.grad.rohf import make_rdm1e
-        # from functools import partial
-        # mf_grad.make_rdm1e = partial (make_rdm1e, mf_grad)
-        ### END DEBUGGING ###
         g = mf_grad.kernel()
         mf_scanner = mf.as_scanner()
 
@@ -146,11 +141,6 @@ H             -0.43459905    0.65805058   -0.00861418''')
         mf.conv_tol = 1e-14
         e0 = mf.kernel()
         mf_grad = mf.nuc_grad_method ()
-        ### BEGIN DEBUGGING ###
-        # from pyscf.grad.rohf import make_rdm1e
-        # from functools import partial
-        # mf_grad.make_rdm1e = partial (make_rdm1e, mf_grad)
-        ### END DEBUGGING ###
         g = mf_grad.kernel()
         mf_scanner = mf.as_scanner()
 

--- a/pyscf/grad/test/test_roks.py
+++ b/pyscf/grad/test/test_roks.py
@@ -57,6 +57,30 @@ class KnownValues(unittest.TestCase):
                         H    0.   0.757    0.587''')
         self.assertAlmostEqual(g[2,1], (e2-e1)/2e-3*lib.param.BOHR, 4)
 
+    def test_finite_diff_df_roks_grad(self):
+        mf = scf.ROKS(mol).density_fit ()
+        mf.xc = 'b3lypg'
+        mf.conv_tol = 1e-14
+        e0 = mf.kernel()
+        mf_grad = mf.nuc_grad_method ()
+        ### BEGIN DEBUGGING ###
+        # from pyscf.grad.rohf import make_rdm1e
+        # from functools import partial
+        # mf_grad.make_rdm1e = partial (make_rdm1e, mf_grad)
+        ### END DEBUGGING ###
+        g = mf_grad.kernel()
+        mf_scanner = mf.as_scanner()
+
+        e1 = mf_scanner('''O    0.   0.       0.
+                        H     0.8  0.3      0.2
+                        H    0.   -0.758   0.587
+                        H    0.   0.757    0.587''')
+        e2 = mf_scanner('''O    0.   0.       0.
+                        H     0.8  0.3      0.2
+                        H    0.   -0.756   0.587
+                        H    0.   0.757    0.587''')
+        self.assertAlmostEqual(g[2,1], (e2-e1)/2e-3*lib.param.BOHR, 4)
+
     def test_roks_lda_grid_response(self):
         mol = gto.Mole()
         mol.atom = [

--- a/pyscf/grad/test/test_roks.py
+++ b/pyscf/grad/test/test_roks.py
@@ -63,11 +63,6 @@ class KnownValues(unittest.TestCase):
         mf.conv_tol = 1e-14
         e0 = mf.kernel()
         mf_grad = mf.nuc_grad_method ()
-        ### BEGIN DEBUGGING ###
-        # from pyscf.grad.rohf import make_rdm1e
-        # from functools import partial
-        # mf_grad.make_rdm1e = partial (make_rdm1e, mf_grad)
-        ### END DEBUGGING ###
         g = mf_grad.kernel()
         mf_scanner = mf.as_scanner()
 

--- a/pyscf/grad/test/test_uhf.py
+++ b/pyscf/grad/test/test_uhf.py
@@ -104,6 +104,59 @@ H              0.99207379    1.16253558   -0.88226569
 H             -0.43459905    0.65805058   -0.00861418''')
         self.assertAlmostEqual(g[2,1], (e2-e1)/2e-4*lib.param.BOHR, 7)
 
+    def test_finite_diff_df_uhf_grad(self):
+        mf = scf.UHF(mol).density_fit ()
+        mf.conv_tol = 1e-14
+        e0 = mf.kernel()
+        g = mf.nuc_grad_method ().kernel()
+        mf_scanner = mf.as_scanner()
+
+        e1 = mf_scanner('''O    0.   0.       0.
+                        1    0.   -0.758   0.587
+                        1    0.   0.757    0.587''')
+        e2 = mf_scanner('''O    0.   0.       0.
+                        1    0.   -0.756   0.587
+                        1    0.   0.757    0.587''')
+        self.assertAlmostEqual(g[1,1], (e2-e1)/2e-3*lib.param.BOHR, 5)
+
+        e1 = mf_scanner('''O    0.   0.       0.
+                        1    0.   -0.7571  0.587
+                        1    0.   0.757    0.587''')
+        e2 = mf_scanner('''O    0.   0.       0.
+                        1    0.   -0.7569 0.587
+                        1    0.   0.757    0.587''')
+        self.assertAlmostEqual(g[1,1], (e2-e1)/2e-4*lib.param.BOHR, 7)
+
+        mf = scf.UHF(mol1).density_fit ()
+        mf.conv_tol = 1e-14
+        e0 = mf.kernel()
+        g = mf.nuc_grad_method ().kernel()
+        mf_scanner = mf.as_scanner()
+
+        e1 = mf_scanner('''
+C              0.63540095    0.65803739   -0.00861418
+H              0.99205538   -0.35077261   -0.00861418
+H              0.99207379    1.16143558   -0.88226569
+H             -0.43459905    0.65805058   -0.00861418''')
+        e2 = mf_scanner('''
+C              0.63540095    0.65803739   -0.00861418
+H              0.99205538   -0.35077261   -0.00861418
+H              0.99207379    1.16343558   -0.88226569
+H             -0.43459905    0.65805058   -0.00861418''')
+        self.assertAlmostEqual(g[2,1], (e2-e1)/2e-3*lib.param.BOHR, 5)
+
+        e1 = mf_scanner('''
+C              0.63540095    0.65803739   -0.00861418
+H              0.99205538   -0.35077261   -0.00861418
+H              0.99207379    1.16233558   -0.88226569
+H             -0.43459905    0.65805058   -0.00861418''')
+        e2 = mf_scanner('''
+C              0.63540095    0.65803739   -0.00861418
+H              0.99205538   -0.35077261   -0.00861418
+H              0.99207379    1.16253558   -0.88226569
+H             -0.43459905    0.65805058   -0.00861418''')
+        self.assertAlmostEqual(g[2,1], (e2-e1)/2e-4*lib.param.BOHR, 7)
+
     def test_uhf_grad_one_atom(self):
         mol = gto.Mole()
         mol.atom = [['He', (0.,0.,0.)], ]

--- a/pyscf/grad/test/test_uks.py
+++ b/pyscf/grad/test/test_uks.py
@@ -63,6 +63,17 @@ class KnownValues(unittest.TestCase):
         e2 = mf_scanner(mol1.set_geom_('O  0. 0. -.0001; 1  0. -0.757 0.587; 1  0. 0.757 0.587'))
         self.assertAlmostEqual(g[0,2], (e1-e2)/2e-4*lib.param.BOHR, 6)
 
+    def test_finite_diff_df_uks_grad(self):
+        mf1 = mf.density_fit ().run ()
+        g = mf1.nuc_grad_method().set(grid_response=True).kernel()
+        self.assertAlmostEqual(lib.fp(g), -0.12093220501429122, 6)
+
+        mol1 = mol.copy()
+        mf_scanner = mf1.as_scanner()
+        e1 = mf_scanner(mol1.set_geom_('O  0. 0. 0.0001; 1  0. -0.757 0.587; 1  0. 0.757 0.587'))
+        e2 = mf_scanner(mol1.set_geom_('O  0. 0. -.0001; 1  0. -0.757 0.587; 1  0. 0.757 0.587'))
+        self.assertAlmostEqual(g[0,2], (e1-e2)/2e-4*lib.param.BOHR, 6)
+
     def test_uks_grad_lda(self):
         mol = gto.Mole()
         mol.atom = [

--- a/pyscf/grad/uhf.py
+++ b/pyscf/grad/uhf.py
@@ -44,6 +44,7 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     hcore_deriv = mf_grad.hcore_generator(mol)
     s1 = mf_grad.get_ovlp(mol)
     dm0 = mf.make_rdm1(mo_coeff, mo_occ)
+    dm0 = mf_grad._tag_rdm1 (dm0, mo_coeff=mo_coeff, mo_occ=mo_occ)
 
     t0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Computing Gradients of NR-UHF Coulomb repulsion')

--- a/pyscf/mcscf/df.py
+++ b/pyscf/mcscf/df.py
@@ -145,7 +145,16 @@ def density_fit(casscf, auxbasis=None, with_df=None):
                 return casscf_class._exact_paaa(self, mol, u, out)
 
         def nuc_grad_method(self):
-            raise NotImplementedError
+            if 'CASCI' in str (casscf_class):
+                raise NotImplementedError ("DFCASCI nuclear gradients")
+            from pyscf.df.grad import casscf
+            return casscf.Gradients (self)
+
+        def _state_average_nuc_grad_method (self, state=None):
+            if 'CASCI' in str (casscf_class):
+                raise NotImplementedError ("DFCASCI nuclear gradients")
+            from pyscf.df.grad import sacasscf
+            return sacasscf.Gradients (self, state=state)
 
     return DFCASSCF()
 


### PR DESCRIPTION
Also add unit tests for molecular nuclear gradients with density-fitted two-electron integrals for ROHF, ROKS, UHF, UKS, CASSCF, and SA-CASSCF methods. This involved significant refactoring of df/grad/rhf.py, which ended up including some performance optimizations I had been using over the past couple of years in _mrh_.

This was mentioned at the 2022 developer's meeting (issue #1371). BTW, although ROHF and ROKS were "implemented" already, they weren't actually working because of an oversight involving the make_rdm1e method. IDK if this is already an issue somewhere.