### PR TITLE
Fix memory leaks in C kernels for CCSD(T)

### DIFF
--- a/pyscf/lib/cc/ccsd_t.c
+++ b/pyscf/lib/cc/ccsd_t.c
@@ -421,6 +421,7 @@ void CCsd_t_contract(double *e_tot,
         *e_tot += e;
 }
         free(permute_idx);
+        free(jobs);
 }
 
 void QCIsd_t_contract(double *e_tot,
@@ -470,6 +471,7 @@ void QCIsd_t_contract(double *e_tot,
         *e_tot += e;
 }
         free(permute_idx);
+        free(jobs);
 }
 
 
@@ -645,6 +647,7 @@ void CCsd_t_zcontract(double complex *e_tot,
         *e_tot += e;
 }
         free(permute_idx);
+        free(jobs);
 }
 
 void QCIsd_t_zcontract(double complex *e_tot,
@@ -697,6 +700,7 @@ void QCIsd_t_zcontract(double complex *e_tot,
         *e_tot += e;
 }
         free(permute_idx);
+        free(jobs);
 }
 
 
@@ -876,6 +880,7 @@ void MPICCsd_t_contract(double *e_tot, double *mo_energy, double *t1T,
         *e_tot += e;
 }
         free(permute_idx);
+        free(jobs);
 }
 
 /*****************************************************************************

--- a/pyscf/lib/cc/uccsd_t.c
+++ b/pyscf/lib/cc/uccsd_t.c
@@ -323,6 +323,7 @@ void CCuccsd_t_aaa(double complex *e_tot,
 }
         free(permute_idx);
         free(fvohalf);
+        free(jobs);
 }
 
 
@@ -562,6 +563,7 @@ void CCuccsd_t_baa(double complex *e_tot,
 #pragma omp critical
         *e_tot += e;
 }
+        free(jobs);
 }
 
 
@@ -718,6 +720,7 @@ void CCuccsd_t_zaaa(double complex *e_tot,
 }
         free(permute_idx);
         free(fvohalf);
+        free(jobs);
 }
 
 
@@ -917,5 +920,6 @@ void CCuccsd_t_zbaa(double complex *e_tot,
 #pragma omp critical
         *e_tot += e;
 }
+        free(jobs);
 }
 


### PR DESCRIPTION
Fixes #1513. There were a bunch of `malloc` statements without corresponding `free` statements. I've done some simple testing of both CCSD(T) and UCCSD(T) calculations, and I'm not observing any more leaked memory.