### PR TITLE
Various updates for k-point symmetry related stuffs

### DIFF
--- a/examples/pbc/20-k_points_scf_ksymm.py
+++ b/examples/pbc/20-k_points_scf_ksymm.py
@@ -15,17 +15,17 @@ cell = gto.M(
               Si  1.3467560987 1.3467560987 1.3467560987''', 
     basis = 'gth-szv',
     pseudo = 'gth-pade',
-    mesh = [24,24,24],
     verbose = 5,
+    space_group_symmetry = True,
+    #symmorphic: if True, only the symmorphic subgroup is considered
+    symmorphic = True,
 )
 
 nk = [2,2,2]
 #The Brillouin Zone symmetry info is contained in the kpts object
-#symmorphic: if True, only the symmorphic subgroup is considered
 kpts = cell.make_kpts(nk, 
                       space_group_symmetry=True, 
-                      time_reversal_symmetry=True,
-                      symmorphic=True)
+                      time_reversal_symmetry=True)
 print(kpts)
 
 kmf = scf.KRHF(cell, kpts)

--- a/examples/pbc/22-k_points_mp2_ksymm.py
+++ b/examples/pbc/22-k_points_mp2_ksymm.py
@@ -17,6 +17,7 @@ cell = gto.M(
     pseudo = 'gth-pade',
     mesh = [24,24,24],
     verbose = 5,
+    space_group_symmetry = True,
 )
 
 nk = [2,2,2]

--- a/examples/pbc/43-k_point_ccsd_ksymm.py
+++ b/examples/pbc/43-k_point_ccsd_ksymm.py
@@ -1,0 +1,44 @@
+'''
+K-point symmetry adapted KRCCSD
+Reference result:
+converged SCF energy = -6.97030826215306
+E(KsymAdaptedRCCSD) = -7.08763343861385  E_corr = -0.1173251757710611
+'''
+import numpy as np
+from pyscf.pbc import gto, df, scf, cc
+
+a = 5.431020511
+xyz = np.array([[0, 0, 0], [0.25, 0.25, 0.25]]) * a
+
+atom = []
+for ix in xyz:
+    atom.append(['Si', list(ix)])
+
+cell = gto.Cell()
+cell.atom = atom
+cell.basis = 'gth-dzv'
+cell.pseudo  = 'gth-pade'
+cell.a = np.array([[0., .5, .5],[.5, 0., .5],[.5, .5, 0.]]) * a
+cell.max_memory = 16000
+cell.verbose = 4
+cell.space_group_symmetry = True
+cell.build()
+
+kmesh = [4,2,2]
+kpts = cell.make_kpts(kmesh, with_gamma_point=True, space_group_symmetry=True)
+
+gdf = df.RSGDF(cell, kpts=kpts.kpts)
+gdf._cderi = gdf._cderi_to_save = 'si_dzv_rsgdf_4x2x2.h5'
+gdf.build()
+
+kmf = scf.KRHF(cell, kpts, exxdiv=None).density_fit()
+kmf.with_df = gdf
+kmf.kernel()
+
+kcc = cc.KsymAdaptedRCCSD(kmf)
+# setting eris_outcore to True enforces the integrals to be stored on the disk
+#kcc.eris_outcore = True
+# setting ktensor_direct to True computes the symmetry related blocks of tensors on-the-fly;
+# this reduces the memory usage but may introduce more overhead for small k-point meshes.
+kcc.ktensor_direct = True
+kcc.kernel()

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2573,7 +2573,7 @@ class Mole(lib.StreamObject):
         return self
     kernel = build
 
-    def _build_symmetry(self):
+    def _build_symmetry(self, *args, **kwargs):
         '''
         Update symmetry related attributes: topgroup, groupname, _symm_orig,
         _symm_axes, irrep_id, irrep_name, symm_orb

--- a/pyscf/lib/numpy_helper.py
+++ b/pyscf/lib/numpy_helper.py
@@ -1243,6 +1243,169 @@ def locs_to_indices(locs, segement_list):
         idx = numpy.hstack(idx)
     return numpy.asarray(idx, dtype=numpy.int32)
 
+def cleanse(a, axis=0, tol=0):
+    '''
+    Remove floating-point errors by setting the
+    numbers with differences smaller than `tol`
+    to the same value. This should allow
+    `numpy.round_` and `numpy.unique` together
+    to work as expected.
+
+    Args:
+        a : ndarray
+            Array to be cleansed.
+        axis : int or None
+            Axis along which the array values are compared.
+            Default is the first axis. If set to None,
+            the flattened array is used.
+        tol : floating
+            Tolerance, default is 0.
+    Returns:
+        Cleansed array.
+    '''
+    def _cleanse_1d(a_flat, tol):
+        sorted_index = numpy.argsort(a_flat, axis=None)
+        sorted_a_flat = a_flat[sorted_index]
+        diff = numpy.diff(sorted_a_flat)
+        cluster_loc = numpy.append(numpy.append(0, numpy.argwhere(diff > tol)[:,0]+1), a_flat.size)
+        for i in range(len(cluster_loc)-1):
+            id0, id1 = cluster_loc[i], cluster_loc[i+1]
+            a_flat[sorted_index[id0:id1]] = a_flat[sorted_index[id0]]
+        return a_flat
+
+    if axis is None:
+        a_flat = a.flatten()
+        return _cleanse_1d(a_flat, tol).reshape(a.shape)
+    else:
+        a0 = numpy.moveaxis(a, axis, -1)
+        shape = a0.shape
+        a0 = a0.reshape(-1, a0.shape[-1])
+        out = []
+        for i in range(len(a0)):
+            out.append(_cleanse_1d(a0[i].flatten(), tol))
+        out = numpy.asarray(out).reshape(shape)
+        return numpy.moveaxis(out, -1, axis)
+
+def base_repr_int(number, base, ndigits=None):
+    '''
+    Similar to numpy.base_repr, but returns a list of integers.
+
+    Args:
+        number : array or int
+            The value to convert. Negative values are converted to
+            their absolute values.
+        base : int
+            Convert `number` to the `base` number system.
+        ndigits : int, optional
+            Number of digits. If given, pad zeros to the left until the number
+            of digits reaches `ndigits`. Default is None, meaning no padding.
+
+    Returns:
+        out : list
+            Representation of `number` in `base` system.
+
+    Examples::
+
+    >>> lib.base_repr_int(29, 8)
+    [3, 5]
+
+    >>> lib.base_repr_int(29, 8, 3)
+    [0, 3, 5]
+    '''
+    if isinstance(number, numpy.ndarray):
+        assert ndigits is not None
+        number = number.flatten()
+        res = numpy.empty([ndigits, len(number)], dtype=int)
+        for i in range(ndigits-1, -1, -1):
+            ki = number // base**i
+            number -= ki * base**i
+            res[ndigits-1-i] = ki
+        return res.T
+
+    num = abs(number)
+    res = []
+    if num == 0:
+        res = [0]
+    while num:
+        res.append(num % base)
+        num //= base
+    if ndigits:
+        padding = ndigits - len(res)
+        res += [0] * padding
+    res.reverse()
+    return res
+
+def inv_base_repr_int(x, base):
+    '''Inverse of `base_repr_int`.
+    Similar to Python function int(), but for arbitrary base.
+
+    Args:
+        x : array like
+        base : int
+
+    Returns:
+        out : int
+
+    Examples::
+
+    >>> lib.inv_base_repr_int([0, 18, 9], 27)
+    495
+
+    >>> lib.base_repr_int(495, 27, 3)
+    [0, 18, 9]
+    '''
+    out = 0
+    x = numpy.asarray(x, dtype=int)
+    if x.ndim > 1:
+        shape = x.shape
+        nd = shape[-1]
+        x = x.reshape(-1, nd)
+        for i in range(nd):
+            out += x[:,i] * base ** (nd-i-1)
+        out = out.reshape(shape[:-1])
+    else:
+        for i, ix in enumerate(x[::-1]):
+            out += ix * base**i
+    return out
+
+def isin_1d(v, vs, return_index=False):
+    '''Check if vector `v` is in vectors `vs`.
+
+    Args:
+        v : array like
+            The target vector. `v` is flattened.
+        vs : array like
+            A list of vectors. The last dimenstion of `vs`
+            should be the same as the size of `v`.
+        return_index : bool
+            Index of `v` in `vs`.
+
+    Examples::
+
+    >>> lib.isin_1d([1,2], [[2,1],[1,2]])
+    True
+
+    >>> lib.isin_1d([1,2], [[2,1],[2,1]])
+    False
+    '''
+    v = numpy.asarray(v).flatten()
+    n = len(v)
+    vs = numpy.asarray(vs).reshape(-1, n)
+    diff = abs(v[None,:] - vs)
+    diff = numpy.sum(diff, axis=1)
+    idx = numpy.where(diff == 0)[0]
+    if len(idx) > 0:
+        v_in_vs = True
+    else:
+        v_in_vs = False
+
+    if not return_index:
+        return v_in_vs
+    else:
+        if len(idx) == 1:
+            idx = idx[0]
+        return v_in_vs, idx
+
 if __name__ == '__main__':
     a = numpy.random.random((30,40,5,10))
     b = numpy.random.random((10,30,5,20))

--- a/pyscf/pbc/cc/__init__.py
+++ b/pyscf/pbc/cc/__init__.py
@@ -21,6 +21,7 @@ from pyscf.pbc.cc import kccsd     as kgccsd
 from pyscf.pbc.cc import eom_kccsd_rhf
 from pyscf.pbc.cc import eom_kccsd_uhf
 from pyscf.pbc.cc import eom_kccsd_ghf
+from pyscf.pbc.cc.kccsd_rhf_ksymm import KsymAdaptedRCCSD
 
 def RCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     mf = scf.addons.convert_to_rhf(mf)

--- a/pyscf/pbc/cc/kccsd_rhf_ksymm.py
+++ b/pyscf/pbc/cc/kccsd_rhf_ksymm.py
@@ -1,0 +1,806 @@
+#!/usr/bin/env python
+# Copyright 2022-2023 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: Xing Zhang <zhangxing.nju@gmail.com>
+#
+
+from functools import reduce
+import numpy as np
+
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf.pbc.lib import ktensor
+from pyscf.pbc.lib.kpts import MORotationMatrix, KQuartets
+
+from pyscf.pbc.df import GDF, RSGDF
+from pyscf.pbc.mp.kmp2 import (
+    get_nocc,
+    padded_mo_coeff,
+    padding_k_idx,
+)
+from pyscf.pbc.cc import kintermediates_rhf_ksymm as imdk
+from pyscf.pbc.cc.kccsd_rhf import (
+    RCCSD,
+    _get_epq,
+    _init_df_eris,
+)
+
+einsum = lib.einsum
+
+def update_amps(cc, t1, t2, eris):
+    kpts = cc.kpts
+    kqrts = cc.kqrts
+    rmat = cc.rmat
+    kconserv = cc.khelper.kconserv
+
+    nkpts, nocc, nvir = t1.shape
+    fock = eris.fock
+    mo_e_o = [e[:nocc] for e in eris.mo_energy]
+    mo_e_v = [e[nocc:] for e in eris.mo_energy]
+
+    # Get location of padded elements in occupied and virtual space
+    nonzero_opadding, nonzero_vpadding = padding_k_idx(cc, kind="split")
+
+    ki_ibz_bz = kpts.ibz2bz[np.arange(kpts.nkpts_ibz)]
+    fov = fock[:, :nocc, nocc:]
+    kconserv = cc.khelper.kconserv
+
+    Foo = imdk.cc_Foo(kpts, kqrts, t1, t2, eris, rmat)
+    Fvv = imdk.cc_Fvv(kpts, kqrts, t1, t2, eris, rmat)
+    Fov = imdk.cc_Fov(kpts, kqrts, t1, t2, eris, rmat)
+    Loo = imdk.Loo(kpts, kqrts, t1, t2, eris, rmat)
+    Lvv = imdk.Lvv(kpts, kqrts, t1, t2, eris, rmat)
+
+    Fov = Fov.todense()
+
+    # Move energy terms to the other side
+    for ki_ibz in range(kpts.nkpts_ibz):
+        ki = kpts.ibz2bz[ki_ibz]
+        Foo[ki][np.diag_indices(nocc)] -= mo_e_o[ki]
+        Fvv[ki][np.diag_indices(nvir)] -= mo_e_v[ki]
+        Loo[ki][np.diag_indices(nocc)] -= mo_e_o[ki]
+        Lvv[ki][np.diag_indices(nvir)] -= mo_e_v[ki]
+
+    t1new = ktensor.empty_like(t1)
+    t1 = t1.todense()
+    t2new = ktensor.empty_like(t2)
+    t2 = t2.todense()
+
+    # T1 equation
+    for ka_ibz in range(kpts.nkpts_ibz):
+        ki = ka = kpts.ibz2bz[ka_ibz]
+        t1new[ka]  = fov[ka].conj()
+        t1new[ka] += -2. * einsum('kc,ka,ic->ia', fov[ki], t1[ka], t1[ki])
+        t1new[ka] += einsum('ac,ic->ia', Fvv[ka], t1[ki])
+        t1new[ka] += -einsum('ki,ka->ia', Foo[ki], t1[ka])
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        ki, kk, kc, kd = kq
+        ka = ki
+
+        Svovv = 2 * eris.vovv[ka, kk, kc] - eris.vovv[ka, kk, kd].transpose(0, 1, 3, 2)
+        tau_term_1 = t2[ki, kk, kc].copy()
+        if ki == kc and kk == kd:
+            tau_term_1 += einsum('ic,kd->ikcd', t1[ki], t1[kk])
+        fock = einsum('akcd,ikcd->ia', Svovv, tau_term_1)
+        for _, iop in kqrts.loop_stabilizer(i):
+            rmat_oo = rmat.oo[ka][iop]
+            rmat_vv = rmat.vv[ka][iop]
+            t1new[ka] += einsum('ia,im,ae->me', fock, rmat_oo, rmat_vv.conj())
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        kk, kl, ki, kd = kq
+        ka = ki
+        Sooov = 2 * eris.ooov[kk, kl, ki] - eris.ooov[kl, kk, ki].transpose(1, 0, 2, 3)
+        tau_term_1 = t2[kk, kl, ka].copy()
+        if kk == ka and kl == kc:
+            tau_term_1 += einsum('ka,lc->klac', t1[ka], t1[kc])
+        fock = -einsum('klic,klac->ia', Sooov, tau_term_1)
+
+        op_group = kqrts.stars_ops[i]
+        ka_prim = kpts.k2opk[ka, op_group]
+        mask = np.isin(ka_prim, ki_ibz_bz)
+        for iop, ka_p in zip(op_group[mask], ka_prim[mask]):
+            rmat_oo = rmat.oo[ka][iop]
+            rmat_vv = rmat.vv[ka][iop]
+            t1new[ka_p] += einsum('ia,im,ae->me', fock, rmat_oo, rmat_vv.conj())
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        ki, kk, ka, kc = kq
+        if ka == ki and kk == kc:
+            tau_term = 2 * t2[kk, ki, kk] - t2[ki, kk, kk].transpose(1, 0, 2, 3)
+            if ki == kk:
+                tau_term += einsum('ic,ka->kica', t1[ki], t1[ka])
+
+            fock = einsum('kc,kica->ia', Fov[kc], tau_term)
+            fock += einsum('akic,kc->ia', 2 * eris.voov[ka, kk, ki], t1[kc])
+            fock += einsum('kaic,kc->ia', -eris.ovov[kk, ka, ki], t1[kc])
+
+            for _, iop in kqrts.loop_stabilizer(i):
+                rmat_oo = rmat.oo[ka][iop]
+                rmat_vv = rmat.vv[ka][iop]
+                t1new[ka] += einsum('ia,im,ae->me', fock, rmat_oo, rmat_vv.conj())
+
+    for ki_ibz in range(kpts.nkpts_ibz):
+        ka = ki = kpts.ibz2bz[ki_ibz]
+        # Remove zero/padded elements from denominator
+        eia = _get_epq([0,nocc,ki,mo_e_o,nonzero_opadding],
+                       [0,nvir,ka,mo_e_v,nonzero_vpadding],
+                       fac=[1.0,-1.0])
+        t1new[ki] /= eia
+
+
+    # T2 equation
+    Loo = Loo.todense()
+    Lvv = Lvv.todense()
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        ki, kj, ka, kb = kq
+        t2new[ki, kj, ka] = eris.oovv[ki, kj, ka].conj()
+
+    mem_now = lib.current_memory()[0]
+    if (cc.incore_complete or
+        _memory_4d(cc, [nocc,]*4) + mem_now < cc.max_memory * .9):
+        Woooo = imdk.cc_Woooo(kpts, kqrts, t1, t2, eris, rmat)
+    else:
+        metadata = {'kpts': kpts, 'kqrts': kqrts, 'rmat': rmat,
+                    'label': 'oooo', 'trans': 'ccnn',
+                    'incore': False}
+        Woooo = ktensor.empty([nocc,]*4, dtype=t1.dtype, metadata=metadata)
+        Woooo = imdk.cc_Woooo(kpts, kqrts, t1, t2, eris, rmat, Woooo)
+
+    mem_now = lib.current_memory()[0]
+    if (not cc.ktensor_direct and
+        _memory_4d(cc, [nocc,]*4, False) + mem_now < cc.max_memory * .9):
+        Woooo = Woooo.todense()
+
+    def _t2_oooo(ki,kj,ka,kb):
+        t2new_tmp = 0
+        for kl in range(nkpts):
+            kk = kconserv[kj, kl, ki]
+            tau_term = t2[kk, kl, ka].copy()
+            if kl == kb and kk == ka:
+                tau_term += einsum('ic,jd->ijcd', t1[ka], t1[kb])
+            t2new_tmp += 0.5 * einsum('klij,klab->ijab', Woooo[kk, kl, ki], tau_term)
+        return t2new_tmp
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        ki, kj, ka, kb = kq
+        t2new_tmp = _t2_oooo(ki,kj,ka,kb)
+        t2new[ki, kj, ka] += t2new_tmp
+        if lib.isin_1d((kj,ki,kb,ka), kqrts.kqrts_ibz):
+            t2new[kj, ki, kb] += t2new_tmp.transpose(1, 0, 3, 2)
+        else:
+            t2new_tmp = _t2_oooo(kj,ki,kb,ka)
+            t2new[ki, kj, ka] += t2new_tmp.transpose(1, 0, 3, 2)
+
+    Woooo = None
+
+    add_vvvv_(cc, t2new, t1, t2, eris)
+
+    def _t2_voov1(ki,kj,ka,kb):
+        t2new_tmp = einsum('ac,ijcb->ijab', Lvv[ka], t2[ki, kj, ka])
+        t2new_tmp += einsum('ki,kjab->ijab', -Loo[ki], t2[ki, kj, ka])
+
+        kc = kj
+        tmp2 = np.asarray(eris.vovv[kc, ki, kb]).transpose(3, 2, 1, 0).conj() \
+               - einsum('kbic,ka->abic', eris.ovov[ka, kb, ki], t1[ka])
+        t2new_tmp += einsum('abic,jc->ijab', tmp2, t1[kj])
+
+        kk = kb
+        tmp2 = np.asarray(eris.ooov[kj, ki, kk]).transpose(3, 2, 1, 0).conj() \
+               + einsum('akic,jc->akij', eris.voov[ka, kk, ki], t1[kj])
+        t2new_tmp -= einsum('akij,kb->ijab', tmp2, t1[kb])
+        return t2new_tmp
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        ki, kj, ka, kb = kq
+        t2new_tmp = _t2_voov1(ki,kj,ka,kb)
+        t2new[ki, kj, ka] += t2new_tmp
+        if lib.isin_1d((kj,ki,kb,ka), kqrts.kqrts_ibz):
+            t2new[kj, ki, kb] += t2new_tmp.transpose(1, 0, 3, 2)
+        else:
+            t2new_tmp = _t2_voov1(kj,ki,kb,ka)
+            t2new[ki, kj, ka] += t2new_tmp.transpose(1, 0, 3, 2)
+
+    mem_now = lib.current_memory()[0]
+    if (cc.incore_complete or
+        _memory_4d(cc, [nocc,nocc,nvir,nvir])*2 + mem_now < cc.max_memory*.9):
+        Wvoov = imdk.cc_Wvoov(kpts, kqrts, t1, t2, eris, rmat)
+        Wvovo = imdk.cc_Wvovo(kpts, kqrts, t1, t2, eris, rmat)
+    else:
+        metadata = {'kpts': kpts, 'kqrts': kqrts, 'rmat': rmat,
+                    'trans': 'ccnn', 'incore': False}
+        Wvoov = ktensor.empty([nvir,nocc,nocc,nvir], dtype=t1.dtype,
+                              metadata={**metadata, 'label':'voov'})
+        Wvovo = ktensor.empty([nvir,nocc,nvir,nocc], dtype=t1.dtype,
+                              metadata={**metadata, 'label':'vovo'})
+        Wvoov = imdk.cc_Wvoov(kpts, kqrts, t1, t2, eris, rmat, Wvoov)
+        Wvovo = imdk.cc_Wvovo(kpts, kqrts, t1, t2, eris, rmat, Wvovo)
+
+    mem_now = lib.current_memory()[0]
+    if (not cc.ktensor_direct and
+        _memory_4d(cc, [nocc,nocc,nvir,nvir], False)*2 + mem_now < cc.max_memory*.9):
+        Wvoov = Wvoov.todense()
+        Wvovo = Wvovo.todense()
+
+    def _t2_voov2(ki,kj,ka,kb):
+        t2new_tmp = 0
+        for kk in range(nkpts):
+            kc = kconserv[ka, ki, kk]
+            tmp_voov = 2. * Wvoov[ka, kk, ki] - Wvovo[ka, kk, kc].transpose(0, 1, 3, 2)
+            t2new_tmp += einsum('akic,kjcb->ijab', tmp_voov, t2[kk, kj, kc])
+
+            kc = kconserv[ka, ki, kk]
+            t2new_tmp -= einsum('akic,kjbc->ijab', Wvoov[ka, kk, ki], t2[kk, kj, kb])
+
+            kc = kconserv[kk, ka, kj]
+            t2new_tmp -= einsum('bkci,kjac->ijab', Wvovo[kb, kk, kc], t2[kk, kj, ka])
+        return t2new_tmp
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        ki, kj, ka, kb = kq
+        t2new_tmp = _t2_voov2(ki,kj,ka,kb)
+        t2new[ki, kj, ka] += t2new_tmp
+        if lib.isin_1d((kj,ki,kb,ka), kqrts.kqrts_ibz):
+            t2new[kj, ki, kb] += t2new_tmp.transpose(1, 0, 3, 2)
+        else:
+            t2new_tmp = _t2_voov2(kj,ki,kb,ka)
+            t2new[ki, kj, ka] += t2new_tmp.transpose(1, 0, 3, 2)
+
+    Wvoov = Wvovo = None
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        ki, kj, ka, kb = kq
+        eia = _get_epq([0,nocc,ki,mo_e_o,nonzero_opadding],
+                       [0,nvir,ka,mo_e_v,nonzero_vpadding],
+                       fac=[1.0,-1.0])
+        ejb = _get_epq([0,nocc,kj,mo_e_o,nonzero_opadding],
+                       [0,nvir,kb,mo_e_v,nonzero_vpadding],
+                       fac=[1.0,-1.0])
+        eijab = eia[:, None, :, None] + ejb[:, None, :]
+        t2new[ki, kj, ka] /= eijab
+
+    return t1new, t2new
+
+def add_vvvv_(cc, Ht2, t1, t2, eris):
+    kpts = cc.kpts
+    kqrts = cc.kqrts
+    rmat = cc.rmat
+
+    nocc = cc.nocc
+    nmo = cc.nmo
+    nvir = nmo - nocc
+    nkpts = kpts.nkpts
+    kconserv = cc.khelper.kconserv
+
+    mem_now = lib.current_memory()[0]
+    if (not cc.incore_complete and
+        cc.direct and getattr(eris, 'Lpv', None) is not None):
+        def get_Wvvvv(ka, kb, kc):
+            Lpv = eris.Lpv
+            kd = kconserv[ka, kc, kb]
+            Lbd = (Lpv[kb,kd][:,nocc:] -
+                   lib.einsum('Lkd,kb->Lbd', Lpv[kb,kd][:,:nocc], t1[kb]))
+            Wvvvv = lib.einsum('Lac,Lbd->abcd', Lpv[ka,kc][:,nocc:], Lbd)
+            Lbd = None
+            kcbd = lib.einsum('Lkc,Lbd->kcbd', Lpv[ka,kc][:,:nocc],
+                              Lpv[kb,kd][:,nocc:])
+            Wvvvv -= lib.einsum('kcbd,ka->abcd', kcbd, t1[ka])
+            Wvvvv *= (1. / nkpts)
+            return Wvvvv
+    elif (cc.incore_complete or
+          _memory_4d(cc, [nvir,]*4) + mem_now < cc.max_memory * .9):
+        _Wvvvv = imdk.cc_Wvvvv(kpts, kqrts, t1, t2, eris, rmat)
+
+        mem_now = lib.current_memory()[0]
+        if (not cc.ktensor_direct and
+            _memory_4d(cc, [nvir,]*4, False) + mem_now < cc.max_memory * .9):
+            _Wvvvv = _Wvvvv.todense()
+
+        get_Wvvvv = lambda ka, kb, kc: _Wvvvv[ka, kb, kc]
+    else:
+        metadata = {'kpts': kpts, 'kqrts': kqrts, 'rmat': rmat,
+                    'label': 'vvvv', 'trans': 'ccnn',
+                    'incore': False}
+        _Wvvvv = ktensor.empty([nvir,]*4, dtype=t1.dtype, metadata=metadata)
+        _Wvvvv = imdk.cc_Wvvvv(kpts, kqrts, t1, t2, eris, rmat, _Wvvvv)
+
+        mem_now = lib.current_memory()[0]
+        if (not cc.ktensor_direct and
+            _memory_4d(cc, [nvir,]*4, False) + mem_now < cc.max_memory * .9):
+            _Wvvvv = _Wvvvv.todense()
+
+        get_Wvvvv = lambda ka, kb, kc: _Wvvvv[ka, kb, kc]
+
+    kakb, igroup = np.unique(kqrts.kqrts_ibz[:,2:], axis=0, return_inverse=True)
+    for i in range(np.amax(igroup) + 1):
+        ka, kb = kakb[i]
+        idx = np.where(igroup==i)[0]
+
+        for kc in range(nkpts):
+            kd = kconserv[ka, kc, kb]
+            Wvvvv = get_Wvvvv(ka, kb, kc)
+            for m in idx:
+                ki,kj,kaa,kbb = kqrts.kqrts_ibz[m]
+                assert kaa==ka and kbb==kb
+                tau = t2[ki, kj, kc].copy()
+                if ki == kc and kj == kd:
+                    tau += np.einsum('ic,jd->ijcd', t1[ki], t1[kj])
+                Ht2[ki, kj, ka] += einsum('abcd,ijcd->ijab', Wvvvv, tau)
+
+    _Wvvvv = None
+    return Ht2
+
+def energy(cc, t1, t2, eris):
+    kpts = cc.kpts
+    kqrts = cc.kqrts
+
+    nkpts, nocc, nvir = t1.shape
+    fock = eris.fock
+    e = 0
+
+    for ki_ibz in range(kpts.nkpts_ibz):
+        ki = kpts.ibz2bz[ki_ibz]
+        weight = kpts.weights_ibz[ki_ibz]
+        e += 2 * einsum('ia,ia', fock[ki,:nocc,nocc:], t1[ki]) * weight
+
+    tau = ktensor.empty_like(t2)
+    for kq in kqrts.kqrts_ibz:
+        ki, kj, ka, kb = kq
+        tau[ki, kj, ka] = t2[ki, kj, ka]
+        if ki == ka and kj == kb:
+            tau[ki, kj, ka] += einsum('ia,jb->ijab', t1[ki], t1[kj])
+
+    kq_weights = kqrts.weights_ibz
+    for k, kq in enumerate(kqrts.kqrts_ibz):
+        ki, kj, ka, kb = kq
+        weight = kq_weights[k] * nkpts**3
+        e += 2 * einsum('ijab,ijab', tau[ki, kj, ka], eris.oovv[ki, kj, ka]) * weight
+        e += -einsum('ijab,ijba', tau[ki, kj, ka], eris.oovv[ki, kj, kb]) * weight
+
+    e /= nkpts
+    if abs(e.imag) > 1e-4:
+        logger.warn(cc, 'Non-zero imaginary part found in KRCCSD energy %s', e)
+    return e.real
+
+
+class KsymAdaptedRCCSD(RCCSD):
+    def __init__(self, mf, frozen=None, mo_coeff=None, mo_occ=None):
+        '''
+        Attributes:
+            ktensor_direct : bool
+                If set to True, the tensors will be stored as block-sparse,
+                and the symmetry related blocks are computed on-the-fly when needed.
+                Otherwise, the tensors will be converted to dense tensors whenever
+                there is enough memory. Default is False.
+            eris_outcore : bool
+                If set to True, the integrals will be always stored on the disk.
+                Otherwise, whether the integrals are stored on the disk or in memory
+                depends on the available memory size. Default is False.
+        '''
+        # NOTE self._scf is a non-symmetry object, see RCCSD.__init__
+        RCCSD.__init__(self, mf, frozen, mo_coeff, mo_occ)
+        self.kqrts = KQuartets(self.kpts).build()
+        self.rmat = None
+        self.ktensor_direct = False
+        self.eris_outcore = False
+
+        keys = set(['kqrts', 'rmat', 'ktensor_direct', 'eris_outcore'])
+        self._keys = self._keys.union(keys)
+
+    def ao2mo(self, mo_coeff=None):
+        eris = _PhysicistsERIs()
+        eris._common_init_(self, mo_coeff)
+
+        # use padded mo_coeff to construct the rotation matrix
+        self.rmat = MORotationMatrix(self.kpts, eris.mo_coeff,
+                                     self._scf.get_ovlp(), eris.nocc, eris.nmo)
+        self.rmat.build()
+
+        mem_now = lib.current_memory()[0]
+        mem_incore = _mem_usage(self)
+        if not self.eris_outcore and (
+                self.incore_complete or mem_incore + mem_now < self.max_memory):
+            eris = _make_eris_incore(self, eris, self._scf.with_df.ao2mo)
+        else:
+            eris = _make_eris_outcore(self, eris, self._scf.with_df.ao2mo)
+        return eris
+
+    def init_amps(self, eris):
+        time0 = logger.process_clock(), logger.perf_counter()
+        nocc = self.nocc
+        nvir = self.nmo - nocc
+        nkpts = self.nkpts
+
+        kpts = self.kpts
+        kqrts = self.kqrts
+        rmat = self.rmat
+        assert rmat is not None
+
+        metadata = {'kpts': kpts, 'rmat': rmat,
+                    'label': 'ov', 'trans': 'nc', 'incore': True}
+        t1 = ktensor.zeros((nocc, nvir), dtype=eris.fock.dtype,
+                           metadata=metadata)
+
+        metadata = {'kpts': kpts, 'kqrts': kqrts, 'rmat': rmat,
+                    'label': 'oovv', 'trans': 'nncc', 'incore': True}
+        t2 = ktensor.empty((nocc,nocc,nvir,nvir), dtype=eris.fock.dtype,
+                           metadata=metadata)
+        mo_e_o = [eris.mo_energy[k][:nocc] for k in range(nkpts)]
+        mo_e_v = [eris.mo_energy[k][nocc:] for k in range(nkpts)]
+
+        # Get location of padded elements in occupied and virtual space
+        nonzero_opadding, nonzero_vpadding = padding_k_idx(self, kind="split")
+
+        emp2 = 0
+        for i, kq in enumerate(kqrts.kqrts_ibz):
+            ki, kj, ka, kb = kq
+            weight = kqrts.weights_ibz[i] * nkpts**3
+
+            eia = _get_epq([0,nocc,ki,mo_e_o,nonzero_opadding],
+                           [0,nvir,ka,mo_e_v,nonzero_vpadding],
+                           fac=[1.0,-1.0])
+
+            ejb = _get_epq([0,nocc,kj,mo_e_o,nonzero_opadding],
+                           [0,nvir,kb,mo_e_v,nonzero_vpadding],
+                           fac=[1.0,-1.0])
+            eijab = eia[:, None, :, None] + ejb[:, None, :]
+
+            eris_ijab = eris.oovv[ki, kj, ka]
+            eris_ijba = eris.oovv[ki, kj, kb]
+            t2[ki, kj, ka] = eris_ijab.conj() / eijab
+            woovv = 2 * eris_ijab - eris_ijba.transpose(0, 1, 3, 2)
+            emp2 += np.einsum('ijab,ijab', t2[ki, kj, ka], woovv) * weight
+
+        self.emp2 = emp2.real / nkpts
+        logger.info(self, 'Init t2, MP2 energy (with fock eigenvalue shift) = %.15g', self.emp2)
+        logger.timer(self, 'init mp2', *time0)
+        return self.emp2, t1, t2
+
+    def amplitudes_to_vector(self, t1, t2):
+        t1_raw = np.asarray(getattr(t1, 'data', t1))
+        t2_raw = np.asarray(getattr(t2, 'data', t2))
+        return np.concatenate((t1_raw, t2_raw), axis=None)
+
+    def vector_to_amplitudes(self, vec):
+        kpts = self.kpts
+        kqrts = self.kqrts
+        rmat = self.rmat
+        nocc = self.nocc
+        nvir = self.nmo - nocc
+        t1_size = kpts.nkpts_ibz * nocc * nvir
+        t1_flat = vec[:t1_size]
+        t2_flat = vec[t1_size:]
+
+        metadata = {'kpts': kpts, 'rmat': rmat,
+                    'label': 'ov', 'trans': 'nc', 'incore': True}
+        t1 = ktensor.fromraw(t1_flat, (nocc,nvir), dtype=vec.dtype,
+                             metadata=metadata)
+
+        metadata = {'kpts': kpts, 'kqrts': kqrts, 'rmat': rmat,
+                    'label': 'oovv', 'trans': 'nncc', 'incore': True}
+        t2 = ktensor.fromraw(t2_flat, (nocc,nocc,nvir,nvir), dtype=vec.dtype,
+                             metadata=metadata)
+        return t1, t2
+
+    energy = energy
+    update_amps = update_amps
+
+
+def _make_eris_incore(cc, eris, fao2mo):
+    log = logger.Logger(cc.stdout, cc.verbose)
+    log.info('using incore ERI storage')
+    cput0 = (logger.process_clock(), logger.perf_counter())
+
+    mo_coeff = eris.mo_coeff
+    nocc = eris.nocc
+    nvir = eris.nvir
+    nmo = eris.nmo
+    dtype = eris.dtype
+
+    common_metadata = {'kpts'  : cc.kpts,
+                       'kqrts' : cc.kqrts,
+                       'rmat'  : cc.rmat,
+                       'trans' : 'ccnn',
+                       'incore': True}
+
+    eris.oooo = ktensor.empty([nocc,nocc,nocc,nocc], dtype=dtype,
+                              metadata={**common_metadata, 'label': 'oooo'})
+    eris.ooov = ktensor.empty([nocc,nocc,nocc,nvir], dtype=dtype,
+                              metadata={**common_metadata, 'label': 'ooov'})
+    eris.oovv = ktensor.empty([nocc,nocc,nvir,nvir], dtype=dtype,
+                              metadata={**common_metadata, 'label': 'oovv'})
+    eris.ovov = ktensor.empty([nocc,nvir,nocc,nvir], dtype=dtype,
+                              metadata={**common_metadata, 'label': 'ovov'})
+    eris.voov = ktensor.empty([nvir,nocc,nocc,nvir], dtype=dtype,
+                              metadata={**common_metadata, 'label': 'voov'})
+    eris.vovv = ktensor.empty([nvir,nocc,nvir,nvir], dtype=dtype,
+                              metadata={**common_metadata, 'label': 'vovv'})
+    eris.vvvv = ktensor.empty([nvir,nvir,nvir,nvir], dtype=dtype,
+                              metadata={**common_metadata, 'label': 'vvvv'})
+
+    kpts = cc.kpts.kpts
+    nkpts = len(kpts)
+    kqrts = cc.kqrts
+    khelper = cc.khelper
+    kconserv = khelper.kconserv
+    kptlist = kqrts.kqrts_ibz[:,:3][:,[0,2,1]] #chemists' notation
+    khelper.build_symm_map(kptlist=kptlist)
+
+    for (iki, ika, ikj) in khelper.symm_map.keys():
+        ikb = kconserv[iki, ika, ikj]
+        eri_kpt = fao2mo((mo_coeff[iki],mo_coeff[ika],mo_coeff[ikj],mo_coeff[ikb]),
+                         (kpts[iki],kpts[ika],kpts[ikj],kpts[ikb]), compact=False)
+
+        if np.issubdtype(dtype, np.floating):
+            eri_kpt = eri_kpt.real
+        eri_kpt = eri_kpt.reshape(nmo, nmo, nmo, nmo)
+
+        for (ki, ka, kj) in khelper.symm_map[(iki, ika, ikj)]:
+            eri_kpt_symm = khelper.transform_symm(eri_kpt, ki, ka, kj).transpose(0, 2, 1, 3)
+            eris.oooo[ki, kj, ka] = eri_kpt_symm[:nocc, :nocc, :nocc, :nocc] / nkpts
+            eris.ooov[ki, kj, ka] = eri_kpt_symm[:nocc, :nocc, :nocc, nocc:] / nkpts
+            eris.oovv[ki, kj, ka] = eri_kpt_symm[:nocc, :nocc, nocc:, nocc:] / nkpts
+            eris.ovov[ki, kj, ka] = eri_kpt_symm[:nocc, nocc:, :nocc, nocc:] / nkpts
+            eris.voov[ki, kj, ka] = eri_kpt_symm[nocc:, :nocc, :nocc, nocc:] / nkpts
+            eris.vovv[ki, kj, ka] = eri_kpt_symm[nocc:, :nocc, nocc:, nocc:] / nkpts
+            eris.vvvv[ki, kj, ka] = eri_kpt_symm[nocc:, nocc:, nocc:, nocc:] / nkpts
+
+    if not cc.ktensor_direct:
+        eris.oooo = eris.oooo.todense()
+        eris.ooov = eris.ooov.todense()
+        eris.oovv = eris.oovv.todense()
+        eris.ovov = eris.ovov.todense()
+        eris.voov = eris.voov.todense()
+        eris.vovv = eris.vovv.todense()
+        eris.vvvv = eris.vvvv.todense()
+
+    log.timer('CCSD integral transformation', *cput0)
+    return eris
+
+def _make_eris_outcore(cc, eris, fao2mo):
+    log = logger.Logger(cc.stdout, cc.verbose)
+    log.info('using outcore ERI storage')
+    cput0 = (logger.process_clock(), logger.perf_counter())
+
+    mo_coeff = eris.mo_coeff
+    nocc = eris.nocc
+    nvir = eris.nvir
+    nmo = eris.nmo
+    dtype = eris.dtype
+
+    common_metadata = {'kpts'  : cc.kpts,
+                       'kqrts' : cc.kqrts,
+                       'rmat'  : cc.rmat,
+                       'trans' : 'ccnn',
+                       'incore': False}
+
+    eris.oooo = ktensor.empty([nocc,nocc,nocc,nocc], dtype=dtype,
+                              metadata={**common_metadata, 'label': 'oooo'})
+    eris.ooov = ktensor.empty([nocc,nocc,nocc,nvir], dtype=dtype,
+                              metadata={**common_metadata, 'label': 'ooov'})
+    eris.oovv = ktensor.empty([nocc,nocc,nvir,nvir], dtype=dtype,
+                              metadata={**common_metadata, 'label': 'oovv'})
+    eris.ovov = ktensor.empty([nocc,nvir,nocc,nvir], dtype=dtype,
+                              metadata={**common_metadata, 'label': 'ovov'})
+    eris.voov = ktensor.empty([nvir,nocc,nocc,nvir], dtype=dtype,
+                              metadata={**common_metadata, 'label': 'voov'})
+    eris.vovv = ktensor.empty([nvir,nocc,nvir,nvir], dtype=dtype,
+                              metadata={**common_metadata, 'label': 'vovv'})
+
+    vvvv_required = (not cc.direct
+                     or not isinstance(cc._scf.with_df, (GDF, RSGDF))
+                     or cc._scf.cell.dimension == 2)
+    if vvvv_required:
+        eris.vvvv = ktensor.empty([nvir,nvir,nvir,nvir], dtype=dtype,
+                                  metadata={**common_metadata, 'label': 'vvvv'})
+
+    kpts = cc.kpts.kpts
+    nkpts = len(kpts)
+    kqrts = cc.kqrts
+
+    # <ij|pq>  = (ip|jq)
+    cput1 = logger.process_clock(), logger.perf_counter()
+    for kprqs in kqrts.kqrts_ibz:
+        kp, kr, kq, ks = kprqs
+        orbo_p = mo_coeff[kp][:, :nocc]
+        orbo_r = mo_coeff[kr][:, :nocc]
+        buf_kpt = fao2mo((orbo_p, mo_coeff[kq], orbo_r, mo_coeff[ks]),
+                         (kpts[kp], kpts[kq], kpts[kr], kpts[ks]), compact=False)
+        if np.issubdtype(dtype, np.floating):
+            buf_kpt = buf_kpt.real
+        buf_kpt = buf_kpt.reshape(nocc, nmo, nocc, nmo).transpose(0, 2, 1, 3)
+        eris.oooo[kp, kr, kq] = buf_kpt[:, :, :nocc, :nocc] / nkpts
+        eris.ooov[kp, kr, kq] = buf_kpt[:, :, :nocc, nocc:] / nkpts
+        eris.oovv[kp, kr, kq] = buf_kpt[:, :, nocc:, nocc:] / nkpts
+    cput1 = log.timer_debug1('transforming oopq', *cput1)
+
+    # <ia|jb> = (ij|ab)
+    for kiajb in kqrts.kqrts_ibz:
+        ki, ka, kj, kb = kiajb
+        orb_i = mo_coeff[ki][:, :nocc]
+        orb_a = mo_coeff[ka][:, nocc:]
+        orb_j = mo_coeff[kj][:, :nocc]
+        orb_b = mo_coeff[kb][:, nocc:]
+        buf_kpt = fao2mo((orb_i, orb_j, orb_a, orb_b),
+                         (kpts[ki], kpts[kj], kpts[ka], kpts[kb]), compact=False)
+        if np.issubdtype(dtype, np.floating):
+            buf_kpt = buf_kpt.real
+        buf_kpt = buf_kpt.reshape(nocc, nocc, nvir, nvir).transpose(0, 2, 1, 3)
+        eris.ovov[ki, ka, kj] = buf_kpt / nkpts
+    cput1 = log.timer_debug1('transforming ovov', *cput1)
+
+    # <ai|pq> = (ap|iq)
+    for kaipq in kqrts.kqrts_ibz:
+        ka, ki, kp, kq = kaipq
+        orb_a = mo_coeff[ka][:, nocc:]
+        orb_i = mo_coeff[ki][:, :nocc]
+        buf_kpt = fao2mo((orb_a, mo_coeff[kp], orb_i, mo_coeff[kq]),
+                         (kpts[ka], kpts[kp], kpts[ki], kpts[kq]), compact=False)
+        if np.issubdtype(dtype, np.floating):
+            buf_kpt = buf_kpt.real
+        buf_kpt = buf_kpt.reshape(nvir, nmo, nocc, nmo).transpose(0, 2, 1, 3)
+        # TODO: compute vovv on the fly
+        eris.vovv[ka, ki, kp] = buf_kpt[:, :, nocc:, nocc:] / nkpts
+        eris.voov[ka, ki, kp] = buf_kpt[:, :, :nocc, nocc:] / nkpts
+    cput1 = log.timer_debug1('transforming vopq', *cput1)
+
+    mem_now = lib.current_memory()[0]
+    if not vvvv_required:
+        _init_df_eris(cc, eris)
+    elif nvir ** 4 * 16 / 1e6 + mem_now < cc.max_memory:
+        khelper = cc.khelper
+        kconserv = khelper.kconserv
+        kptlist = kqrts.kqrts_ibz[:,:3][:,[0,2,1]] #chemists' notation
+        khelper.build_symm_map(kptlist=kptlist)
+        for (ikp, ikq, ikr) in khelper.symm_map.keys():
+            iks = kconserv[ikp, ikq, ikr]
+            orbv_p = mo_coeff[ikp][:, nocc:]
+            orbv_q = mo_coeff[ikq][:, nocc:]
+            orbv_r = mo_coeff[ikr][:, nocc:]
+            orbv_s = mo_coeff[iks][:, nocc:]
+            buf_kpt = fao2mo((orbv_p,orbv_q,orbv_r,orbv_s),
+                             kpts[[ikp,ikq,ikr,iks]], compact=False)
+            if np.issubdtype(dtype, np.floating):
+                buf_kpt = buf_kpt.real
+            buf_kpt = buf_kpt.reshape([nvir,]*4)
+            for (kp, kq, kr) in khelper.symm_map[(ikp, ikq, ikr)]:
+                buf_kpt_symm = khelper.transform_symm(buf_kpt, kp, kq, kr).transpose(0, 2, 1, 3)
+                eris.vvvv[kp, kr, kq] = buf_kpt_symm / nkpts
+    else:
+        raise MemoryError(f'Minimal memory requirements '
+                          f'{mem_now + nvir ** 4 / 1e6 * 16 * 2} MB')
+    cput1 = log.timer_debug1('transforming vvvv', *cput1)
+
+    log.timer('CCSD integral transformation', *cput0)
+    return eris
+
+
+class _PhysicistsERIs():
+    def __init__(self, cell=None):
+        self.cell = cell
+        self.kpts = None
+        self.mo_coeff = None
+        self.nocc = None
+        self.nmo = None
+        self.nvir = None
+        self.fock = None
+        self.dtype = None
+
+        self.oooo = None
+        self.ooov = None
+        self.oovv = None
+        self.ovov = None
+        self.voov = None
+        self.vovv = None
+        self.vvvv = None
+        self.Lpv = None
+
+    def _common_init_(self, cc, mo_coeff=None):
+        from pyscf.pbc import tools
+        from pyscf.pbc.cc.ccsd import _adjust_occ
+        mf = cc._scf
+        self.cell = cell = mf.cell
+        self.kpts = kpts = cc.kpts
+        self.nocc = nocc = cc.nocc
+        self.nmo = nmo = cc.nmo
+        self.nvir = nmo - nocc
+
+        if mo_coeff is None:
+            mo_coeff = cc.mo_coeff
+        self.dtype = mo_coeff[-1].dtype
+
+        # Re-make our fock MO matrix elements from density and fock AO
+        # FIXME what if mo_coeff is not consistent with cc.mo_occ?
+        dm = mf.make_rdm1(mo_coeff, cc.mo_occ)
+        exxdiv = mf.exxdiv if cc.keep_exxdiv else None
+        with lib.temporary_env(mf, exxdiv=exxdiv):
+            # _scf.exxdiv affects eris.fock. HF exchange correction should be
+            # excluded from the Fock matrix.
+            vhf = mf.get_veff(cell, dm)
+        fockao = mf.get_hcore() + vhf
+
+        self.mo_coeff = mo_coeff = padded_mo_coeff(cc, mo_coeff)
+
+        fock = np.asarray([reduce(np.dot, (mo.T.conj(), fockao[k], mo))
+                          for k, mo in enumerate(mo_coeff)])
+        self.fock = fock
+
+        mo_energy = [fock[k].diagonal().real for k in range(len(fock))]
+        if not cc.keep_exxdiv:
+            # Add HFX correction in the self.mo_energy to improve convergence in
+            # CCSD iteration. It is useful for the 2D systems since their occupied and
+            # the virtual orbital energies may overlap which may lead to numerical
+            # issue in the CCSD iterations.
+            # FIXME: Whether to add this correction for other exxdiv treatments?
+            # Without the correction, MP2 energy may be largely off the correct value.
+            madelung = tools.madelung(cell, kpts.kpts)
+            mo_energy = [_adjust_occ(mo_e, nocc, -madelung)
+                         for k, mo_e in enumerate(mo_energy)]
+
+        # Get location of padded elements in occupied and virtual space.
+        nocc_per_kpt = get_nocc(cc, per_kpoint=True)
+        nonzero_padding = padding_k_idx(cc, kind="joint")
+
+        # Check direct and indirect gaps for possible issues with CCSD convergence.
+        mo_e = [mo_energy[kp][nonzero_padding[kp]] for kp in range(len(mo_energy))]
+        mo_e = np.sort([y for x in mo_e for y in x])  # Sort de-nested array
+        gap = mo_e[np.sum(nocc_per_kpt)] - mo_e[np.sum(nocc_per_kpt)-1]
+        if gap < 1e-5:
+            logger.warn(cc, 'HOMO-LUMO gap %s too small for KCCSD. '
+                            'May cause issues in convergence.', gap)
+        self.mo_energy = mo_energy
+
+
+def _mem_usage(cc):
+    nocc = cc.nocc
+    nmo = cc.nmo
+    nvir = nmo - nocc
+    nkpts = cc.kpts.nkpts
+    #Wvvvv, eris.vvvv
+    incore  = _memory_4d(cc, [nvir,]*4) * 2
+    #eris.vovv
+    incore += _memory_4d(cc, [nvir,nvir,nvir,nocc])
+    #Wvoov, Wvovo, eris.oovv, eris.ovov, eris.voov, t2new, t2
+    incore += _memory_4d(cc, [nvir,nvir,nocc,nocc]) * 7
+    #eris.ooov
+    incore += _memory_4d(cc, [nvir,nocc,nocc,nocc])
+    #Woooo, eris.oooo
+    incore += _memory_4d(cc, [nocc,]*4) * 2
+
+    if not cc.ktensor_direct:
+        incore += _memory_4d(cc, [nvir,]*4, False) * 2
+        incore += _memory_4d(cc, [nvir,nvir,nvir,nocc], False)
+        incore += _memory_4d(cc, [nvir,nvir,nocc,nocc], False) * 5
+        incore += _memory_4d(cc, [nvir,nocc,nocc,nocc], False)
+        incore += _memory_4d(cc, [nocc,]*4, False) * 2
+
+    #temp
+    incore += nkpts * nmo**4 * 16 / 1e6
+    #1e, fock, t1
+    incore += nkpts * nmo**2 * 16 / 1e6 * 7
+    #t2_bz
+    incore += _memory_4d(cc, [nvir,nvir,nocc,nocc], False)
+
+    logger.info(cc, f"Incore memory estimation: {incore} MB")
+    return incore
+
+def _memory_4d(cc, shape, ibz=True):
+    if ibz:
+        nk = len(cc.kqrts.kqrts_ibz)
+    else:
+        nk = cc.kpts.nkpts**3
+    return nk * np.prod(shape) * 16 / 1e6

--- a/pyscf/pbc/cc/kintermediates_rhf_ksymm.py
+++ b/pyscf/pbc/cc/kintermediates_rhf_ksymm.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python
+# Copyright 2022-2023 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: Xing Zhang <zhangxing.nju@gmail.com>
+#
+
+import numpy as np
+from pyscf import lib
+from pyscf.pbc.lib import ktensor
+
+einsum = lib.einsum
+
+def cc_Foo(kpts, kqrts, t1, t2, eris, rmat):
+    nkpts, nocc, nvir = t1.shape
+    #Fki = np.empty((nkpts,nocc,nocc), dtype=t2.dtype)
+    metadata = {'kpts': kpts, 'rmat': rmat,
+                'label': 'oo', 'trans': 'cn',
+                'incore': True}
+    Fki = ktensor.empty([nocc,nocc], dtype=t2.dtype, metadata=metadata)
+
+    for i in range(kpts.nkpts_ibz):
+        ki = kpts.ibz2bz[i]
+        Fki[ki] = eris.fock[ki,:nocc,:nocc].copy()
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        ki, kl, kc, kd = kq
+        kk = ki
+        Soovv = 2 * eris.oovv[kk,kl,kc] - eris.oovv[kk,kl,kd].transpose(0,1,3,2)
+        fock = einsum('klcd,ilcd->ki', Soovv, t2[ki,kl,kc])
+        if ki == kc:
+            fock += einsum('klcd,ic,ld->ki', Soovv, t1[ki], t1[kl])
+        for _, iop in kqrts.loop_stabilizer(i):
+            rmat_oo = rmat.oo[ki][iop]
+            Fki[ki] += einsum('ki,km,in->mn', fock, rmat_oo.conj(), rmat_oo)
+    return Fki
+
+def cc_Fov(kpts, kqrts, t1, t2, eris, rmat):
+    nkpts, nocc, nvir = t1.shape
+    #Fkc = np.empty((nkpts,nocc,nvir), dtype=t2.dtype)
+    metadata = {'kpts': kpts, 'rmat': rmat,
+                'label': 'ov', 'trans': 'cn',
+                'incore': True}
+    Fkc = ktensor.empty([nocc,nvir], dtype=t2.dtype, metadata=metadata)
+
+    for i in range(kpts.nkpts_ibz):
+        ki = kpts.ibz2bz[i]
+        Fkc[ki] = eris.fock[ki,:nocc,nocc:].copy()
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        kk, kl, kc, kd = kq
+        if kc == kk and kl == kd:
+            Soovv = 2 * eris.oovv[kk,kl,kk] - eris.oovv[kk,kl,kl].transpose(0,1,3,2)
+            fock = einsum('klcd,ld->kc', Soovv, t1[kl])
+            for _, iop in kqrts.loop_stabilizer(i):
+                rmat_oo = rmat.oo[kk][iop]
+                rmat_vv = rmat.vv[kk][iop]
+                Fkc[kk] += einsum('kc,km,cb->mb', fock, rmat_oo.conj(), rmat_vv)
+    return Fkc
+
+def cc_Fvv(kpts, kqrts, t1, t2, eris, rmat):
+    nkpts, nocc, nvir = t1.shape
+    #Fac = np.empty((nkpts,nvir,nvir), dtype=t2.dtype)
+    metadata = {'kpts': kpts, 'rmat': rmat,
+                'label': 'vv', 'trans': 'cn',
+                'incore': True}
+    Fac = ktensor.empty([nvir,nvir], dtype=t2.dtype, metadata=metadata)
+
+    for i in range(kpts.nkpts_ibz):
+        ki = kpts.ibz2bz[i]
+        Fac[ki] = eris.fock[ki,nocc:,nocc:].copy()
+
+    ka_ibz_bz = kpts.ibz2bz[np.arange(kpts.nkpts_ibz)]
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        kk, kl, ka, kd = kq
+        kc = ka
+        Soovv = 2*eris.oovv[kk,kl,kc] - eris.oovv[kk,kl,kd].transpose(0,1,3,2)
+        fock = -einsum('klcd,klad->ac', Soovv, t2[kk,kl,ka])
+        if kk == ka:
+            fock += -einsum('klcd,ka,ld->ac', Soovv, t1[ka], t1[kl])
+
+        op_group = kqrts.stars_ops[i]
+        ka_prim = kpts.k2opk[ka, op_group]
+        mask = np.isin(ka_prim, ka_ibz_bz)
+        for iop, ka_p in zip(op_group[mask], ka_prim[mask]):
+            rmat_vv = rmat.vv[ka][iop]
+            Fac[ka_p] += einsum('ac,ae,cf->ef', fock, rmat_vv.conj(), rmat_vv)
+    return Fac
+
+def Loo(kpts, kqrts, t1, t2, eris, rmat):
+    nkpts, nocc, nvir = t1.shape
+    fov = eris.fock[:,:nocc,nocc:]
+
+    Lki = cc_Foo(kpts, kqrts, t1, t2, eris, rmat)
+    for ki_ibz in range(kpts.nkpts_ibz):
+        ki = kpts.ibz2bz[ki_ibz]
+        Lki[ki] += einsum('kc,ic->ki', fov[ki], t1[ki])
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        ki, kl, ka, kb = kq
+        if ki == ka:
+            fock = (2*einsum('klic,lc->ki', eris.ooov[ki,kl,ki], t1[kl])
+                     -einsum('lkic,lc->ki', eris.ooov[kl,ki,ki], t1[kl]))
+            for _, iop in kqrts.loop_stabilizer(i):
+                rmat_oo = rmat.oo[ki][iop]
+                Lki[ki] += einsum('ki,km,in->mn', fock, rmat_oo.conj(), rmat_oo)
+    return Lki
+
+def Lvv(kpts, kqrts, t1, t2, eris, rmat):
+    nkpts, nocc, nvir = t1.shape
+    fov = eris.fock[:,:nocc,nocc:]
+
+    Lac = cc_Fvv(kpts, kqrts, t1, t2, eris, rmat)
+    for ka_ibz in range(kpts.nkpts_ibz):
+        ka = kpts.ibz2bz[ka_ibz]
+        Lac[ka] += -einsum('kc,ka->ac', fov[ka], t1[ka])
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        ka, kk, kc, kl = kq
+        if ka == kc:
+            Svovv = 2 * eris.vovv[ka,kk,ka] - eris.vovv[ka,kk,kk].transpose(0,1,3,2)
+            fock = einsum('akcd,kd->ac', Svovv, t1[kk])
+            for _, iop in kqrts.loop_stabilizer(i):
+                rmat_vv = rmat.vv[ka][iop]
+                Lac[ka] += einsum('ac,ae,cf->ef', fock, rmat_vv.conj(), rmat_vv)
+    return Lac
+
+
+def _s2_index(kqrts_ibz):
+    kqrts_ibz_t = kqrts_ibz[:, np.array([1,0,3,2])]
+    diff = kqrts_ibz_t[:,None,:] - kqrts_ibz[None,:,:]
+    idx = np.sum(abs(diff), axis=-1)
+    idx = np.array(np.where(idx == 0)).T
+    idx1 = np.where(idx[:,0] < idx[:,1])[0]
+    return idx[idx1][:,1]
+
+def cc_Woooo(kpts, kqrts, t1, t2, eris, rmat, out=None):
+    nkpts, nocc, nvir = t1.shape
+    if out is None: #default incore
+        #Wklij = ktensor.empty_like(eris.oooo)
+        metadata = {'kpts': kpts, 'kqrts': kqrts, 'rmat': rmat,
+                    'label': 'oooo', 'trans': 'ccnn',
+                    'incore': True}
+        Wklij = ktensor.empty([nocc,nocc,nocc,nocc], dtype=t1.dtype,
+                              metadata=metadata)
+    else:
+        Wklij = out
+
+    s2_idx = _s2_index(kqrts.kqrts_ibz)
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        if i in s2_idx:
+            continue
+        kk, kl, ki, kj = kq
+        oooo  = einsum('klic,jc->klij',eris.ooov[kk,kl,ki],t1[kj])
+        oooo += einsum('lkjc,ic->klij',eris.ooov[kl,kk,kj],t1[ki])
+        oooo += eris.oooo[kk,kl,ki]
+
+        vvoo = eris.oovv[kk,kl].transpose(0,3,4,1,2).reshape(nkpts*nvir,nvir,nocc,nocc)
+        t2t  = t2[ki,kj].copy().transpose(0,3,4,1,2)
+        t2t[ki] += einsum('ic,jd->cdij',t1[ki],t1[kj])
+        t2t = t2t.reshape(nkpts*nvir,nvir,nocc,nocc)
+        oooo += einsum('cdkl,cdij->klij',vvoo,t2t)
+        Wklij[kk,kl,ki] = oooo
+
+    for i, kq in enumerate(kqrts.kqrts_ibz[s2_idx]):
+        kl, kk, kj, ki = kq
+        Wklij[kl,kk,kj] = Wklij[kk,kl,ki].transpose(1,0,3,2)
+    return Wklij
+
+def cc_Wvvvv(kpts, kqrts, t1, t2, eris, rmat, out=None):
+    nkpts, nocc, nvir = t1.shape
+    if out is None: #default incore
+        #Wabcd = ktensor.empty_like(eris.vvvv)
+        metadata = {'kpts': kpts, 'kqrts': kqrts, 'rmat': rmat,
+                    'label': 'vvvv', 'trans': 'ccnn',
+                    'incore': True}
+        Wabcd = ktensor.empty([nvir,nvir,nvir,nvir], dtype=t1.dtype,
+                              metadata=metadata)
+    else:
+        Wabcd = out
+
+    s2_idx = _s2_index(kqrts.kqrts_ibz)
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        if i in s2_idx:
+            continue
+        ka, kb, kc, kd = kq
+        vvvv  = einsum('akcd,kb->abcd', eris.vovv[ka,kb,kc], -t1[kb])
+        vvvv += einsum('bkdc,ka->abcd', eris.vovv[kb,ka,kd], -t1[ka])
+        vvvv += eris.vvvv[ka,kb,kc]
+        Wabcd[ka,kb,kc] = vvvv
+
+    for i, kq in enumerate(kqrts.kqrts_ibz[s2_idx]):
+        kb, ka, kd, kc = kq
+        Wabcd[kb,ka,kd] = Wabcd[ka,kb,kc].transpose(1,0,3,2)
+    return Wabcd
+
+def cc_Wvoov(kpts, kqrts, t1, t2, eris, rmat, out=None):
+    nkpts, nocc, nvir = t1.shape
+    if out is None: #default incore
+        #Wakic = ktensor.empty_like(eris.voov)
+        metadata = {'kpts': kpts, 'kqrts': kqrts, 'rmat': rmat,
+                    'label': 'voov', 'trans': 'ccnn',
+                    'incore': True}
+        Wakic = ktensor.empty([nvir,nocc,nocc,nvir], dtype=t1.dtype,
+                              metadata=metadata)
+    else:
+        Wakic = out
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        ka, kk, ki, kc = kq
+        voov  = einsum('akdc,id->akic', eris.vovv[ka,kk,ki], t1[ki])
+        voov -= einsum('lkic,la->akic', eris.ooov[ka,kk,ki], t1[ka])
+        voov += eris.voov[ka,kk,ki]
+
+        kd = ki
+        tau = t2[:,ki,ka].copy()
+        tau[ka] += 2*einsum('id,la->liad', t1[kd], t1[ka])
+        oovv_tmp = np.array(eris.oovv[kk,:,kc])
+        voov -= 0.5*einsum('xklcd,xliad->akic', oovv_tmp, tau)
+        Soovv_tmp = 2*oovv_tmp - eris.oovv[:,kk,kc].transpose(0,2,1,3,4)
+        voov += 0.5*einsum('xklcd,xilad->akic', Soovv_tmp, t2[ki,:,ka])
+
+        Wakic[ka,kk,ki] = voov
+    return Wakic
+
+def cc_Wvovo(kpts, kqrts, t1, t2, eris, rmat, out=None):
+    nkpts, nocc, nvir = t1.shape
+    if out is None: #default incore
+        #Wakci = np.empty((nkpts,nkpts,nkpts,nvir,nocc,nvir,nocc), t1.dtype)
+        metadata = {'kpts': kpts, 'kqrts': kqrts, 'rmat': rmat,
+                    'label': 'vovo', 'trans': 'ccnn',
+                    'incore': True}
+        Wakci = ktensor.empty([nvir,nocc,nvir,nocc], dtype=t1.dtype,
+                              metadata=metadata)
+    else:
+        Wakci = out
+
+    for i, kq in enumerate(kqrts.kqrts_ibz):
+        ka, kk, kc, ki = kq
+        vovo  = einsum('akcd,id->akci',eris.vovv[ka,kk,kc],t1[ki])
+        vovo -= einsum('klic,la->akci',eris.ooov[kk,ka,ki],t1[ka])
+        vovo += np.asarray(eris.ovov[kk,ka,ki]).transpose(1,0,3,2)
+
+        oovvf = eris.oovv[:,kk,kc].reshape(nkpts*nocc,nocc,nvir,nvir)
+        t2f   = t2[:,ki,ka].copy()
+        kd = ki
+        t2f[ka] += 2*einsum('id,la->liad',t1[kd],t1[ka])
+        t2f = t2f.reshape(nkpts*nocc,nocc,nvir,nvir)
+        vovo -= 0.5*einsum('lkcd,liad->akci',oovvf,t2f)
+
+        Wakci[ka,kk,kc] = vovo
+    return Wakci

--- a/pyscf/pbc/cc/test/test_kccsd_ksymm.py
+++ b/pyscf/pbc/cc/test/test_kccsd_ksymm.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# Copyright 2022-2023 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: Xing Zhang <zhangxing.nju@gmail.com>
+#
+
+import unittest
+import numpy as np
+from pyscf.pbc import gto, scf, cc
+
+def setUpModule():
+    global kccref, kmf
+    L = 2.
+    He = gto.Cell()
+    He.verbose = 5
+    He.a = np.eye(3)*L
+    He.atom =[['He' , ( L/2+0., L/2+0., L/2+0.)],]
+    He.basis = {'He': [[0, (4.0, 1.0)], [0, (1.0, 1.0)]]}
+    He.space_group_symmetry = True
+    He.build()
+
+    nk = [2,2,2]
+
+    kpts0 = He.make_kpts(nk)
+    kmf0 = scf.KRHF(He, kpts0, exxdiv=None).density_fit()
+    kmf0.kernel()
+    kccref = cc.KRCCSD(kmf0)
+    kccref.kernel()
+
+    kpts = He.make_kpts(nk,space_group_symmetry=True,time_reversal_symmetry=True)
+    kmf = scf.KRHF(He, kpts, exxdiv=None).density_fit()
+    kmf.kernel()
+
+def tearDownModule():
+    global kccref, kmf
+    del kccref, kmf
+
+class KnownValues(unittest.TestCase):
+    def test_krccsd(self):
+        kcc = cc.KsymAdaptedRCCSD(kmf)
+        kcc.kernel()
+        self.assertAlmostEqual(kcc.e_corr, kccref.e_corr, 8)
+
+        t1 = kcc.t1.todense()
+        self.assertAlmostEqual(abs(kccref.t1 - t1).max(), 0, 6)
+        #t2 = kcc.t2.todense()
+        #self.assertAlmostEqual(abs(kccref.t2 - t2).max(), 0, 6)
+
+if __name__ == '__main__':
+    print("Full Tests for CCSD with k-point symmetry")
+    unittest.main()

--- a/pyscf/pbc/df/df.py
+++ b/pyscf/pbc/df/df.py
@@ -500,11 +500,14 @@ class CDERIArray:
         self.kpts = data_group['kpts'][:]
         self.nkpts = self.kpts.shape[0]
         nao_pair = sum(dat.shape[1] for dat in self.j3c['0'].values())
-        nao = int(nao_pair ** .5)
-        if nao ** 2 == nao_pair:  # s
+        if self.aosym == 's1':
+            nao = int(nao_pair ** .5)
+            assert nao ** 2 == nao_pair
             self.nao = nao
-        else:
+        elif self.aosym == 's2':
             self.nao = int((nao_pair * 2)**.5)
+        else:
+            raise NotImplementedError
         self.naux = self.j3c['0/0'].shape[0]
 
     def __del__(self):

--- a/pyscf/pbc/df/gdf_builder.py
+++ b/pyscf/pbc/df/gdf_builder.py
@@ -97,6 +97,8 @@ class _CCGDFBuilder(rsdf_builder._RSGDFBuilder):
             ke_cutoff = pbctools.mesh_to_cutoff(cell.lattice_vectors(), self.mesh)
             self.ke_cutoff = ke_cutoff.min()
 
+        self.mesh = cell.symmetrize_mesh(self.mesh)
+
         self.dump_flags()
 
         self.fused_cell, self.fuse = fuse_auxcell(auxcell, self.eta)
@@ -137,6 +139,7 @@ class _CCGDFBuilder(rsdf_builder._RSGDFBuilder):
         mesh = pbctools.cutoff_to_mesh(auxcell.lattice_vectors(), ke)
         if auxcell.dimension < 2 or auxcell.low_dim_ft_type == 'inf_vacuum':
             mesh[auxcell.dimension:] = self.mesh[auxcell.dimension:]
+        mesh = self.cell.symmetrize_mesh(mesh)
         logger.debug(self, 'Set 2c2e integrals precision %g, mesh %s', precision, mesh)
 
         Gv, Gvbase, kws = fused_cell.get_Gv_weights(mesh)

--- a/pyscf/pbc/df/rsdf.py
+++ b/pyscf/pbc/df/rsdf.py
@@ -223,6 +223,8 @@ cell.dimension=3 with large vacuum.""")
                                                 kmax=kmax,
                                                 round2odd=r2o)
 
+        self.mesh_compact = self.cell.symmetrize_mesh(self.mesh_compact)
+
         # build auxcell
         auxcell = make_auxmol(self.cell, self.auxbasis)
         # drop exponents
@@ -242,6 +244,7 @@ cell.dimension=3 with large vacuum.""")
         if self.mesh_j2c is None:
             self.mesh_j2c = rsdf_helper.estimate_mesh_for_omega(
                                     auxcell, self.omega_j2c, round2odd=True)[1]
