### PR TITLE
PBC DF K-build with a smaller overhead

### DIFF
--- a/pyscf/pbc/df/df.py
+++ b/pyscf/pbc/df/df.py
@@ -131,6 +131,8 @@ class GDF(lib.StreamObject, aft.AFTDFMixin):
     # Call _CCGDFBuilder if applicable. _CCGDFBuilder is slower than
     # _RSGDFBuilder but numerically more close to previous versions
     _prefer_ccdf = False
+    # If True, force using denisty matrix-based K-build
+    force_dm_kbuild = False
 
     def __init__(self, cell, kpts=numpy.zeros((1,3))):
         self.cell = cell
@@ -160,7 +162,6 @@ class GDF(lib.StreamObject, aft.AFTDFMixin):
         self.blockdim = getattr(__config__, 'pbc_df_df_DF_blockdim', 240)
         self.linear_dep_threshold = LINEAR_DEP_THR
         self._j_only = False
-        self.force_dm_kbuild = False # use mo coeff for K-build if possible
 # If _cderi_to_save is specified, the 3C-integral tensor will be saved in this file.
         self._cderi_to_save = tempfile.NamedTemporaryFile(dir=lib.param.TMPDIR)
 # If _cderi is specified, the 3C-integral tensor will be read from this file

--- a/pyscf/pbc/df/df.py
+++ b/pyscf/pbc/df/df.py
@@ -160,6 +160,7 @@ class GDF(lib.StreamObject, aft.AFTDFMixin):
         self.blockdim = getattr(__config__, 'pbc_df_df_DF_blockdim', 240)
         self.linear_dep_threshold = LINEAR_DEP_THR
         self._j_only = False
+        self.force_dm_kbuild = False # use mo coeff for K-build if possible
 # If _cderi_to_save is specified, the 3C-integral tensor will be saved in this file.
         self._cderi_to_save = tempfile.NamedTemporaryFile(dir=lib.param.TMPDIR)
 # If _cderi is specified, the 3C-integral tensor will be read from this file

