### PR TITLE
Add support for complex dtype in fci slow contract functions

### DIFF
--- a/pyscf/fci/fci_slow.py
+++ b/pyscf/fci/fci_slow.py
@@ -32,7 +32,7 @@ def contract_1e(f1e, fcivec, norb, nelec):
     na = cistring.num_strings(norb, neleca)
     nb = cistring.num_strings(norb, nelecb)
     ci0 = fcivec.reshape(na,nb)
-    t1 = numpy.zeros((norb,norb,na,nb))
+    t1 = numpy.zeros((norb,norb,na,nb), dtype=fcivec.dtype)
     for str0, tab in enumerate(link_indexa):
         for a, i, str1, sign in tab:
             t1[a,i,str1] += sign * ci0[str0]
@@ -55,7 +55,7 @@ def contract_2e(eri, fcivec, norb, nelec, opt=None):
     na = cistring.num_strings(norb, neleca)
     nb = cistring.num_strings(norb, nelecb)
     ci0 = fcivec.reshape(na,nb)
-    t1 = numpy.zeros((norb,norb,na,nb))
+    t1 = numpy.zeros((norb,norb,na,nb), dtype=fcivec.dtype)
     for str0, tab in enumerate(link_indexa):
         for a, i, str1, sign in tab:
             t1[a,i,str1] += sign * ci0[str0]
@@ -65,7 +65,7 @@ def contract_2e(eri, fcivec, norb, nelec, opt=None):
 
     t1 = lib.einsum('bjai,aiAB->bjAB', eri.reshape([norb]*4), t1)
 
-    fcinew = numpy.zeros_like(ci0)
+    fcinew = numpy.zeros_like(ci0, dtype=fcivec.dtype)
     for str0, tab in enumerate(link_indexa):
         for a, i, str1, sign in tab:
             fcinew[str1] += sign * t1[a,i,str0]

--- a/pyscf/fci/test/test_direct_nosym.py
+++ b/pyscf/fci/test/test_direct_nosym.py
@@ -48,6 +48,18 @@ class KnownValues(unittest.TestCase):
         ci1 = fci.direct_nosym.contract_2e(h2e, ci0, norb, nelec)
         self.assertTrue(numpy.allclose(ci1ref, ci1))
 
+    def test_contract_complex(self):
+        ci0 = numpy.random.random((na,nb)) + 1j * numpy.random.random((na,nb))
+        ci1ref = fci_slow.contract_1e(h1e, ci0, norb, nelec)
+        ci1 = fci.direct_nosym.contract_1e(h1e, ci0.real, norb, nelec).astype(complex)
+        ci1 += 1j * fci.direct_nosym.contract_1e(h1e, ci0.imag, norb, nelec)
+        self.assertTrue(numpy.allclose(ci1ref, ci1))
+
+        ci1ref = fci_slow.contract_2e(h2e, ci0, norb, nelec)
+        ci1 = fci.direct_nosym.contract_2e(h2e, ci0.real, norb, nelec).astype(complex)
+        ci1 += 1j * fci.direct_nosym.contract_2e(h2e, ci0.imag, norb, nelec)
+        self.assertTrue(numpy.allclose(ci1ref, ci1))
+
     def test_absorb_h1e(self):
         href = fci_slow.absorb_h1e(h1e, h2e, norb, nelec)
         h1 = fci.direct_nosym.absorb_h1e(h1e, h2e, norb, nelec)


### PR DESCRIPTION
Adds support for complex-valued fci vectors to the contraction functions in `fci_slow.py`.