### PR TITLE
Fully spin-polarized UMP2, DF-UMP2, UCCSD, & UCCSD(T) bug fixes

### DIFF
--- a/pyscf/cc/uccsd.py
+++ b/pyscf/cc/uccsd.py
@@ -511,9 +511,12 @@ def _add_vvvv(mycc, t1, t2, eris, out=None, with_ovvv=False, t2sym=None):
             u2bb[otrilb[1],otrilb[0]] = u2tril.transpose(0,2,1)
             u2bb[otrilb] = u2tril
 
-        u2ab = _ao2mo.nr_e2(buf[-nocca*noccb:].reshape(nocca*noccb,nao**2), mo,
-                            (0,nvira,nvira,nvira+nvirb), 's1', 's1')
-        u2ab = u2ab.reshape(t2ab.shape)
+        if nocca*noccb > 0:
+            u2ab = _ao2mo.nr_e2(buf[-nocca*noccb:].reshape(nocca*noccb,nao**2), mo,
+                                (0,nvira,nvira,nvira+nvirb), 's1', 's1')
+            u2ab = u2ab.reshape(t2ab.shape)
+        else:
+            u2ab = np.zeros_like(t2ab)
 
     else:
         assert (not with_ovvv)

--- a/pyscf/cc/uccsd_t.py
+++ b/pyscf/cc/uccsd_t.py
@@ -63,7 +63,7 @@ def kernel(mycc, eris, t1=None, t2=None, verbose=logger.NOTE):
     mem_now = lib.current_memory()[0]
     max_memory = max(0, mycc.max_memory - mem_now)
     # aaa