+        self.mesh_j2c = self.cell.symmetrize_mesh(self.mesh_j2c)
         self.auxcell = auxcell
 
     def _kpts_build(self, kpts_band=None):

--- a/pyscf/pbc/df/rsdf_builder.py
+++ b/pyscf/pbc/df/rsdf_builder.py
@@ -137,6 +137,8 @@ class _RSGDFBuilder(_Int3cBuilder):
             ke_cutoff = pbctools.mesh_to_cutoff(cell.lattice_vectors(), self.mesh)
             self.ke_cutoff = ke_cutoff[:cell.dimension].min()
 
+        self.mesh = cell.symmetrize_mesh(self.mesh)
+
         self.dump_flags()
 
         self.rs_cell = rs_cell = ft_ao._RangeSeparatedCell.from_cell(
@@ -370,6 +372,7 @@ class _RSGDFBuilder(_Int3cBuilder):
         mesh = pbctools.cutoff_to_mesh(auxcell.lattice_vectors(), ke)
         if auxcell.dimension < 2 or auxcell.low_dim_ft_type == 'inf_vacuum':
             mesh[auxcell.dimension:] = self.mesh[auxcell.dimension:]
+        mesh = self.cell.symmetrize_mesh(mesh)
         logger.debug(self, 'Set 2c2e integrals precision %g, mesh %s', precision, mesh)
 
         Gv, Gvbase, kws = auxcell.get_Gv_weights(mesh)

--- a/pyscf/pbc/dft/test/test_krks_ksym.py
+++ b/pyscf/pbc/dft/test/test_krks_ksym.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+# Copyright 2020-2023 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,14 +23,6 @@ from pyscf.pbc import gto as pbcgto
 from pyscf.pbc import scf as pscf
 from pyscf.pbc.dft import krks,kuks,multigrid
 
-L = 2.
-He = pbcgto.Cell()
-He.verbose = 0
-He.a = np.eye(3)*L
-He.atom =[['He' , ( L/2+0., L/2+0., L/2+0.)],]
-He.basis = {'He': [[0, (4.0, 1.0)], [0, (1.0, 1.0)]]}
-He.build()
-
 def make_primitive_cell(mesh):
     cell = pbcgto.Cell()
     cell.unit = 'A'
@@ -45,11 +37,23 @@ def make_primitive_cell(mesh):
     cell.spin = 0
     cell.verbose = 0
     cell.output = '/dev/null'
+    cell.space_group_symmetry = True
     cell.build()
     return cell
 
-cell = make_primitive_cell([17]*3)
-nk = [1,2,2]
+def setUpModule():
+    global cell, He, nk
+    cell = make_primitive_cell([16]*3)
+    nk = [1,2,2]
+
+    L = 2.
+    He = pbcgto.Cell()
+    He.verbose = 0
+    He.a = np.eye(3)*L
+    He.atom =[['He' , ( L/2+0., L/2+0., L/2+0.)],]
+    He.basis = {'He': [[0, (4.0, 1.0)], [0, (1.0, 1.0)]]}
+    He.space_group_symmetry = True
+    He.build()
 
 def tearDownModule():
     global cell, He, nk
@@ -82,7 +86,7 @@ class KnownValues(unittest.TestCase):
         kmf = pscf.KRKS(cell, kpts=kpts)
         kmf.xc = 'lda'
         kmf.kernel()
-        self.assertAlmostEqual(kmf.e_tot, kmf0.e_tot, 7)
+        self.assertAlmostEqual(kmf.e_tot, kmf0.e_tot, 6)
 
     def test_kuks_gamma_center(self):
         kpts0 = cell.make_kpts(nk, with_gamma_point=True)
@@ -110,7 +114,7 @@ class KnownValues(unittest.TestCase):
         kumf = pscf.KUKS(cell, kpts=kpts)
         kumf.xc = 'lda'
         kumf.kernel()
-        self.assertAlmostEqual(kumf.e_tot, kumf0.e_tot, 7)
+        self.assertAlmostEqual(kumf.e_tot, kumf0.e_tot, 6)
 
     def test_rsh(self):
         kpts0 = He.make_kpts(nk, with_gamma_point=False)

--- a/pyscf/pbc/dft/test/test_krkspu.py
+++ b/pyscf/pbc/dft/test/test_krkspu.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2023 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ def setUpModule():
     cell.verbose = 7
     cell.output = '/dev/null'
     cell.mesh = [29]*3
+    cell.space_group_symmetry=True
     cell.build()
 
 def tearDownModule():
@@ -58,16 +59,25 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e1, -10.694460059491741, 8)
 
     def test_KRKSpU_ksymm(self):
