### PR TITLE
Add spin density population analysis

### DIFF
--- a/pyscf/mcscf/addons.py
+++ b/pyscf/mcscf/addons.py
@@ -712,6 +712,22 @@ def make_rdm1s(casscf, mo_coeff=None, ci=None, **kwargs):
     '''
     return casscf.make_rdm1s(mo_coeff, ci, **kwargs)
 
+def get_spin_square(casdm1, casdm2):
+    # DOI:10.1021/acs.jctc.1c00589 Eq (49)
+    spin_square = (0.75*numpy.einsum("ii", casdm1)
+                   - 0.5*numpy.einsum("ijji", casdm2)
+                   - 0.25*numpy.einsum("iijj", casdm2))
+    return spin_square
+
+def make_spin_casdm1(casdm1, casdm2, spin=None, nelec=None):
+    # DOI: 10.1002/qua.22320 Eq (3)
+    if spin is None:
+        spin = numpy.sqrt(get_spin_square(casdm1, casdm2) + 0.25) - 0.5
+    if nelec is None:
+        nelec = numpy.einsum("ii", casdm1)
+    spin_casdm1 = ((2. - nelec/2.)*casdm1 - numpy.einsum('ikkj->ij', casdm2))/(spin + 1)
+    return spin_casdm1
+
 def _is_uhf_mo(mo_coeff):
     return not (isinstance(mo_coeff, numpy.ndarray) and mo_coeff.ndim == 2)
 

--- a/pyscf/mcscf/casci.py
+++ b/pyscf/mcscf/casci.py
@@ -100,6 +100,7 @@ def analyze(casscf, mo_coeff=None, ci=None, verbose=None,
         dm1a = dm1b + reduce(numpy.dot, (mocas, casdm1a, mocas.conj().T))
         dm1b += reduce(numpy.dot, (mocas, casdm1b, mocas.conj().T))
         dm1 = dm1a + dm1b
+        spin_dm1 = dm1a - dm1b
         if log.verbose >= logger.DEBUG2:
             log.info('alpha density matrix (on AO)')
             dump_mat.dump_tri(log.stdout, dm1a, label, **kwargs)
@@ -111,6 +112,7 @@ def analyze(casscf, mo_coeff=None, ci=None, verbose=None,
                 reduce(numpy.dot, (mocas, casdm1, mocas.conj().T)))
         dm1b = None
         dm1 = dm1a
+        spin_dm1 = None
 
     if log.verbose >= logger.INFO:
         ovlp_ao = casscf._scf.get_ovlp()
@@ -168,6 +170,20 @@ def analyze(casscf, mo_coeff=None, ci=None, verbose=None,
             casscf._scf.mulliken_meta(casscf.mol, dm1, s=ovlp_ao, verbose=log)
         else:
             casscf._scf.mulliken_pop(casscf.mol, dm1, s=ovlp_ao, verbose=log)
+        if spin_dm1 is not None:
+            if with_meta_lowdin:
+                log.info('Mulliken spin population analysis on meta-Lowdin AOs:')
+                spin_pop, spin_chg = casscf._scf.mulliken_meta(casscf.mol, spin_dm1, s=ovlp_ao, verbose=log)
+            else:
+                log.info('Mulliken spin population analysis on AOs:')
+                spin_pop, spin_chg = casscf._scf.mulliken_pop(casscf.mol, spin_dm1, s=ovlp_ao, verbose=log)
+            for i, s in enumerate(label):
+                log.info('spop of %-12s %10.5f', s, spin_pop[i])
+            spin_chg = casscf.mol.atom_charges() - spin_chg
+            log.note('Mulliken atomic spins:')
+            for ia in range(casscf.mol.natm):
+                symb = casscf.mol.atom_symbol(ia)
+                log.note('spin of  %d%s =   %10.5f', ia, symb, spin_chg[ia])
     return dm1a, dm1b
 
 def get_fock(mc, mo_coeff=None, ci=None, eris=None, casdm1=None, verbose=None):


### PR DESCRIPTION
Add spin density population analysis and function to compute S^2 and spin density from 2rdm. The latter makes it easy to get spin density using external solvers (DMRG, FCIQMC, HCI etc).

I think that `get_spin_square(casdm1, casdm2)` can also be used to check the spin purity of non-spin-adapted solution.