-    bufsize = max(8, int((max_memory*.5e6/8-nocca**3*3*lib.num_threads())*.4/(nocca*nmoa)))
+    bufsize = max(8, int((max_memory*.5e6/8-nocca**3*3*lib.num_threads())*.4/max(1,nocca*nmoa)))
     log.debug('max_memory %d MB (%d MB in use)', max_memory, mem_now)
     orbsym = numpy.zeros(nocca, dtype=int)
     contract = _gen_contract_aaa(t1aT, t2aaT, eris_vooo, eris.focka,
@@ -89,7 +89,7 @@ def kernel(mycc, eris, t1=None, t2=None, verbose=logger.NOTE):
     cpu1 = log.timer_debug1('contract_aaa', *cpu1)
 
     # bbb
-    bufsize = max(8, int((max_memory*.5e6/8-noccb**3*3*lib.num_threads())*.4/(noccb*nmob)))
+    bufsize = max(8, int((max_memory*.5e6/8-noccb**3*3*lib.num_threads())*.4/max(1,noccb*nmob)))
     log.debug('max_memory %d MB (%d MB in use)', max_memory, mem_now)
     orbsym = numpy.zeros(noccb, dtype=int)
     contract = _gen_contract_aaa(t1bT, t2bbT, eris_VOOO, eris.fockb,
@@ -119,7 +119,7 @@ def kernel(mycc, eris, t1=None, t2=None, verbose=logger.NOTE):
     t2abT = lib.transpose(t2ab.copy().reshape(nocca*noccb,nvira*nvirb), out=t2ab)
     t2abT = t2abT.reshape(nvira,nvirb,nocca,noccb)
     # baa
-    bufsize = int(max(12, (max_memory*.5e6/8-noccb*nocca**2*5)*.7/(nocca*nmob)))
+    bufsize = int(max(12, (max_memory*.5e6/8-noccb*nocca**2*5)*.7/max(1,nocca*nmob)))
     ts = t1aT, t1bT, t2aaT, t2abT
     fock = (eris.focka, eris.fockb)
     vooo = (eris_vooo, eris_vOoO, eris_VoOo)
@@ -282,7 +282,7 @@ def _sort_eri(mycc, eris, h5tmp, log):
     max_memory = max(2000, mycc.max_memory - lib.current_memory()[0])
     max_memory = min(8000, max_memory*.9)
 
-    blksize = min(nvira, max(16, int(max_memory*1e6/8/(nvira*nocca*nmoa))))
+    blksize = min(nvira, max(16, int(max_memory*1e6/8/max(1,nvira*nocca*nmoa))))
     with lib.call_in_background(eris_vvop.__setitem__, sync=not mycc.async_io) as save:
         bufopv = numpy.empty((nocca,nmoa,nvira), dtype=dtype)
         buf1 = numpy.empty_like(bufopv)
@@ -297,7 +297,7 @@ def _sort_eri(mycc, eris, h5tmp, log):
             ovov = ovvv = None
             cpu1 = log.timer_debug1('transpose %d:%d'%(j0,j1), *cpu1)
 
-    blksize = min(nvirb, max(16, int(max_memory*1e6/8/(nvirb*noccb*nmob))))
+    blksize = min(nvirb, max(16, int(max_memory*1e6/8/max(1,nvirb*noccb*nmob))))
     with lib.call_in_background(eris_VVOP.__setitem__, sync=not mycc.async_io) as save:
         bufopv = numpy.empty((noccb,nmob,nvirb), dtype=dtype)
         buf1 = numpy.empty_like(bufopv)
@@ -312,7 +312,7 @@ def _sort_eri(mycc, eris, h5tmp, log):
             ovov = ovvv = None
             cpu1 = log.timer_debug1('transpose %d:%d'%(j0,j1), *cpu1)
 
-    blksize = min(nvira, max(16, int(max_memory*1e6/8/(nvirb*nocca*nmob))))
+    blksize = min(nvira, max(16, int(max_memory*1e6/8/max(1,nvirb*nocca*nmob))))
     with lib.call_in_background(eris_vVoP.__setitem__, sync=not mycc.async_io) as save:
         bufopv = numpy.empty((nocca,nmob,nvirb), dtype=dtype)
         buf1 = numpy.empty_like(bufopv)
@@ -327,7 +327,7 @@ def _sort_eri(mycc, eris, h5tmp, log):
             ovov = ovvv = None
             cpu1 = log.timer_debug1('transpose %d:%d'%(j0,j1), *cpu1)
 
-    blksize = min(nvirb, max(16, int(max_memory*1e6/8/(nvira*noccb*nmoa))))
+    blksize = min(nvirb, max(16, int(max_memory*1e6/8/max(1,nvira*noccb*nmoa))))
     OVov = numpy.asarray(eris.ovOV).transpose(2,3,0,1)
     with lib.call_in_background(eris_VvOp.__setitem__, sync=not mycc.async_io) as save:
         bufopv = numpy.empty((noccb,nmoa,nvira), dtype=dtype)

--- a/pyscf/mp/dfmp2_native.py
+++ b/pyscf/mp/dfmp2_native.py
@@ -342,7 +342,7 @@ def ints3c_cholesky(mol, auxmol, mo_coeff1, mo_coeff2, max_memory, logger):
         bufsize = int((max_memory - lib.current_memory()[0]) * 1e6 / (nauxfcns * nmo2 * 8))
         if bufsize < 1:
             raise MemoryError('Insufficient memory (PYSCF_MAX_MEMORY).')
-        bufsize = min(nmo1, bufsize)
+        bufsize = max(1, min(nmo1, bufsize))
         logger.debug('    Batch size: {0:d} (of {1:d})'.format(bufsize, nmo1))
 
         # In batches:

--- a/pyscf/mp/ump2.py
+++ b/pyscf/mp/ump2.py
@@ -542,7 +542,7 @@ def _make_eris(mp, mo_coeff=None, ao2mofn=None, verbose=None):
         if nocca*nvira*noccb*nvirb > 0:
             eris.ovOV = eris.feri['ovOV']
         else:
-            eris.ovOV =	numpy.zeros((nocca*nvira,noccb*nvirb))
+            eris.ovOV = numpy.zeros((nocca*nvira,noccb*nvirb))
         if noccb*nvirb > 0:
             eris.OVOV = eris.feri['OVOV']
         else:

--- a/pyscf/mp/ump2.py
+++ b/pyscf/mp/ump2.py
@@ -535,9 +535,18 @@ def _make_eris(mp, mo_coeff=None, ao2mofn=None, verbose=None):
         eris.feri = lib.H5TmpFile()
         _ao2mo_ovov(mp, (orboa,orbva,orbob,orbvb), eris.feri,
                     max(2000, max_memory), log)
-        eris.ovov = eris.feri['ovov']
-        eris.ovOV = eris.feri['ovOV']
-        eris.OVOV = eris.feri['OVOV']
+        if nocca*nvira > 0:
+            eris.ovov = eris.feri['ovov']
+        else:
+            eris.ovov = numpy.zeros((nocca*nvira,nocca*nvira))
+        if nocca*nvira*noccb*nvirb > 0:
+            eris.ovOV = eris.feri['ovOV']
+        else:
+            eris.ovOV =	numpy.zeros((nocca*nvira,noccb*nvirb))
+        if noccb*nvirb > 0:
+            eris.OVOV = eris.feri['OVOV']
+        else:
+            eris.OVOV = numpy.zeros((noccb*nvirb,noccb*nvirb))
 
     log.timer('Integral transformation', *time0)
     return eris
@@ -614,14 +623,17 @@ def _ao2mo_ovov(mp, orbs, feri, max_memory=2000, verbose=None):
     time1 = time0 = log.timer('mp2 ao2mo_ovov pass1', *time0)
     eri = eribuf = tmp_i = tmp_li = None
 
-    fovov = feri.create_dataset('ovov', (nocca*nvira,nocca*nvira), 'f8',
-                                chunks=(nvira,nvira))
-    fovOV = feri.create_dataset('ovOV', (nocca*nvira,noccb*nvirb), 'f8',
-                                chunks=(nvira,nvirb))
-    fOVOV = feri.create_dataset('OVOV', (noccb*nvirb,noccb*nvirb), 'f8',
-                                chunks=(nvirb,nvirb))
+    if nocca*nvira > 0:
+        fovov = feri.create_dataset('ovov', (nocca*nvira,nocca*nvira), 'f8',
+                                    chunks=(nvira,nvira))
+    if nocca*nvira*noccb*nvirb > 0:
+        fovOV = feri.create_dataset('ovOV', (nocca*nvira,noccb*nvirb), 'f8',
+                                    chunks=(nvira,nvirb))
+    if noccb*nvirb > 0:
+        fOVOV = feri.create_dataset('OVOV', (noccb*nvirb,noccb*nvirb), 'f8',
+                                    chunks=(nvirb,nvirb))
     occblk = int(min(max(nocca,noccb),
-                     max(4, 250/nocca, max_memory*.9e6/8/(nao**2*nocca)/5)))
+                     max(4, 250/max(1,nocca), max_memory*.9e6/8/(nao**2*max(1,nocca))/5)))
 
     def load_aa(h5g, nocc, i0, eri):
         if i0 < nocc:
@@ -644,41 +656,44 @@ def _ao2mo_ovov(mp, orbs, feri, max_memory=2000, verbose=None):
 
     with lib.call_in_background(save) as bsave:
         with lib.call_in_background(load_aa) as prefetch:
-            buf_prefecth = numpy.empty((occblk,nocca,nao,nao))
-            buf = numpy.empty_like(buf_prefecth)
-            load_aa(ftmp['aa'], nocca, 0, buf_prefecth)
-            for i0, i1 in lib.prange(0, nocca, occblk):
-                buf, buf_prefecth = buf_prefecth, buf
-                prefetch(ftmp['aa'], nocca, i1, buf_prefecth)
-                eri = buf[:i1-i0].reshape((i1-i0)*nocca,nao,nao)
-                dat = _ao2mo.nr_e2(eri, orbva, (0,nvira,0,nvira), 's1', 's1')
-                bsave(fovov, nvira, i0, i1,
-                      dat.reshape(i1-i0,nocca,nvira,nvira).transpose(0,2,1,3))
-                time1 = log.timer_debug1('pass2 ao2mo for aa [%d:%d]' % (i0,i1), *time1)
+            if nocca*nvira > 0:
+                buf_prefecth = numpy.empty((occblk,nocca,nao,nao))
+                buf = numpy.empty_like(buf_prefecth)
+                load_aa(ftmp['aa'], nocca, 0, buf_prefecth)
+                for i0, i1 in lib.prange(0, nocca, occblk):
+                    buf, buf_prefecth = buf_prefecth, buf
+                    prefetch(ftmp['aa'], nocca, i1, buf_prefecth)
+                    eri = buf[:i1-i0].reshape((i1-i0)*nocca,nao,nao)
+                    dat = _ao2mo.nr_e2(eri, orbva, (0,nvira,0,nvira), 's1', 's1')
+                    bsave(fovov, nvira, i0, i1,
+                          dat.reshape(i1-i0,nocca,nvira,nvira).transpose(0,2,1,3))
+                    time1 = log.timer_debug1('pass2 ao2mo for aa [%d:%d]' % (i0,i1), *time1)
 