+        cell1 = cell.copy()
+        cell1.basis = 'gth-szv'
+        cell1.mesh = [16,]*3
+        cell1.build()
+
         U_idx = ["1 C 2p"]
         U_val = [5.0]
+
         kmesh = [2, 2, 1]
-        kpts = cell.make_kpts(kmesh, wrap_around=True,
-                              space_group_symmetry=True, time_reversal_symmetry=True)
-        mf = pdft.KRKSpU(cell, kpts, U_idx=U_idx, U_val=U_val, C_ao_lo='minao',
-                         minao_ref='gth-szv')
-        mf.conv_tol = 1e-10
+        kpts0 = cell1.make_kpts(kmesh, wrap_around=True)
+        mf0 = pdft.KRKSpU(cell1, kpts0, U_idx=U_idx, U_val=U_val, C_ao_lo='minao')
+        e0 = mf0.kernel()
+
+        kpts = cell1.make_kpts(kmesh, wrap_around=True,
+                               space_group_symmetry=True, time_reversal_symmetry=True)
+        assert kpts.nkpts_ibz == 3
+        mf = pdft.KRKSpU(cell1, kpts, U_idx=U_idx, U_val=U_val, C_ao_lo='minao')
         e1 = mf.kernel()
-        self.assertAlmostEqual(e1, -11.0115546012593, 8)
+        self.assertAlmostEqual(e1, e0, 8)
 
     def test_get_veff(self):
         kmesh = [2, 1, 1]

--- a/pyscf/pbc/dft/test/test_kukspu.py
+++ b/pyscf/pbc/dft/test/test_kukspu.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2023 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ def setUpModule():
     cell.verbose = 7
     cell.output = '/dev/null'
     cell.mesh = [29]*3
+    cell.space_group_symmetry = True
     cell.build()
 
 def tearDownModule():
@@ -58,16 +59,25 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e1, -10.694460059491741, 8)
 
     def test_KUKSpU_ksymm(self):
+        cell1 = cell.copy()
+        cell1.basis = 'gth-szv'
+        cell1.mesh = [16,]*3
+        cell1.build()
+
         U_idx = ["1 C 2p"]
         U_val = [5.0]
+
         kmesh = [2, 2, 1]
-        kpts = cell.make_kpts(kmesh, wrap_around=True,
-                              space_group_symmetry=True, time_reversal_symmetry=True)
-        mf = pdft.KRKSpU(cell, kpts, U_idx=U_idx, U_val=U_val, C_ao_lo='minao',
-                         minao_ref='gth-szv')
-        mf.conv_tol = 1e-10
+        kpts0 = cell1.make_kpts(kmesh, wrap_around=True)
+        mf0 = pdft.KUKSpU(cell1, kpts0, U_idx=U_idx, U_val=U_val, C_ao_lo='minao')
+        e0 = mf0.kernel()
+
+        kpts = cell1.make_kpts(kmesh, wrap_around=True,
+                               space_group_symmetry=True, time_reversal_symmetry=True)
+        assert kpts.nkpts_ibz == 3
+        mf = pdft.KUKSpU(cell1, kpts, U_idx=U_idx, U_val=U_val, C_ao_lo='minao')
         e1 = mf.kernel()
-        self.assertAlmostEqual(e1, -11.0115546012593, 8)
+        self.assertAlmostEqual(e1, e0, 8)
 
     def test_get_veff(self):
         kmesh = [2, 1, 1]

--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -874,7 +874,7 @@ energy_nuc = ewald
 def make_kpts(cell, nks, wrap_around=WRAP_AROUND, with_gamma_point=WITH_GAMMA,
               scaled_center=None,
               space_group_symmetry=False, time_reversal_symmetry=False,
-              symmorphic=True):
+              **kwargs):
     '''Given number of kpoints along x,y,z , generate kpoints
 
     Args:
@@ -919,7 +919,14 @@ def make_kpts(cell, nks, wrap_around=WRAP_AROUND, with_gamma_point=WITH_GAMMA,
     scaled_kpts += np.array(scaled_center)
     kpts = cell.get_abs_kpts(scaled_kpts)
     if space_group_symmetry or time_reversal_symmetry:
-        kpts = libkpts.make_kpts(cell, kpts, space_group_symmetry, time_reversal_symmetry, symmorphic)
+        if space_group_symmetry and not cell.space_group_symmetry:
+            raise RuntimeError('Using k-point symmetry now requires cell '
+                               'to be built with space group symmetry info:\n'
+                               'cell.space_group_symmetry = True\n'
+                               'cell.symmorphic = False\n'
+                               'cell.build()')
+        kpts = libkpts.make_kpts(cell, kpts, space_group_symmetry,
+                                 time_reversal_symmetry)
     return kpts
 
 def get_uniform_grids(cell, mesh=None, wrap_around=True):
@@ -1086,6 +1093,15 @@ class Cell(mole.Mole):
             infinity vacuum (inf_vacuum) or truncated Coulomb potential
             (analytic_2d_1). Unless explicitly specified, analytic_2d_1 is
             used for 2D system and inf_vacuum is assumed for 1D and 0D.
+        space_group_symmetry : bool
+            Whether to consider space group symmetry. Default is False.
+        symmorphic : bool
+            Whether the lattice is symmorphic. If set to True, even if the
+            lattice is non-symmorphic, only symmorphic space group symmetry
+            will be considered. Default is False, meaning the space group is
+            determined by the lattice symmetry to be symmorphic or non-symmorphic.
+        lattice_symmetry : None or :class:`pbc.symm.Symmetry` instance
+            The object containing the lattice symmetry information. Default is None.
 
     (See other attributes in :class:`Mole`)
 
@@ -1114,6 +1130,9 @@ class Cell(mole.Mole):
         #       density-fitting class.  This determines how the ewald produces
         #       its energy.
         self.low_dim_ft_type = None
+        self.space_group_symmetry = False
+        self.symmorphic = False
+        self.lattice_symmetry = None
 
 ##################################################
 # These attributes are initialized by build function if not given
@@ -1122,7 +1141,8 @@ class Cell(mole.Mole):
 
 ##################################################
 # don't modify the following variables, they are not input arguments
-        keys = ('precision', 'exp_to_discard')
+        keys = ('precision', 'exp_to_discard',
+                'space_group_symmetry', 'symmorphic', 'lattice_symmetry')
         self._keys = self._keys.union(self.__dict__).union(keys)
         self.__dict__.update(kwargs)
 
@@ -1234,11 +1254,33 @@ class Cell(mole.Mole):
 
     tot_electrons = tot_electrons
 
+    def _build_symmetry(self, kpts=None, **kwargs):
+        '''Construct symmetry adapted crystalline atomic orbitals
+        '''
+        from pyscf.pbc.symm.basis import symm_adapted_basis
+        if not isinstance(kpts, libkpts.KPoints):
+            return mole.Mole._build_symmetry(self)
+        self.symm_orb, self.irrep_id = symm_adapted_basis(self, kpts)
+        return self
+
+    def symmetrize_mesh(self, mesh=None):
+        if mesh is None:
+            mesh = self.mesh
+        if not self.space_group_symmetry:
+            return mesh
+
+        _, mesh1 = self.lattice_symmetry.check_mesh_symmetry(mesh=mesh,
+                                                             return_mesh=True)
+        if np.prod(mesh1) != np.prod(mesh):
+            logger.debug(self, 'mesh %s is symmetrized as %s', mesh, mesh1)
+        return mesh1
+
 #Note: Exculde dump_input, parse_arg, basis from kwargs to avoid parsing twice
     def build(self, dump_input=True, parse_arg=True,
               a=None, mesh=None, ke_cutoff=None, precision=None, nimgs=None,
               pseudo=None, basis=None, h=None, dimension=None, rcut= None,
-              ecp=None, low_dim_ft_type=None, *args, **kwargs):
+              ecp=None, low_dim_ft_type=None,
+              space_group_symmetry=None, symmorphic=None, *args, **kwargs):
         '''Setup Mole molecule and Cell and initialize some control parameters.
         Whenever you change the value of the attributes of :class:`Cell`,
         you need call this function to refresh the internal data of Cell.
@@ -1276,6 +1318,13 @@ class Cell(mole.Mole):
                 infinity vacuum (inf_vacuum) or truncated Coulomb potential
                 (analytic_2d_1). Unless explicitly specified, analytic_2d_1 is
                 used for 2D system and inf_vacuum is assumed for 1D and 0D.
