### PR TITLE
Adds UCISD with density-fitting

### DIFF
--- a/pyscf/ci/__init__.py
+++ b/pyscf/ci/__init__.py
@@ -40,7 +40,7 @@ def RCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
         mf = scf.addons.convert_to_rhf(mf)
 
     if getattr(mf, 'with_df', None):
-        raise NotImplementedError('DF-RCISD')
+        return cisd.RCISD(mf, frozen, mo_coeff, mo_occ)
     else:
         return cisd.RCISD(mf, frozen, mo_coeff, mo_occ)
 RCISD.__doc__ = cisd.RCISD.__doc__

--- a/pyscf/ci/__init__.py
+++ b/pyscf/ci/__init__.py
@@ -73,9 +73,9 @@ GCISD.__doc__ = gcisd.GCISD.__doc__
 
 def QCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     if isinstance(mf, scf.uhf.UHF):
-        raise NotImplementedError 
+        raise NotImplementedError
     elif isinstance(mf, scf.ghf.GHF):
-        raise NotImplementedError 
+        raise NotImplementedError
     else:
         return RQCISD(mf, frozen, mo_coeff, mo_occ)
 QCISD.__doc__ = qcisd.QCISD.__doc__
@@ -93,13 +93,13 @@ def RQCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
         lib.logger.warn(mf, 'RQCISD method does not support ROHF method. ROHF object '
                         'is converted to UHF object and UQCISD method is called.')
         mf = scf.addons.convert_to_uhf(mf)
-        raise NotImplementedError 
+        raise NotImplementedError
 
     if isinstance(mf, newton_ah._CIAH_SOSCF) or not isinstance(mf, scf.hf.RHF):
         mf = scf.addons.convert_to_rhf(mf)
 
     elif numpy.iscomplexobj(mo_coeff) or numpy.iscomplexobj(mf.mo_coeff):
-        raise NotImplementedError 
+        raise NotImplementedError
 
     else:
         return qcisd.QCISD(mf, frozen, mo_coeff, mo_occ)

--- a/pyscf/ci/__init__.py
+++ b/pyscf/ci/__init__.py
@@ -52,7 +52,7 @@ def UCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
         mf = scf.addons.convert_to_uhf(mf)
 
     if getattr(mf, 'with_df', None):
-        raise NotImplementedError('DF-UCISD')
+        return ucisd.UCISD(mf, frozen, mo_coeff, mo_occ)
     else:
         return ucisd.UCISD(mf, frozen, mo_coeff, mo_occ)
 UCISD.__doc__ = ucisd.UCISD.__doc__

--- a/pyscf/ci/test/test_ucisd.py
+++ b/pyscf/ci/test/test_ucisd.py
@@ -23,6 +23,7 @@ from pyscf import lib
 from pyscf import scf
 from pyscf import fci
 from pyscf import ci
+from pyscf import cc
 from pyscf.ci import ucisd
 from pyscf import ao2mo
 
@@ -304,6 +305,38 @@ class KnownValues(unittest.TestCase):
         t2ab[:] = 1
         t2bb[:] = 1
         self.assertAlmostEqual(abs(vec - vec_orig).max(), 0, 15)
+
+    def test_with_df_s0(self):
+        mol = gto.Mole()
+        mol.atom = [
+            [8 , (0. , 0.     , 0.)],
+            [1 , (0. , -0.757 , 0.587)],
+            [1 , (0. , 0.757  , 0.587)]]
+        mol.basis = '631g'
+        mol.build()
+        rhf = scf.RHF(mol).density_fit(auxbasis='weigend')
+        rhf.conv_tol_grad = 1e-8
+        rhf.kernel()
+        mf = scf.addons.convert_to_uhf(rhf)
+        myci = ci.UCISD(mf)
+        myci.kernel()
+        self.assertAlmostEqual(myci.e_tot, -76.1131374309989, 8)
+
+    def test_with_df_s2(self):
+        mol = gto.Mole()
+        mol.atom = [
+            [8 , (0. , 0.     , 0.)],
+            [1 , (0. , -0.757 , 0.587)],
+            [1 , (0. , 0.757  , 0.587)]]
+        mol.basis = '631g'
+        mol.spin = 2
+        mol.build()
+        mf = scf.UHF(mol).density_fit(auxbasis='weigend')
+        mf.conv_tol_grad = 1e-8
+        mf.kernel()
+        myci = ci.UCISD(mf)
+        myci.kernel()
+        self.assertAlmostEqual(myci.e_tot, -75.8307298990769, 8)
 
 
 if __name__ == "__main__":

--- a/pyscf/ci/ucisd.py
+++ b/pyscf/ci/ucisd.py
@@ -944,8 +944,7 @@ class UCISD(cisd.CISD):
             return uccsd._make_eris_incore(self, mo_coeff)
 
         elif getattr(self._scf, 'with_df', None):
-            raise NotImplementedError
-
+            return uccsd._make_df_eris_outcore(self, mo_coeff)
         else:
             return uccsd._make_eris_outcore(self, mo_coeff)
 


### PR DESCRIPTION
In #1158 we added `_make_df_eris_outcore` to the UCCSD module, we can use the same to allow UCISD with density fitting
(Like in the case of UCCSD, this is just a precontraction of the 3c->4c integrals, rather than a true DF-UCISD).

I enabled this functionality and added two tests. I also removed the `NotImplementedError` when using the `ci.RCISD(mf)` factory,
since RCISD with density fitting is already supported. 