### PR TITLE
Add SCS-MP2

### DIFF
--- a/pyscf/mp/test/test_mp2.py
+++ b/pyscf/mp/test/test_mp2.py
@@ -61,12 +61,16 @@ class KnownValues(unittest.TestCase):
         pt = mp.MP2(mf)
         emp2, t2 = pt.kernel(mf.mo_energy, mf.mo_coeff)
         self.assertAlmostEqual(emp2, -0.204019967288338, 8)
+        self.assertAlmostEqual(pt.e_corr_ss, -0.05153088565639835, 8)
+        self.assertAlmostEqual(pt.e_corr_os, -0.15248908163191538, 8)
         self.assertAlmostEqual(abs(t2 - t2ref0).max(), 0, 8)
 
         pt.max_memory = 1
         pt.frozen = None
         emp2, t2 = pt.kernel()
         self.assertAlmostEqual(emp2, -0.204019967288338, 8)
+        self.assertAlmostEqual(pt.e_corr_ss, -0.05153088565639835, 8)
+        self.assertAlmostEqual(pt.e_corr_os, -0.15248908163191538, 8)
         self.assertAlmostEqual(abs(t2 - t2ref0).max(), 0, 8)
 
     def test_mp2_outcore(self):
@@ -307,4 +311,3 @@ class KnownValues(unittest.TestCase):
 if __name__ == "__main__":
     print("Full Tests for mp2")
     unittest.main()
-

--- a/pyscf/mp/test/test_ump2.py
+++ b/pyscf/mp/test/test_ump2.py
@@ -49,11 +49,15 @@ class KnownValues(unittest.TestCase):
         pt = mp.MP2(mf)
         emp2, t2 = pt.kernel(mf.mo_energy, mf.mo_coeff)
         self.assertAlmostEqual(emp2, -0.16575150552336643, 8)
+        self.assertAlmostEqual(pt.e_corr_ss, -0.042627186675330754, 8)
+        self.assertAlmostEqual(pt.e_corr_os, -0.12312431898078077, 8)
 
         pt.max_memory = 1
         pt.frozen = None
         emp2, t2 = pt.kernel()
         self.assertAlmostEqual(emp2, -0.16575150552336643, 8)
+        self.assertAlmostEqual(pt.e_corr_ss, -0.042627186675330754, 8)
+        self.assertAlmostEqual(pt.e_corr_os, -0.12312431898078077, 8)
 
     def test_ump2_dm(self):
         pt = mp.MP2(mf)
@@ -232,7 +236,7 @@ class KnownValues(unittest.TestCase):
         vjb+= numpy.einsum('klij,lk->ij', eri_ab, dm[0])
         vka = numpy.einsum('ijkl,jk->il', eri_aa, dm[0])
         vkb = numpy.einsum('ijkl,jk->il', eri_bb, dm[1])
-        mf.get_veff = lambda *args: (vja - vka, vjb - vkb) 
+        mf.get_veff = lambda *args: (vja - vka, vjb - vkb)
         vhf = mf.get_veff()
         hcore = (numpy.diag(mo_energy[0]) - vhf[0],
                  numpy.diag(mo_energy[1]) - vhf[1])

--- a/pyscf/pbc/mp/kmp2.py
+++ b/pyscf/pbc/mp/kmp2.py
@@ -90,7 +90,6 @@ def kernel(mp, mo_energy, mo_coeff, verbose=logger.NOTE, with_t2=WITH_T2):
 
     fao2mo = mp._scf.with_df.ao2mo
     kconserv = mp.khelper.kconserv
-    emp2 = 0.
     oovv_ij = np.zeros((nkpts,nocc,nocc,nvir,nvir), dtype=mo_coeff[0].dtype)
 
     mo_e_o = [mo_energy[k][:nocc] for k in range(nkpts)]
@@ -108,6 +107,7 @@ def kernel(mp, mo_energy, mo_coeff, verbose=logger.NOTE, with_t2=WITH_T2):
     if with_df_ints:
         Lov = _init_mp_df_eris(mp)
 
+    emp2_ss = emp2_os = 0.
     for ki in range(nkpts):
         for kj in range(nkpts):
             for ka in range(nkpts):
@@ -139,12 +139,16 @@ def kernel(mp, mo_energy, mo_coeff, verbose=logger.NOTE, with_t2=WITH_T2):
                 t2_ijab = np.conj(oovv_ij[ka]/eijab)
                 if with_t2:
                     t2[ki, kj, ka] = t2_ijab
-                woovv = 2*oovv_ij[ka] - oovv_ij[kb].transpose(0,1,3,2)
-                emp2 += einsum('ijab,ijab', t2_ijab, woovv).real
+                edi = einsum('ijab,ijab', t2_ijab, oovv_ij[ka]).real * 2
+                exi = -einsum('ijab,ijba', t2_ijab, oovv_ij[kb]).real
+                emp2_ss += edi*0.5 + exi
+                emp2_os += edi*0.5
 
     log.timer("KMP2", *cput0)
 
-    emp2 /= nkpts
+    emp2_ss /= nkpts
+    emp2_os /= nkpts
+    emp2 = lib.tag_array(emp2_ss+emp2_os, e_corr_ss=emp2_ss, e_corr_os=emp2_os)
 
     return emp2, t2
 
@@ -723,6 +727,8 @@ class KMP2(mp2.MP2):
         self._nmo = None
         self.e_hf = None
         self.e_corr = None
+        self.e_corr_ss = None
+        self.e_corr_os = None
         self.t2 = None
         self._keys = set(self.__dict__.keys())
 