+            space_group_symmetry : bool
+                Whether to consider space group symmetry. Default is False.
+            symmorphic : bool
+                Whether the lattice is symmorphic. If set to True, even if the
+                lattice is non-symmorphic, only symmorphic space group symmetry
+                will be considered. Default is False, meaning the space group is
+                determined by the lattice symmetry to be symmorphic or non-symmorphic.
         '''
         if h is not None: self.h = h
         if a is not None: self.a = a
@@ -1289,6 +1338,10 @@ class Cell(mole.Mole):
         if ecp is not None: self.ecp = ecp
         if ke_cutoff is not None: self.ke_cutoff = ke_cutoff
         if low_dim_ft_type is not None: self.low_dim_ft_type = low_dim_ft_type
+        if space_group_symmetry is not None:
+            self.space_group_symmetry = space_group_symmetry
+        if symmorphic is not None:
+            self.symmorphic = symmorphic
 
         if 'unit' in kwargs:
             self.unit = kwargs['unit']
@@ -1442,6 +1495,19 @@ class Cell(mole.Mole):
             # system, cell.mesh was initialized to 0.
             self._mesh[self._mesh == 0] = 30
 
+        if self.space_group_symmetry:
+            from pyscf.pbc.symm import Symmetry
+            _check_mesh_symm = False
+            if not self._mesh_from_build:
+                _check_mesh_symm = True
+            _lattice_symm = Symmetry(self)
+            _lattice_symm.build(space_group_symmetry=True,
+                                symmorphic=self.symmorphic,
+                                check_mesh_symmetry=_check_mesh_symm)
+            self.lattice_symmetry = _lattice_symm
+            if self._mesh_from_build:
+                self._mesh = self.symmetrize_mesh()
+
         if dump_input and not _built and self.verbose > logger.NOTE:
             self.dump_input()
             logger.info(self, 'lattice vectors  a1 [%.9f, %.9f, %.9f]', *_a[0])
@@ -1465,6 +1531,8 @@ class Cell(mole.Mole):
                             self.mesh, np.prod(self.mesh))
                 Ecut = pbctools.mesh_to_cutoff(self.lattice_vectors(), self.mesh)
                 logger.info(self, '    = ke_cutoff %s', Ecut)
+            if self.space_group_symmetry:
+                self.lattice_symmetry.dump_info()
         return self
     kernel = build
 

--- a/pyscf/pbc/lib/kpts.py
+++ b/pyscf/pbc/lib/kpts.py
@@ -1009,7 +1009,7 @@ class KPoints(symm.Symmetry, lib.StreamObject):
             kptsij = kptsi[:,None,:] + kptsj[None,:,:]
             diff = kptsij[:,:,None,:] - self.kpts_scaled[None,None,:,:]
             diff = round_to_fbz(diff, tol=tol)
-            idx = np.where(np.sum(abs(diff), axis=-1) < tol)
+            idx = np.where(abs(diff).max(axis=-1) < tol)
 
             nk = self.nkpts
             table= -np.ones((nk,nk), dtype=np.int32)
@@ -1023,7 +1023,7 @@ class KPoints(symm.Symmetry, lib.StreamObject):
         if self._inverse_table is None:
             diff = -self.kpts_scaled[:,None,:] - self.kpts_scaled[None,:,:]
             diff = round_to_fbz(diff, tol=tol)
-            idx = np.where(np.sum(abs(diff), axis=-1) < tol)
+            idx = np.where(abs(diff).max(axis=-1) < tol)
 
             table = -np.ones((self.nkpts,), dtype=np.int32)
             table[idx[0]] = idx[1]

--- a/pyscf/pbc/lib/kpts.py
+++ b/pyscf/pbc/lib/kpts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+# Copyright 2020-2023 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,18 +16,20 @@
 # Authors: Xing Zhang <zhangxing.nju@gmail.com>
 #
 
+from functools import reduce
 import numpy as np
 import ctypes
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf import __config__
 from pyscf.pbc.symm import symmetry as symm
-from pyscf.pbc.lib.kpts_helper import member, KPT_DIFF_TOL, KptsHelper
+from pyscf.pbc.symm.group import PGElement, PointGroup, Representation
+from pyscf.pbc.lib.kpts_helper import member, round_to_fbz, KPT_DIFF_TOL
 from numpy.linalg import inv
 
 libpbc = lib.load_library('libpbc')
 
-def make_kpts_ibz(kpts):
+def make_kpts_ibz(kpts, tol=KPT_DIFF_TOL):
     """
     Locate k-points in IBZ.
 
@@ -46,7 +48,7 @@ def make_kpts_ibz(kpts):
     if kpts.time_reversal:
         op_rot = np.concatenate([op_rot, -op_rot])
 
-    bz2bz_ks = map_k_points_fast(kpts.kpts_scaled, op_rot, KPT_DIFF_TOL)
+    bz2bz_ks = map_k_points_fast(kpts.kpts_scaled, op_rot, tol)
     kpts.k2opk = bz2bz_ks.copy()
     if -1 in bz2bz_ks:
         bz2bz_ks[:, np.unique(np.where(bz2bz_ks == -1)[1])] = -1
@@ -85,16 +87,22 @@ def make_kpts_ibz(kpts):
                 continue
             diff = bz_k_scaled - np.dot(ibz_k_scaled, op.T)
             diff = diff - diff.round()
-            if (np.absolute(diff) < KPT_DIFF_TOL).all():
+            if (np.absolute(diff) < tol).all():
                 kpts.time_reversal_symm_bz[k] = io // nop
                 kpts.stars_ops_bz[k] = io % nop
                 break
 
     for i in range(kpts.nkpts_ibz):
-        ibz_k_scaled = kpts.kpts_scaled_ibz[i]
         idx = np.where(kpts.bz2ibz == i)[0]
         kpts.stars.append(idx)
         kpts.stars_ops.append(kpts.stars_ops_bz[idx])
+
+    little_cogroup_ops = []
+    for ki_ibz in range(kpts.nkpts_ibz):
+        ki = kpts.ibz2bz[ki_ibz]
+        ops_id = np.where(kpts.k2opk[ki] == ki)[0]
+        little_cogroup_ops.append(ops_id)
+    kpts.little_cogroup_ops = little_cogroup_ops
 
 def make_ktuples_ibz(kpts, kpts_scaled=None, ntuple=2, tol=KPT_DIFF_TOL):
     """
@@ -114,100 +122,109 @@ def make_ktuples_ibz(kpts, kpts_scaled=None, ntuple=2, tol=KPT_DIFF_TOL):
 
     Returns
     -------
-        ibz2bz_kk : (nibz,) ndarray of int
+        ibz2bz : (nibz,) ndarray of int
             Mapping table from IBZ to full BZ.
-        ibz_kk_weight : (nibz,) ndarray of int
+        weight_ibz : (nibz,) ndarray of int
             Weights of each k-point tuple in the IBZ.
-        bz2ibz_kk : (nkpts**ntuple,) ndarray of int
+        bz2ibz : (nkpts**ntuple,) ndarray of int
             Mapping table from full BZ to IBZ.
-        kk_group : list of (nk,) ndarrays of int
+        stars : list of (nibz,) ndarrays of int
             Similar as :attr:`.stars`.
-        kk_sym_group : list of (nk,) ndarrays of int
+        stars_ops : list of (nibz,) ndarrays of int
             Similar as :attr:`.stars_ops`.
+        stars_ops_bz : (nkpts**ntuple,) ndarray of int
+            Similar as :attr:`.stars_ops_bz`.
     """
     if kpts_scaled is not None:
         cell = kpts.cell
         op_rot = np.asarray([op.a2b(cell).rot for op in kpts.ops])
         if kpts.time_reversal:
             op_rot = np.concatenate([op_rot, -op_rot])
-        bz2bz_ksks = map_k_tuples(kpts_scaled, op_rot, ntuple=ntuple, tol=tol)
-        bz2bz_ksks[:, np.unique(np.where(bz2bz_ksks == -1)[1])] = -1
-        nbzk2 = bz2bz_ksks.shape[0]
+        kt2opkt = map_kpts_tuples(kpts_scaled, op_rot, ntuple=ntuple, tol=tol)
+        kt2opkt[:, np.unique(np.where(kt2opkt == -1)[1])] = -1
+        nktuple = kt2opkt.shape[0]
     else:
-        bz2bz_ks = kpts.k2opk
-        nop = bz2bz_ks.shape[-1]
-        nbzk = kpts.nkpts
-        nbzk2 = nbzk**ntuple
-        bz2bz_T = np.zeros([nop, nbzk2], dtype=int)
+        k2opk = kpts.k2opk
+        nkpts, nop = k2opk.shape
+        nktuple = nkpts ** ntuple
+        kt2opkt_T = np.empty([nop, nktuple], dtype=np.int64)
         for iop in range(nop):
-            tmp = lib.cartesian_prod([bz2bz_ks[:,iop]]*ntuple)
-            if -1 in tmp:
-                bz2bz_T[iop,:] = -1
+            if -1 in k2opk[:,iop]:
+                kt2opkt_T[iop,:] = -1
             else:
-                #idx_throw = np.unique(np.where(tmp == -1)[0])
-                for i in range(ntuple):
-                    bz2bz_T[iop] += tmp[:,i] * nbzk**(ntuple-i-1)
-                #bz2bz_T[iop, idx_throw] = -1
-        bz2bz_ksks = bz2bz_T.T
+                tmp = lib.cartesian_prod([k2opk[:,iop],] * ntuple)
+                kt2opkt_T[iop] = lib.inv_base_repr_int(tmp, nkpts)
+                tmp = None
+        kt2opkt = kt2opkt_T.T
 
     if kpts.verbose >= logger.INFO:
-        logger.info(kpts, 'Number of k-point %d-tuples: %d', ntuple, nbzk2)
+        logger.info(kpts, 'Number of k-point %d-tuples: %d', ntuple, nktuple)
 
-    bz2bz_kk = -np.ones(nbzk2+1, dtype=int)
-    ibz2bz_kk = []
-    k_group = []
-    sym_group = []
-    for k in range(nbzk2-1, -1, -1):
-        if bz2bz_kk[k] == -1:
-            bz2bz_kk[bz2bz_ksks[k]] = k
-            ibz2bz_kk.append(k)
-            k_idx, op_idx = np.unique(bz2bz_ksks[k], return_index=True)
+    bz2bz = -np.ones(nktuple+1, dtype=np.int64)
+    ibz2bz = []
+    stars = []
+    stars_ops = []
+    stars_ops_bz = np.empty(nktuple, dtype=np.int32)
+    for k in range(nktuple-1, -1, -1):
+        if bz2bz[k] == -1:
+            bz2bz[kt2opkt[k]] = k
+            ibz2bz.append(k)
+            k_idx, op_idx = np.unique(kt2opkt[k], return_index=True)
             if k_idx[0] == -1:
                 k_idx = k_idx[1:]
                 op_idx = op_idx[1:]
-            k_group.append(k_idx)
-            sym_group.append(op_idx)
+            stars.append(k_idx)
+            stars_ops.append(op_idx)
+            stars_ops_bz[k_idx] = op_idx
 
-    ibz2bz_kk = np.array(ibz2bz_kk[::-1])
+    kt2opkt =None
+
+    ibz2bz = np.array(ibz2bz, dtype=np.int64)[::-1]
     if kpts.verbose >= logger.INFO:
-        logger.info(kpts, 'Number of k %d-tuples in IBZ: %s', ntuple, len(ibz2bz_kk))
+        logger.info(kpts, f'Number of k {ntuple}-tuples in IBZ: {len(ibz2bz)}')
 
-    bz2bz_kk = bz2bz_kk[:-1].copy()
-    bz2ibz_kk = np.empty(nbzk2,dtype=int)
-    bz2ibz_kk[ibz2bz_kk] = np.arange(len(ibz2bz_kk))
-    bz2ibz_kk = bz2ibz_kk[bz2bz_kk]
+    bz2bz = bz2bz[:-1]
+    bz2ibz = np.empty(nktuple, dtype=np.int64)
+    bz2ibz[ibz2bz] = np.arange(len(ibz2bz))
+    bz2ibz = bz2ibz[bz2bz]
 
-    kk_group = k_group[::-1]
-    kk_sym_group = sym_group[::-1]
-    ibz_kk_weight = np.bincount(bz2ibz_kk) * (1.0 / nbzk2)
-    return ibz2bz_kk, ibz_kk_weight, bz2ibz_kk, kk_group, kk_sym_group
+    stars = stars[::-1]
+    stars_ops = stars_ops[::-1]
+    weight_ibz = np.bincount(bz2ibz) * (1.0 / nktuple)
+    return ibz2bz, weight_ibz, bz2ibz, stars, stars_ops, stars_ops_bz
 
-def make_k4_ibz(kpts, sym='s1'):
+def make_k4_ibz(kpts, sym='s1', return_ops=False):
     #physicist's notation
-    ibz2bz, weight, bz2ibz, group, _ = kpts.make_ktuples_ibz(ntuple=3)
-    khelper = KptsHelper(kpts.cell, kpts.kpts)
-    k4 = []
-    for ki, kj, ka in kpts.loop_ktuples(ibz2bz, 3):
-        kb = khelper.kconserv[ki,ka,kj]
-        k4.append([ki,kj,ka,kb])
+    ibz2bz, weight, bz2ibz, stars, stars_ops, stars_ops_bz = \
+            kpts.make_ktuples_ibz(ntuple=3)
+    kconserv = kpts.get_kconserv()
+
+    kija = kpts.index_to_ktuple(ibz2bz, 3)
+    kb = kconserv[kija[:,0], kija[:,2], kija[:,1]]
+    k4 = np.concatenate((kija, kb[:,None]), axis=1)
 
     if sym == "s1":
-        return np.asarray(k4), np.asarray(weight), np.asarray(bz2ibz)
+        if return_ops:
+            return k4, weight, bz2ibz, ibz2bz, stars_ops, stars_ops_bz
+        else:
+            return k4, weight, bz2ibz
     elif sym == "s2" or sym == "s4":
         ibz2ibz_s2 = np.arange(len(k4))
         k4_s2 = []
         weight_s2 = []
-        for i, k in enumerate(k4):
-            ki,kj,ka,kb = k
-            k_sym = [kj,ki,kb,ka] #interchange dummy indices
+        for i, kijab in enumerate(k4):
+            ki, kj, ka, kb = kijab
+            k = list(kijab)
+            k_sym = [kj, ki, kb, ka] #interchange dummy indices
             if k not in k4_s2 and k_sym not in k4_s2:
                 k4_s2.append(k)
                 ibz2ibz_s2[i] = len(k4_s2) - 1
                 w = weight[i]
-                if k != k_sym and k_sym in k4:
-                    idx = k4.index(k_sym)
-                    ibz2ibz_s2[idx] = ibz2ibz_s2[i]
-                    w += weight[idx]
+                if k != k_sym:
+                    k_sym_in_k4, idx = lib.isin_1d(k_sym, k4, True)
+                    if k_sym_in_k4:
+                        ibz2ibz_s2[idx] = ibz2ibz_s2[i]
+                        w += weight[idx]
                 weight_s2.append(w)
         #refine s2 symmetry
         k4_s2_refine = []
@@ -215,22 +232,24 @@ def make_k4_ibz(kpts, sym='s1'):
         skip = np.zeros([len(k4_s2)], dtype=int)
         ibz_s22ibz_s2_refine = np.arange(len(k4_s2))
         for i, k in enumerate(k4_s2):
-            if skip[i]: continue
-            ki,kj,ka,kb = k
-            k_sym = [kj,ki,kb,ka]
-            if ki==kj and ka==kb:
+            if skip[i]:
+                continue
+            ki, kj, ka, kb = k
+            k_sym = [kj, ki, kb, ka]
+            if ki == kj and ka == kb:
                 k4_s2_refine.append(k)
                 ibz_s22ibz_s2_refine[i] = len(k4_s2_refine) - 1
                 weight_s2_refine.append(weight_s2[i])
                 continue
             idx_sym = None
             for j in range(i+1, len(k4_s2)):
-                if skip[j]: continue
+                if skip[j]:
+                    continue
                 k_tmp = k4_s2[j]
                 if ki in k_tmp and kj in k_tmp and ka in k_tmp and kb in k_tmp:
-                    idx = k4.index(k_tmp)
-                    for kii,kjj,kaa in kpts.loop_ktuples(group[idx], 3):
-                        kbb = khelper.kconserv[kii,kaa,kjj]
+                    _, idx = lib.isin_1d(k_tmp, k4, True)
+                    for kii,kjj,kaa in kpts.loop_ktuples(stars[idx], 3):
+                        kbb = kconserv[kii,kaa,kjj]
                         if k_sym == [kii,kjj,kaa,kbb]:
                             idx_sym = j
                             break
@@ -298,37 +317,10 @@ def map_k_points_fast(kpts_scaled, ops, tol=KPT_DIFF_TOL):
             bz2bz_ks[k1,s] = k2 if ops[s] * kpts_scaled[k1] = kpts_scaled[k2] + K,
             where K is a reciprocal lattice vector.
     """
-    nkpts = len(kpts_scaled)
-    nop = len(ops)
-    bz2bz_ks = -np.ones((nkpts, nop), dtype=int)
-    for s, op in enumerate(ops):
-        # Find mapped kpoints
-        op_kpts_scaled = np.dot(kpts_scaled, op.T)
+    return map_kpts_tuples(kpts_scaled.reshape(len(kpts_scaled),-1,3),
+                           ops, ntuple=1, tol=tol)
 
-        # Do some work on the input
-        k_kc = np.concatenate([kpts_scaled, op_kpts_scaled])
-        k_kc = np.mod(np.mod(k_kc, 1), 1)
-        k_kc = aglomerate_points(k_kc, tol)
-        k_kc = k_kc.round(-np.log10(tol).astype(int))
-        k_kc = np.mod(k_kc, 1)
-
-        # Find the lexicographical order
-        order = np.lexsort(k_kc.T)
-        k_kc = k_kc[order]
-        diff_kc = np.diff(k_kc, axis=0)
-        equivalentpairs_k = np.array((diff_kc == 0).all(1), dtype=bool)
-
-        # Mapping array.
-        orders = np.array([order[:-1][equivalentpairs_k],
-                           order[1:][equivalentpairs_k]])
-
-        # This has to be true.
-        assert (orders[0] < nkpts).all()
-        assert (orders[1] >= nkpts).all()
-        bz2bz_ks[orders[1] - nkpts, s] = orders[0]
-    return bz2bz_ks
-
-def map_k_tuples(kpts_scaled, ops, ntuple=2, tol=KPT_DIFF_TOL):
+def map_kpts_tuples(kpts_scaled, ops, ntuple=2, tol=KPT_DIFF_TOL):
     """
     Find symmetry-related k-point tuples.
 
@@ -341,8 +333,8 @@ def map_k_tuples(kpts_scaled, ops, ntuple=2, tol=KPT_DIFF_TOL):
         ntuple : int
             Dimension of tuples. Default is 2.
         tol : float
-            K-points differ by ``tol`` are considered as different.
-            Default is 1e-6.
+            K-points differ less than ``tol`` are considered
+            as the same. Default is 1e-6.
 
     Returns
     -------
@@ -355,54 +347,23 @@ def map_k_tuples(kpts_scaled, ops, ntuple=2, tol=KPT_DIFF_TOL):
     nop = len(ops)
     bz2bz_ks = -np.ones((nkpts, nop), dtype=int)
     for s, op in enumerate(ops):
-        # Find mapped kpoints
-        op_kpts_scaled = np.empty((nkpts, ntuple, 3), dtype=float)
-        for i in range(ntuple):
-            op_kpts_scaled[:,i] = np.dot(kpts_scaled[:,i], op.T)
+        op_kpts_scaled = np.einsum('kix,xy->kiy', kpts_scaled, op.T)
         op_kpts_scaled = op_kpts_scaled.reshape((nkpts,-1))
 
-        # Do some work on the input
-        k_kc = np.concatenate([kpts_scaled.reshape((nkpts,-1)), op_kpts_scaled])
-        k_kc = np.mod(np.mod(k_kc, 1), 1)
-        k_kc = aglomerate_points(k_kc, tol)
-        k_kc = k_kc.round(-np.log10(tol).astype(int))
-        k_kc = np.mod(k_kc, 1)
+        k_opk = np.concatenate([kpts_scaled.reshape((nkpts,-1)), op_kpts_scaled])
+        k_opk = round_to_fbz(k_opk, tol=tol)
+        order = np.lexsort(k_opk.T)
+        k_opk = k_opk[order]
+        diff = np.diff(k_opk, axis=0)
+        equivalent_pairs = np.array((diff == 0).all(1), dtype=bool)
 
-        # Find the lexicographical order
-        order = np.lexsort(k_kc.T)
-        k_kc = k_kc[order]
-        diff_kc = np.diff(k_kc, axis=0)
-        equivalentpairs_k = np.array((diff_kc == 0).all(1), dtype=bool)
+        maps = np.array([order[:-1][equivalent_pairs],
+                         order[ 1:][equivalent_pairs]])
 
-        # Mapping array.
-        orders = np.array([order[:-1][equivalentpairs_k],
-                           order[1:][equivalentpairs_k]])
-
-        # This has to be true.
-        assert (orders[0] < nkpts).all()
-        assert (orders[1] >= nkpts).all()
-        bz2bz_ks[orders[1] - nkpts, s] = orders[0]
+        assert (maps[0] < nkpts).all()
+        assert (maps[1] >= nkpts).all()
+        bz2bz_ks[maps[1] - nkpts, s] = maps[0]
     return bz2bz_ks
-
-def aglomerate_points(k_kc, tol=KPT_DIFF_TOL):
-    #This routine is adopted from GPAW
-    '''
-    Remove numerical error
-    '''
-    nd = k_kc.shape[1]
-    nbzkpts = len(k_kc)
-
-    inds_kc = np.argsort(k_kc, axis=0)
-
-    for c in range(nd):
-        sk_k = k_kc[inds_kc[:, c], c]
-        dk_k = np.diff(sk_k)
-
-        pt_K = np.argwhere(dk_k > tol)[:, 0]
-        pt_K = np.append(np.append(0, pt_K + 1), nbzkpts*2)
-        for i in range(len(pt_K) - 1):
-            k_kc[inds_kc[pt_K[i]:pt_K[i + 1], c], c] = k_kc[inds_kc[pt_K[i], c], c]
-    return k_kc
 
 def symmetrize_density(kpts, rhoR_k, ibz_k_idx, mesh):
     '''
@@ -767,9 +728,56 @@ def check_mo_occ_symmetry(kpts, mo_occ, tol=1e-5):
         mo_occ_ibz.append(mo_occ[kpts.ibz2bz[k]])
     return mo_occ_ibz
 
+def get_rotation_mat_for_mos(kpts, mo_coeff, ovlp, k1, k2, ops_id=None):
+    '''Rotation matrices for rotating MO[k1] to MO[k2].
+
+    Args:
+        kpts : :class:`KPoints` instance
+            K-point object.
+        mo_coeff : array
+            MO coefficients.
+        ovlp : array
+            Overlap matrix in AOs.
+        k1 : array like
+            Indices of the original k-points in the BZ.
+        k2 : array like
+            Indices of the target k-points in the BZ.
+        ops_id : list, optional
+            Indices of space group operations.
+            If not given, all the rotations are considered.
+
+    Returns:
+        out : list
+            Rotation matrices.
+    '''
+    from pyscf.pbc.symm.symmetry import _get_rotation_mat
+    cell = kpts.cell
+    nk = len(k1)
+    assert nk == len(k2)
+    if ops_id is not None:
+        assert nk == len(ops_id)
+
+    out = []
+    for k, (k_orig, k_target) in enumerate(zip(k1, k2)):
+        mats = []
+        if ops_id is None:
+            ids = np.arange(kpts.nop)
+        else:
+            ids = np.asarray(ops_id[k]).reshape(-1)
+        for iop in ids:
+            mat_ao = _get_rotation_mat(cell, kpts.kpts_scaled[k_orig],
+                                       mo_coeff[k_orig], kpts.ops[iop],
+                                       kpts.Dmats[iop])
+            mat = reduce(np.dot,(mo_coeff[k_orig].conj().T, ovlp[k_orig],
+                                 mat_ao.conj().T, mo_coeff[k_target]))
+            mats.append(mat)
+        out.append(np.asarray(mats))
+    return out
+
+
 def make_kpts(cell, kpts=np.zeros((1,3)),
               space_group_symmetry=False, time_reversal_symmetry=False,
-              symmorphic=True):
+              **kwargs):
     """
     A wrapper function to build the :class:`KPoints` object.
 
@@ -783,8 +791,6 @@ def make_kpts(cell, kpts=np.zeros((1,3)),
             Whether to consider space group symmetry. Default is False.
         time_reversal_symmetry : bool
             Whether to consider time reversal symmetry. Default is False.
-        symmorphic : bool
-            Whether to consider only the symmorphic subgroup. Default is True.
 
     Examples
     --------
@@ -792,16 +798,25 @@ def make_kpts(cell, kpts=np.zeros((1,3)),
     ...     atom = '''He 0. 0. 0.''',
     ...     a = numpy.eye(3)*2.0).build()
     >>> kpts = make_kpts(cell,
-    ...                  numpy.array([[0.,0.,0.],[0.5,0.,0.],[0.,0.5,0.],[0.,0.,0.5]])
+    ...                  numpy.array([[0.,0.,0.],
+    ...                               [0.5,0.,0.],
+    ...                               [0.,0.5,0.],
+    ...                               [0.,0.,0.5]]),
     ...                  space_group_symmetry=True)
     >>> print(kpts.kpts_ibz)
     [[0.  0.  0. ]
      [0.  0.  0.5]]
     """
     if isinstance(kpts, KPoints):
-        return kpts.build(space_group_symmetry, time_reversal_symmetry, symmorphic)
+        return kpts.build(space_group_symmetry,
+                          time_reversal_symmetry,
+                          **kwargs)
     else:
