### PR TITLE
Update libxc to stable 6.0.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
             yum install -y epel-release && \
             yum-config-manager --enable epel && \
             yum install -y openblas-devel gcc cmake curl && \
-            cd ./pyscf/lib && curl -o deps.tar.gz -L "https://github.com/pyscf/pyscf-build-deps/blob/master/pyscf-2.1-aarch64-deps.tar.gz?raw=true"  && \
+            cd ./pyscf/lib && curl -o deps.tar.gz -L "https://github.com/pyscf/pyscf-build-deps/blob/master/pyscf-2.2a-aarch64-deps.tar.gz?raw=true"  && \
             tar xzf deps.tar.gz && \
             mkdir build && cd build && \
             cmake -DBUILD_LIBXC=OFF -DBUILD_XCFUN=OFF -DBUILD_LIBCINT=OFF .. && \

--- a/.github/workflows/ci_linux/build_pyscf.sh
+++ b/.github/workflows/ci_linux/build_pyscf.sh
@@ -3,7 +3,7 @@
 set -e
 
 cd ./pyscf/lib
-curl -L "https://github.com/pyscf/pyscf-build-deps/blob/master/pyscf-2.1-deps.tar.gz?raw=true" | tar xzf -
+curl -L "https://github.com/pyscf/pyscf-build-deps/blob/master/pyscf-2.2a-deps.tar.gz?raw=true" | tar xzf -
 mkdir build; cd build
 cmake -DBUILD_LIBXC=OFF -DBUILD_XCFUN=OFF -DBUILD_LIBCINT=OFF ..
 make -j4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         uses: docker://pyscf/pyscf-pypa-env:latest
         with:
           entrypoint: /build-wheels.sh
-          #args: http://www.sunqm.net/pyscf/files/bin/pyscf-2.1a-deps.tar.gz
+          #args: http://www.sunqm.net/pyscf/files/bin/pyscf-2.2a-deps.tar.gz
       - name: List available wheels
         run: |
           ls ${{ github.workspace }}/linux-wheels

--- a/pyscf/lib/CMakeLists.txt
+++ b/pyscf/lib/CMakeLists.txt
@@ -198,7 +198,7 @@ if(ENABLE_LIBXC AND BUILD_LIBXC)
   ExternalProject_Add(libxc
     #GIT_REPOSITORY https://gitlab.com/libxc/libxc.git
     #GIT_TAG master
-    URL https://gitlab.com/libxc/libxc/-/archive/5.2.0/libxc-5.2.0.tar.gz
+    URL https://gitlab.com/libxc/libxc/-/archive/6.0.0/libxc-6.0.0.tar.gz
     PREFIX ${PROJECT_BINARY_DIR}/deps
     INSTALL_DIR ${PROJECT_SOURCE_DIR}/deps
     CMAKE_ARGS -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_SHARED_LIBS=1

--- a/pyscf/lib/dft/libxc_itrf.c
+++ b/pyscf/lib/dft/libxc_itrf.c
@@ -453,7 +453,7 @@ int LIBXC_is_hybrid(int xc_id)
                 raise_error -1;
         }
 
-#if XC_MAJOR_VERSION < 6
+#if XC_MAJOR_VERSION <= 6
         switch(func.info->family)
         {
 #ifdef XC_FAMILY_HYB_LDA
@@ -483,7 +483,7 @@ double LIBXC_hybrid_coeff(int xc_id)
                 raise_error 0.0;
         }
 
-#if XC_MAJOR_VERSION < 6
+#if XC_MAJOR_VERSION <= 6
         switch(func.info->family)
         {
 #ifdef XC_FAMILY_HYB_LDA
@@ -530,7 +530,7 @@ void LIBXC_rsh_coeff(int xc_id, double *rsh_pars) {
         rsh_pars[1] = 0.0;
         rsh_pars[2] = 0.0;
 
-#if XC_MAJOR_VERSION < 6
+#if XC_MAJOR_VERSION <= 6
         XC(hyb_cam_coef)(&func, &rsh_pars[0], &rsh_pars[1], &rsh_pars[2]);
 #else
         switch(xc_hyb_type(&func)) {
@@ -548,7 +548,7 @@ int LIBXC_is_cam_rsh(int xc_id) {
                 fprintf(stderr, "XC functional %d not found\n", xc_id);
                 raise_error -1;
         }
-#if XC_MAJOR_VERSION < 6
+#if XC_MAJOR_VERSION <= 6
         int is_cam = func.info->flags & XC_FLAGS_HYB_CAM;
 #else
         int is_cam = (xc_hyb_type(&func) == XC_HYB_CAM);
@@ -793,7 +793,7 @@ void LIBXC_eval_xc(int nfn, int *fn_id, double *fac, double *omega,
                 // set the range-separated parameter
                 if (omega[i] != 0) {
                         // skip if func is not a RSH functional
-#if XC_MAJOR_VERSION < 6
+#if XC_MAJOR_VERSION <= 6
                         if (func.cam_omega != 0) {
                                 func.cam_omega = omega[i];
                         }
@@ -805,7 +805,7 @@ void LIBXC_eval_xc(int nfn, int *fn_id, double *fac, double *omega,
                         // Recursively set the sub-functionals if they are RSH
                         // functionals
                         for (j = 0; j < func.n_func_aux; j++) {
-#if XC_MAJOR_VERSION < 6
+#if XC_MAJOR_VERSION <= 6
                                 if (func.func_aux[j]->cam_omega != 0) {
                                         func.func_aux[j]->cam_omega = omega[i];
                                 }


### PR DESCRIPTION
This PR updates libxc to the stable 6.0.0 release.

More fundamental API changes in Libxc (support for double hybrids) were relegated to version 7.0.0.