### PR TITLE
fix due to float precision on arccos function of beta

### DIFF
--- a/pyscf/symm/Dmatrix.py
+++ b/pyscf/symm/Dmatrix.py
@@ -141,7 +141,12 @@ def get_euler_angles(c1, c2):
     c2 = numpy.asarray(c2)
     if c1.ndim == 2 and c2.ndim == 2:
         zz = c1[2].dot(c2[2])
-        beta = numpy.arccos(zz)
+        if abs(zz - 1.0) < 1e-12:
+            beta = numpy.arccos(1.0)
+        elif abs(zz + 1.0) < 1e-12:
+            beta = numpy.arccos(-1.0)
+        else:
+            beta = numpy.arccos(zz)
         if abs(zz) < 1 - 1e-12:
             yp = numpy.cross(c1[2], c2[2])
             yp /= numpy.linalg.norm(yp)


### PR DESCRIPTION
The following structure yields `pyscf/pyscf/symm/Dmatrix.py:144: RuntimeWarning: invalid value encountered in arccos`
```
atom = '''
C           0.00000        1.26900       -0.96100
C           0.00000       -0.71400       -2.35000
C           0.00000        0.71400       -2.35000
C           0.00000        1.12700       -3.61700
H           0.86700        1.88900       -0.75900
H          -0.86700        1.88900       -0.75900
H           0.00000        2.09900       -4.06000
C           0.00000        0.00000       -0.02800
C           1.25800        0.00000        0.92600
C           0.66500        0.00000        2.29500
H           1.88700        0.86900        0.78400
H           1.88700       -0.86900        0.78400
C          -0.66500        0.00000        2.29500
C           1.09400        0.00000        3.66800
H           2.08000        0.00000        4.08800
C          -1.09400        0.00000        3.66800
C           0.00000       -1.12700       -3.61700
C           0.00000       -1.26900       -0.96100
H           0.86700       -1.88900       -0.75900
H          -0.86700       -1.88900       -0.75900
C          -1.25800        0.00000        0.92600
H          -1.88700        0.86900        0.78400
H          -1.88700       -0.86900        0.78400
H           0.00000       -2.09900       -4.06000
H          -2.08000        0.00000        4.08800
N           0.00000        0.00000        4.44800
H           0.00000        0.00000        5.44500
N           0.00000        0.00000       -4.38900
H           0.00000        0.00000       -5.37800'''

mol = gto.M(atom=atom,
                basis='631gs',
                unit='Angstrom',
                symmetry=True)

```

The value of `zz` is `-1.0000000000000002` so it is just a floating point issue similar to what is fixed in #1456 (see lines 157-172 of the Dmatrix.py file). This just checks if `zz` is close to -1 or 1 to since arccos has a valid range of [-1, 1].