-        return KPoints(cell, kpts).build(space_group_symmetry, time_reversal_symmetry, symmorphic)
+        kpts_symm = KPoints(cell, kpts)
+        kpts_symm.build(space_group_symmetry,
+                        time_reversal_symmetry,
+                        **kwargs)
+        return kpts_symm
 
 class KPoints(symm.Symmetry, lib.StreamObject):
     """
@@ -880,10 +895,15 @@ class KPoints(symm.Symmetry, lib.StreamObject):
         self.stars_ops = []
         self.stars_ops_bz = np.zeros(nkpts, dtype=int)
         self.time_reversal_symm_bz = np.zeros(nkpts, dtype=int)
+        self.little_cogroup_ops = []
 
         #private variables
         self._nkpts = len(self.kpts)
         self._nkpts_ibz = len(self.kpts_ibz)
+        self._addition_table = None
+        self._inverse_table = None
+        self._copgs = None
+        self._copg_ops_map_ibz2bz = None
 
     @property
     def nkpts(self):
@@ -926,10 +946,16 @@ class KPoints(symm.Symmetry, lib.StreamObject):
     def __len__(self):
         return self.nkpts_ibz
 
-    def build(self, space_group_symmetry=True, time_reversal_symmetry=True,
-              symmorphic=True, *args, **kwargs):
-        symm.Symmetry.build(self, space_group_symmetry, symmorphic, *args, **kwargs)
-        if not getattr(self.cell, '_built', None): return
+    def build(self, space_group_symmetry=False, time_reversal_symmetry=False,
+              *args, **kwargs):
+        if space_group_symmetry:
+            _lattice_symm = getattr(self.cell, 'lattice_symmetry', None)
+            if isinstance(_lattice_symm, symm.Symmetry):
+                self.__dict__.update(_lattice_symm.__dict__)
+        if not self._built:
+            symm.Symmetry.build(self, space_group_symmetry, *args, **kwargs)
+        if not getattr(self.cell, '_built', None):
+            return self
 
         self.time_reversal = time_reversal_symmetry and not self.has_inversion
         self.kpts_scaled_ibz = self.kpts_scaled = self.cell.get_scaled_kpts(self.kpts)
@@ -940,10 +966,10 @@ class KPoints(symm.Symmetry, lib.StreamObject):
     def dump_info(self):
         if self.verbose >= logger.INFO:
             logger.info(self, 'time reversal: %s', self.time_reversal)
-            logger.info(self, 'k-points in IBZ                           weights')
+            logger.info(self, 'k-points in IBZ                         weights')
             ibzk = self.kpts_scaled_ibz
             for k in range(self.nkpts_ibz):
-                logger.info(self, '%d:  %11.8f, %11.8f, %11.8f    %d/%d',
+                logger.info(self, '%3d: %9.6f, %9.6f, %9.6f    %d/%d',
                             k, ibzk[k][0], ibzk[k][1], ibzk[k][2],
                             np.floor(self.weights_ibz[k]*self.nkpts), self.nkpts)
 
@@ -966,19 +992,83 @@ class KPoints(symm.Symmetry, lib.StreamObject):
         return kptij_lst
 
     def loop_ktuples(self, ibz2bz, ntuple):
-        nkpts = self.nkpts
         for k in ibz2bz:
-            res = []
-            for i in range(ntuple-1, -1, -1):
-                ki = k // nkpts**(i)
-                k = k - ki * nkpts**(i)
-                res.append(ki)
+            res = self.index_to_ktuple(k, ntuple)
             yield tuple(res)
+
+    def ktuple_to_index(self, kk):
+        return lib.inv_base_repr_int(kk, self.nkpts)
+
+    def index_to_ktuple(self, k, ntuple):
+        return lib.base_repr_int(k, self.nkpts, ntuple)
+
+    @property
+    def addition_table(self, tol=KPT_DIFF_TOL):
+        if self._addition_table is None:
+            kptsi = kptsj = self.kpts_scaled
+            kptsij = kptsi[:,None,:] + kptsj[None,:,:]
+            diff = kptsij[:,:,None,:] - self.kpts_scaled[None,None,:,:]
+            diff = round_to_fbz(diff, tol=tol)
+            idx = np.where(np.sum(abs(diff), axis=-1) < tol)
+
+            nk = self.nkpts
+            table= -np.ones((nk,nk), dtype=np.int32)
+            table[idx[0],idx[1]] = idx[2]
+            assert (table > -1).all()
+            self._addition_table = table
+        return self._addition_table
+
+    @property
+    def inverse_table(self, tol=KPT_DIFF_TOL):
+        if self._inverse_table is None:
+            diff = -self.kpts_scaled[:,None,:] - self.kpts_scaled[None,:,:]
+            diff = round_to_fbz(diff, tol=tol)
+            idx = np.where(np.sum(abs(diff), axis=-1) < tol)
+
+            table = -np.ones((self.nkpts,), dtype=np.int32)
+            table[idx[0]] = idx[1]
+            assert (table > -1).all()
+            self._inverse_table = table
+        return self._inverse_table
+
+    def get_kconserv(self):
+        '''Equivalent to `kpts_helper.get_kconserv`,
+           but with better performance.
+        '''
+        add_tab = self.addition_table
+        inv_tab = self.inverse_table
+        kconserv = add_tab[add_tab[:, inv_tab[:]],:]
+        return kconserv
+
+    def little_cogroups(self, return_indices=True):
+        if self._copgs is not None:
+            return self._copgs, self._copg_ops_map_ibz2bz
+        copgs = []
+        indices = []
+        for ki in range(self.nkpts):
+            ki_ibz = self.bz2ibz[ki]
+            ops_ibz = self.little_cogroup_ops[ki_ibz]
+            elements = np.sort([PGElement(self.ops[i].rot) for i in ops_ibz])
+            iop = self.stars_ops_bz[ki]
+            op_i = PGElement(self.ops[iop].rot)
+            elements_i = np.asarray([op_i @ g @ op_i.inv() for g in elements])
+            idx = np.argsort(elements_i)
+            indices.append(idx)
+            copgs.append(PointGroup(elements_i[idx]))
+        self._copgs, self._copg_ops_map_ibz2bz = copgs, indices
+        return self._copgs, self._copg_ops_map_ibz2bz
+
+    def little_cogroup_rep(self, ki, ir):
+        copgs, indices = self.little_cogroups()
+        ki_ibz = self.bz2ibz[ki]
+        pg_ibz = copgs[self.ibz2bz[ki_ibz]]
+        chi = pg_ibz.get_irrep_chi(ir)
+        chi_ki = chi[indices[ki]]
+        return Representation(copgs[ki], chi=chi_ki)
 
     make_kpts_ibz = make_kpts_ibz
     make_ktuples_ibz = make_ktuples_ibz
     make_k4_ibz = make_k4_ibz
-    loop_ktuples = loop_ktuples
     symmetrize_density = symmetrize_density
     symmetrize_wavefunction = symmetrize_wavefunction
     transform_mo_coeff = transform_mo_coeff
@@ -990,6 +1080,107 @@ class KPoints(symm.Symmetry, lib.StreamObject):
     transform_fock = transform_fock
     transform_1e_operator = transform_1e_operator
     dm_at_ref_cell = dm_at_ref_cell
+    get_rotation_mat_for_mos = get_rotation_mat_for_mos
+
+
+class MORotationMatrix:
+    '''
+    The class holding the rotation matrices that transform
+    MOs from one k-point to another.
+    '''
+    def __init__(self, kpts, mo_coeff, ovlp, nocc, nmo):
+        self.kpts = kpts
+        self.mo_coeff = mo_coeff
+        self.ovlp = ovlp
+        assert nmo >= nocc
+        self.nocc = nocc
+        self.nmo = nmo
+        self.oo = None
+        self.vv = None
+
+    def build(self):
+        kpts = self.kpts
+        mo_coeff = self.mo_coeff
+        ovlp = self.ovlp
+        nocc = self.nocc
+        nmo = self.nmo
+        nvir = nmo - nocc
+        orb_occ = [mo[:,:nocc] for mo in mo_coeff]
+        orb_vir = [mo[:,nocc:] for mo in mo_coeff]
+        nkpts = kpts.nkpts
+        nop = kpts.nop
+        k2opk = kpts.k2opk
+
+        self.oo = []
+        self.vv = []
+        for ki in range(nkpts):
+            k1 = np.repeat(ki, nop)
+            k2 = k2opk[ki]
+            rot_oo = kpts.get_rotation_mat_for_mos(orb_occ, ovlp, k1, k2,
+                                                   ops_id=np.arange(nop))
+            rot_oo = np.asarray(rot_oo).reshape(nop,nocc,nocc)
+            rot_vv = kpts.get_rotation_mat_for_mos(orb_vir, ovlp, k1, k2,
+                                                   ops_id=np.arange(nop))
+            rot_vv = np.asarray(rot_vv).reshape(nop,nvir,nvir)
+            self.oo.append(rot_oo)
+            self.vv.append(rot_vv)
+
+        self.oo = np.asarray(self.oo)
+        self.vv = np.asarray(self.vv)
+        return self
+
+
+class KQuartets:
+    '''
+    The class holding the symmetry relations between k-quartets.
+    '''
+    def __init__(self, kpts):
+        self.kpts = kpts
+        self.kqrts_ibz = None
+        self.weights_ibz = None
+        self.ibz2bz = None
+        self.bz2ibz = None
+        self.stars_ops = None
+        self.stars_ops_bz = None
+        self._kqrts_stab = None
+        self._ops_stab = None
+
+    def build(self):
+        kpts = self.kpts
+        (self.kqrts_ibz, self.weights_ibz, self.bz2ibz,
+         self.ibz2bz, self.stars_ops, self.stars_ops_bz) = \
+                kpts.make_k4_ibz(sym='s1', return_ops=True)
+
+        # Sanity check
+        #assert -1 not in self.stars_ops_bz
+        #for ki, ki_ibz in enumerate(self.bz2ibz):
+        #    iop = self.stars_ops_bz[ki]
+        #    iops = self.stars_ops[ki_ibz]
+        #    assert iop in iops
+        #    i,j,a,b = self.kqrts_ibz[ki_ibz]
+        #    k,l,c = kpts.k2opk[[i,j,a,], iop]
+        #    kk, ll, cc = lib.base_repr_int(ki, kpts.nkpts, 3)
+        #    assert (k,l,c) == (kk,ll,cc)
+        return self
+
+    def cache_stabilizer(self):
+        self._kqrts_stab = []
+        self._ops_stab = []
+        for i, kq in enumerate(self.kqrts_ibz):
+            op_group = self.stars_ops[i]
+            ks = self.kpts.k2opk[kq[0], op_group]
+            idx = np.where(ks == kq[0])[0]
+            op_group_small = op_group[idx]
+            klcd = self.kpts.k2opk[kq[:,None], op_group_small].T
+            self._kqrts_stab.append(klcd)
+            self._ops_stab.append(op_group_small)
+
+    def loop_stabilizer(self, index):
+        if self._kqrts_stab is None or self._ops_stab is None:
+            self.cache_stabilizer()
+        for klcd, iop in zip(self._kqrts_stab[index], self._ops_stab[index]):
+            yield klcd, iop
+
 
 if __name__ == "__main__":
     import numpy

--- a/pyscf/pbc/lib/kpts.py
+++ b/pyscf/pbc/lib/kpts.py
@@ -1180,26 +1180,3 @@ class KQuartets:
             self.cache_stabilizer()
         for klcd, iop in zip(self._kqrts_stab[index], self._ops_stab[index]):
             yield klcd, iop
-
-
-if __name__ == "__main__":
-    import numpy
-    from pyscf.pbc import gto
-    cell = gto.Cell()
-    cell.atom = """
-        Si  0.0 0.0 0.0
-        Si  1.3467560987 1.3467560987 1.3467560987
-    """
-    cell.a = [[0.0, 2.6935121974, 2.6935121974],
-              [2.6935121974, 0.0, 2.6935121974],
-              [2.6935121974, 2.6935121974, 0.0]]
-    cell.verbose = 4
-    cell.build()
-    nk = [3,3,3]
-    kpts_bz = cell.make_kpts(nk)
-    kpts0 = cell.make_kpts(nk, space_group_symmetry=True, time_reversal_symmetry=True)
-    kpts1 = KPoints(cell, kpts_bz).build(space_group_symmetry=True, time_reversal_symmetry=True)
-    print(numpy.allclose(kpts0.kpts_ibz, kpts1.kpts_ibz))
-
-    kpts = KPoints()
-    print(kpts.kpts)

--- a/pyscf/pbc/lib/ktensor.py
+++ b/pyscf/pbc/lib/ktensor.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python
+# Copyright 2022-2023 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: Xing Zhang <zhangxing.nju@gmail.com>
+#
+
+import warnings
+from functools import reduce
+import numpy as np
+from numpy.lib.mixins import NDArrayOperatorsMixin
+from pyscf import lib
+
+
+def empty(shape, dtype=float, order='C', metadata=None):
+    if metadata is None:
+        return np.empty(shape, dtype, order)
+    else:
+        return KsymmArray(shape, dtype, order, metadata)
+
+def empty_like(a, *args, **kwargs):
+    if isinstance(a, KsymmArray):
+        return KsymmArray(a.subarray_shape,
+                          a.dtype,
+                          a.subarray_order,
+                          a.metadata)
+    else:
+        return np.empty_like(a)
+
+
+class KsymmArray(NDArrayOperatorsMixin):
+    def __init__(self, subarray_shape, dtype=float, subarray_order='C', metadata={},
+                 init_with_zeros=False):
+        self.metadata = metadata
+        self._subarray_shape = list(subarray_shape)
+        self._subarray_ndim = len(subarray_shape)
+        self._subarray_order = subarray_order
+        self._dtype = np.dtype(dtype)
+        incore = metadata.get('incore', True)
+        self._datafile = None
+        self.data = self._init(subarray_order, incore, init_with_zeros)
+
+    def _init(self, order, incore=True, init_with_zeros=False):
+        if self.subarray_ndim == 2:
+            kpts = self.metadata['kpts']
+            n_subarray = kpts.nkpts_ibz
+        elif self.subarray_ndim == 4:
+            kqrts = self.metadata['kqrts']
+            n_subarray = len(kqrts.kqrts_ibz)
+        else:
+            raise NotImplementedError
+
+        data = None
+        shape = [n_subarray,] + self.subarray_shape
+        if incore:
+            if init_with_zeros:
+                fn_init = np.zeros
+            else:
+                fn_init = np.empty
+            if order == 'C':
+                data = fn_init(shape, self.dtype, order)
+            else:
+                data = []
+                for i in range(n_subarray):
+                    data.append(fn_init(self.subarray_shape, self.dtype, order))
+                data = np.asarray(data, order='K')
+        else:
+            self._datafile = lib.H5TmpFile()
+            data = self._datafile.create_dataset('data', shape, self.dtype.char)
+        return data
+
+    @property
+    def shape(self):
+        nkpts = self.metadata['kpts'].nkpts
+        nk = [nkpts,] * (self.subarray_ndim-1)
+        return tuple(nk + list(self.subarray_shape))
+
+    @property
+    def ndim(self):
+        return self.subarray_ndim-1 + self.subarray_ndim
+
+    @property
+    def subarray_ndim(self):
+        return self._subarray_ndim
+
+    @property
+    def subarray_shape(self):
+        return self._subarray_shape
+
+    @property
+    def subarray_order(self):
+        return self._subarray_order
+
+    @property
+    def dtype(self):
+        return self._dtype
+
+    def __getitem__(self, key):
+        if self.subarray_ndim == 2:
+            return self._getitem_2d(key)
+        elif self.subarray_ndim == 4:
+            return self._getitem_4d(key)
+        else:
+            raise NotImplementedError
+
+    def __setitem__(self, key, value):
+        if self.subarray_ndim == 2:
+            return self._setitem_2d(key, value)
+        elif self.subarray_ndim == 4:
+            return self._setitem_4d(key, value)
+        else:
+            raise NotImplementedError
+
+    def _getitem_2d(self, key):
+        kpts = self.metadata['kpts']
+        rmat = self.metadata['rmat']
+        label = self.metadata['label']
+        trans = self.metadata['trans']
+        if isinstance(key, (int, np.integer)):
+            return transform_2d(self.data, kpts, key, rmat, label, trans)
+        elif isinstance(key, (slice, np.ndarray)):
+            data = []
+            for ki in np.arange(kpts.nkpts)[key]:
+                data.append(transform_2d(self.data, kpts, ki, rmat, label, trans))
+            return np.asarray(data)
+        else:
+            raise NotImplementedError
+
+    def _getitem_4d(self, key):
+        kpts = self.metadata['kpts']
+        kqrts = self.metadata['kqrts']
+        rmat = self.metadata['rmat']
+        label = self.metadata['label']
+        trans = self.metadata['trans']
+
+        shape = [kpts.nkpts,] * 3
+        coords = index_to_coords(key, shape)
+        if coords.ndim == 1:
+            klc = coords
+            return transform_4d(self.data, kpts, kqrts, klc, rmat, label, trans)
+        else:
+            data = []
+            for klc in coords:
+                data.append(transform_4d(self.data, kpts, kqrts, klc, rmat, label, trans))
+            return np.asarray(data)
+
+    def _setitem_2d(self, key, value):
+        kpts = self.metadata['kpts']
+        #TODO allow broadcasting
+        value = value.reshape(-1, *self.subarray_shape)
+        if isinstance(key, (int, np.integer)):
+            set_2d(self.data, value, kpts, key)
+        elif isinstance(key, (slice, np.ndarray)):
+            ki = np.arange(kpts.nkpts)[key]
+            set_2d(self.data, value, kpts, ki)
+        else:
+            raise NotImplementedError
+
+    def _setitem_4d(self, key, value):
+        kpts = self.metadata['kpts']
+        kqrts = self.metadata['kqrts']
+        #TODO allow broadcasting
+        value = value.reshape(-1, *self.subarray_shape)
+
+        shape = [kpts.nkpts,] * 3
+        coords = index_to_coords(key, shape)
+        set_4d(self.data, value, kpts, kqrts, coords)
+
+    def todense(self):
+        #TODO allow to return a hdf5 dataset
+        return self[:].reshape(self.shape)
+
+    @staticmethod
+    def fromdense(arr, shape, dtype=None, order=None, metadata=None):
+        if dtype is None:
+            dtype = arr.dtype
+        order = _guess_input_order(arr, order)
+        if metadata is None:
+            raise RuntimeError('metadata not initialized')
+
+        out = KsymmArray(shape, dtype, order, metadata)
+        arr = arr.reshape(out.shape)
+        if out.subarray_ndim == 2:
+            kpts = out.metadata['kpts']
+            for ki in kpts.ibz2bz:
+                ki_ibz = kpts.bz2ibz[ki]
+                out[ki_ibz] = arr[ki]
+        elif out.subarray_ndim == 4:
+            kqrts = out.metadata['kqrts']
+            for m, kq in enumerate(kqrts.kqrts_ibz):
+                ki, kj, ka, kb = kq
+                out[m] = arr[ki, kj, ka]
+        else:
+            raise NotImplementedError
+        return out
+
+    @staticmethod
+    def fromraw(arr, shape, dtype=None, order=None, metadata=None):
+        if dtype is None:
+            dtype = arr.dtype
+        order = _guess_input_order(arr, order)
+        if metadata is None:
+            raise RuntimeError('metadata not initialized')
+
+        out = KsymmArray(shape, dtype, order, metadata)
+        arr = arr.reshape(-1, *out.subarray_shape)
+        for i, a in enumerate(arr):
+            out.data[i] = np.asarray(a, dtype=dtype, order=order)
+        return out
+
+    @staticmethod
+    def zeros(shape, dtype=float, order='C', metadata=None):
+        out = KsymmArray(shape, dtype, order, metadata, init_with_zeros=True)
+        return out
+
+
+def _guess_input_order(arr, order=None):
+    if order is None:
+        order = 'C'
+        if isinstance(arr, np.ndarray):
+            if arr.flags.c_contiguous:
+                order = 'C'
+            elif arr.flags.f_contiguous:
+                order = 'F'
+    elif order not in ('C', 'F'):
+        order = 'C'
+    return order
+
+def set_2d(arr, value, kpts, ki):
+    if isinstance(ki, (int, np.integer)):
+        ki = np.asarray([ki,])
+
+    mask = np.isin(ki, kpts.ibz2bz)
+    if not mask.all():
+        warnings.warn(f'Indices {ki[~mask]} are not in the irreducible wedge. '
+                       'The corresponding data will be discarded.')
+
+    ki_ibz = kpts.bz2ibz[ki[mask]]
+    arr[ki_ibz] = value[mask]
+
+def set_4d(arr, value, kpts, kqrts, klc):
+    klc = klc.reshape(-1, 3)
+    kk_bz = [kpts.ktuple_to_index(s) for s in klc]
+    kk_bz = np.asarray(kk_bz)
+
+    mask = np.isin(kk_bz, kqrts.ibz2bz)
+    if not mask.all():
+        kk_tmp = [kpts.index_to_ktuple(k, 3) for k in kk_bz[~mask]]
+        warnings.warn(f'Indices {kk_tmp} are not in the irreducible wedge. '
+                       'The corresponding data will be discarded.')
+
+    kk_ibz = kqrts.bz2ibz[kk_bz[mask]]
+    arr[kk_ibz] = value[mask]
+
+def transform_2d(arr, kpts, ki, rmat, label, trans):
+    ki_ibz = kpts.bz2ibz[ki]
+    ki_ibz_bz = kpts.ibz2bz[ki_ibz]
+    if ki == ki_ibz_bz:
+        return arr[ki_ibz]
+
+    pi, pj = label
+    rmat_i = getattr(rmat, pi*2)
+    rmat_j = getattr(rmat, pj*2)
+
+    iop = kpts.stars_ops_bz[ki]
+    rot_i = rmat_i[ki_ibz_bz][iop]
+    rot_j = rmat_j[ki_ibz_bz][iop]
+    ti, tj = trans
+    if ti == 'c':
+        rot_i = rot_i.conj()
+    if tj == 'c':
+        rot_j = rot_j.conj()
+
+    #:einsum('ia,ij,ab->jb', arr[ki_ibz], rot_i, rot_j)
+    out = reduce(np.dot, (rot_i.T, arr[ki_ibz], rot_j))
+    return out
+
+def transform_4d(arr, kpts, kqrts, klc, rmat, label, trans):
+    kk_bz = kpts.ktuple_to_index(klc)
+    kk_ibz = kqrts.bz2ibz[kk_bz]
+    i,j,a,b = kqrts.kqrts_ibz[kk_ibz]
+    if (i,j,a) == tuple(klc):
+        return arr[kk_ibz]
+
+    pi, pj, pa, pb = label
+    rmat_i = getattr(rmat, pi*2)
+    rmat_j = getattr(rmat, pj*2)
+    rmat_a = getattr(rmat, pa*2)
+    rmat_b = getattr(rmat, pb*2)
+
+    iop = kqrts.stars_ops_bz[kk_bz]
+    rot_i = rmat_i[i][iop]
+    rot_j = rmat_j[j][iop]
+    rot_a = rmat_a[a][iop]
+    rot_b = rmat_b[b][iop]
+
+    ti, tj, ta, tb = trans
+    if ti == 'c':
+        rot_i = rot_i.conj()
+    if tj == 'c':
+        rot_j = rot_j.conj()
+    if ta == 'c':
+        rot_a = rot_a.conj()
+    if tb == 'c':
+        rot_b = rot_b.conj()
+
+    di, dj, da, db = arr[kk_ibz].shape
+    #:einsum('ijab,ik,jl,ac,bd->klcd', arr[kk_ibz],
+    #        rot_i, rot_j, rot_a, rot_b)
+
+    #tmp = np.einsum('ik,ijab->jkab', rot_i, arr[kk_ibz])
+    tmp = np.dot(rot_i.T, arr[kk_ibz].reshape(di,-1)) #k,jab
+    tmp = tmp.reshape(di,dj,-1).transpose(1,0,2) #j,k,ab
+
+    #tmp = np.einsum('jkab,jl->klab', tmp, rot_j)
+    tmp = np.dot(rot_j.T, tmp.reshape(dj,-1)) #l,kab
+    tmp = tmp.reshape(dj,di,-1).transpose(1,0,2) #k,l,ab
+
+    #tmp = np.einsum('klab,ac->klbc', tmp, rot_a)
+    tmp = tmp.reshape(-1,da,db).transpose(0,2,1).reshape(-1,da) #klb,a
+    tmp = np.dot(tmp, rot_a) #klb,c
+
+    #out = np.einsum('klbc,bd->klcd', tmp, rot_b)
+    tmp = tmp.reshape(-1,db,da).transpose(0,2,1).reshape(-1,db) #klc,b
+    out = np.dot(tmp, rot_b).reshape(di,dj,da,db) #k,l,c,d
+    return out
+
+def index_to_coords(key, shape):
+    if not isinstance(key, tuple):
+        key = (key,)
+
+    idxs = []
+    for i, k in enumerate(key):
+        n = shape[i]
+        if isinstance(k, slice):
+            idx = slice_to_coords(k, n)
+        elif isinstance(k, (int, np.integer)):
+            idx = [k,]
+        elif isinstance(k, np.ndarray) and k.ndim == 1:
+            idx = k
+        else:
+            raise NotImplementedError
+        idxs.append(idx)
+
+    ndim = len(shape)
+    if len(idxs) > ndim:
+        raise RuntimeError
+    elif len(idxs) < ndim:
+        for i in range(len(idxs),ndim):
+            n = shape[i]
+            idxs.append(np.arange(n))
+
+    coords = lib.cartesian_prod(idxs)
+    if all(isinstance(k, (int, np.integer)) for k in key) and len(key) == ndim:
+        coords = coords[0]
+    return coords
+
+def slice_to_coords(k, n):
+    start, stop, step = k.start, k.stop, k.step
+    if start is None:
+        start = 0
+    elif start < 0:
+        start += n
+    if stop is None:
+        stop = n
+    elif stop < 0:
+        stop += n
+    if step is None:
+        step = 1
+    return np.arange(start, stop, step)
+
+
+zeros = KsymmArray.zeros
+fromraw = KsymmArray.fromraw
+fromdense = KsymmArray.fromdense

--- a/pyscf/pbc/lib/test/test_kpts.py
+++ b/pyscf/pbc/lib/test/test_kpts.py
@@ -28,6 +28,7 @@ def setUpModule():
                 1.7834  0.      1.7834
                 1.7834  1.7834  0.    '''
     cell.verbose = 0
+    cell.space_group_symmetry = True
     cell.build()
 
 def tearDownModule():
@@ -38,6 +39,9 @@ class KnownValues(unittest.TestCase):
     def test_kconserve(self):
         kpts = cell.make_kpts([3,4,5])
         kconserve = kpts_helper.get_kconserv(cell, kpts)
+        self.assertAlmostEqual(lib.finger(kconserve), 84.88659638289468, 9)
+        kpts = cell.make_kpts([3,4,5], space_group_symmetry=True)
+        kconserve = kpts_helper.KptsHelper(cell, kpts).kconserv
         self.assertAlmostEqual(lib.finger(kconserve), 84.88659638289468, 9)
 
     def test_kconserve3(self):

--- a/pyscf/pbc/lib/test/test_kpts_ksymm.py
+++ b/pyscf/pbc/lib/test/test_kpts_ksymm.py
@@ -24,30 +24,37 @@ from pyscf.pbc import scf
 from pyscf.pbc.scf import khf, kuhf
 from pyscf.pbc.lib import kpts as libkpts
 
-cell = gto.Cell()
-cell.atom = """
-    Si  0.0 0.0 0.0
-    Si  1.3467560987 1.3467560987 1.3467560987
-"""
-cell.a = [[0.0, 2.6935121974, 2.6935121974],
-          [2.6935121974, 0.0, 2.6935121974],
-          [2.6935121974, 2.6935121974, 0.0]]
-cell.basis = 'gth-szv'
-cell.pseudo  = 'gth-pade'
-cell.mesh = [24,24,24]
-cell.build()
-kpts0 = cell.make_kpts([2,2,2])
-kmf = scf.KRKS(cell, kpts0)
-kmf.kernel()
+def setUpModule():
+    global cell, cell1, kpts0, kmf
+    cell = gto.Cell()
+    cell.atom = """
+        Si  0.0 0.0 0.0
+        Si  1.3467560987 1.3467560987 1.3467560987
+    """
+    cell.a = [[0.0, 2.6935121974, 2.6935121974],
+              [2.6935121974, 0.0, 2.6935121974],
+              [2.6935121974, 2.6935121974, 0.0]]
+    cell.basis = 'gth-szv'
+    cell.pseudo  = 'gth-pade'
+    cell.mesh = [24,24,24]
+    cell.space_group_symmetry = True
+    cell.build()
+
+    cell1 = cell.copy()
+    cell1.build(symmorphic=True)
+
+    kpts0 = cell.make_kpts([2,2,2])
+    kmf = scf.KRKS(cell, kpts0)
+    kmf.kernel()
 
 def tearDownModule():
-    global cell, kpts0, kmf
-    del cell, kpts0, kmf
+    global cell, cell1, kpts0, kmf
+    del cell, cell1, kpts0, kmf
 
 class KnownValues(unittest.TestCase):
     def test_make_kpts_ibz(self):
         kmesh = [16,16,16]
-        kpts = cell.make_kpts(kmesh, space_group_symmetry=True, symmorphic=False)
+        kpts = cell.make_kpts(kmesh, space_group_symmetry=True)
         self.assertEqual(kpts.nkpts_ibz, 145)
         error = False
         for star, star_op in zip(kpts.stars, kpts.stars_ops):
@@ -57,25 +64,28 @@ class KnownValues(unittest.TestCase):
                     break
         self.assertEqual(error, False)
         self.assertAlmostEqual(finger(kpts.kpts_ibz), 2.211640884021115, 9)
-        self.assertAlmostEqual(finger(kpts.stars_ops_bz), 61.98395458751813, 9)
+        #self.assertAlmostEqual(finger(kpts.stars_ops_bz), 61.98395458751813, 9)
 
-        kpts1 = cell.make_kpts(kmesh, space_group_symmetry=True, time_reversal_symmetry=True, symmorphic=True)
+        kpts1 = cell1.make_kpts(kmesh, space_group_symmetry=True, time_reversal_symmetry=True)
         self.assertAlmostEqual(abs(kpts1.kpts_ibz - kpts.kpts_ibz).max(), 0, 9)
 
-        kpts2 = cell.make_kpts(kmesh, space_group_symmetry=True, time_reversal_symmetry=False, symmorphic=True)
+        kpts2 = cell1.make_kpts(kmesh, space_group_symmetry=True, time_reversal_symmetry=False)
         self.assertEqual(kpts2.nkpts_ibz, 245)
         self.assertAlmostEqual(finger(kpts2.kpts_ibz), -2.0196383066365353, 9)
-        self.assertAlmostEqual(finger(kpts2.stars_ops_bz), 177.9781708308629, 9)
+        #self.assertAlmostEqual(finger(kpts2.stars_ops_bz), 177.9781708308629, 9)
 
-        kpts3 = cell.make_kpts(kmesh, with_gamma_point=False, space_group_symmetry=True, symmorphic=False)
+        kpts3 = cell.make_kpts(kmesh, with_gamma_point=False, space_group_symmetry=True)
         self.assertEqual(kpts3.nkpts_ibz, 408)
         self.assertAlmostEqual(finger(kpts3.kpts_ibz), -2.581114561328012, 9)
-        self.assertAlmostEqual(finger(kpts3.stars_ops_bz), -9.484769880571442, 9)
+        #self.assertAlmostEqual(finger(kpts3.stars_ops_bz), -9.484769880571442, 9)
 
-        kpts4 = cell.make_kpts(kmesh, with_gamma_point=False, space_group_symmetry=True, symmorphic=True)
+        kpts4 = cell1.make_kpts(kmesh, with_gamma_point=False, space_group_symmetry=True)
         self.assertEqual(kpts4.nkpts_ibz, 816)
         self.assertAlmostEqual(finger(kpts4.kpts_ibz), -1.124492399508386, 9)
-        self.assertAlmostEqual(finger(kpts4.stars_ops_bz), -16.75874526830733, 9)
+        #self.assertAlmostEqual(finger(kpts4.stars_ops_bz), -16.75874526830733, 9)
+
+        kpts5 = cell.make_kpts(kmesh, time_reversal_symmetry=True)
+        self.assertEqual(kpts5.nkpts_ibz, 2052)
 
     def test_transform(self):
         kpts = libkpts.make_kpts(cell, kpts0, space_group_symmetry=True, time_reversal_symmetry=True)

--- a/pyscf/pbc/mp/kmp2_stagger.py
+++ b/pyscf/pbc/mp/kmp2_stagger.py
@@ -22,7 +22,6 @@ Reference: Staggered Mesh Method for Correlation Energy Calculations of Solids: 
 
 import h5py
 import numpy as np
-from pyscf import __config__
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf.lib.parameters import LARGE_DENOM

--- a/pyscf/pbc/mp/kmp2_stagger.py
+++ b/pyscf/pbc/mp/kmp2_stagger.py
@@ -22,6 +22,7 @@ Reference: Staggered Mesh Method for Correlation Energy Calculations of Solids: 
 
 import h5py
 import numpy as np
+from pyscf import __config__
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf.lib.parameters import LARGE_DENOM

--- a/pyscf/pbc/mp/test/test_ksym.py
+++ b/pyscf/pbc/mp/test/test_ksym.py
@@ -26,6 +26,7 @@ He.verbose = 0
 He.a = np.eye(3)*L
 He.atom =[['He' , ( L/2+0., L/2+0., L/2+0.)],]
 He.basis = {'He': [[0, (4.0, 1.0)], [0, (1.0, 1.0)]]}
+He.space_group_symmetry=True
 He.build()
 
 nk = [2,2,2]

--- a/pyscf/pbc/scf/addons.py
+++ b/pyscf/pbc/scf/addons.py
@@ -96,7 +96,6 @@ def smearing_(mf, sigma=None, method=SMEARING_METHOD, mu0=None, fix_spin=False):
         kpts = getattr(mf, 'kpts', None)
         if isinstance(kpts, KPoints):
             mo_energy_kpts = kpts.transform_mo_energy(mo_energy_kpts)
-            #mo_coeff_kpts = mf.kpts_descriptor.transform_mo_coeff(mo_coeff_kpts)
 
         #mo_occ_kpts = mf_class.get_occ(mf, mo_energy_kpts, mo_coeff_kpts)
         if (mf.sigma == 0) or (not mf.sigma) or (not mf.smearing_method):

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -227,8 +227,8 @@ def get_occ(mf, mo_energy_kpts=None, mo_coeff_kpts=None):
         for k,kpt in enumerate(mf.cell.get_scaled_kpts(mf.kpts)):
             logger.debug(mf, '  %2d (%6.3f %6.3f %6.3f)   %s %s',
                          k, kpt[0], kpt[1], kpt[2],
-                         mo_energy_kpts[k][mo_occ_kpts[k]> 0],
-                         mo_energy_kpts[k][mo_occ_kpts[k]==0])
+                         np.sort(mo_energy_kpts[k][mo_occ_kpts[k]> 0]),
+                         np.sort(mo_energy_kpts[k][mo_occ_kpts[k]==0]))
         np.set_printoptions(threshold=1000)
 
     return mo_occ_kpts
@@ -839,6 +839,9 @@ class KSCF(pbchf.SCF):
     def to_ghf(self, mf=None):
         '''Convert the input mean-field object to a KGHF/KGKS object'''
         return addons.convert_to_ghf(self, mf)
+
+    def to_khf(self):
+        return self
 
     as_scanner = as_scanner
 

--- a/pyscf/pbc/scf/khf_ksymm.py
+++ b/pyscf/pbc/scf/khf_ksymm.py
@@ -135,7 +135,7 @@ class KsymAdaptedKSCF(khf.KSCF):
     """
     def __init__(self, cell, kpts=libkpts.KPoints(),
                  exxdiv=getattr(__config__, 'pbc_scf_SCF_exxdiv', 'ewald'),
-                 use_ao_symmetry=False):
+                 use_ao_symmetry=True):
         ksymm_scf_common_init(self, cell, kpts, use_ao_symmetry)
         khf.KSCF.__init__(self, cell, kpts=kpts, exxdiv=exxdiv)
 