@@ -767,7 +773,13 @@ class KMP2(mp2.MP2):
 
         self.e_corr, self.t2 = \
                 kernel(self, mo_energy, mo_coeff, verbose=self.verbose, with_t2=with_t2)
-        logger.log(self, 'KMP2 energy = %.15g', self.e_corr)
+
+        self.e_corr_ss = getattr(self.e_corr, 'e_corr_ss', 0)
+        self.e_corr_os = getattr(self.e_corr, 'e_corr_os', 0)
+        self.e_corr = float(self.e_corr)
+
+        self._finalize()
+
         return self.e_corr, self.t2
 
 KRMP2 = KMP2
@@ -804,4 +816,3 @@ if __name__ == '__main__':
     mymp = mp.KMP2(kmf)
     emp2, t2 = mymp.kernel()
     print(emp2 - -0.204721432828996)
-

--- a/pyscf/pbc/mp/test/test_scs.py
+++ b/pyscf/pbc/mp/test/test_scs.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# Copyright 2014-2018 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import unittest
+import numpy as np
+
+from pyscf.pbc import gto as pbcgto
+from pyscf.pbc import scf as pbcscf
+import pyscf.pbc.mp
+import pyscf.pbc.mp.kmp2
+
+
+atom = 'C 0 0 0'
+a = np.eye(3) * 5
+basis = 'cc-pvdz'
+cell = pbcgto.M(atom=atom, basis=basis, a=a).set(precision=1e-12, verbose=4)
+
+
+class KnownValues(unittest.TestCase):
+    def test_mp2(self):
+        mf = pbcscf.RHF(cell).density_fit()
+        mf.conv_tol = 1e-10
+        mf.kernel()
+        pt = pyscf.pbc.mp.mp2.RMP2(mf).run()
+
+        self.assertAlmostEqual(pt.e_corr, -0.0634551885557889, 7)
+        self.assertAlmostEqual(pt.e_corr_ss, -0.00561754117341521, 7)
+        self.assertAlmostEqual(pt.e_corr_os, -0.0578376473823737, 7)
+
+    def test_kmp2(self):
+        def run_k(kmesh):
+            kpts = cell.make_kpts(kmesh)
+            mf = pbcscf.KRHF(cell, kpts).density_fit()
+            mf.conv_tol = 1e-10
+            mf.kernel()
+            pt = pyscf.pbc.mp.kmp2.KMP2(mf).run()
+            return pt
+
+        pt = run_k((1,1,1))
+        self.assertAlmostEqual(pt.e_corr, -0.0634551885557889, 7)
+        self.assertAlmostEqual(pt.e_corr_ss, -0.00561754117341521, 7)
+        self.assertAlmostEqual(pt.e_corr_os, -0.0578376473823737, 7)
+
+        pt = run_k((2,1,1))
+        self.assertAlmostEqual(pt.e_corr, -0.0640728626841088, 7)
+        self.assertAlmostEqual(pt.e_corr_ss, -0.00558491559563941, 7)
+        self.assertAlmostEqual(pt.e_corr_os, -0.0584879470884693, 7)
+
+    def test_ksymm(self):
+        def run_k(kmesh):
+            kpts = cell.make_kpts(kmesh, space_group_symmetry=True)
+            mf = pbcscf.KRHF(cell, kpts).density_fit()
+            mf.conv_tol = 1e-10
+            mf.kernel()
+            pt = pyscf.pbc.mp.kmp2_ksymm.KMP2(mf).run()
+            return pt
+
+        pt = run_k((1,1,1))
+        self.assertAlmostEqual(pt.e_corr, -0.0634551885557889, 7)
+        self.assertAlmostEqual(pt.e_corr_ss, -0.00561754117341521, 7)
+        self.assertAlmostEqual(pt.e_corr_os, -0.0578376473823737, 7)
+
+        pt = run_k((2,1,1))
+        self.assertAlmostEqual(pt.e_corr, -0.0640728626841088, 7)
+        self.assertAlmostEqual(pt.e_corr_ss, -0.00558491559563941, 7)
+        self.assertAlmostEqual(pt.e_corr_os, -0.0584879470884693, 7)
+
+
+if __name__ == '__main__':
+    print("Full kpoint test")
+    unittest.main()


### PR DESCRIPTION
Added same-spin (ss), ooposite-spin (os), and spin-component-scaled MP2 for
- `MP2` (mol & pbc)
- `DFMP2` (mol & pbc)
- `UMP2` (mol & pbc)
- `KMP2`
- `KMP2` with ksymm

and the corresponding tests in
- `mp/test/test_mp2.py`
- `mp/test/test_ump2.py`
- `pbc/mp/test/test_scs.py` (new file)

For all MP2 classes mentioned above, the following attributes are added
```python
self.e_corr_ss  # same-spin
self.e_corr_os  # oppo-spin
```
Given the popularity and usually decent performance of SCS-MP2, the following properties are added
```python
self.emp2_scs # SCS MP2 energy
self.e_tot_scs # SCS total energy
```
Other variants (e.g., SOS-MP2) can be readily added by modifying the base molecular `RMP2` class and the change will apply to all other classes.

The PBC SCS-MP2 was benchmarked in a recent paper: [Accurate thermochemistry of covalent and ionic solids from spin-component-scaled MP2](https://aip.scitation.org/doi/full/10.1063/5.0119633) and was found to outperform MP2 for the ground-state bulk properties of covalent and ionic crystals.

Thanks to @tamigoldzak @xwang862 and @tberkel for help!