### PR TITLE
Boys localization jacobi sweep

### DIFF
--- a/pyscf/lo/boys.py
+++ b/pyscf/lo/boys.py
@@ -54,12 +54,6 @@ def rotate(R, theta):
     return numpy.array([U.dot(r).dot(U.T) for r in R])
 
 
-def get_score(R):
-    n = R.shape[1]
-    Rdiag = R[:, numpy.arange(n), numpy.arange(n)]
-    return numpy.sum(numpy.square(Rdiag))
-
-
 def get_optimized_rotation(R):
     R11 = R[:, 0, 0]
     R12 = R[:, 0, 1]
@@ -115,8 +109,6 @@ def kernel(localizer, mo_coeff=None, callback=None, verbose=None):
         nmo = localizer.mo_coeff.shape[1]
         mo_coeff = localizer.mo_coeff.dot(u0)
         dip = dipole_integral(localizer.mol, mo_coeff)
-        #dip = numpy.asarray([reduce(lib.dot, (mo_coeff.conj().T, x, mo_coeff))
-        #                     for x in localizer.mol.intor_symmetric('int1e_r', comp=3)])
         for imacro in range(localizer.max_cycle):
             for i in range(nmo):
                 for j in range(i + 1, nmo):
@@ -127,7 +119,6 @@ def kernel(localizer, mo_coeff=None, callback=None, verbose=None):
                     dip[:, :, [i, j]] = numpy.einsum("ik,xpk->xpi", u_sub, dip[:, :, [i, j]])
                     u0[:, [i, j]] = u0[:, [i, j]].dot(u_sub.T)
             score = localizer.cost_function(u0)
-            #score = get_score(dip)
             residual = numpy.max(numpy.abs(get_residual(dip)))
             log.info('macro= %d  f(x)= %.14g  res= %.14g',
                     imacro+1, score, residual)


### PR DESCRIPTION
In many systems, I can find that Jacobi sweep (i.e. exact optimization in a two-orbital subspace each time) can lead to a lower cost function than the current optimization result of the Boys localization, so I hope to have this pull request to add the functionality of Jacobi sweep as an option. There's also a related issue about Boys localization at https://github.com/pyscf/pyscf/issues/820.
Here's an example showing that Jacobi sweep gives more localized orbitals in a 3-water system (valid for the modified code).

```
import pyscf
import pyscf.lo

atom = '''
O 2.07091 -0.46191 -0.00993;
H 2.56267 -0.75858 0.76451;
H 2.70113 -0.40578 -0.73813;
O 0.0 0.91527 -0.05817;
H -0.87302 0.35992 0.01707;
H 0.87302 0.35993 0.01707;
O -2.07092 -0.4619 -0.00993;
H -2.70115 -0.40575 -0.73811;
H -2.56265 -0.75862 0.76451;
'''


mol = pyscf.gto.M(atom=atom, basis='cc-pVTZ')

rhf = pyscf.scf.RHF(mol).density_fit()
rhf.run()
C = rhf.mo_coeff

print('jacobi sweep')
boys = pyscf.lo.Boys(mol, C.copy()[:, 3:15])
boys.jacobi = True
Cloc1 = boys.kernel(verbose=4)

print('original optimization')
boys = pyscf.lo.Boys(mol, C.copy()[:, 3:15])
Cloc2 = boys.kernel(verbose=4)
```

The output I get is 
```
converged SCF energy = -228.137524073691
jacobi sweep
Set conv_tol_grad to 0.000316228
macro= 1  f(x)= -387.32837908711  res= 0.30631398498355
macro= 2  f(x)= -388.24630408055  res= 0.090436807320824
macro= 3  f(x)= -388.57519368992  res= 0.043949165770448
macro= 4  f(x)= -388.60894029858  res= 0.023533942030739
macro= 5  f(x)= -388.61551796336  res= 0.0079208038076226
macro= 6  f(x)= -388.61629827424  res= 0.0027455288434352
macro= 7  f(x)= -388.61639111717  res= 0.000889717664449
macro= 8  f(x)= -388.616401279  res= 0.00028671113884098
macro= 9  f(x)= -388.61640239729  res= 9.1383331136231e-05
macro= 10  f(x)= -388.61640252295  res= 2.9070033855052e-05
macro= 11  f(x)= -388.61640253781  res= 1.0386948741309e-05
macro= 12  f(x)= -388.6164025397  res= 4.3830683319757e-06
macro= 13  f(x)= -388.61640253996  res= 1.850489558558e-06
macro= 14  f(x)= -388.61640254  res= 7.814476686574e-07
original optimization
Set conv_tol_grad to 0.000316228
macro= 1  f(x)= -382.68819754405  delta_f= -382.688  |g|= 1.82799  4 KF 20 Hx
macro= 2  f(x)= -385.20261559432  delta_f= -2.51442  |g|= 1.20919  3 KF 20 Hx
macro= 3  f(x)= -386.34609403168  delta_f= -1.14348  |g|= 0.859595  4 KF 20 Hx
macro= 4  f(x)= -386.79949451582  delta_f= -0.4534  |g|= 0.157767  3 KF 9 Hx
macro= 5  f(x)= -386.80983075277  delta_f= -0.0103362  |g|= 0.000126891  4 KF 13 Hx
macro= 6  f(x)= -386.80983075277  delta_f= -2.84217e-13  |g|= 2.22564e-05  1 KF 1 Hx
macro X = 6  f(x)= -386.80983075277  |g|= 2.22564e-05  12 intor 19 KF 83 Hx
```