--- a/pyscf/pbc/scf/khf_ksymm.py
+++ b/pyscf/pbc/scf/khf_ksymm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+# Copyright 2020-2023 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,6 +25,44 @@ from pyscf.scf import hf as mol_hf
 from pyscf.pbc import tools
 from pyscf.pbc.lib import kpts as libkpts
 from pyscf.pbc.scf import khf
+
+@lib.with_doc(khf.get_occ.__doc__)
+def get_occ(mf, mo_energy_kpts=None, mo_coeff_kpts=None):
+    if mo_energy_kpts is None:
+        mo_energy_kpts = mf.mo_energy
+    cell = mf.cell
+    kpts = mf.kpts
+    assert isinstance(kpts, libkpts.KPoints)
+
+    nocc = cell.tot_electrons(kpts.nkpts) // 2
+    mo_energy_kpts = kpts.transform_mo_energy(mo_energy_kpts)
+    mo_energy = np.sort(np.hstack(mo_energy_kpts))
+    fermi = mo_energy[nocc-1]
+    mo_occ_kpts = []
+    for mo_e in mo_energy_kpts:
+        mo_occ_kpts.append((mo_e <= fermi).astype(np.double) * 2)
+
+    if nocc < mo_energy.size:
+        logger.info(mf, 'HOMO = %.12g  LUMO = %.12g',
+                    mo_energy[nocc-1], mo_energy[nocc])
+        if mo_energy[nocc-1]+1e-3 > mo_energy[nocc]:
+            logger.warn(mf, 'HOMO %.12g == LUMO %.12g',
+                        mo_energy[nocc-1], mo_energy[nocc])
+    else:
+        logger.info(mf, 'HOMO = %.12g', mo_energy[nocc-1])
+
+    if mf.verbose >= logger.DEBUG:
+        np.set_printoptions(threshold=len(mo_energy))
+        logger.debug(mf, '     k-point                  mo_energy')
+        for k,kpt in enumerate(mf.cell.get_scaled_kpts(mf.kpts, kpts_in_ibz=False)):
+            logger.debug(mf, '  %2d (%6.3f %6.3f %6.3f)   %s %s',
+                         k, kpt[0], kpt[1], kpt[2],
+                         np.sort(mo_energy_kpts[k][mo_occ_kpts[k]> 0]),
+                         np.sort(mo_energy_kpts[k][mo_occ_kpts[k]==0]))
+        np.set_printoptions(threshold=1000)
+
+    mo_occ_kpts = kpts.check_mo_occ_symmetry(mo_occ_kpts)
+    return mo_occ_kpts
 
 @lib.with_doc(khf.energy_elec.__doc__)
 def energy_elec(mf, dm_kpts=None, h1e_kpts=None, vhf_kpts=None):
@@ -62,13 +100,43 @@ def get_rho(mf, dm=None, grids=None, kpts=None):
     dm = kpts.transform_dm(dm)
     return khf.get_rho(mf, dm, grids, kpts.kpts)
 
+def eig(kmf, h_kpts, s_kpts):
+    from pyscf.scf.hf_symm import eig as eig_symm
+    cell = kmf.cell
+    symm_orb = cell.symm_orb
+    irrep_id = cell.irrep_id
+
+    nkpts = len(h_kpts)
+    assert len(symm_orb) == nkpts
+    eig_kpts = []
+    mo_coeff_kpts = []
+
+    for k in range(nkpts):
+        e, c = eig_symm(kmf, h_kpts[k], s_kpts[k], symm_orb[k], irrep_id[k])
+        eig_kpts.append(e)
+        mo_coeff_kpts.append(c)
+    return eig_kpts, mo_coeff_kpts
+
+def ksymm_scf_common_init(kmf, cell, kpts, use_ao_symmetry=True):
+    kmf._kpts = None
+    kmf.use_ao_symmetry = (cell.dimension == 3 and
+                           use_ao_symmetry and
+                           not kpts.time_reversal and
+                           kpts.symmorphic and
+                           len(kpts.little_cogroup_ops) > 0)
+    if kmf.use_ao_symmetry and cell.symm_orb is None:
+        cell._build_symmetry(kpts)
+    return kmf
+
+
 class KsymAdaptedKSCF(khf.KSCF):
     """
     KRHF with k-point symmetry
     """
     def __init__(self, cell, kpts=libkpts.KPoints(),
-                 exxdiv=getattr(__config__, 'pbc_scf_SCF_exxdiv', 'ewald')):
-        self._kpts = None
+                 exxdiv=getattr(__config__, 'pbc_scf_SCF_exxdiv', 'ewald'),
+                 use_ao_symmetry=False):
+        ksymm_scf_common_init(self, cell, kpts, use_ao_symmetry)
         khf.KSCF.__init__(self, cell, kpts=kpts, exxdiv=exxdiv)
 
     @property
@@ -212,6 +280,50 @@ class KsymAdaptedKSCF(khf.KSCF):
                 fh5['scf/kpts'] = self.kpts.kpts_ibz #FIXME Shall we rebuild kpts? If so, more info is needed.
         return self
 
+    def eig(self, h_kpts, s_kpts):
+        if self.use_ao_symmetry:
+            return eig(self, h_kpts, s_kpts)
+        else:
+            return khf.KSCF.eig(self, h_kpts, s_kpts)
+
+    def get_orbsym(self, mo_coeff=None, s=None):
+        if not self.use_ao_symmetry:
+            raise RuntimeError("AO symmetry not initiated")
+        from pyscf.scf.hf_symm import get_orbsym
+        if mo_coeff is None:
+            mo_coeff = self.mo_coeff
+        if s is None:
+            s = self.get_ovlp()
+
+        cell = self.cell
+        symm_orb = cell.symm_orb
+        irrep_id = cell.irrep_id
+        orbsym = []
+        for k in range(len(mo_coeff)):
+            orbsym_k = np.asarray(get_orbsym(cell, mo_coeff[k], s=s[k],
+                                             symm_orb=symm_orb[k], irrep_id=irrep_id[k]))
+            orbsym.append(orbsym_k)
+        return orbsym
+
+    orbsym = property(get_orbsym)
+
+    def _finalize(self):
+        khf.KSCF._finalize(self)
+        if not self.use_ao_symmetry:
+            return self
+
+        orbsym = self.get_orbsym()
+        for k, mo_e in enumerate(self.mo_energy):
+            idx = np.argsort(mo_e.round(9), kind='mergesort')
+            self.mo_energy[k] = self.mo_energy[k][idx]
+            self.mo_occ[k] = self.mo_occ[k][idx]
+            self.mo_coeff[k] = lib.tag_array(self.mo_coeff[k][:,idx], orbsym=orbsym[k][idx])
+
+        self.dump_chk({'e_tot': self.e_tot, 'mo_energy': self.mo_energy,
+                       'mo_coeff': self.mo_coeff, 'mo_occ': self.mo_occ})
+        return self
+
+    get_occ = get_occ
     get_rho = get_rho
     energy_elec = energy_elec
 

--- a/pyscf/pbc/symm/__init__.py
+++ b/pyscf/pbc/symm/__init__.py
@@ -1,3 +1,19 @@
+# Copyright 2020-2023 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+''' 
+Space group symmetry for PBC calculations
 '''
-Symmetry related stuffs for PBC calculations
-'''
+from .symmetry import Symmetry

--- a/pyscf/pbc/symm/basis.py
+++ b/pyscf/pbc/symm/basis.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+# Copyright 2022-2023 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: Xing Zhang <zhangxing.nju@gmail.com>
+#
+
+'''
+Symmetry adapted crystalline Gaussian orbitals for symmorphic space groups
+'''
+import numpy as np
+from pyscf.pbc.symm import symmetry
+from pyscf.pbc.symm.group import PGElement, PointGroup
+
+def _symm_adapted_basis(cell, kpt_scaled, pg, spg_ops, Dmats, tol=1e-9):
+    chartab = pg.character_table(return_full_table=True)
+    dim = chartab[:,0]
+    nirrep = len(chartab)
+    nao = cell.nao
+    atm_maps = []
+    phases = []
+    for op in spg_ops:
+        atm_map, phase = symmetry._get_phase(cell, op, kpt_scaled)
+        atm_maps.append(atm_map)
+        phases.append(phase)
+    atm_maps = np.asarray(atm_maps)
+    tmp = np.unique(atm_maps, axis=0)
+    tmp = np.sort(tmp, axis=0)
+    tmp = np.unique(tmp, axis=1)
+    eql_atom_ids = []
+    for i in range(tmp.shape[-1]):
+        eql_atom_ids.append(np.unique(tmp[:,i]))
+
+    aoslice = cell.aoslice_by_atom()
+    cbase = np.zeros((nirrep, nao, nao), dtype=np.complex128)
+    for atom_ids in eql_atom_ids:
+        for iatm in atom_ids:
+            op_relate_idx = []
+            for iop in range(pg.order):
+                op_relate_idx.append(atm_maps[iop][iatm])
+            ao_loc = np.asarray([aoslice[i,2] for i in op_relate_idx])
+
+            b0, b1 = aoslice[iatm,:2]
+            ioff = 0
+            icol = aoslice[iatm, 2]
+            for ib in range(b0, b1):
+                nctr = cell.bas_nctr(ib)
+                l = cell.bas_angular(ib)
+                if cell.cart:
+                    degen = (l+1) * (l+2) // 2
+                else:
+                    degen = l * 2 + 1
+
+                for n in range(degen):
+                    for iop in range(pg.order):
+                        Dmat = Dmats[iop][l]
+                        fac = dim/pg.order * chartab[:,iop].conj() * phases[iop][iatm]
+                        tmp = np.einsum('x,y->xy', fac, Dmat[:,n])
+                        idx = ao_loc[iop] + ioff
+                        for ictr in range(nctr):
+                            cbase[:, idx:idx+degen, icol+n+ictr*degen] += tmp
+                            idx += degen
+                ioff += degen * nctr
+                icol += degen * nctr
+
+    sos = []
+    irrep_ids = []
+    nso = 0
+    for ir in range(nirrep):
+        idx = np.where(np.sum(abs(cbase[ir]), axis=0) > tol)[0]
+        so = cbase[ir][:,idx]
+        if abs(so.imag).sum() < tol:
+            so = so.real
+        if so.shape[-1] > 0:
+            so = _gram_schmidt(so)
+            nso += so.shape[-1]
+            sos.append(so)
+            irrep_ids.append(ir)
+    assert nso == cell.nao
+    return sos, irrep_ids
+
+def _gram_schmidt(v, tol=1e-9):
+    ncol = v.shape[-1]
+    u = np.zeros_like(v)
+    u[:,0] = v[:,0] / np.linalg.norm(v[:,0])
+    for k in range(1, ncol):
+        uk = v[:,k]
+        for j in range(k):
+            uk = uk - np.dot(u[:,j].conj(), uk) * u[:,j]
+        norm = np.linalg.norm(uk)
+        if norm < tol:
+            continue
+        u[:,k] = uk / norm
+    idx = np.where(np.sum(abs(u), axis=0) > tol)[0]
+    u = u[:,idx]
+    return u
+
+def symm_adapted_basis(cell, kpts, tol=1e-9):
+    sos_ks = []
+    irrep_ids_ks = []
+    Dmats = kpts.Dmats
+    for i, ops in enumerate(kpts.little_cogroup_ops):
+        kpt_scaled = kpts.kpts_scaled_ibz[i]
+        elements = []
+        for iop in ops:
+            elements.append(kpts.ops[iop].rot)
+        elements = np.asarray([PGElement(rot) for rot in elements])
+        sort_idx = np.argsort(elements)
+        Dmats_small = []
+        spg_ops = []
+        for iop in ops[sort_idx]:
+            Dmats_small.append(Dmats[iop])
+            spg_ops.append(kpts.ops[iop])
+        elements = elements[sort_idx]
+        pg = PointGroup(elements)
+        sos, irrep_ids = _symm_adapted_basis(cell, kpt_scaled, pg, spg_ops, Dmats_small, tol)
+        sos_ks.append(sos)
+        irrep_ids_ks.append(irrep_ids)
+    return sos_ks, irrep_ids_ks
+
+if __name__ == "__main__":
+    from pyscf.pbc import gto
+    cell = gto.Cell()
+    cell.atom = [['O' , (1. , 0.    , 0.   ,)],
+                 ['H' , (0. , -.757 , 0.587,)],
+                 ['H' , (0. , 0.757 , 0.587,)]]
+    cell.a = [[1., 0., 0.],
+              [0., 1., 0.],
+              [0., 0., 1.]]
+    cell.basis = 'ccpvdz'
+    cell.verbose = 5
+    cell.space_group_symmetry = True
+    cell.symmorphic = True
+    cell.build()
+    kpts = cell.make_kpts([1,1,1], space_group_symmetry=True)
+    so = symm_adapted_basis(cell, kpts)[0][0]
+
+    from pyscf import gto as mol_gto
+    from pyscf.symm import geom as mol_geom
+    from pyscf.symm.basis import symm_adapted_basis as mol_symm_adapted_basis
+    mol = cell.copy()
+    gpname, origin, axes = mol_geom.detect_symm(mol._atom)
+    atoms = mol_gto.format_atom(cell._atom, origin, axes)
+    mol.build(False, False, atom=atoms)
+    mol_so = mol_symm_adapted_basis(mol, gpname)[0]
+
+    print(abs(so[0] - mol_so[0]).max())
+    print(abs(so[1] - mol_so[1]).max())
+    print(abs(so[2] - mol_so[3]).max())
+    print(abs(so[3] - mol_so[2]).max())

--- a/pyscf/pbc/symm/geom.py
+++ b/pyscf/pbc/symm/geom.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+# Copyright 2020-2023 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ def search_space_group_ops(cell, rotations=None, tol=SYMPREC):
     '''
     Search for the allowed space group operations for a specific cell.
 
-    Note:
+    Notes:
         The current implementation treats the cell with the spins on all
         atoms flipped as the same as the original cell. If this is not desired,
         then one can use different names for the two sets of atoms and set their
@@ -116,7 +116,7 @@ def search_space_group_ops(cell, rotations=None, tol=SYMPREC):
     if atm[-2:] in ['_u', '_d']:
         x_spin_inv = coords[atmgrp_spin_inv[atm]]
 
-    from pyscf.pbc.symm.space_group import SpaceGroup_element
+    from pyscf.pbc.symm.space_group import SPGElement
     ops = []
     for rot in rotations:
         w = x - np.dot(x[0], rot.T)
@@ -129,10 +129,10 @@ def search_space_group_ops(cell, rotations=None, tol=SYMPREC):
         w = np.unique(w, axis=0)
         for trans in w:
             if test_trans(rot, trans):
-                ops.append(SpaceGroup_element(rot, trans))
+                ops.append(SPGElement(rot, trans))
             elif has_spin:
                 if test_trans(rot, trans, True):
-                    ops.append(SpaceGroup_element(rot, trans))
+                    ops.append(SPGElement(rot, trans))
     return ops
 
 def get_crystal_class(cell, ops=None, tol=SYMPREC):

--- a/pyscf/pbc/symm/group.py
+++ b/pyscf/pbc/symm/group.py
@@ -157,6 +157,7 @@ class FiniteGroup(ABC):
         self._chartab = None
         self._group_name = None
         self._group_index = None
+        self._check_sanity()
 
     @staticmethod
     @abstractmethod
@@ -380,6 +381,19 @@ class FiniteGroup(ABC):
     def get_irrep_chi(self, ir):
         chartab = self.character_table(True)
         return chartab[ir]
+
+    def _check_sanity(self):
+        try:
+            # check duplication
+            assert len(self.hash_table) == self.order
+            # check inversion
+            assert (abs(np.sort(self.inverse_table)
+                       -np.arange(self.order)).max() == 0)
+            # check multiplication
+            assert (abs(np.sort(self.multiplication_table, axis=-1)
+                       -np.arange(self.order)[None,:]).max() == 0)
+        except (AssertionError, KeyError, ValueError):
+            raise ValueError('The elements do not form a group.')
 
 
 class PointGroup(FiniteGroup):

--- a/pyscf/pbc/symm/group.py
+++ b/pyscf/pbc/symm/group.py
@@ -304,7 +304,7 @@ class FiniteGroup(ABC):
         inverse = -np.ones((self.order), dtype=int)
         diff = (self.conjugacy_mask[None,:,:]==classes[:,None,:]).all(axis=-1)
         for i, a in enumerate(diff):
-            inverse[np.where(a==True)[0]] = i # noqa: E712
+            inverse[np.where(a)[0]] = i
         assert (inverse >= 0).all()
         assert (classes[inverse] == self.conjugacy_mask).all()
         return classes, representatives, inverse

--- a/pyscf/pbc/symm/group.py
+++ b/pyscf/pbc/symm/group.py
@@ -1,50 +1,118 @@
+#!/usr/bin/env python
+# Copyright 2020-2022 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Xing Zhang <zhangxing.nju@gmail.com>
+#
+
 from abc import ABC, abstractmethod
 import numpy as np
-from multimethod import multimethod
+from pyscf import lib
 from pyscf.pbc.symm import geom
-from pyscf.pbc.symm import symmetry
+from pyscf.pbc.symm.tables import SchoenfliesNotation
+
+def _round_zero(a, tol=1e-9):
+    a[np.where(abs(a) < tol)] = 0
+    return a
 
 class GroupElement(ABC):
     '''
-    Group element
+    The abstract class for group elements.
     '''
     def __call__(self, other):
-        return product(self, other)
+        return self.__matmul__(other)
 
+    @abstractmethod
     def __matmul__(self, other):
-        return product(self, other)
+        pass
 
-class FiniteGroup():
-    '''
-    Finite group
-    '''
-    def __init__(self, elements):
-        self.elements = elements
+    def __mul__(self, other):
+        assert isinstance(other, self.__class__)
+        return self @ other
 
-    def __len__(self):
-        return len(self.elements)
+    @abstractmethod
+    def __hash__(self):
+        pass
 
-    def __getitem__(self, i):
-        return self.elements[i]
+    @abstractmethod
+    def inv(self):
+        '''
+        Inverse of the group element.
+        '''
+        pass
+
 
 class PGElement(GroupElement):
     '''
-    Point group element
+    The class for crystallographic point group elements.
+    The group elements are rotation matrices represented
+    in lattice translation vector basis.
+
+    Attributes:
+        matrix : (d,d) array of ints
+            Rotation matrix in lattice translation vector basis.
+        dimension : int
+            Dimension of the space: `d`.
     '''
     def __init__(self, matrix):
         self.matrix = matrix
         self.dimension = matrix.shape[0]
 
+    def __matmul__(self, other):
+        if not isinstance(other, PGElement):
+            raise TypeError(f"{other} is not a point group element.")
+        return PGElement(np.dot(self.matrix, other.matrix))
+
     def __repr__(self):
         return self.matrix.__repr__()
 
     def __hash__(self):
-        rot = self.matrix.flatten()
-        r = 0
-        size = self.dimension ** 2
-        for i in range(size):
-            r += 3**(size-1-i) * (rot[i] + 1)
+        def _id(op):
+            s = op.flatten() + 1
+            return lib.inv_base_repr_int(s, op.shape[0])
+
+        r = _id(self.rot)
+        # move identity to the first place
+        d = self.dimension
+        r -= _id(np.eye(d, dtype=int))
+        if r < 0:
+            r += _id(np.ones((d,d), dtype=int)) + 1
         return int(r)
+
+    @staticmethod
+    def decrypt_hash(h, dimension=3):
+        if dimension == 3:
+            id_eye = int('211121112', 3)
+            id_max = int('222222222', 3)
+        elif dimension == 2:
+            id_eye = int('2112', 3)
+            id_max = int('2222', 3)
+        else:
+            raise NotImplementedError
+
+        r = h + id_eye
+        if r > id_max:
+            r -= id_max + 1
+        #s = np.base_repr(r, 3)
+        #s = '0'*(dimension**2-len(s)) + s
+        #rot = np.asarray([int(i) for i in s]) - 1
+        rot = np.asarray(lib.base_repr_int(r, 3, dimension**2)) - 1
+        rot = rot.reshape(dimension,dimension)
+        # sanity check
+        #element = PGElement(rot)
+        #assert hash(element) == h
+        return rot
 
     def __lt__(self, other):
         if not isinstance(other, PGElement):
@@ -64,244 +132,331 @@ class PGElement(GroupElement):
     def inv(self):
         return PGElement(np.asarray(np.linalg.inv(self.matrix), dtype=np.int32))
 
-class PointGroup(FiniteGroup):
+
+class FiniteGroup(ABC):
     '''
