### PR TITLE
Add option to use user provided logIni to geomTRIC optimization

### DIFF
--- a/pyscf/geomopt/geometric_solver.py
+++ b/pyscf/geomopt/geometric_solver.py
@@ -145,7 +145,7 @@ def kernel(method, assert_convergence=ASSERT_CONV,
 
     # geomeTRIC library on pypi requires to provide config file log.ini.
     if not os.path.exists(os.path.abspath(
-            os.path.join(geometric.optimize.__file__, '..', 'log.ini'))):
+            os.path.join(geometric.optimize.__file__, '..', 'log.ini'))) and kwargs.get('logIni') is None:
         kwargs['logIni'] = os.path.abspath(os.path.join(__file__, '..', 'log.ini'))
 
     engine.assert_convergence = assert_convergence


### PR DESCRIPTION
In the GeomeTRIC geometry optimization library, it is possible to pass the "logIni" keyword so that you can change the default logging. In the PySCF wrapper, it is possible to pass the logIni keyword, but it gets overwritten if PySCF's attempt to find it fails. The logIni keyword then points to the path of the log.ini file installed with PySCF. Here, I added a simple check to make sure that the user didn't provide the logIni keyword before overwriting it. 