### PR TITLE
Fix issue 1577

### DIFF
--- a/pyscf/cc/ccsd_t.py
+++ b/pyscf/cc/ccsd_t.py
@@ -137,8 +137,9 @@ def _sort_eri(mycc, eris, nocc, nvir, vvop, log):
     nmo = nocc + nvir
 
     if mol.symmetry:
+        ovlp = mycc._scf.get_ovlp()
         orbsym = symm.addons.label_orb_symm(mol, mol.irrep_id, mol.symm_orb,
-                                            eris.mo_coeff, check=False)
+                                            eris.mo_coeff, s=ovlp, check=False)
         orbsym = numpy.asarray(orbsym, dtype=numpy.int32) % 10
     else:
         orbsym = numpy.zeros(nmo, dtype=numpy.int32)


### PR DESCRIPTION
CCSD(T) fails after reading FCIDUMP. When determining orbital symmetries, it attempts to rebuild overlap matrix with `mol.intor_symmetric('int1e_ovlp')` ([code](https://github.com/pyscf/pyscf/blob/c0c4dbcb97b5725b5bbec3257b78f18c63663c76/pyscf/symm/addons.py#L69)), which will return an empty array because `mol` has no atom information. However, we have a working `get_ovlp()` in the mean-field object recovered from FCIDUMP ([code](https://github.com/pyscf/pyscf/blob/c0c4dbcb97b5725b5bbec3257b78f18c63663c76/pyscf/tools/fcidump.py#L343)). 

This pull request simply gets overlap from `mycc._scf.get_ovlp()` and provides it to `label_orb_symm()`. 