-    Crystallographic point group
+    The class for finite groups.
+
+    Attributes:
+        elements : list
+            Group elements.
+        order : int
+            Group order.
     '''
+    def __init__(self, elements, from_hash=False):
+        if from_hash:
+            elements = self.__class__.elements_from_hash(elements)
+        self.elements = np.asarray(elements)
+        self._order = None
+        self._hash_table = None
+        self._inverse_table = None
+        self._multiplication_table = None
+        self._conjugacy_table = None
+        self._conjugacy_mask = None
+        self._chartab_full = None
+        self._chartab = None
+        self._group_name = None
+        self._group_index = None
+
+    @staticmethod
+    @abstractmethod
+    def elements_from_hash(hashes, **kwargs):
+        pass
+
+    def __len__(self):
+        return self.order
+
+    def __getitem__(self, i):
+        return self.elements[i]
+
+    def __and__(self, other):
+        if type(self) is not type(other):
+            raise TypeError(f'{self} and {other} must be the same type')
+        if self is other:
+            return self
+        hi = list(self.hash_table.keys())
+        hj = list(other.hash_table.keys())
+        hij = np.intersect1d(hi, hj)
+        return self.__class__(hij, from_hash=True)
+
+    def __or__(self, other):
+        if type(self) is not type(other):
+            raise TypeError(f'{self} and {other} must be the same type')
+        if self is other:
+            return self
+        hi = list(self.hash_table.keys())
+        hj = list(other.hash_table.keys())
+        hij = np.union1d(hi, hj)
+        return self.__class__(hij, from_hash=True)
+
+    def issubset(self, other):
+        if type(self) is not type(other):
+            raise TypeError(f'{self} and {other} must be the same type')
+        if self is other:
+            return True
+        hi = list(self.hash_table.keys())
+        hj = list(other.hash_table.keys())
+        return set(hi).issubset(set(hj))
+
     @property
-    def group_name(self):
-        return geom.get_crystal_class(None, self.elements)[0]
+    def order(self):
+        if self._order is None:
+            self._order = len(self.elements)
+        return self._order
 
-    def lookup_table(self):
-        '''
-        Mappings between elements' hash values and their indices.
-        '''
-        return {hash(g) : i for i, g in enumerate(self.elements)}
+    @order.setter
+    def order(self, n):
+        self._order = n
 
+    @property
+    def hash_table(self):
+        '''
+        Hash table for group elements: {hash : index}.
+        '''
+        if self._hash_table is None:
+            self._hash_table = {hash(g) : i for i, g in enumerate(self.elements)}
+        return self._hash_table
+
+    @hash_table.setter
+    def hash_table(self, table):
+        self._hash_table = table
+
+    @property
     def inverse_table(self):
         '''
-        Inverse of the elements. Returns the indices.
-        '''
-        n = len(self)
-        inv_table = np.zeros((n,), dtype=np.int32)
-        lookup = self.lookup_table()
-        for i, g in enumerate(self.elements):
-            inv_table[i] = lookup[hash(g.inv())]
-        return inv_table
+        Table for inverse of the group elements.
 
+        Return : (n,) array of ints
+            The indices of elements.
+        '''
+        if self._inverse_table is None:
+            _table = [self.hash_table[hash(g.inv())] for g in self.elements]
+            self._inverse_table = np.asarray(_table)
+        return self._inverse_table
+
+    @inverse_table.setter
+    def inverse_table(self, table):
+        self._inverse_table = table
+
+    @property
     def multiplication_table(self):
         '''
-        Multiplication table of the group. Returns the indices of elements.
-        '''
-        n = len(self)
-        prod_table = np.zeros((n,n), dtype=np.int32)
-        lookup = self.lookup_table()
-        for i, g in enumerate(self.elements):
-            for j, h in enumerate(self.elements):
-                prod = g @ h
-                prod_table[i,j] = lookup[hash(prod)]
-        return prod_table
+        Multiplication table of the group.
 
+        Return : (n, n) array of ints
+             The indices of elements.
+        '''
+        if self._multiplication_table is None:
+            prod = self.elements[:,None] * self.elements[None,:]
+            _table = [self.hash_table[hash(gh)] for gh in prod.flatten()]
+            self._multiplication_table = np.asarray(_table).reshape(prod.shape)
+        return self._multiplication_table
+
+    @multiplication_table.setter
+    def multiplication_table(self, table):
+        self._multiplication_table = table
+
+    @property
     def conjugacy_table(self):
         '''
-        conjugacy_table[idx_g, idx_h] gives index of :math:`h^{-1} g h`.
+        conjugacy_table[`index_g`, `index_x`] returns the index of element `h`,
+        where :math:`h = x * g * x^{-1}`.
         '''
-        inv_table = self.inverse_table()
-        prod_table = self.multiplication_table()
-        ginv_h = prod_table[inv_table]
-        idx = np.arange(len(self))[None, :]
-        return ginv_h[ginv_h, idx]
+        if self._conjugacy_table is None:
+            prod_table = self.multiplication_table
+            g_xinv = prod_table[:,self.inverse_table]
+            self._conjugacy_table = prod_table[np.arange(self.order)[None,:], g_xinv]
+        return self._conjugacy_table
+
+    @conjugacy_table.setter
+    def conjugacy_table(self, table):
+        self._conjugacy_table = table
+
+    @property
+    def conjugacy_mask(self):
+        '''
+        Boolean mask array indicating whether two elements
+        are conjugate with each other.
+        '''
+        if self._conjugacy_mask is None:
+            n = self.order
+            is_conjugate = np.zeros((n,n), dtype=bool)
+            is_conjugate[np.arange(n)[:,None], self.conjugacy_table] = True
+            self._conjugacy_mask = is_conjugate
+        return self._conjugacy_mask
 
     def conjugacy_classes(self):
         '''
-        Conjugacy classes. Unsorted
-        '''
-        n = len(self)
-        idx = np.arange(len(self))[:, None]
-        is_conjugate = np.zeros((n,n), dtype=np.int32)
-        is_conjugate[idx, self.conjugacy_table()] = 1
+        Compute conjugacy classes.
 
-        classes, representatives, inverse = np.unique(is_conjugate, axis=0, return_index=True, return_inverse=True)
+        Returns:
+            classes : (n_irrep,n) boolean array
+                The indices of `True` correspond to the
+                indices of elements in this class.
+            representatives : (n_irrep,) array of ints
+                Representive elements' indices in each class.
+            inverse : (n,) array of ints
+                The indices to reconstruct `conjugacy_mask` from `classes`.
+        '''
+        _, idx = np.unique(self.conjugacy_mask, axis=0, return_index=True)
+        representatives = np.sort(idx)
+        classes = self.conjugacy_mask[representatives]
+        inverse = -np.ones((self.order), dtype=int)
+        diff = (self.conjugacy_mask[None,:,:]==classes[:,None,:]).all(axis=-1)
+        for i, a in enumerate(diff):
+            inverse[np.where(a==True)[0]] = i # noqa: E712
+        assert (inverse >= 0).all()
+        assert (classes[inverse] == self.conjugacy_mask).all()
         return classes, representatives, inverse
 
-    def character_table_by_class(self):
+    def character_table(self, return_full_table=False, recompute=False):
         '''
         Character table of the group.
+
+        Args:
+            return_full_table : bool
+                If True, return the characters for all elements.
+            recompute : bool
+                Whether to recompute the character table. Default is False,
+                meaning to use the cached table if possible.
+
+        Returns:
+            chartab : array
+                Character table for classes.
+            chartab_full : array, optional
+                Character table for all elements.
         '''
-        classes, _, _ = self.conjugacy_classes()
+        if not recompute:
+            if not return_full_table and self._chartab is not None:
+                return self._chartab
+            if return_full_table and self._chartab_full is not None:
+                return self._chartab_full
+
+        classes, _, inverse = self.conjugacy_classes()
         class_sizes = classes.sum(axis=1)
 
-        inv_table = self.inverse_table()
-        prod_table = self.multiplication_table()
-        ginv_h = prod_table[inv_table]
-        M = classes @ np.random.rand(len(self))[ginv_h] @ classes.T
+        ginv_h = self.multiplication_table[self.inverse_table]
+        M  = classes @ np.random.rand(self.order)[ginv_h] @ classes.T
         M /= class_sizes
 
-        _, table = np.linalg.eig(M)
-        table = table.T / class_sizes
+        _, Rchi = np.linalg.eig(M)
+        chi = Rchi.T / class_sizes
 
-        norm = np.sum(np.abs(table) ** 2 * class_sizes, axis=1, keepdims=True) ** 0.5
-        table /= norm
-        table /= (table[:, 0] / np.abs(table[:, 0]))[:, np.newaxis]  # ensure correct sign
-        table *= len(self) ** 0.5
+        norm = np.sum(np.abs(chi) ** 2 * class_sizes[None,:], axis=1) ** 0.5
+        chi  = chi / norm[:,None] * self.order ** 0.5
+        chi /= (chi[:, 0] / np.abs(chi[:, 0]))[:,None]
+        chi  = np.round(chi, 9)
+        chi_copy = chi.copy()
+        chi_copy[:,1:] *= -1
+        idx = np.lexsort(np.rot90(chi_copy))
+        chi = chi[idx]
+        chi = _round_zero(chi)
+        self._chartab = chi
+        self._chartab_full = chi[:, inverse]
+        if return_full_table:
+            return self._chartab_full
+        else:
+            return self._chartab
 
-        table[np.isclose(table, 0, atol=1e-9)] = 0
-        return table
-
-    def character_table(self):
+    def project_chi(self, chi, other):
         '''
-        Character of each element.
+        Project characters to another group.
         '''
-        _, _, inverse = self.conjugacy_classes()
-        CT = self.character_table_by_class()
-        return CT[:, inverse]
+        if self is other:
+            return chi
+        i_ind, j_ind = self.get_elements_map(other)
+        chi_j = np.zeros((other.order,))
+        chi_j[j_ind] = chi[i_ind]
+        return chi_j
 
+    def get_elements_map(self, other):
+        if not (other.issubset(self) or self.issubset(other)):
+            raise KeyError(f'{self} or {other} must be a subset of the other.')
+        hi = [hash(g) for g in self.elements]
+        hj = [hash(g) for g in other.elements]
+        _, i_ind, j_ind = np.intersect1d(hi, hj, return_indices=True)
+        return i_ind, j_ind
+
+    def get_irrep_chi(self, ir):
+        chartab = self.character_table(True)
+        return chartab[ir]
+
+
+class PointGroup(FiniteGroup):
     '''
-    def irrep(self):
-        true_product_table = self.multiplication_table()
-        inverted_product_table = true_product_table[:, self.inverse_table()]
-
-        def invariant_subspaces(e, seed):
-            e = e[inverted_product_table]
-            e = e + e.T.conj()
-            e, v = np.linalg.eigh(e)
-            _, starting_idx = np.unique(e, return_index=True)
-            vs = v[:, starting_idx]
-            s = np.random.rand(len(self))[inverted_product_table]
-            proj = self.character_table().conj() @ s @ vs
-            starting_idx = list(starting_idx) + [len(self)]
-            return v, starting_idx, proj
-
-        squares = np.diag(true_product_table)
-        frob = np.array(
-            np.rint(
-                np.sum(self.character_table()[:, squares], axis=1).real / len(self)
-            ),
-            dtype=int,
-        )
-        eigen = {}
-        if np.any(frob == 1):
-            e = np.random.rand(len(self))
-            eigen["real"] = invariant_subspaces(e, seed=1)
-        if np.any(frob != 1):
-            raise
-            #e = random(len(self), seed=2, cplx=True)
-            #eigen["cplx"] = invariant_subspaces(e, seed=3)
-
-        irreps = []
-        for i, chi in enumerate(self.character_table()):
-            v, idx, proj = eigen["real"] if frob[i] == 1 else eigen["cplx"]
-            proj = np.logical_not(np.isclose(proj[i], 0.0))
-        for i, chi in enumerate(self.character_table()):
-            v, idx, proj = eigen["real"] if frob[i] == 1 else eigen["cplx"]
-            proj = np.logical_not(np.isclose(proj[i], 0.0))
-            first = np.arange(len(idx) - 1, dtype=int)[proj][0]
-            v = v[:, idx[first] : idx[first + 1]]
-            irreps.append(np.einsum("gi,ghj ->hij", v.conj(), v[true_product_table, :]))
-
-        return irreps
+    The class for crystallographic point groups.
     '''
+    def group_name(self, notation='international'):
+        if self._group_name is not None and notation=='international':
+            return self._group_name
+        name = geom.get_crystal_class(None, self.elements)[0]
+        self._group_name = name
+        if notation.lower().startswith('scho'): # Schoenflies
+            name = SchoenfliesNotation[name]
+        return name
 
-@multimethod
-def product(g : PGElement, h : PGElement):
-    return PGElement(np.dot(g.matrix, h.matrix))
+    @property
+    def group_index(self):
+        if self._group_index is None:
+            name = self.group_name()
+            self._group_index = list(SchoenfliesNotation.keys()).index(name)
+        return self._group_index
 
-@multimethod # noqa: F811
-def product(g : PGElement, h : np.ndarray):
-    return np.dot(g.matrix, h)
+    @staticmethod
+    def elements_from_hash(hashes, dimension=3):
+        elements = [PGElement(PGElement.decrypt_hash(h, dimension)) for h in hashes]
+        return elements
 
-def symm_adapted_basis(cell):
-    sym = symmetry.Symmetry(cell).build(symmorphic=True)
-    Dmats = sym.Dmats
 
-    elements = []
-    for op in sym.ops:
-        assert(op.trans_is_zero)
-        elements.append(op.rot)
+class Representation:
+    '''
+    Helper class for representation reductions.
+    Only characters are stored at the moment.
+    '''
+    def __init__(self, group, rep=None, chi=None):
+        self.group = group
+        self.rep = rep
+        self.chi = chi
 
-    elements = np.asarray(elements)
-    elements = np.unique(elements, axis=0)
-    elements = [PGElement(rot) for rot in elements]
+    @property
+    def rep(self):
+        if self._rep is None:
+            self._rep = self.chi_to_rep(self.chi)
+        return self._rep
 
-    pg = PointGroup(elements)
-    chartab = pg.character_table()
-    nirrep = len(chartab)
-    nao = cell.nao
-    coords = cell.get_scaled_positions()
-    atm_maps = []
-    for op in sym.ops:
-        atm_map, _ = symmetry._get_phase(cell, op, coords, None, ignore_phase=True)
-        atm_maps.append(atm_map)
-    atm_maps = np.asarray(atm_maps)
-    tmp = np.unique(atm_maps, axis=0)
-    tmp = np.sort(tmp, axis=0)
-    tmp = np.unique(tmp, axis=1)
-    eql_atom_ids = []
-    for i in range(tmp.shape[-1]):
-        eql_atom_ids.append(np.unique(tmp[:,i]))
+    @rep.setter
+    def rep(self, value):
+        self._rep = value
 
-    aoslice = cell.aoslice_by_atom()
-    cbase = np.zeros((nirrep, nao, nao))
-    for atom_ids in eql_atom_ids:
-        iatm = atom_ids[0]
-        op_relate_idx = []
-        for iop in range(len(pg)):
-            op_relate_idx.append(atm_maps[iop][iatm])
-        ao_loc = np.array([aoslice[i,2] for i in op_relate_idx])
+    @property
+    def chi(self):
+        if self._chi is None:
+            self._chi = self.rep_to_chi(self.rep)
+        return self._chi
 
-        b0, b1 = aoslice[iatm,:2]
-        ioff = 0
-        icol = aoslice[iatm, 2]
-        for ib in range(b0, b1):
-            nctr = cell.bas_nctr(ib)
-            l = cell.bas_angular(ib)
-            if cell.cart:
-                degen = (l+1) * (l+2) // 2
-            else:
-                degen = l * 2 + 1
-            for n in range(degen):
-                for iop in range(len(pg)):
-                    Dmat = Dmats[iop][l]
-                    tmp = np.einsum('x,y->xy', chartab[:,iop], Dmat[:,n])
-                    idx = ao_loc[iop] + ioff
-                    for ictr in range(nctr):
-                        cbase[:, idx:idx+degen, icol+n+ictr*degen] += tmp / len(pg)
-                        idx += degen
-            ioff += degen * nctr
-            icol += degen * nctr
+    @chi.setter
+    def chi(self, value):
+        self._chi = value
 
-    so = []
-    for ir in range(nirrep):
-        idx = np.where(np.sum(abs(cbase[ir]), axis=0) > 1e-9)[0]
-        so.append(cbase[ir][:,idx])
+    def rep_to_chi(self, rep):
+        chartab = self.group.character_table(True)
+        chi = np.einsum('ni,n->i', chartab, rep)
+        return chi
 
-    for ir in range(nirrep):
-        norm = np.linalg.norm(so[ir], axis=0)
-        so[ir] /= norm[None,:]
-    return so
+    def chi_to_rep(self, chi):
+        group = self.group
+        chartab = group.character_table(True)
+        assert len(chi) == chartab.shape[1]
+        nA = np.einsum('ni,i->n', chartab.conj(), chi) / group.order
+        assert (abs(nA - nA.round()) < 1e-9).all()
+        nA = np.rint(nA).astype(int)
+        return nA
 
-if __name__ == "__main__":
-    from pyscf.pbc import gto
-    cell = gto.Cell()
-    cell.atom = [['O' , (1. , 0.    , 0.   ,)],
-                 ['H' , (0. , -.757 , 0.587,)],
-                 ['H' , (0. , 0.757 , 0.587,)]]
-    cell.a = [[1., 0., 0.],
-              [0., 1., 0.],
-              [0., 0., 1.]]
-    cell.basis = 'ccpvdz'
-    cell.verbose = 5
-    cell.build()
-    so = symm_adapted_basis(cell)
-
-    from pyscf import gto as mol_gto
-    from pyscf.symm import geom as mol_geom
-    from pyscf.symm.basis import symm_adapted_basis as mol_symm_adapted_basis
-    mol = cell.copy()
-    gpname, origin, axes = mol_geom.detect_symm(mol._atom)
-    atoms = mol_gto.format_atom(cell._atom, origin, axes)
-    mol.build(False, False, atom=atoms)
-    mol_so = mol_symm_adapted_basis(mol, gpname)[0]
-
-    print(abs(so[0] - mol_so[0]).max())
-
+    def __matmul__(self, other):
+        g1, chi1 =  self.group,  self.chi
+        g2, chi2 = other.group, other.chi
+        g12 = g1 & g2
+        chi1_proj = g1.project_chi(chi1, g12)
+        chi2_proj = g2.project_chi(chi2, g12)
+        chi12_proj = chi1_proj * chi2_proj
+        return self.__class__(g12, chi=chi12_proj)

--- a/pyscf/pbc/symm/pyscf_spglib.py
+++ b/pyscf/pbc/symm/pyscf_spglib.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+# Copyright 2020-2022 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pyscf/pbc/symm/space_group.py
+++ b/pyscf/pbc/symm/space_group.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+# Copyright 2020-2023 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ from pyscf import lib
 from pyscf.lib import logger
 from pyscf.pbc.symm import geom
 from functools import reduce
+from pyscf.pbc.symm.group import PGElement
 
 SYMPREC = getattr(__config__, 'pbc_symm_space_group_symprec', 1e-6)
 XYZ = np.eye(3)
@@ -50,6 +51,7 @@ def transform_rot(op, a, b, allow_non_integer=False):
     '''
     P = np.dot(np.linalg.inv(b.T), a.T)
     R = reduce(np.dot,(P, op, np.linalg.inv(P))).round(15)
+    R[np.where(abs(R) < 1e-9)] = 0
     if not allow_non_integer:
         if(np.amax(np.absolute(R-R.round())) > SYMPREC):
             raise RuntimeError("Point-group symmetries of the two coordinate systems are different.")
@@ -77,19 +79,26 @@ def transform_trans(op, a, b):
     return np.dot(op, P.T)
 
 
-class SpaceGroup_element():
+class SPGElement():
     '''
     Matrix representation of space group operations
 
     Attributes:
-        rot : (3,3) array
+        rot : (d,d) array
             Rotation operator.
-        trans : (3,) array
+        trans : (d,) array
             Translation operator.
+        dimension : int
+            Dimension of the space: `d`.
     '''
-    def __init__(self, rot=np.eye(3, dtype=int), trans=np.zeros((3))):
+    def __init__(self,
+                 rot=np.eye(3, dtype=np.int32),
+                 trans=np.zeros((3)), dimension=3):
         self.rot = np.asarray(rot)
         self.trans = np.asarray(trans)
+        self.dimension = dimension
+        if dimension != 3:
+            raise NotImplementedError
 
     def dot(self, r_or_op):
         '''
@@ -97,12 +106,12 @@ class SpaceGroup_element():
         '''
         if isinstance(r_or_op, np.ndarray) and r_or_op.ndim==1 and len(r_or_op)==3:
             return np.dot(r_or_op, self.rot.T) + self.trans
-        elif isinstance(r_or_op, SpaceGroup_element):
+        elif isinstance(r_or_op, SPGElement):
             beta = self.rot
             b = self.trans
             alpha = r_or_op.rot
             a = r_or_op.trans
-            op = SpaceGroup_element(np.dot(beta, alpha), b + np.dot(a, beta.T))
+            op = SPGElement(np.dot(beta, alpha), b + np.dot(a, beta.T))
             return op
         else:
             raise KeyError("Input has wrong type: %s" % type(r_or_op))
@@ -119,7 +128,7 @@ class SpaceGroup_element():
         '''
         inv_rot = np.linalg.inv(self.rot)
         trans = -np.dot(self.trans, inv_rot.T)
-        return SpaceGroup_element(inv_rot, trans)
+        return SPGElement(inv_rot, trans)
 
     def transform(self, a, b, allow_non_integer=False):
         r'''
@@ -127,15 +136,15 @@ class SpaceGroup_element():
         '''
         rot = transform_rot(self.rot, a, b, allow_non_integer)
         trans = transform_trans(self.trans, a, b)
-        return SpaceGroup_element(rot, trans)
+        return SPGElement(rot, trans)
 
     @property
     def rot_is_eye(self):
-        return ((self.rot - np.eye(3,dtype=int)) == 0).all()
+        return ((self.rot - np.eye(self.dimension,dtype=int)) == 0).all()
 
     @property
     def rot_is_inversion(self):
-        return ((self.rot + np.eye(3,dtype=int)) == 0).all()
+        return ((self.rot + np.eye(self.dimension,dtype=int)) == 0).all()
 
     @property
     def trans_is_zero(self):
@@ -156,47 +165,44 @@ class SpaceGroup_element():
         return self.rot_is_inversion and self.trans_is_zero
 
     def __eq__(self, other):
-        if not isinstance(other, SpaceGroup_element):
+        if not isinstance(other, SPGElement):
             raise TypeError
         return self.__hash__() == other.__hash__()
 
     def __ne__(self, other):
-        if not isinstance(other, SpaceGroup_element):
+        if not isinstance(other, SPGElement):
             raise TypeError
         return not self.__eq__(other)
 
     def __lt__(self, other):
-        if not isinstance(other, SpaceGroup_element):
+        if not isinstance(other, SPGElement):
             raise TypeError
         return self.__hash__() < other.__hash__()
 
     def __le__(self, other):
-        if not isinstance(other, SpaceGroup_element):
+        if not isinstance(other, SPGElement):
             raise TypeError
         return self.__eq__(other) or self.__lt__(other)
 
     def __gt__(self, other):
-        if not isinstance(other, SpaceGroup_element):
+        if not isinstance(other, SPGElement):
             raise TypeError
         return not self.__le__(other)
 
     def __ge__(self, other):
-        if not isinstance(other, SpaceGroup_element):
+        if not isinstance(other, SPGElement):
             raise TypeError
         return not self.__lt__(other)
 
     def __hash__(self):
-        rot = self.rot.flatten()
-        r = 0
-        for i in range(9):
-            r += 3**(8-i) * (rot[i] + 1)
+        r = PGElement.__hash__(self)
 
         trans = self.trans
         t = 0
-        for i in range(3):
+        for i in range(self.dimension):
             t += int(np.round(trans[i] * 12.)) * 12**(2-i)
 
-        return int(t * (3**9) + r)
+        return int(t * (3**(self.dimension ** 2)) + r)
 
     def a2b(self, cell):
         '''
@@ -254,7 +260,7 @@ class SpaceGroup(lib.StreamObject):
         backend: str
             Choose which backend to use for symmetry detection.
             Default is `pyscf` and other choices are `spglib`.
-        ops : list of :class:`SpaceGroup_element` objects
+        ops : list of :class:`SPGElement` objects
             Matrix representation of the space group operations (in direct lattice system).
         nop : int
             Order of the space group.
@@ -291,7 +297,7 @@ class SpaceGroup(lib.StreamObject):
             pg_symbol = dataset['pointgroup']
             symmetry = get_symmetry(spgcell, symprec=self.symprec)
             for rot, trans in zip(symmetry['rotations'], symmetry['translations']):
-                self.ops.append(SpaceGroup_element(rot, trans))
+                self.ops.append(SPGElement(rot, trans))
         elif self.backend == 'pyscf':
             self.ops = geom.search_space_group_ops(self.cell, tol=self.symprec)
             pg_symbol = geom.get_crystal_class(self.cell, tol=self.symprec)[0]
@@ -309,7 +315,9 @@ class SpaceGroup(lib.StreamObject):
             self.dump_info()
         return self
 
-    def dump_info(self):
+    def dump_info(self, ops=None):
+        if ops is None:
+            ops = self.ops
         if self.verbose >= logger.INFO:
             gn = self.groupname
             if gn['international_symbol'] is not None:
@@ -317,8 +325,12 @@ class SpaceGroup(lib.StreamObject):
                             gn['international_symbol'], gn['international_number'])
             logger.info(self, '[Cell] Point group symbol:  %s', gn['point_group_symbol'])
         if self.verbose >= logger.DEBUG:
-            logger.debug(self, "Space group symmetry operations:")
-            for op in self.ops:
+            if len(ops) < len(self.ops):
+                message = 'Subset of space group symmetry operations:'
+            else:
+                message = 'Space group symmetry operations:'
+            logger.debug(self, message)
+            for op in ops:
                 logger.debug(self, op.__str__())
 
 if __name__ == "__main__":

--- a/pyscf/pbc/symm/symmetry.py
+++ b/pyscf/pbc/symm/symmetry.py
@@ -119,9 +119,9 @@ def check_mesh_symmetry(cell, ops, mesh=None, tol=SYMPREC,
                     break
 
         if not return_mesh:
-            logger.warn(cell, 'Input mesh %s has lower symmetry than the lattice.\
-                        \nSome of the symmetry operations will be removed.\
-                        \nRecommended mesh is %s.', mesh, mesh1)
+            logger.warn(cell, 'Input mesh %s has lower symmetry than the lattice.\n'
+                        'Some of the symmetry operations will be removed.\n'
+                        'Recommended mesh is %s.', mesh, mesh1)
     if return_mesh:
         return rm_list, mesh1
     else:

--- a/pyscf/pbc/symm/symmetry.py
+++ b/pyscf/pbc/symm/symmetry.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+# Copyright 2020-2023 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,25 +18,16 @@
 
 import sys
 import copy
+from functools import reduce
 import numpy as np
-from numpy.linalg import inv
+from numpy.linalg import inv, det
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf.symm import param
 from pyscf.symm.Dmatrix import Dmatrix, get_euler_angles
 from pyscf.pbc.symm import space_group
 from pyscf.pbc.symm.space_group import SYMPREC, XYZ
-from functools import reduce
-
-def _is_right_handed(c):
-    '''
-    Check if coordinate system is right-handed
-    '''
-    x = c[0]
-    y = c[1]
-    z = c[2]
-    val = np.dot(np.cross(x,y), z)
-    return val > 0
+from pyscf.pbc.tools import pbc as pbctools
 
 def get_Dmat(op, l):
     '''
