### PR TITLE
label_symmetry_ degen mapping on the fly (#1548)

### DIFF
--- a/pyscf/mcscf/casci_symm.py
+++ b/pyscf/mcscf/casci_symm.py
@@ -113,7 +113,7 @@ def label_symmetry_(mc, mo_coeff, ci0=None):
             if getattr(mo_coeff, 'degen_mapping', None) is not None:
                 degen_mapping = mo_coeff.degen_mapping[ncore:nocc] - ncore
             else:
-                h1e = mc.h1e_for_cas (mo_coeff=mo_coeff)[0][ncore:nocc]
+                h1e = numpy.diag (mc.h1e_for_cas (mo_coeff=mo_coeff)[0])
                 degen_mapping = map_degeneracy (h1e, orbsym[ncore:nocc])
             mc.fcisolver.orbsym = lib.tag_array(
                 orbsym[ncore:nocc], degen_mapping=degen_mapping)


### PR DESCRIPTION
Fixed #1548 by computing the "degen_mapping" tag on-the-fly in casci_symm.label_symmetry_ using h1eff from casci.h1e_for_cas, if a pre-existing tag is unavailable. This fixes the MWE in #1548 as well as the MC-PDFT unit tests, but is this the kind of solution you want to use? It's not quite comparable to what's done in hf_symm.finalize_ because that function uses mo_energy from the Fock matrix, for which the corresponding operation here would involve building an effective Fock matrix from ci0. However, if I read hf_symm.map_degeneracy correctly, it's really just a proxy for, i.e., finding the off-diagonal 1's in |<mo_coeff|Rz(90 degrees)|mo_coeff>|, so you should be able to do this even with the bare hcore, or even with the h1e argument in the FCI solver itself... am I missing something?