### PR TITLE
Allow using k-point symmetry with RSDF

### DIFF
--- a/pyscf/pbc/df/rsdf.py
+++ b/pyscf/pbc/df/rsdf.py
@@ -144,7 +144,8 @@ cell.dimension=3 with large vacuum.""")
         log.info('j2c_eig_always = %s', self.j2c_eig_always)
         log.info('omega = %s', self.omega)
         log.info('ke_cutoff = %s', self.ke_cutoff)
-        log.info('mesh = %s (%d PWs)', self.mesh, np.prod(self.mesh))
+        if self.mesh is not None:
+            log.info('mesh = %s (%d PWs)', self.mesh, np.prod(self.mesh))
         log.info('mesh_compact = %s (%d PWs)', self.mesh_compact,
                  np.prod(self.mesh_compact))
         if self.auxcell is None:

--- a/pyscf/pbc/df/rsdf_jk.py
+++ b/pyscf/pbc/df/rsdf_jk.py
@@ -38,6 +38,7 @@ def density_fit(mf, auxbasis=None, mesh=None, with_df=None):
         else:
             kpts = numpy.reshape(mf.kpt, (1,3))
 
+        kpts = getattr(kpts, 'kpts', kpts)
         with_df = rsdf.RSDF(mf.cell, kpts)
         with_df.max_memory = mf.max_memory
         with_df.stdout = mf.stdout


### PR DESCRIPTION
This seems to do be enough to get RSDF working with IBZ k-points.
(For the time being - my understanding is we still just generate integrals for the full BZ, but should be able to use IBZ integrals + symmetry operations instead?) 

@hongzhouye Anything else that should be changed?