@@ -47,17 +38,18 @@ def get_Dmat(op, l):
         l : int
             angular momentum
     '''
+    fac = 1
+    det_op = det(op)
+    if det_op < 0:
+        # improper rotation has |R| = -1
+        assert abs(det_op + 1) < 1e-9
+        op = -1 * op
+        fac = (-1) ** l
+
     c1 = XYZ
-    c2 = np.dot(inv(op), c1.T).T
-    right_handed = _is_right_handed(c2)
+    c2 = np.dot(op, c1.T).T
     alpha, beta, gamma = get_euler_angles(c1, c2)
-    D = Dmatrix(l, alpha, beta, gamma, reorder_p=True)
-    if not right_handed:
-        if l > 7:
-            raise NotImplementedError("Parities for orbitals with l > 7 are unknown.")
-        for m in range(-l, l+1):
-            if param.SPHERIC_GTO_PARITY_ODD[l][m+l][0]:
-                D[:, m+l] *= -1.0
+    D = fac * Dmatrix(l, alpha, beta, gamma, reorder_p=True)
     return D.round(15)
 
 def get_Dmat_cart(op,l_max):
@@ -100,6 +92,41 @@ def make_Dmats(cell, ops, l_max=None):
             Dmats.append(get_Dmat_cart(op, l_max))
     return Dmats, l_max
 
+def check_mesh_symmetry(cell, ops, mesh=None, tol=SYMPREC,
+                        return_mesh=False):
+    if mesh is None:
+        mesh = cell.mesh
+    ft = []
+    rm_list = []
+    for i, op in enumerate(ops):
+        if not op.trans_is_zero:
+            ft.append(op.trans)
+            tmp = op.trans * np.asarray(mesh)
+            if (abs(tmp - tmp.round()) > tol).any():
+                rm_list.append(i)
+
+    if len(rm_list) == 0:
+        mesh1 = mesh
+    else:
+        ft = np.reshape(np.asarray(ft), (-1,3))
+        mesh1 = copy.deepcopy(mesh)
+        for x in range(3):
+            while True:
+                tmp = ft[:,x] * mesh1[x]
+                if (abs(tmp - tmp.round()) > tol).any():
+                    mesh1[x] = mesh1[x] + 1
+                else:
+                    break
+
+        if not return_mesh:
+            logger.warn(cell, 'Input mesh %s has lower symmetry than the lattice.\
+                        \nSome of the symmetry operations will be removed.\
+                        \nRecommended mesh is %s.', mesh, mesh1)
+    if return_mesh:
+        return rm_list, mesh1
+    else:
+        return rm_list
+
 class Symmetry():
     '''
     Symmetry info of a crystal.
@@ -111,7 +138,7 @@ class Symmetry():
             Whether space group is symmorphic
         has_inversion : bool
             Whether space group contains inversion operation
-        ops : list of :class:`SpaceGroup_element` object
+        ops : list of :class:`SPGElement` object
             Symmetry operators (may be a subset of the operators in the space group)
         nop : int
             Length of `ops`.
@@ -124,33 +151,44 @@ class Symmetry():
         self.cell = cell
         self.spacegroup = None
         self.symmorphic = True
-        self.ops = [space_group.SpaceGroup_element(),]
+        self.ops = [space_group.SPGElement(),]
         self.nop = len(self.ops)
         self.has_inversion = False
         self.Dmats = None
         self.l_max = None
+        self._built = False
 
-    def build(self, space_group_symmetry=True, symmorphic=True, *args, **kwargs):
-        if self.cell is None: return
-        if not self.cell._built:
-            sys.stderr.write('Warning: %s must be initialized before calling Symmetry.\n'
-                             'Initialize %s in %s\n' % (self.cell, self.cell, self))
-            self.cell.build()
-        self.spacegroup = space_group.SpaceGroup(self.cell).build()
-        self.symmorphic = symmorphic
-        if self.cell.dimension < 3:
-            if not self.symmorphic:
-                sys.stderr.write('Warning: setting symmorphic=True for low-dimensional system.\n')
-                self.symmorphic = True
-        if space_group_symmetry:
-            self.ops = copy.deepcopy(self.spacegroup.ops) #in case that a subset of ops is considered
-            if self.symmorphic:
-                self.ops[:] = [op for op in self.ops if op.trans_is_zero]
-            else:
-                rm_list = check_mesh_symmetry(self.cell, self.ops)
-                self.ops[:] = [op for i, op in enumerate(self.ops) if i not in rm_list]
+    def build(self, space_group_symmetry=True, symmorphic=True,
+              check_mesh_symmetry=True, *args, **kwargs):
+        cell = self.cell
+        if cell is None:
+            self._built = True
+            return self
+
+        if not space_group_symmetry:
+            self.ops = [space_group.SPGElement(),]
         else:
-            self.ops = [space_group.SpaceGroup_element(),]
+            if not cell._built:
+                sys.stderr.write('Warning: %s must be initialized before calling Symmetry.\n'
+                                 'Initialize %s in %s\n' % (cell, cell, self))
+                cell.build()
+
+            self.spacegroup = space_group.SpaceGroup(cell).build(dump_info=False)
+            self.symmorphic = symmorphic
+            if cell.dimension < 3:
+                if not self.symmorphic:
+                    sys.stderr.write('Warning: setting symmorphic=True for low-dimensional system.\n')
+                    self.symmorphic = True
+
+            ops = self.spacegroup.ops
+            if self.symmorphic:
+                self.ops = [op for op in ops if op.trans_is_zero]
+            elif check_mesh_symmetry:
+                rm_list = self.check_mesh_symmetry(ops=ops)
+                self.ops = [op for i, op in enumerate(ops) if i not in rm_list]
+            else:
+                self.ops = ops
+
         self.nop = len(self.ops)
         self.has_inversion = any([op.rot_is_inversion for op in self.ops])
 
@@ -161,64 +199,48 @@ class Symmetry():
                 l_max = np.max(auxcell._bas[:,1])
         op_rot = [op.a2r(self.cell).rot for op in self.ops]
         self.Dmats, self.l_max = make_Dmats(self.cell, op_rot, l_max)
+        self._built = True
         return self
 
+    def check_mesh_symmetry(self, cell=None, ops=None, mesh=None,
+                            tol=SYMPREC, return_mesh=False):
+        if cell is None:
+            cell = self.cell
+        if ops is None:
+            ops = self.ops
+        return check_mesh_symmetry(cell, ops, mesh, tol, return_mesh)
 
-def check_mesh_symmetry(cell, ops, mesh=None, tol=SYMPREC):
-    #FIXME what if GDF?
-    if mesh is None: mesh = cell.mesh
-    ft = []
-    rm_list = []
-    for i, op in enumerate(ops):
-        if not op.trans_is_zero:
-            ft.append(op.trans)
-            tmp = op.trans * np.asarray(mesh)
-            if (abs(tmp - tmp.round()) > tol).any():
-                rm_list.append(i)
+    def dump_info(self):
+        self.spacegroup.dump_info(ops=self.ops)
 
-    ft = np.reshape(np.asarray(ft), (-1,3))
-    mesh1 = copy.deepcopy(mesh)
-    for x in range(3):
-        while True:
-            tmp = ft[:,x] * mesh1[x]
-            if (abs(tmp - tmp.round()) > tol).any():
-                mesh1[x] = mesh1[x] + 1
-            else:
-                break
 
-    if rm_list:
-        logger.warn(cell, 'Cell.mesh has lower symmetry than the lattice.\
-                    \nSome of the symmetry operations have been removed.\
-                    \nRecommended mesh is %s', mesh1)
-    return rm_list
-
-def _get_phase(cell, op, coords_scaled, kpt_scaled, ignore_phase=False):
-    natm = cell.natm
-    phase = np.ones([natm], dtype = np.complex128)
+def _get_phase(cell, op, kpt_scaled, ignore_phase=False, tol=SYMPREC):
+    kpt_scaled = op.a2b(cell).dot_rot(kpt_scaled)
+    coords_scaled = cell.get_scaled_positions().reshape(-1,3)
+    natm = coords_scaled.shape[0]
+    phase = np.ones((natm,), dtype=np.complex128)
     atm_map = np.arange(natm)
-    coords0 = np.mod(coords_scaled, 1).round(-np.log10(SYMPREC).astype(int))
-    coords0 = np.mod(coords0, 1)
+    coords0 = pbctools.round_to_cell0(coords_scaled, tol=tol)
     for iatm in range(natm):
         r = coords_scaled[iatm]
-        op_dot_r = op.dot_rot(r - op.inv().trans)
-        #op_dot_r = op.inv().dot_rot(r) - op.inv().trans
-        op_dot_r_0 = np.mod(np.mod(op_dot_r, 1), 1)
-        op_dot_r_0 = op_dot_r_0.round(-np.log10(SYMPREC).astype(int))
-        op_dot_r_0 = np.mod(op_dot_r_0, 1)
-        diff = np.einsum('ki->k', abs(op_dot_r_0 - coords0))
-        atm_map[iatm] = np.where(diff < SYMPREC)[0]
-        r_diff = coords_scaled[atm_map[iatm]] - op_dot_r
-        #r_diff = op_dot_r_0 - op_dot_r
-        #sanity check
-        assert(np.linalg.norm(r_diff - r_diff.round()) < SYMPREC)
+        op_dot_r = op.dot_rot(r) + op.trans
+        op_dot_r_0 = pbctools.round_to_cell0(op_dot_r, tol=tol)
+        equiv_atm = np.where(abs(op_dot_r_0 - coords0).sum(axis=1) < tol)[0]
+        assert len(equiv_atm) == 1
+        equiv_atm = equiv_atm[0]
+        atm_map[iatm] = equiv_atm
+        Lshift = coords_scaled[equiv_atm] - op_dot_r
+        # Lshift is a lattice vector
+        assert abs(Lshift - Lshift.round()).sum() < tol
+        # remove numerical noise, important for symmetry adaptation
+        Lshift = Lshift.round()
         if not ignore_phase:
-            phase[iatm] = np.exp(-1j * np.dot(kpt_scaled, r_diff) * 2.0 * np.pi)
+            phase[iatm] = np.exp(-1j * np.dot(kpt_scaled, Lshift) * 2.0 * np.pi)
     return atm_map, phase
 
-def _get_rotation_mat(cell, kpt_scaled_ibz, mo_coeff_or_dm, op, Dmats, ignore_phase=False):
-    kpt_scaled = op.a2b(cell).dot_rot(kpt_scaled_ibz)
-    coords = cell.get_scaled_positions()
-    atm_map, phases = _get_phase(cell, op, coords, kpt_scaled, ignore_phase)
+def _get_rotation_mat(cell, kpt_scaled_ibz, mo_coeff_or_dm, op, Dmats,
+                      ignore_phase=False, tol=SYMPREC):
+    atm_map, phases = _get_phase(cell, op, kpt_scaled_ibz, ignore_phase, tol)
 
     dim = mo_coeff_or_dm.shape[0]
     mat = np.zeros([dim, dim], dtype=np.complex128)
@@ -245,20 +267,20 @@ def _get_rotation_mat(cell, kpt_scaled_ibz, mo_coeff_or_dm, op, Dmats, ignore_ph
         shlid_0 = aoslice[iatm][0]
         shlid_1 = aoslice[iatm][1]
         for ishl in range(shlid_0, shlid_1):
-            l = cell._bas[ishl,1]
-            D = Dmats[l] * phase
+            l = cell.bas_angular(ishl)
+            Dmat = Dmats[l] * phase
             if not cell.cart:
-                nao = 2*l + 1
+                nao = 2 * l + 1
             else:
-                nao = (l+1)*(l+2)//2
-            nz = cell._bas[ishl,3]
-            for j in range(nz):
-                mat[ao_off_i:ao_off_i+nao, ao_off_j:ao_off_j+nao] = D
+                nao = (l+1) * (l+2) // 2
+            nc = cell.bas_nctr(ishl)
+            for _ in range(nc):
+                mat[ao_off_j:ao_off_j+nao, ao_off_i:ao_off_i+nao] = Dmat
                 ao_off_i += nao
                 ao_off_j += nao
-        assert(ao_off_i == aoslice[iatm][3])
-        assert(ao_off_j == aoslice[jatm][3])
-    return mat.T.conj()
+        assert ao_off_i == aoslice[iatm][3]
+        assert ao_off_j == aoslice[jatm][3]
+    return mat
 
 def transform_mo_coeff(cell, kpt_scaled, mo_coeff, op, Dmats):
     '''
@@ -270,7 +292,7 @@ def transform_mo_coeff(cell, kpt_scaled, mo_coeff, op, Dmats):
             scaled k-point
         mo_coeff : (nao, nmo) array
             MO coefficients at the input k-point
-        op : :class:`SpaceGroup_element` object
+        op : :class:`SPGElement` object
             Space group operation that connects the two k-points
         Dmats: list of arrays
             Wigner D-matrices for op

--- a/pyscf/pbc/symm/symmetry.py
+++ b/pyscf/pbc/symm/symmetry.py
@@ -336,17 +336,3 @@ def is_eye(op):
 
 def is_inversion(op):
     raise NotImplementedError
-
-if __name__ == "__main__":
-    from pyscf.pbc import gto
-    cell = gto.Cell()
-    cell.atom = """
-        Si  0.0 0.0 0.0
-        Si  1.3467560987 1.3467560987 1.3467560987
-    """
-    cell.a = [[0.0, 2.6935121974, 2.6935121974],
-              [2.6935121974, 0.0, 2.6935121974],
-              [2.6935121974, 2.6935121974, 0.0]]
-    cell.verbose = 5
-    cell.build()
-    Symmetry(cell).build()

--- a/pyscf/pbc/symm/tables.py
+++ b/pyscf/pbc/symm/tables.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+# Copyright 2020-2023 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,7 +50,6 @@ CrystalClass = {
     'm-3m'  : [0, 6, 8, 9, 1, 1, 9, 8, 6, 0],
 }
 
-
 LaueClass = {
     '-1'    : ['1', '-1'],
     '2/m'   : ['2', 'm', '2/m'],
@@ -64,4 +62,39 @@ LaueClass = {
     '6/mmm' : ['622', '6mm', '-6m2', '6/mmm'],
     'm-3'   : ['23', 'm-3'],
     'm-3m'  : ['432', '-43m', 'm-3m'],
+}
+
+SchoenfliesNotation = {
+    '1'     : 'C1',
+    '-1'    : 'Ci',
+    '2'     : 'C2',
+    'm'     : 'Cs',
+    '2/m'   : 'C2h',
+    '222'   : 'D2',
+    'mm2'   : 'C2v',
+    'mmm'   : 'D2h',
+    '4'     : 'C4',
+    '-4'    : 'S4',
+    '4/m'   : 'C4h',
+    '422'   : 'D4',
+    '4mm'   : 'C4v',
+    '-42m'  : 'D2d',
+    '4/mmm' : 'D4h',
+    '3'     : 'C3',
+    '-3'    : 'S6',
+    '32'    : 'D3',
+    '3m'    : 'C3v',
+    '-3m'   : 'D3d',
+    '6'     : 'C6',
+    '-6'    : 'C3h',
+    '6/m'   : 'C6h',
+    '622'   : 'D6',
+    '6mm'   : 'C6v',
+    '-6m2'  : 'D3h',
+    '6/mmm' : 'D6h',
+    '23'    : 'T',
+    'm-3'   : 'Th',
+    '432'   : 'O',
+    '-43m'  : 'Td',
+    'm-3m'  : 'Oh',
 }

--- a/pyscf/pbc/symm/test/test_basis.py
+++ b/pyscf/pbc/symm/test/test_basis.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+# Copyright 2022-2023 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: Xing Zhang <zhangxing.nju@gmail.com>
+#
+
+import unittest
+import numpy as np
+from pyscf.pbc import gto
+from pyscf.pbc.symm.basis import symm_adapted_basis
+
+def get_so(atom, a, basis, kmesh):
+    cell = gto.Cell()
+    cell.atom = atom
+    cell.a = a
+    cell.basis = basis
+    cell.space_group_symmetry = True
+    cell.symmorphic = True
+    cell.build()
+    kpts = cell.make_kpts(kmesh, with_gamma_point=True,
+                          space_group_symmetry=True)
+    sos_ks, irrep_ids_ks = symm_adapted_basis(cell, kpts)
+    return sos_ks, irrep_ids_ks
+
+def get_norb(sos_ks):
+    norb_ks = []
+    for sos_k in sos_ks:
+        norb = []
+        for sos in sos_k:
+            norb.append(sos.shape[1])
+        norb_ks.append(norb)
+    return norb_ks
+
+class KnowValues(unittest.TestCase):
+    def test_C2h_symorb(self):
+        atom = """
+            Cu    1.145000    8.273858   11.128085
+        """
+        a = [[2.2899999619, 0.0000000000, 0.0000000000],
+             [0.0000000000,11.8430004120, 0.0000000000],
+             [0.0000000000, 4.7047163727,22.2561701795]]
+        basis = 'gth-dzvp-molopt-sr'
+        kmesh = [3,] * 3
+        sos_ks, irrep_ids_ks = get_so(atom, a, basis, kmesh)
+        assert irrep_ids_ks == [[0, 1, 2, 3],
+                                [0, 1], [0, 1], [0, 1], [0, 1], [0, 1],
+                                [0], [0], [0], [0]]
+        norb_ks = get_norb(sos_ks)
+        assert norb_ks == [[8, 4, 8, 5],
+                           [16, 9], [16, 9], [16, 9], [16, 9], [13, 12],
+                           [25], [25], [25], [25]]
+
+    def test_D3d_symorb(self):
+        atom = """
+            Li    5.281899    1.082489    0.642479
+            Li   18.499727    3.791392    2.250266
+        """
+        a = [[8.3774538040, 0.0000000000, 0.0000000000],
+             [7.7020859454, 3.2953913771, 0.0000000000],
+             [7.7020859454, 1.5784896835, 2.8927451749]]
+        basis = 'gth-dzvp-molopt-sr'
+        kmesh = [2,] * 3
+        sos_ks, irrep_ids_ks = get_so(atom, a, basis, kmesh)
+        assert irrep_ids_ks == [[0, 3, 4, 5],
+                                [0, 1, 2, 3],
+                                [0, 1, 2, 3],
+                                [0, 3, 4, 5]]
+        norb_ks = get_norb(sos_ks)
+        assert norb_ks == [[4, 4, 2, 2],
+                           [5, 1, 1, 5],
+                           [5, 1, 1, 5],
+                           [4, 4, 2, 2]]
+
+    def test_D6h_symorb(self):
+        atom = """
+            Zn    0.000000    1.516699    1.301750
+            Zn    1.313500    0.758350    3.905250
+        """
+        a = [[ 2.627000, 0.000000, 0.000000],
+             [-1.313500, 2.275049, 0.000000],
+             [ 0.000000, 0.000000, 5.207000]]
+        basis = 'gth-dzvp-molopt-sr'
+        kmesh = [2,] * 3
+        sos_ks, irrep_ids_ks = get_so(atom, a, basis, kmesh)
+        assert irrep_ids_ks == [[0, 1, 2, 3, 4, 5],
+                                [0, 1, 2, 3, 4, 5],
+                                [0, 1, 2, 3],
+                                [0, 1, 2, 3]]
+        norb_ks = get_norb(sos_ks)
+        assert norb_ks == [[8, 8, 1, 1, 16, 16],
+                           [8, 8, 1, 1, 16, 16],
+                           [16, 9, 16, 9],
+                           [16, 9, 16, 9]]
+
+    def test_Td_symorb(self):
+        atom = """
+            Si  0.0 0.0 0.0
+            Si  1.3467560987 1.3467560987 1.3467560987
+        """
+        a = [[0.0, 2.6935121974, 2.6935121974],
+             [2.6935121974, 0.0, 2.6935121974],
+             [2.6935121974, 2.6935121974, 0.0]]
+        basis = 'gth-dzvp-molopt-sr'
+        kmesh = [2,] * 3
+        sos_ks, irrep_ids_ks = get_so(atom, a, basis, kmesh)
+        assert irrep_ids_ks == [[0, 2, 4],
+                                [0, 1, 2, 3, 4],
+                                [0, 2]]
+        norb_ks = get_norb(sos_ks)
+        assert norb_ks == [[4, 4, 18], [6, 1, 1, 6, 12], [10, 16]]
+
+        a = 5.431020511
+        xyz = np.array(
+                [[0,0,0],
+                 [0.25,0.25,0.25],
+                 [0, 0.5, 0.5],
+                 [0.25, 0.75, 0.75],
+                 [0.5, 0, 0.5],
+                 [.75, .25, .75],
+                 [.5, .5, 0],
+                 [.75, .75, .25]]
+            ) * a
+        atom = []
+        for ix in xyz:
+            atom.append(['Si', list(ix)])
+        a = np.eye(3) * a
+        sos_ks, irrep_ids_ks = get_so(atom, a, basis, kmesh)
+        assert irrep_ids_ks == [[0, 1, 2, 3, 4],
+                                [0, 1, 2, 3, 4],
+                                [0, 1, 2, 3, 4],
+                                [0, 2, 3, 4]]
+        norb_ks = get_norb(sos_ks)
+        assert norb_ks == [[10, 1, 18, 21, 54], [18, 9, 8, 19, 50],
+                           [18, 8, 18, 8, 52], [10, 16, 24, 54]]
+
+    def test_Oh_symorb(self):
+        atom = """
+            Si  0.0 0.0 0.0
+        """
+        a = np.eye(3) * 2.
+        basis = 'gth-dzvp-molopt-sr'
+        kmesh = [2,] * 3
+        sos_ks, irrep_ids_ks = get_so(atom, a, basis, kmesh)
+        assert irrep_ids_ks == [[0, 4, 6, 9],
+                                [0, 1, 2, 7, 8, 9],
+                                [0, 1, 2, 7, 8, 9],
+                                [0, 4, 6, 9]]
+        norb_ks = get_norb(sos_ks)
+        assert norb_ks == [[2, 2, 3, 6], [3, 1, 1, 2, 2, 4],
+                           [3, 1, 1, 2, 2, 4], [2, 2, 3, 6]]
+
+if __name__ == "__main__":
+    print("Full Tests for pbc.symm.basis")

--- a/pyscf/pbc/symm/test/test_spg.py
+++ b/pyscf/pbc/symm/test/test_spg.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2020 The PySCF Developers. All Rights Reserved.
+# Copyright 2020-2023 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 import unittest
 import numpy as np
+from pyscf import lib
 from pyscf.pbc import gto
 from pyscf.pbc.symm import space_group as spg
 
@@ -187,17 +188,27 @@ class KnownValues(unittest.TestCase):
         rot = np.empty([3,3], dtype=int)
         trans = np.empty([3], dtype=float)
         r = num % (3**9)
-        degit = 3**8
-        for i in range(3):
-            for j in range(3):
-                rot[i][j] = ( r % ( degit * 3 ) ) // degit - 1
-                degit = degit // 3
+        id_eye = int('211121112', 3)
+        id_max = int('222222222', 3)
+        r += id_eye
+        if r > id_max:
+            r -= id_max + 1
+        #s = np.base_repr(r, 3)
+        #s = '0'*(9-len(s)) + s
+        #rot = np.asarray([int(i) for i in s]) - 1
+        rot = np.asarray(lib.base_repr_int(r, 3, 9)) - 1
+        rot = rot.reshape(3,3)
+        #degit = 3**8
+        #for i in range(3):
+        #    for j in range(3):
+        #        rot[i][j] = ( r % ( degit * 3 ) ) // degit - 1
+        #        degit = degit // 3
         t = num // (3**9)
         degit = 12**2
         for i in range(3):
             trans[i] = ( float( ( t % ( degit * 12 ) ) // degit ) ) / 12.;
             degit = degit // 12
-        op = spg.SpaceGroup_element(rot, trans)
+        op = spg.SPGElement(rot, trans)
         self.assertTrue(hash(op) == num)
 
 

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -713,3 +713,9 @@ def cutoff_to_gs(a, cutoff):
 def gs_to_cutoff(a, gs):
     '''Deprecated.  Replaced by function mesh_to_cutoff.'''
     return mesh_to_cutoff(a, [2*n+1 for n in gs])
+
+def round_to_cell0(r, tol=1e-6):
+    '''Round scaled coordinates to reference unit cell
+    '''
+    from pyscf.pbc.lib import kpts_helper
+    return kpts_helper.round_to_fbz(r, wrap_around=False, tol=tol)

--- a/pyscf/pbc/tools/test/test_k2gamma.py
+++ b/pyscf/pbc/tools/test/test_k2gamma.py
@@ -81,6 +81,7 @@ class KnownValues(unittest.TestCase):
         '''
         cell.basis = {'He': [[0, (4.0, 1.0)], [0, (1.0, 1.0)]]}
         cell.a = np.eye(3) * 2.
+        cell.space_group_symmetry = True
         cell.build()
 
         kmesh = [2,2,1]


### PR DESCRIPTION
This PR adds the following new features:
1. Add symmetry adapted crystalline GTOs for symmorphic space groups. For non-symmorphic space groups, the factor system for the projective representation is not 1, which can be added in the future if needed.
2. Allow using symmetry adapted GTOs in PBC SCF calculations.
3. Add k-point symmetry adapted KRCCSD. The current implementation, at the best case, reduces both the memory footprint and the CPU time by a factor of the order of the point group. This code is meant to be a template, and k-point symmetry can be applied to other methods following the same strategy. A benchmark is shown below (run on 16 CPU cores). To further improve the performance, we will need an efficient sparse tensor contraction engine which also considers space group symmetry.
![image](https://user-images.githubusercontent.com/8757014/214005670-ecba0044-e5a8-4fa8-9f33-0f26dd43ca01.png)
![image](https://user-images.githubusercontent.com/8757014/214006982-5dbb5724-092e-4b06-98fe-0319daaf943e.png)


In addition, this PR also fixes the following issues:
1. fix occupation number error in pbc.khf_ksymm.get_occ (issue #1470)
2. fix dimension error in pbc.df.df.CDERIArray (issue #1563)