### PR TITLE
Fix typo in augccpwcvdz basis specification (#1508).

### DIFF
--- a/pyscf/gto/basis/__init__.py
+++ b/pyscf/gto/basis/__init__.py
@@ -212,7 +212,7 @@ ALIAS = {
     'ccpwcv5zdk' : 'cc-pwCV5Z-DK.dat',
     'ccpwcvtzdk3': 'cc-pwCVTZ-DK3.dat',
     'ccpwcvqzdk3': 'cc-pwCVQZ-DK3.dat',
-    'augccpwcvdz': 'aug-cc-pwcvtz.dat',
+    'augccpwcvdz': 'aug-cc-pwcvdz.dat',
     'augccpwcvtz': 'aug-cc-pwcvtz.dat',
     'augccpwcvqz': 'aug-cc-pwcvqz.dat',
     'augccpwcv5z': 'aug-cc-pwcv5z.dat',


### PR DESCRIPTION
Closes #1508 