### PR TITLE
Fix bug when reading FCIDUMP file generated with SO3, Dooh, or Coov

### DIFF
--- a/pyscf/tools/fcidump.py
+++ b/pyscf/tools/fcidump.py
@@ -248,7 +248,7 @@ def read(filename, molpro_orbsym=MOLPRO_ORBSYM, verbose=True):
         else:
             result[key] = val
 
-    # Convert to molpr orbsym convert_orbsym
+    # Convert to Molpro orbsym convert_orbsym
     if 'ORBSYM' in result:
         if molpro_orbsym:
             # Guess which point group the orbsym belongs to. FCIDUMP does not
@@ -267,7 +267,7 @@ def read(filename, molpro_orbsym=MOLPRO_ORBSYM, verbose=True):
                 result['ORBSYM'] = [0] * len(orbsym)
             else:
                 raise RuntimeError('Unknown orbsym')
-        elif max(result['ORBSYM']) >= 8:
+        elif min(result['ORBSYM']) < 0:
             raise RuntimeError('Unknown orbsym convention')
 
     norb = result['NORB']


### PR DESCRIPTION
This statement causes PySCF to crash when reading an FCIDUMP that has an `ORBSYM` element greater than 8:
```
        elif max(result['ORBSYM']) >= 8:
            raise RuntimeError('Unknown orbsym convention')
```            
However in Dooh the FCIDUMP will have numbers as high as 11 in the example below (Oxygen atom in aug-cc-pCVDZ):
```
  ORBSYM=0,0,5,6,7,5,6,7,0,10,11,2,0,3,0,7,6,5
```
A better condition is to raise the RuntimeError when there's an `ORBSYM` value that's negative, and this is what my pull request does. 

I used to get the following error:
```
  File "/home/nike/.local/lib/python3.10/site-packages/pyscf/tools/fcidump.py", line 271, in read
    raise RuntimeError('Unknown orbsym convention')
RuntimeError: Unknown orbsym convention
```
Now, the program runs to completion:
```
CCSD converged
E(CCSD) = -74.85891099383272  E_corr = -0.1935550785590202
```