--- a/pyscf/pbc/df/df_jk.py
+++ b/pyscf/pbc/df/df_jk.py
@@ -768,12 +768,14 @@ def get_jk(mydf, dm, hermi=1, kpt=numpy.zeros(3),
         tspans[2] += tock - tick
 
         LpqR = LpqI = pLqR = pLqI = None
+
+    tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
     if thread_k is not None:
         thread_k.join()
     thread_k = None
 
-    tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
-    tspans[2] += tick - tock
+    tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+    tspans[2] += tock - tick
 
     for tspan,tspanname,tspanmask in zip(tspans,tspannames,tspanmasks):
         if tspanmask:
@@ -801,6 +803,7 @@ def get_jk(mydf, dm, hermi=1, kpt=numpy.zeros(3),
 def _mo_from_dm(dms, method='eigh', shape=None, order='C', precision=DM2MO_PREC):
     import scipy.linalg
     nkpts = len(dms)
+    precision *= 1e-2
 
     def sep_real_imag(a, ncolmax, order):
         nrow = a.shape[0]
@@ -830,7 +833,6 @@ def _mo_from_dm(dms, method='eigh', shape=None, order='C', precision=DM2MO_PREC)
 
         nmos = [mo.shape[1] for mo in mos]
         nmomax = max(nmos)
-        nao = mos[0].shape[0]
         moRs = numpy.empty(nkpts, dtype=object)
         moIs = numpy.empty(nkpts, dtype=object)
         for k,mo in enumerate(mos):
@@ -850,7 +852,6 @@ def _mo_from_dm(dms, method='eigh', shape=None, order='C', precision=DM2MO_PREC)
         mos = [fsvd(dm) for k,dm in enumerate(dms)]
         nmos = [x[0].shape[1] for x in mos]
         nmomax = max(nmos)
-        nao = mos[0][0].shape[0]
         mo1Rs = numpy.empty(nkpts, dtype=object)
         mo1Is = numpy.empty(nkpts, dtype=object)
         mo2Rs = numpy.empty(nkpts, dtype=object)

--- a/pyscf/pbc/df/df_jk.py
+++ b/pyscf/pbc/df/df_jk.py
@@ -31,6 +31,9 @@ from pyscf.lib import logger, zdotNN, zdotCN, zdotNC
 from pyscf.pbc import tools
 from pyscf.pbc.lib.kpts import KPoints
 from pyscf.pbc.lib.kpts_helper import is_zero, gamma_point, member
+from pyscf import __config__
+
+DM2MO_PREC = getattr(__config__, 'pbc_gto_df_df_jk_dm2mo_prec', 1e-10)
 
 def density_fit(mf, auxbasis=None, mesh=None, with_df=None):
     '''Generte density-fitting SCF object
@@ -69,14 +72,14 @@ def density_fit(mf, auxbasis=None, mesh=None, with_df=None):
 
 def get_j_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None):
     log = logger.Logger(mydf.stdout, mydf.verbose)
-    t1 = (logger.process_clock(), logger.perf_counter())
+    t0 = (logger.process_clock(), logger.perf_counter())
     if mydf._cderi is None or not mydf.has_kpts(kpts_band):
         if mydf._cderi is not None:
             log.warn('DF integrals for band k-points were not found %s. '
                      'DF integrals will be rebuilt to include band k-points.',
                      mydf._cderi)
         mydf.build(kpts_band=kpts_band)
-        t1 = log.timer_debug1('Init get_j_kpts', *t1)
+        t0 = log.timer_debug1('Init get_j_kpts', *t0)
 
     dm_kpts = lib.asarray(dm_kpts, order='C')
     dms = _format_dms(dm_kpts, kpts)
@@ -93,6 +96,7 @@ def get_j_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None):
     nband = len(kpts_band)
     j_real = gamma_point(kpts_band) and not numpy.iscomplexobj(dms)
 
+    t1 = (logger.process_clock(), logger.perf_counter())
     dmsR = dms.real.transpose(0,1,3,2).reshape(nset,nkpts,nao**2)
     dmsI = dms.imag.transpose(0,1,3,2).reshape(nset,nkpts,nao**2)
     rhoR = numpy.zeros((nset,naux))
@@ -143,6 +147,8 @@ def get_j_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None):
     vj_kpts = lib.unpack_tril(vj_kpts.reshape(-1,nao_pair))
     vj_kpts = vj_kpts.reshape(nset,nband,nao,nao)
 
+    log.timer('get_j', *t0)
+
     return _format_jks(vj_kpts, dm_kpts, input_band, kpts)
 
 
@@ -156,65 +162,319 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None,
                  'exxdiv needs to be "ewald" or None', exxdiv)
         raise RuntimeError('GDF does not support exxdiv %s' % exxdiv)
 
-    t1 = (logger.process_clock(), logger.perf_counter())
+    t0 = (logger.process_clock(), logger.perf_counter())
     if mydf._cderi is None or not mydf.has_kpts(kpts_band):
         if mydf._cderi is not None:
             log.warn('DF integrals for band k-points were not found %s. '
                      'DF integrals will be rebuilt to include band k-points.',
                      mydf._cderi)
         mydf.build(kpts_band=kpts_band)
-        t1 = log.timer_debug1('Init get_k_kpts', *t1)
+        t0 = log.timer_debug1('Init get_k_kpts', *t0)
 
     dm_kpts = lib.asarray(dm_kpts, order='C')
     dms = _format_dms(dm_kpts, kpts)
     nset, nkpts, nao = dms.shape[:3]
 
+    skmoR = skmo2R = None
+    if not mydf.force_dm_kbuild:
+        if hermi == 1:
+            skmoR, skmoI = _mo_from_dm(dms.reshape(-1,nao,nao), method='eigh',
+                                       shape=(nset,nkpts), order='F',
+                                       precision=cell.precision)
+            if skmoR is None:
+                log.debug1('get_k_kpts: Eigh fails for input dm due to non-PSD. '
+                           'Try SVD instead.')
+        if skmoR is None:
+            skmoR, skmoI, skmo2R, skmo2I = _mo_from_dm(dms.reshape(-1,nao,nao),
+                                                   method='svd', shape=(nset,nkpts),
+                                                   order='F', precision=cell.precision)
+            if skmoR[0,0].shape[1] > nao//2:
+                log.debug1('get_k_kpts: rank(dm) = %d exceeds half of nao = %d. '
+                           'Fall back to DM-based build.', skmoR[0,0].shape[1], nao)
+                skmoR = skmo2R = None
+
     kpts_band, input_band = _format_kpts_band(kpts_band, kpts), kpts_band
     nband = len(kpts_band)
     vkR = numpy.zeros((nset,nband,nao,nao))
     vkI = numpy.zeros((nset,nband,nao,nao))
-    dmsR = numpy.asarray(dms.real, order='C')
-    dmsI = numpy.asarray(dms.imag, order='C')
 
+    tspans = numpy.zeros((7,2))
+    tspannames = ['buf1', 'ct11', 'ct12', 'buf2', 'ct21', 'ct22', 'load']
+
+    ''' math
+    K(p,q; k2 from k1)
+        = V(r k1, q k2, p k2, s k1) * D(s,r; k1)
+        = V(L, r k1, q k2) * V(L, s k1, p k2).conj() * D(s,r; k1)         eqn (1)
+    --> in case of Hermitian & PSD DM
+        = ( V(L, s k1, p k2) * C(s,i; k1).conj() ).conj()
+          * V(L, r k1, q k2) * C(r,i; k1).conj()                          eqn (2)
+        = W(L, i k1, p k2).conj() * W(L, i k1, q k2)                      eqn (3)
+    --> in case of non-Hermitian or non-PSD DM
+        = ( V(L, s k1, p k2) * A(s,i; k1).conj() ).conj()
+          * V(L, r k1, q k2) * B(r,i; k1).conj()                          eqn (4)
+        = X(L, i k1, p k2).conj() * Y(L, i k1, q k2)                      eqn (5)
+
+    if swap_2e:
+    K(p,q; k1 from k2)
+        = V(p k1, s k2, r k2, q k1) * D(s,r; k2)
+        = V(L, p k1, s k2) * V(L, q k1, r k2).conj() * D(s,r; k2)         eqn (1')
+    --> in case of Hermitian & PSD DM
+        = V(L, p k1, s k2) * C(s,i; k2)
+          * ( V(L, q k1, r k2) * C(r,i; k2) ).conj()                      eqn (2')
+        = W(L, p k1, i k2) * W(L, q k1, i k2).conj()                      eqn (3')
+    --> in case of non-Hermitian or non-PSD DM
+        = V(L, p k1, s k2) * A(s,i; k2)
+          * ( V(L, q k1, r k2) * B(r,i; k2) ).conj()                      eqn (4')
+        = X(L, p k1, i k2) * Y(L, q k1, i k2).conj()                      eqn (5')
+
+    Mode 1: DM-based K-build uses eqn (1) and eqn (1')
+    Mode 2: Symm MO-based K-build uses eqns (2,3) and eqns (2',3')
+    Mode 3: Asymm MO-based K-build uses eqns (4,5) and eqns (4',5')
+    '''
     # K_pq = ( p{k1} i{k2} | i{k2} q{k1} )
-    bufR = numpy.empty((mydf.blockdim*nao**2))
-    bufI = numpy.empty((mydf.blockdim*nao**2))
-    max_memory = max(2000, mydf.max_memory-lib.current_memory()[0])
-    def make_kpt(ki, kj, swap_2e, inverse_idx=None):
-        kpti = kpts[ki]
-        kptj = kpts_band[kj]
+    if skmoR is None: # input dm is not Hermitian/PSD --> build K from dm
+        log.debug2('get_k_kpts: build K from dm')
+        dmsR = numpy.asarray(dms.real, order='C')
+        dmsI = numpy.asarray(dms.imag, order='C')
+        bufR = numpy.empty((mydf.blockdim*nao**2))
+        bufI = numpy.empty((mydf.blockdim*nao**2))
+        max_memory = max(2000, mydf.max_memory-lib.current_memory()[0])
+        def make_kpt(ki, kj, swap_2e, inverse_idx=None):
+            kpti = kpts[ki]
+            kptj = kpts_band[kj]
 
-        for LpqR, LpqI, sign in mydf.sr_loop((kpti,kptj), max_memory, False):
-            nrow = LpqR.shape[0]
-            pLqR = numpy.ndarray((nao,nrow,nao), buffer=bufR)
-            pLqI = numpy.ndarray((nao,nrow,nao), buffer=bufI)
-            tmpR = numpy.ndarray((nao,nrow*nao), buffer=LpqR)
-            tmpI = numpy.ndarray((nao,nrow*nao), buffer=LpqI)
-            pLqR[:] = LpqR.reshape(-1,nao,nao).transpose(1,0,2)
-            pLqI[:] = LpqI.reshape(-1,nao,nao).transpose(1,0,2)
+            tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
 
-            for i in range(nset):
-                zdotNN(dmsR[i,ki], dmsI[i,ki], pLqR.reshape(nao,-1),
-                       pLqI.reshape(nao,-1), 1, tmpR, tmpI)
-                zdotCN(pLqR.reshape(-1,nao).T, pLqI.reshape(-1,nao).T,
-                       tmpR.reshape(-1,nao), tmpI.reshape(-1,nao),
-                       sign, vkR[i,kj], vkI[i,kj], 1)
+            for LpqR, LpqI, sign in mydf.sr_loop((kpti,kptj), max_memory, False):
+                nrow = LpqR.shape[0]
 
-            if swap_2e:
-                tmpR = tmpR.reshape(nao*nrow,nao)
-                tmpI = tmpI.reshape(nao*nrow,nao)
-                ki_tmp = ki
-                kj_tmp = kj
-                if inverse_idx:
-                    ki_tmp = inverse_idx[0]
-                    kj_tmp = inverse_idx[1]
+                tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                tspans[6] += tick - tock
+
+                pLqR = numpy.ndarray((nao,nrow,nao), buffer=bufR)
+                pLqI = numpy.ndarray((nao,nrow,nao), buffer=bufI)
+                tmpR = numpy.ndarray((nao,nrow*nao), buffer=LpqR)
+                tmpI = numpy.ndarray((nao,nrow*nao), buffer=LpqI)
+                pLqR[:] = LpqR.reshape(-1,nao,nao).transpose(1,0,2)
+                pLqI[:] = LpqI.reshape(-1,nao,nao).transpose(1,0,2)
+
+                tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                tspans[0] += tock - tick
+
                 for i in range(nset):
-                    zdotNN(pLqR.reshape(-1,nao), pLqI.reshape(-1,nao),
-                           dmsR[i,kj_tmp], dmsI[i,kj_tmp], 1, tmpR, tmpI)
-                    zdotNC(tmpR.reshape(nao,-1), tmpI.reshape(nao,-1),
-                           pLqR.reshape(nao,-1).T, pLqI.reshape(nao,-1).T,
-                           sign, vkR[i,ki_tmp], vkI[i,ki_tmp], 1)
+                    zdotNN(dmsR[i,ki], dmsI[i,ki], pLqR.reshape(nao,-1),
+                           pLqI.reshape(nao,-1), 1, tmpR, tmpI)
+                    tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                    tspans[1] += tick - tock
+                    zdotCN(pLqR.reshape(-1,nao).T, pLqI.reshape(-1,nao).T,
+                           tmpR.reshape(-1,nao), tmpI.reshape(-1,nao),
+                           sign, vkR[i,kj], vkI[i,kj], 1)
+                    tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                    tspans[2] += tock - tick
 
+                if swap_2e:
+                    tmpR = tmpR.reshape(nao*nrow,nao)
+                    tmpI = tmpI.reshape(nao*nrow,nao)
+                    tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                    tspans[3] += tick - tock
+                    ki_tmp = ki
+                    kj_tmp = kj
+                    if inverse_idx:
+                        ki_tmp = inverse_idx[0]
+                        kj_tmp = inverse_idx[1]
+                    for i in range(nset):
+                        zdotNN(pLqR.reshape(-1,nao), pLqI.reshape(-1,nao),
+                               dmsR[i,kj_tmp], dmsI[i,kj_tmp], 1, tmpR, tmpI)
+                        tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                        tspans[4] += tock - tick
+                        zdotNC(tmpR.reshape(nao,-1), tmpI.reshape(nao,-1),
+                               pLqR.reshape(nao,-1).T, pLqI.reshape(nao,-1).T,
+                               sign, vkR[i,ki_tmp], vkI[i,ki_tmp], 1)
+                        tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                        tspans[5] += tick - tock
+
+                tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+
+                LpqR = LpqI = pLqR = pLqI = tmpR = tmpI = None
+    elif skmo2R is None:
+        log.debug2('get_k_kpts: build K from symm mo coeff')
+        nmo = skmoR[0,0].shape[1]
+        log.debug2('get_k_kpts: rank(dm) = %d / %d', nmo, nao)
+        skmoI_mask = numpy.asarray([[abs(skmoI[i,k]).max() > cell.precision
+                                     for k in range(nkpts)] for i in range(nset)])
+        bufR = numpy.empty((mydf.blockdim*nao**2))
+        bufI = numpy.empty((mydf.blockdim*nao**2))
+        max_memory = max(2000, mydf.max_memory-lib.current_memory()[0])
+        def make_kpt(ki, kj, swap_2e, inverse_idx=None):
+            kpti = kpts[ki]
+            kptj = kpts_band[kj]
+
+            tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+
+            for LpqR, LpqI, sign in mydf.sr_loop((kpti,kptj), max_memory, False):
+                nrow = LpqR.shape[0]
+
+                tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                tspans[6] += tick - tock
+
+                pLqR = numpy.ndarray((nao,nrow,nao), buffer=bufR)
+                pLqI = numpy.ndarray((nao,nrow,nao), buffer=bufI)
+                tmpR = numpy.ndarray((nmo,nrow*nao), buffer=LpqR)
+                tmpI = numpy.ndarray((nmo,nrow*nao), buffer=LpqI)
+                pLqR[:] = LpqR.reshape(-1,nao,nao).transpose(1,0,2)
+                pLqI[:] = LpqI.reshape(-1,nao,nao).transpose(1,0,2)
+
+                tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                tspans[0] += tock - tick
+
+                for i in range(nset):
+                    moR = skmoR[i,ki]
+                    if skmoI_mask[i,ki]:
+                        moI = skmoI[i,ki]
+                        zdotCN(moR.T, moI.T, pLqR.reshape(nao,-1), pLqI.reshape(nao,-1),
+                               1, tmpR, tmpI)
+                    else:
+                        lib.ddot(moR.T, pLqR.reshape(nao,-1), 1, tmpR)
+                        lib.ddot(moR.T, pLqI.reshape(nao,-1), 1, tmpI)
+                    tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                    tspans[1] += tick - tock
+                    zdotCN(tmpR.reshape(-1,nao).T, tmpI.reshape(-1,nao).T,
+                           tmpR.reshape(-1,nao), tmpI.reshape(-1,nao),
+                           sign, vkR[i,kj], vkI[i,kj], 1)
+                    tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                    tspans[2] += tock - tick
+
+                if swap_2e:
+                    tmpR = tmpR.reshape(nrow*nao,nmo)
+                    tmpI = tmpI.reshape(nrow*nao,nmo)
+                    tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                    tspans[3] += tick - tock
+                    ki_tmp = ki
+                    kj_tmp = kj
+                    if inverse_idx:
+                        ki_tmp = inverse_idx[0]
+                        kj_tmp = inverse_idx[1]
+                    for i in range(nset):
+                        moR = skmoR[i,kj_tmp]
+                        if skmoI_mask[i,kj_tmp]:
+                            moI = skmoI[i,kj_tmp]
+                            zdotNN(pLqR.reshape(-1,nao), pLqI.reshape(-1,nao), moR, moI,
+                                   1, tmpR, tmpI)
+                        else:
+                            lib.ddot(pLqR.reshape(-1,nao), moR, 1, tmpR)
+                            lib.ddot(pLqI.reshape(-1,nao), moR, 1, tmpI)
+                        tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                        tspans[4] += tock - tick
+                        zdotNC(tmpR.reshape(nao,-1), tmpI.reshape(nao,-1),
+                               tmpR.reshape(nao,-1).T, tmpI.reshape(nao,-1).T,
+                               sign, vkR[i,ki_tmp], vkI[i,ki_tmp], 1)
+                        tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                        tspans[5] += tick - tock
+
+                tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+
+                LpqR = LpqI = pLqR = pLqI = tmpR = tmpI = None
+    else:
+        log.debug2('get_k_kpts: build K from asymm mo coeff')
+        skmo1R = skmoR
+        skmo1I = skmoI
+        nmo = skmoR[0,0].shape[1]
+        log.debug2('get_k_kpts: rank(dm) = %d / %d', nmo, nao)
+        skmoI_mask = numpy.asarray([[max(abs(skmo1I[i,k]).max(),
+                                         abs(skmo2I[i,k]).max()) > cell.precision
+                                     for k in range(nkpts)] for i in range(nset)])
+        bufR = numpy.empty((mydf.blockdim*nao**2))
+        bufI = numpy.empty((mydf.blockdim*nao**2))
+        max_memory = max(2000, mydf.max_memory-lib.current_memory()[0])
+        def make_kpt(ki, kj, swap_2e, inverse_idx=None):
+            kpti = kpts[ki]
+            kptj = kpts_band[kj]
+
+            tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+
+            for LpqR, LpqI, sign in mydf.sr_loop((kpti,kptj), max_memory, False):
+                nrow = LpqR.shape[0]
+
+                tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                tspans[6] += tick - tock
+
+                pLqR = numpy.ndarray((nao,nrow,nao), buffer=bufR)
+                pLqI = numpy.ndarray((nao,nrow,nao), buffer=bufI)
+                tmp1R = numpy.ndarray((nmo,nrow*nao), buffer=LpqR)
+                tmp1I = numpy.ndarray((nmo,nrow*nao), buffer=LpqI)
+                tmp2R = numpy.ndarray((nmo,nrow*nao),
+                                      buffer=LpqR.reshape(-1)[tmp1R.size:])
+                tmp2I = numpy.ndarray((nmo,nrow*nao),
+                                      buffer=LpqI.reshape(-1)[tmp1I.size:])
+                pLqR[:] = LpqR.reshape(-1,nao,nao).transpose(1,0,2)
+                pLqI[:] = LpqI.reshape(-1,nao,nao).transpose(1,0,2)
+
+                tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                tspans[0] += tock - tick
+
+                for i in range(nset):
+                    mo1R = skmo1R[i,ki]
+                    mo2R = skmo2R[i,ki]
+                    if skmoI_mask[i,ki]:
+                        mo1I = skmo1I[i,ki]
+                        mo2I = skmo2I[i,ki]
+                        zdotCN(mo1R.T, mo1I.T, pLqR.reshape(nao,-1), pLqI.reshape(nao,-1),
+                               1, tmp1R, tmp1I)
+                        zdotCN(mo2R.T, mo2I.T, pLqR.reshape(nao,-1), pLqI.reshape(nao,-1),
+                               1, tmp2R, tmp2I)
+                    else:
+                        lib.ddot(mo1R.T, pLqR.reshape(nao,-1), 1, tmp1R)
+                        lib.ddot(mo1R.T, pLqI.reshape(nao,-1), 1, tmp1I)
+                        lib.ddot(mo2R.T, pLqR.reshape(nao,-1), 1, tmp2R)
+                        lib.ddot(mo2R.T, pLqI.reshape(nao,-1), 1, tmp2I)
+                    tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                    tspans[1] += tick - tock
+                    zdotCN(tmp1R.reshape(-1,nao).T, tmp1I.reshape(-1,nao).T,
+                           tmp2R.reshape(-1,nao), tmp2I.reshape(-1,nao),
+                           sign, vkR[i,kj], vkI[i,kj], 1)
+                    tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                    tspans[2] += tock - tick
+
+                if swap_2e:
+                    tmp1R = tmp1R.reshape(nrow*nao,nmo)
+                    tmp1I = tmp1I.reshape(nrow*nao,nmo)
+                    tmp2R = tmp2R.reshape(nrow*nao,nmo)
+                    tmp2I = tmp2I.reshape(nrow*nao,nmo)
+                    tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                    tspans[3] += tick - tock
+                    ki_tmp = ki
+                    kj_tmp = kj
+                    if inverse_idx:
+                        ki_tmp = inverse_idx[0]
+                        kj_tmp = inverse_idx[1]
+                    for i in range(nset):
+                        mo1R = skmo1R[i,kj_tmp]
+                        mo2R = skmo2R[i,kj_tmp]
+                        if skmoI_mask[i,kj_tmp]:
+                            mo1I = skmo1I[i,kj_tmp]
+                            mo2I = skmo2I[i,kj_tmp]
+                            zdotNN(pLqR.reshape(-1,nao), pLqI.reshape(-1,nao), mo1R, mo1I,
+                                   1, tmp1R, tmp1I)
+                            zdotNN(pLqR.reshape(-1,nao), pLqI.reshape(-1,nao), mo2R, mo2I,
+                                   1, tmp2R, tmp2I)
+                        else:
+                            lib.ddot(pLqR.reshape(-1,nao), mo1R, 1, tmp1R)
+                            lib.ddot(pLqI.reshape(-1,nao), mo1R, 1, tmp1I)
+                            lib.ddot(pLqR.reshape(-1,nao), mo2R, 1, tmp2R)
+                            lib.ddot(pLqI.reshape(-1,nao), mo2R, 1, tmp2I)
+                        tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                        tspans[4] += tock - tick
+                        zdotNC(tmp1R.reshape(nao,-1), tmp1I.reshape(nao,-1),
+                               tmp2R.reshape(nao,-1).T, tmp2I.reshape(nao,-1).T,
+                               sign, vkR[i,ki_tmp], vkI[i,ki_tmp], 1)
+                        tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+                        tspans[5] += tick - tock
+
+                tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+
+                LpqR = LpqI = pLqR = pLqI = tmp1R = tmp1I = tmp2R = tmp2I = None
+
+    t1 = (logger.process_clock(), logger.perf_counter())
     if kpts_band is kpts:  # normal k-points HF/DFT
         for ki in range(nkpts):
             for kj in range(ki):
@@ -251,6 +511,10 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None,
                         make_kpt(ki, kj, False)
             t1 = log.timer_debug1('get_k_kpts: make_kpt (%d,*)'%ki, *t1)
 
+    for tspan, tspanname in zip(tspans,tspannames):
+        log.debug1('    CPU time for %s %10.2f sec, wall time %10.2f sec',
+                   tspanname, *tspan)
+
     if (gamma_point(kpts) and gamma_point(kpts_band) and
         not numpy.iscomplexobj(dm_kpts)):
         vk_kpts = vkR
@@ -260,6 +524,8 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None,
 
     if exxdiv == 'ewald':
         _ewald_exxdiv_for_G0(cell, kpts, dms, vk_kpts, kpts_band)
+
+    log.timer('get_k_kpts', *t0)
 
     return _format_jks(vk_kpts, dm_kpts, input_band, kpts)
 
@@ -284,21 +550,20 @@ def get_jk(mydf, dm, hermi=1, kpt=numpy.zeros(3),
 
     cell = mydf.cell
     log = logger.Logger(mydf.stdout, mydf.verbose)
-    t1 = (logger.process_clock(), logger.perf_counter())
+    t0 = (logger.process_clock(), logger.perf_counter())
     if mydf._cderi is None or not mydf.has_kpts(kpts_band):
         if mydf._cderi is not None:
             log.warn('DF integrals for band k-points were not found %s. '
                      'DF integrals will be rebuilt to include band k-points.',
                      mydf._cderi)
         mydf.build(kpts_band=kpts_band)
-        t1 = log.timer_debug1('Init get_jk', *t1)
+        t0 = log.timer_debug1('Init get_jk', *t0)
 
     dm = numpy.asarray(dm, order='C')
     dms = _format_dms(dm, [kpt])
     nset, _, nao = dms.shape[:3]
     dms = dms.reshape(nset,nao,nao)
     j_real = gamma_point(kpt)
-    k_real = gamma_point(kpt) and not numpy.iscomplexobj(dms)
     kptii = numpy.asarray((kpt,kpt))
     dmsR = dms.real.reshape(nset,nao,nao)
     dmsI = dms.imag.reshape(nset,nao,nao)
@@ -308,40 +573,166 @@ def get_jk(mydf, dm, hermi=1, kpt=numpy.zeros(3),
         vjR = numpy.zeros((nset,nao,nao))
         vjI = numpy.zeros((nset,nao,nao))
     if with_k:
+        ''' math
+        Mode 1: DM-based K-build:
+            K(p,q)
+                = V(r,q,p,s) * D(s,r)
+                = V(L,r,q) * V(L,s,p).conj() * D(s,r)    eqn (1)
+
+        Mode 2: Symm MO-based K-build:
+        In case of Hermitian & PSD DM, eqn (1) can be rewritten as
+            K(p,q)
+                = W(L,i,p).conj() * W(L,i,q)
+        where
+            W(L,i,p) = V(L,s,p) * C(s,i).conj()
+            D(s,r) = C(s,i) * C(r,i).conj()
+
+        Mode 3: Asymm MO-based K-build:
+        In case of non-Hermitian or Hermitian but non-PSD DM, eqn (1) can be rewritten as
+            K(p,q)
+                = X(L,i,p).conj() * Y(L,i,q)
+            where
+                X(L,i,p) = V(L,s,p) * A(s,i).conj()
+                Y(L,i,q) = V(L,r,q) * B(r,i).conj()
+                D(s,r) = A(s,i) * B(r,i).conj()
+        '''
+        smoR = smo2R = None
+        if not mydf.force_dm_kbuild:
+            if hermi == 1:
+                smoR, smoI = _mo_from_dm(dms.reshape(-1,nao,nao), method='eigh',
+                                           order='F', precision=cell.precision)
+                if smoR is None:
+                    log.debug1('get_jk: Eigh fails for input dm due to non-PSD. '
+                               'Try SVD instead.')
+            if smoR is None:
+                smoR, smoI, smo2R, smo2I = _mo_from_dm(dms.reshape(-1,nao,nao),
+                                                       method='svd', order='F',
+                                                       precision=cell.precision)
+                if smoR[0].shape[1] > nao//2:
+                    log.debug1('get_jk: rank(dm) = %d exceeds half of nao = %d. '
+                               'Fall back to DM-based build.', smoR[0].shape[1], nao)
+                    smoR = smo2R = None
+
         vkR = numpy.zeros((nset,nao,nao))
         vkI = numpy.zeros((nset,nao,nao))
         buf1R = numpy.empty((mydf.blockdim*nao**2))
-        buf2R = numpy.empty((mydf.blockdim*nao**2))
         buf1I = numpy.zeros((mydf.blockdim*nao**2))
-        buf2I = numpy.empty((mydf.blockdim*nao**2))
-        max_memory *= .5
-    log.debug1('max_memory = %d MB (%d in use)', max_memory, mem_now)
-    def contract_k(pLqR, pLqI, sign):
-        # K ~ 'iLj,lLk*,li->kj' + 'lLk*,iLj,li->kj'
-        #:pLq = (LpqR + LpqI.reshape(-1,nao,nao)*1j).transpose(1,0,2)
-        #:tmp = numpy.dot(dm, pLq.reshape(nao,-1))
-        #:vk += numpy.dot(pLq.reshape(-1,nao).conj().T, tmp.reshape(-1,nao))
-        nrow = pLqR.shape[1]
-        tmpR = numpy.ndarray((nao,nrow*nao), buffer=buf2R)
-        if k_real:
-            for i in range(nset):
-                lib.ddot(dmsR[i], pLqR.reshape(nao,-1), 1, tmpR)
-                lib.ddot(pLqR.reshape(-1,nao).T, tmpR.reshape(-1,nao), sign, vkR[i], 1)
+        if smoR is None:
+            # K ~ 'iLj,lLk*,li->kj' + 'lLk*,iLj,li->kj'
+            #:pLq = (LpqR + LpqI.reshape(-1,nao,nao)*1j).transpose(1,0,2)
+            #:tmp = numpy.dot(dm, pLq.reshape(nao,-1))
+            #:vk += numpy.dot(pLq.reshape(-1,nao).conj().T, tmp.reshape(-1,nao))
+            log.debug2('get_jk: build K from dm')
+            k_real = gamma_point(kpt) and not numpy.iscomplexobj(dms)
+            buf2R = numpy.empty((mydf.blockdim*nao**2))
+            buf2I = numpy.empty((mydf.blockdim*nao**2))
+            if k_real:
+                def contract_k(pLqR, pLqI, sign):
+                    nrow = pLqR.shape[1]
+                    tmpR = numpy.ndarray((nao,nrow*nao), buffer=buf2R)
+                    for i in range(nset):
+                        lib.ddot(dmsR[i], pLqR.reshape(nao,-1), 1, tmpR)
+                        lib.ddot(pLqR.reshape(-1,nao).T, tmpR.reshape(-1,nao),
+                                 sign, vkR[i], 1)
+            else:
+                buf2I = numpy.empty((mydf.blockdim*nao**2))
+                def contract_k(pLqR, pLqI, sign):
+                    nrow = pLqR.shape[1]
+                    tmpR = numpy.ndarray((nao,nrow*nao), buffer=buf2R)
+                    tmpI = numpy.ndarray((nao,nrow*nao), buffer=buf2I)
+                    for i in range(nset):
+                        zdotNN(dmsR[i], dmsI[i], pLqR.reshape(nao,-1),
+                               pLqI.reshape(nao,-1), 1, tmpR, tmpI, 0)
+                        zdotCN(pLqR.reshape(-1,nao).T, pLqI.reshape(-1,nao).T,
+                               tmpR.reshape(-1,nao), tmpI.reshape(-1,nao),
+                               sign, vkR[i], vkI[i], 1)
+        elif smo2R is None:
+            log.debug2('get_jk: build K from symm mo coeff')
+            nmo = smoR[0].shape[1]
+            log.debug2('get_jk: rank(dm) = %d / %d', nmo, nao)
+            smoI_mask = numpy.asarray([abs(moI).max() > cell.precision for moI in smoI])
+            k_real = gamma_point(kpt) and not numpy.any(smoI_mask)
+            buf2R = numpy.empty((mydf.blockdim*nao*nmo))
+            if k_real:
+                def contract_k(pLqR, pLqI, sign):
+                    nrow = pLqR.shape[1]
+                    tmpR = numpy.ndarray((nmo,nrow*nao), buffer=buf2R)
+                    for i in range(nset):
+                        lib.ddot(smoR[i].T, pLqR.reshape(nao,-1), 1, tmpR)
+                        lib.ddot(tmpR.reshape(-1,nao).T, tmpR.reshape(-1,nao),
+                                 sign, vkR[i], 1)
+                    tmpR = None
+            else:
+                buf2I = numpy.empty((mydf.blockdim*nao*nmo))
+                def contract_k(pLqR, pLqI, sign):
+                    nrow = pLqR.shape[1]
+                    tmpR = numpy.ndarray((nmo,nrow*nao), buffer=buf2R)
+                    tmpI = numpy.ndarray((nmo,nrow*nao), buffer=buf2I)
+                    for i in range(nset):
+                        zdotCN(smoR[i].T, smoI[i].T,
+                               pLqR.reshape(nao,-1), pLqI.reshape(nao,-1),
+                               1, tmpR, tmpI, 0)
+                        zdotCN(tmpR.reshape(-1,nao).T, tmpI.reshape(-1,nao).T,
+                               tmpR.reshape(-1,nao), tmpI.reshape(-1,nao),
+                               sign, vkR[i], vkI[i], 1)
+                    tmpR = tmpI = None
         else:
-            tmpI = numpy.ndarray((nao,nrow*nao), buffer=buf2I)
-            for i in range(nset):
-                zdotNN(dmsR[i], dmsI[i], pLqR.reshape(nao,-1),
-                       pLqI.reshape(nao,-1), 1, tmpR, tmpI, 0)
-                zdotCN(pLqR.reshape(-1,nao).T, pLqI.reshape(-1,nao).T,
-                       tmpR.reshape(-1,nao), tmpI.reshape(-1,nao),
-                       sign, vkR[i], vkI[i], 1)
+            log.debug2('get_jk: build K from asymm mo coeff')
+            smo1R = smoR
+            smo1I = smoI
+            nmo = smo1R[0].shape[1]
+            log.debug2('get_jk: rank(dm) = %d / %d', nmo, nao)
+            smoI_mask = numpy.asarray([max(abs(mo1I).max(),
+                                           abs(mo2I).max()) > cell.precision
+                                       for mo1I,mo2I in zip(smo1I,smo2I)])
+            k_real = gamma_point(kpt) and not numpy.any(smoI_mask)
+            buf2R = numpy.empty((mydf.blockdim*nao*nmo*2))
+            buf3R = buf2R[buf2R.size//2:]
+            if k_real:
+                def contract_k(pLqR, pLqI, sign):
+                    nrow = pLqR.shape[1]
+                    tmp1R = numpy.ndarray((nmo,nrow*nao), buffer=buf2R)
+                    tmp2R = numpy.ndarray((nmo,nrow*nao), buffer=buf3R)
+                    for i in range(nset):
+                        lib.ddot(smo1R[i].T, pLqR.reshape(nao,-1), 1, tmp1R)
+                        lib.ddot(smo2R[i].T, pLqR.reshape(nao,-1), 1, tmp2R)
+                        lib.ddot(tmp1R.reshape(-1,nao).T, tmp2R.reshape(-1,nao),
+                                 sign, vkR[i], 1)
+                    tmp1R = tmp2R = None
+            else:
+                buf2I = numpy.empty((mydf.blockdim*nao*nmo*2))
+                buf3I = buf2I[buf2I.size//2:]
+                def contract_k(pLqR, pLqI, sign):
+                    nrow = pLqR.shape[1]
+                    tmp1R = numpy.ndarray((nmo,nrow*nao), buffer=buf2R)
+                    tmp1I = numpy.ndarray((nmo,nrow*nao), buffer=buf2I)
+                    tmp2R = numpy.ndarray((nmo,nrow*nao), buffer=buf3R)
+                    tmp2I = numpy.ndarray((nmo,nrow*nao), buffer=buf3I)
+                    for i in range(nset):
+                        zdotCN(smo1R[i].T, smo1I[i].T,
+                               pLqR.reshape(nao,-1), pLqI.reshape(nao,-1),
+                               1, tmp1R, tmp1I, 0)
+                        zdotCN(smo2R[i].T, smo2I[i].T,
+                               pLqR.reshape(nao,-1), pLqI.reshape(nao,-1),
+                               1, tmp2R, tmp2I, 0)
+                        zdotCN(tmp1R.reshape(-1,nao).T, tmp1I.reshape(-1,nao).T,
+                               tmp2R.reshape(-1,nao), tmp2I.reshape(-1,nao),
+                               sign, vkR[i], vkI[i], 1)
+                    tmp1R = tmp1I = tmp2R = tmp2I = None
+        max_memory *= .5
+    log.debug1('get_jk: max_memory = %d MB (%d in use)', max_memory, mem_now)
+
+    tspans = numpy.zeros((3,2))
+    tspannames = ['  load', 'with_j', 'with_k']
+    tspanmasks = [True, with_j, with_k]
+
+    tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
     pLqI = None
     thread_k = None
     for LpqR, LpqI, sign in mydf.sr_loop(kptii, max_memory, False):
         LpqR = LpqR.reshape(-1,nao,nao)
-        t1 = log.timer_debug1('        load', *t1)
-        if thread_k is not None:
-            thread_k.join()
+        tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+        tspans[0] += tock - tick
         if with_j:
             #:rho_coeff = numpy.einsum('Lpq,xqp->xL', Lpq, dms)
             #:vj += numpy.dot(rho_coeff, Lpq.reshape(-1,nao**2))
@@ -357,7 +748,11 @@ def get_jk(mydf, dm, hermi=1, kpt=numpy.zeros(3),
                 vjI += sign * numpy.einsum('xL,Lpq->xpq', rhoR, LpqI)
                 vjI += sign * numpy.einsum('xL,Lpq->xpq', rhoI, LpqR)
 
-        t1 = log.timer_debug1('        with_j', *t1)
+        tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+        tspans[1] += tick - tock
+
+        if thread_k is not None:
+            thread_k.join()
         if with_k:
             nrow = LpqR.shape[0]
             pLqR = numpy.ndarray((nao,nrow,nao), buffer=buf1R)
@@ -368,11 +763,22 @@ def get_jk(mydf, dm, hermi=1, kpt=numpy.zeros(3),
                     pLqI[:] = LpqI.reshape(-1,nao,nao).transpose(1,0,2)
 
             thread_k = lib.background_thread(contract_k, pLqR, pLqI, sign)
-            t1 = log.timer_debug1('        with_k', *t1)
+
+        tock = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+        tspans[2] += tock - tick
+
         LpqR = LpqI = pLqR = pLqI = None
     if thread_k is not None:
         thread_k.join()
     thread_k = None
+
+    tick = numpy.asarray((logger.process_clock(), logger.perf_counter()))
+    tspans[2] += tick - tock
+
+    for tspan,tspanname,tspanmask in zip(tspans,tspannames,tspanmasks):
+        if tspanmask:
+            log.debug1('    CPU time for %s %9.2f sec, wall time %9.2f sec',
+                       tspanname, *tspan)
 
     if with_j:
         if j_real:
@@ -389,9 +795,77 @@ def get_jk(mydf, dm, hermi=1, kpt=numpy.zeros(3),
             _ewald_exxdiv_for_G0(cell, kpt, dms, vk)
         vk = vk.reshape(dm.shape)
 
-    t1 = log.timer('sr jk', *t1)
+    log.timer('sr jk', *t0)
     return vj, vk
 
+def _mo_from_dm(dms, method='eigh', shape=None, order='C', precision=DM2MO_PREC):
+    import scipy.linalg
+    nkpts = len(dms)
+
+    def sep_real_imag(a, ncolmax, order):
+        nrow = a.shape[0]
+        aR = numpy.zeros((nrow,ncolmax), dtype=numpy.float64)
+        aI = numpy.zeros((nrow,ncolmax), dtype=numpy.float64)
+        ncol = a.shape[1]
+        aR[:,:ncol] = numpy.asarray(a.real, order=order)
+        aI[:,:ncol] = numpy.asarray(a.imag, order=order)
+        return aR, aI
+
+    if method == 'eigh':
+        def feigh(dm):
+            e, u = scipy.linalg.eigh(dm)
+            if numpy.any(e < -precision): # PSD matrix
+                mo = None
+            else:
+                mask = e > precision
+                mo = u[:,mask] * e[mask]**0.5
+            return mo
+
+        mos = numpy.empty(nkpts, dtype=object)
+        for k,dm in enumerate(dms):
+            mo = feigh(dm)
+            if mo is None:
+                return None, None
+            mos[k] = mo
+
+        nmos = [mo.shape[1] for mo in mos]
+        nmomax = max(nmos)
+        nao = mos[0].shape[0]
+        moRs = numpy.empty(nkpts, dtype=object)
+        moIs = numpy.empty(nkpts, dtype=object)
+        for k,mo in enumerate(mos):
+            moRs[k], moIs[k] = sep_real_imag(mo, nmomax, order)
+        if shape is not None:
+            moRs = moRs.reshape(*shape)
+            moIs = moIs.reshape(*shape)
+        return moRs, moIs
+    elif method == 'svd':
+        def fsvd(dm):
+            u, e, vt = scipy.linalg.svd(dm)
+            mask = e > precision
+            mo1 = u[:,mask] * e[mask]
+            mo2 = vt[mask].T.conj()
+            return mo1, mo2
+
+        mos = [fsvd(dm) for k,dm in enumerate(dms)]
+        nmos = [x[0].shape[1] for x in mos]
+        nmomax = max(nmos)
+        nao = mos[0][0].shape[0]
+        mo1Rs = numpy.empty(nkpts, dtype=object)
+        mo1Is = numpy.empty(nkpts, dtype=object)
+        mo2Rs = numpy.empty(nkpts, dtype=object)
+        mo2Is = numpy.empty(nkpts, dtype=object)
+        for k,(mo1,mo2) in enumerate(mos):
+            mo1Rs[k], mo1Is[k] = sep_real_imag(mo1, nmomax, order)
+            mo2Rs[k], mo2Is[k] = sep_real_imag(mo2, nmomax, order)
+        if shape is not None:
+            mo1Rs = mo1Rs.reshape(*shape)
+            mo1Is = mo1Is.reshape(*shape)
+            mo2Rs = mo2Rs.reshape(*shape)
+            mo2Is = mo2Is.reshape(*shape)
+        return mo1Rs, mo1Is, mo2Rs, mo2Is
+    else:
+        raise RuntimeError('Unknown method %s' % method)
 
 def _format_dms(dm_kpts, kpts):
     nkpts = len(kpts)


### PR DESCRIPTION
# Math

The currently implemented density matrix (DM)-based K-build in the PBC module
```
K(p,q) = \sum_{L,r,s} V(L,p,s) * V(L,q,r).conj() * D(s,r)
```
requires `O(N^3 * X)` cost in both CPU and storage, where `N` and `X` are the size of the AO and auxiliary basis sets, respectively. This algorithm can be accelerated by exploiting the low-rank structure of the DM, which leads to the MO-based algorithm
```
D = A * B.conj()
X(L,p,i) = \sum_{s} V(L,p,s) * A(s,i)
Y(L,q,i) = \sum_{s} V(L,q,r) * B(r,i)
K(p,q) = \sum_{L,i} X(L,p,i) * Y(L,q,i).conj()
```
that now scales as `O(N^2 * O * X)` in both CPU and storage cost, where `O` is the rank of the DM. When `D` is positive semidefinite, the asymmetric algorithm above becomes symmetric.

The speedup of the MO-based algorithm is roughly `N/O`.

For routine K-build tasks such as those in SCF and TD-SCF calculations, `O` is strictly `Nocc` and the reformulation is numerically exact. In more general cases where the DM is only approximately low-rank, truncation by singular values guarantees a controlled error in the K-matrix elements.

*Note that the algorithms implemented here are different from the [occ-RI-K algorithm](https://aip.scitation.org/doi/10.1063/1.4923369). The latter (1) gives a `K` matrix that is different from the normal one in the virtual-virtual block and (2) is best implemented in an integral-direct manner which requires a structural change of existing (RS)DF module.*


# Major changes

The following functions
- `get_k_kpts` from `pbc/df/df_jk.py`
- `get_jk` from `pbc/df/df_jk.py`

are updated with MO-based K-build algorithm outlined above using GDF/RSDF/MDF (only the short-range part for MDF), which complements the existing DM-based algorithm. Both the symmetric mode (via eigen decomposition) and the asymmetric mode (via SVD) are implemented, with the eigen/singular value cutoff set to `cell.precision*1e-2`. One of the three K-build schemes is automatically chosen by the following logic:

- If DM is PSD (hence must be Hermitian), use **symm MO-based**
- if DM is non-PSD (including non-Hermitian) but `rank(DM)*2 < Nao`, use **asymm MO-based**
- otherwise, use **DM-based**

The user can also skip the logic above and force the use of the original DM-based K-build by setting
```
mydf.force_dm_kbuild = True        # default is False
```

The validity of the new K-build schemes have been verified using ground-state HF (for symmetric mode) and excited-state CIS (for asymmetric mode) for both single and multiple k-points.

# Detailed cost analysis

The theoretical speedup of the MO-based K-build is `N/O` over the original DM-based one. The practical speedup is smaller than the theoretical value mainly due to I/O, but can still be a factor of 3 even for a DZ basis set.

Comparison of CPU and memory cost of different K-build
(`N`: AO basis size; `O`: rank of DM; `X`: aux basis size; `[X]`: block size of aux basis index)
| K-build scheme | CPU | Memory |
| --------------- | ---- | --------- |
| DM                     | `2 * N^3*X` | `2 * N^2*[X]` |
| MO, symm         | `2 * N^2*O*X` | `N^2*[X] + N*O*[X]` |
| MO, asymm       | `3 * N^2*O*X` | `N^2*[X] + 2 * N*O*[X]` |

# Minor changes

The timing of `get_j_kpts`, `get_k_kpts`, and `get_jk` have also been updated.
