### PR TITLE
Padding+freezing bug fix

### DIFF
--- a/pyscf/pbc/mp/kmp2.py
+++ b/pyscf/pbc/mp/kmp2.py
@@ -551,7 +551,7 @@ def get_frozen_mask(mp):
 def _add_padding(mp, mo_coeff, mo_energy):
     nmo = mp.nmo
 
-    # Check if these are padded mo coefficients and energies
+    # Check if these are padded mo coefficients and energies and/or if some orbitals are frozen.
     if (mp.frozen is not None) or (not np.all([x.shape[1] == nmo for x in mo_coeff])):
         mo_coeff = padded_mo_coeff(mp, mo_coeff)
 

--- a/pyscf/pbc/mp/kmp2.py
+++ b/pyscf/pbc/mp/kmp2.py
@@ -552,10 +552,10 @@ def _add_padding(mp, mo_coeff, mo_energy):
     nmo = mp.nmo
 
     # Check if these are padded mo coefficients and energies
-    if not np.all([x.shape[1] == nmo for x in mo_coeff]):
+    if (mp.frozen is not None) or (not np.all([x.shape[1] == nmo for x in mo_coeff])):
         mo_coeff = padded_mo_coeff(mp, mo_coeff)
 
-    if not np.all([x.shape[0] == nmo for x in mo_energy]):
+    if (mp.frozen is not None) or (not np.all([x.shape[0] == nmo for x in mo_energy])):
         mo_energy = padded_mo_energy(mp, mo_energy)
     return mo_coeff, mo_energy
 


### PR DESCRIPTION
Freezing reduces nmo, padding increases nmo. This can cancel out, causing mo_energy and mo_coeff not to be appropriately frozen and padded if only the number of elements is compared to nmo instead of also explicitly checking for freezing for example.