### PR TITLE
bug fix number of k points in each direction

### DIFF
--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -468,9 +468,9 @@ def madelung(cell, kpts):
         return 2*cell.omega/np.pi**0.5-np.einsum('i,i,i->', ZSI.conj(), ZSI, coulG*weights).real
 
 
-def get_monkhorst_pack_size(cell, kpts):
+def get_monkhorst_pack_size(cell, kpts, tol=1e-5):
     kpts = np.reshape(kpts, (-1,3))
-    min_tol = 1e-5
+    min_tol = tol
     assert kpts.shape[0] < 1/min_tol
     if kpts.shape[0] == 1:
         Nk = np.array([1,1,1])

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -469,8 +469,17 @@ def madelung(cell, kpts):
 
 
 def get_monkhorst_pack_size(cell, kpts):
-    skpts = cell.get_scaled_kpts(kpts).round(decimals=6)
-    Nk = np.array([len(np.unique(ki)) for ki in skpts.T])
+    kpts = np.reshape(kpts, (-1,3))
+    min_tol = 1e-5
+    assert kpts.shape[0] < 1/min_tol
+    if kpts.shape[0] == 1:
+        Nk = np.array([1,1,1])
+    else:
+        tol = max(10**(-int(-np.log10(1/kpts.shape[0]))-2), min_tol)
+        skpts = cell.get_scaled_kpts(kpts)
+        Nk = np.array([np.count_nonzero(abs(ski[1:]-ski[:-1]) > tol) + 1
+                       for ski in np.sort(skpts.T)])
+    assert np.prod(Nk) == kpts.shape[0]
     return Nk
 
 

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -479,7 +479,6 @@ def get_monkhorst_pack_size(cell, kpts):
         skpts = cell.get_scaled_kpts(kpts)
         Nk = np.array([np.count_nonzero(abs(ski[1:]-ski[:-1]) > tol) + 1
                        for ski in np.sort(skpts.T)])
-    assert np.prod(Nk) == kpts.shape[0]
     return Nk
 
 


### PR DESCRIPTION
This fixes a bug affecting for example the madelung constant evaluation and exxdiv=vcut_ws, etc. It was noticed for shifted k point meshes.

The unique function might consider two k point coordinates as distinct even though they represent the same k point coordinate and only differ very slightly due to floating point noise. Consider 0.055000000001 and 0.0549999999999 (made-up example), which might get rounded to 0.06 and 0.05 respectively and therefore considered different, even though they belong to the same k point. This fix looks at the differences between coordinates directly and is hopefully a little more robust.

How to set the minimum tolerance for the difference is a question. If it is too low, floating point deviations might cause two coordinates being considered distinct even though they are not. If it is too high, we limit the size of k point meshes. Currently, it is set at 1e-5.

Credits for code and discussion goes to @tberkel and @hongzhouye . 