-            buf_prefecth = numpy.empty((occblk,noccb,nao,nao))
-            buf = numpy.empty_like(buf_prefecth)
-            load_aa(ftmp['bb'], noccb, 0, buf_prefecth)
-            for i0, i1 in lib.prange(0, noccb, occblk):
-                buf, buf_prefecth = buf_prefecth, buf
-                prefetch(ftmp['bb'], noccb, i1, buf_prefecth)
-                eri = buf[:i1-i0].reshape((i1-i0)*noccb,nao,nao)
-                dat = _ao2mo.nr_e2(eri, orbvb, (0,nvirb,0,nvirb), 's1', 's1')
-                bsave(fOVOV, nvirb, i0, i1,
-                      dat.reshape(i1-i0,noccb,nvirb,nvirb).transpose(0,2,1,3))
-                time1 = log.timer_debug1('pass2 ao2mo for bb [%d:%d]' % (i0,i1), *time1)
+            if noccb*nvirb > 0:
+                buf_prefecth = numpy.empty((occblk,noccb,nao,nao))
+                buf = numpy.empty_like(buf_prefecth)
+                load_aa(ftmp['bb'], noccb, 0, buf_prefecth)
+                for i0, i1 in lib.prange(0, noccb, occblk):
+                    buf, buf_prefecth = buf_prefecth, buf
+                    prefetch(ftmp['bb'], noccb, i1, buf_prefecth)
+                    eri = buf[:i1-i0].reshape((i1-i0)*noccb,nao,nao)
+                    dat = _ao2mo.nr_e2(eri, orbvb, (0,nvirb,0,nvirb), 's1', 's1')
+                    bsave(fOVOV, nvirb, i0, i1,
+                          dat.reshape(i1-i0,noccb,nvirb,nvirb).transpose(0,2,1,3))
+                    time1 = log.timer_debug1('pass2 ao2mo for bb [%d:%d]' % (i0,i1), *time1)
 
-        orbvab = numpy.asarray(numpy.hstack((orbva, orbvb)), order='F')
-        with lib.call_in_background(load_ab) as prefetch:
-            load_ab(ftmp['ab'], nocca, 0, buf_prefecth)
-            for i0, i1 in lib.prange(0, nocca, occblk):
-                buf, buf_prefecth = buf_prefecth, buf
-                prefetch(ftmp['ab'], nocca, i1, buf_prefecth)
-                eri = buf[:i1-i0].reshape((i1-i0)*noccb,nao,nao)
-                dat = _ao2mo.nr_e2(eri, orbvab, (0,nvira,nvira,nvira+nvirb), 's1', 's1')
-                bsave(fovOV, nvira, i0, i1,
-                      dat.reshape(i1-i0,noccb,nvira,nvirb).transpose(0,2,1,3))
-                time1 = log.timer_debug1('pass2 ao2mo for ab [%d:%d]' % (i0,i1), *time1)
+        if nocca*nvira*noccb*nvirb > 0:
+            orbvab = numpy.asarray(numpy.hstack((orbva, orbvb)), order='F')
+            with lib.call_in_background(load_ab) as prefetch:
+                load_ab(ftmp['ab'], nocca, 0, buf_prefecth)
+                for i0, i1 in lib.prange(0, nocca, occblk):
+                    buf, buf_prefecth = buf_prefecth, buf
+                    prefetch(ftmp['ab'], nocca, i1, buf_prefecth)
+                    eri = buf[:i1-i0].reshape((i1-i0)*noccb,nao,nao)
+                    dat = _ao2mo.nr_e2(eri, orbvab, (0,nvira,nvira,nvira+nvirb), 's1', 's1')
+                    bsave(fovOV, nvira, i0, i1,
+                          dat.reshape(i1-i0,noccb,nvira,nvirb).transpose(0,2,1,3))
+                    time1 = log.timer_debug1('pass2 ao2mo for ab [%d:%d]' % (i0,i1), *time1)
 
     time0 = log.timer('mp2 ao2mo_ovov pass2', *time0)
 


### PR DESCRIPTION
Fixes #1500. This is by no means a thorough attempt to fix this type of problem throughout the code, just all of the places that my present workflow is touching. With the UCCSD(T) fix, the problem could alternatively be fixed higher up in the logic, and that might be a slightly cleaner fix than what I have done. My understanding is that many of the CCSD(T) corrections (e.g. aaa, bbb, aab, etc.) are trivially zero in the absence of alpha or beta electrons, and so the low-level C routines that calculate them can be skipped altogether. My fix does not skip trivial aaa/bbb calculations as the low-level routines still seem to work in the trivial case, but the aab-type corrections must be skipped because they lack low-level checks for no alpha/beta electrons and will crash.