### PR TITLE
Frequency integration grid scaling factor as input to RPA calculations

### DIFF
--- a/pyscf/gw/rpa.py
+++ b/pyscf/gw/rpa.py
@@ -39,7 +39,7 @@ einsum = lib.einsum
 # core routines, kernel, rpa_ecorr, rho_response
 # ****************************************************************************
 
-def kernel(rpa, mo_energy, mo_coeff, Lpq=None, nw=None, x0=None, verbose=logger.NOTE):
+def kernel(rpa, mo_energy, mo_coeff, Lpq=None, nw=40, x0=0.5, verbose=logger.NOTE):
     """
     RPA correlation and total energy
 

--- a/pyscf/gw/rpa.py
+++ b/pyscf/gw/rpa.py
@@ -39,14 +39,14 @@ einsum = lib.einsum
 # core routines, kernel, rpa_ecorr, rho_response
 # ****************************************************************************
 
-def kernel(rpa, mo_energy, mo_coeff, Lpq=None, nw=None, verbose=logger.NOTE):
+def kernel(rpa, mo_energy, mo_coeff, Lpq=None, nw=None, x0=None, verbose=logger.NOTE):
     """
     RPA correlation and total energy
 
     Args:
         Lpq : density fitting 3-center integral in MO basis.
         nw : number of frequency point on imaginary axis.
-        vhf_df : using density fitting integral to compute HF exchange.
+        x0: scaling factor for frequency grid.
 
     Returns:
         e_tot : RPA total energy
@@ -63,7 +63,7 @@ def kernel(rpa, mo_energy, mo_coeff, Lpq=None, nw=None, verbose=logger.NOTE):
         Lpq = rpa.ao2mo(mo_coeff)
 
     # Grids for integration on imaginary axis
-    freqs, wts = _get_scaled_legendre_roots(nw)
+    freqs, wts = _get_scaled_legendre_roots(nw, x0)
 
     # Compute HF exchange energy (EXX)
     dm = mf.make_rdm1()
@@ -222,13 +222,14 @@ class RPA(lib.StreamObject):
     get_nmo = get_nmo
     get_frozen_mask = get_frozen_mask
 
-    def kernel(self, mo_energy=None, mo_coeff=None, Lpq=None, nw=40):
+    def kernel(self, mo_energy=None, mo_coeff=None, Lpq=None, nw=40, x0=0.5):
         """
         Args:
             mo_energy : 1D array (nmo), mean-field mo energy
             mo_coeff : 2D array (nmo, nmo), mean-field mo coefficient
             Lpq : 3D array (naux, nmo, nmo), 3-index ERI
             nw: interger, grid number
+            x0: real, scaling factor for frequency grid
 
         Returns:
             self.e_tot : RPA total eenrgy
@@ -243,7 +244,7 @@ class RPA(lib.StreamObject):
         cput0 = (logger.process_clock(), logger.perf_counter())
         self.dump_flags()
         self.e_tot, self.e_hf, self.e_corr = \
-                        kernel(self, mo_energy, mo_coeff, Lpq=Lpq, nw=nw, verbose=self.verbose)
+                        kernel(self, mo_energy, mo_coeff, Lpq=Lpq, nw=nw, x0=x0, verbose=self.verbose)
 
         logger.timer(self, 'RPA', *cput0)
         return self.e_corr

--- a/pyscf/gw/urpa.py
+++ b/pyscf/gw/urpa.py
@@ -40,14 +40,14 @@ einsum = lib.einsum
 # core routines, kernel, rpa_ecorr, rho_response
 # ****************************************************************************
 
-def kernel(rpa, mo_energy, mo_coeff, Lpq=None, nw=None, verbose=logger.NOTE):
+def kernel(rpa, mo_energy, mo_coeff, Lpq=None, nw=None, x0=None, verbose=logger.NOTE):
     """
     RPA correlation and total energy
 
     Args:
         Lpq : density fitting 3-center integral in MO basis.
         nw : number of frequency point on imaginary axis.
-        vhf_df : using density fitting integral to compute HF exchange.
+        x0: scaling factor for frequency grid.
 
     Returns:
         e_tot : RPA total energy
@@ -64,7 +64,7 @@ def kernel(rpa, mo_energy, mo_coeff, Lpq=None, nw=None, verbose=logger.NOTE):
         Lpq = rpa.ao2mo(mo_coeff)
 
     # Grids for integration on imaginary axis
-    freqs, wts = _get_scaled_legendre_roots(nw)
+    freqs, wts = _get_scaled_legendre_roots(nw, x0)
 
     # Compute HF exchange energy (EXX)
     dm = mf.make_rdm1()
@@ -153,13 +153,14 @@ class URPA(RPA):
     get_nmo = get_nmo
     get_frozen_mask = get_frozen_mask
 
-    def kernel(self, mo_energy=None, mo_coeff=None, Lpq=None, nw=40):
+    def kernel(self, mo_energy=None, mo_coeff=None, Lpq=None, nw=40, x0=0.5):
         """
         Args:
             mo_energy : 2D array (2, nmo), mean-field mo energy
             mo_coeff : 3D array (2, nmo, nmo), mean-field mo coefficient
             Lpq : 4D array (2, naux, nmo, nmo), 3-index ERI
             nw: interger, grid number
+            x0: real, scaling factor for frequency grid
 
         Returns:
             self.e_tot : RPA total eenrgy
@@ -174,7 +175,7 @@ class URPA(RPA):
         cput0 = (logger.process_clock(), logger.perf_counter())
         self.dump_flags()
         self.e_tot, self.e_hf, self.e_corr = \
-                        kernel(self, mo_energy, mo_coeff, Lpq=Lpq, nw=nw, verbose=self.verbose)
+                        kernel(self, mo_energy, mo_coeff, Lpq=Lpq, nw=nw, x0=x0, verbose=self.verbose)
 
         logger.timer(self, 'RPA', *cput0)
         return self.e_corr

--- a/pyscf/gw/urpa.py
+++ b/pyscf/gw/urpa.py
@@ -40,7 +40,7 @@ einsum = lib.einsum
 # core routines, kernel, rpa_ecorr, rho_response
 # ****************************************************************************
 
-def kernel(rpa, mo_energy, mo_coeff, Lpq=None, nw=None, x0=None, verbose=logger.NOTE):
+def kernel(rpa, mo_energy, mo_coeff, Lpq=None, nw=40, x0=0.5, verbose=logger.NOTE):
     """
     RPA correlation and total energy
 


### PR DESCRIPTION
The frequency integration grid used in RPA calculations is determined by two parameters: number of points and scaling factor. However, only the number of frequency points served as an input parameter that could be varied in the RPA calculation. I have added the possibility to vary the scaling factor as well.