### PR TITLE
Cleanup logging messages for SACASSCF module

### DIFF
--- a/pyscf/fci/test/test_spin_op.py
+++ b/pyscf/fci/test/test_spin_op.py
@@ -106,9 +106,8 @@ class KnownValues(unittest.TestCase):
         na = fci.cistring.num_strings(norb, nelec[0])
         c0 = numpy.zeros((na,na))
         c0[0,0] = 1
-        c0[-1,-1] = 1e-4
         e, ci0 = fci.direct_spin0.kernel(h1, h2, norb, nelec, ci0=c0,
-                                         conv_tol=1e-8)
+                                         conv_tol=1e-9)
 
         fci.direct_spin0.contract_2e = bak0
         fci.direct_spin1.contract_2e = bak1

--- a/pyscf/grad/lagrange.py
+++ b/pyscf/grad/lagrange.py
@@ -147,22 +147,25 @@ class Gradients (rhf_grad.GradientsMixin):
 
         self.converged, self.Lvec, bvec, Aop, Adiag = self.solve_lagrange (
             level_shift=level_shift, **kwargs)
-        self.debug_lagrange (self.Lvec, bvec, Aop, Adiag, **kwargs)
-        cput1 = logger.timer (self, 'Lagrange gradient multiplier solution', *cput0)
+        if self.verbose >= logger.INFO:
+            self.debug_lagrange (self.Lvec, bvec, Aop, Adiag, **kwargs)
+            cput1 = logger.timer (self, 'Lagrange gradient multiplier solution', *cput0)
 
         ham_response = self.get_ham_response (**kwargs)
-        logger.info(self, '--------------- %s gradient Hamiltonian response ---------------',
-                    self.base.__class__.__name__)
-        rhf_grad._write(self, self.mol, ham_response, self.atmlst)
-        logger.info(self, '----------------------------------------------')
-        cput1 = logger.timer (self, 'Lagrange gradient Hellmann-Feynman determination', *cput1)
+        if self.verbose >= logger.INFO:
+            logger.info(self, '--------------- %s gradient Hamiltonian response ---------------',
+                        self.base.__class__.__name__)
+            rhf_grad._write(self, self.mol, ham_response, self.atmlst)
+            logger.info(self, '----------------------------------------------')
+            cput1 = logger.timer (self, 'Lagrange gradient Hellmann-Feynman determination', *cput1)
 
         LdotJnuc = self.get_LdotJnuc (self.Lvec, **kwargs)
-        logger.info(self, '--------------- %s gradient Lagrange response ---------------',
-                    self.base.__class__.__name__)
-        rhf_grad._write(self, self.mol, LdotJnuc, self.atmlst)
-        logger.info(self, '----------------------------------------------')
-        cput1 = logger.timer (self, 'Lagrange gradient Jacobian', *cput1)
+        if self.verbose >= logger.INFO:
+            logger.info(self, '--------------- %s gradient Lagrange response ---------------',
+                        self.base.__class__.__name__)
+            rhf_grad._write(self, self.mol, LdotJnuc, self.atmlst)
+            logger.info(self, '----------------------------------------------')
+            cput1 = logger.timer (self, 'Lagrange gradient Jacobian', *cput1)
 
         self.de = ham_response + LdotJnuc
         log.timer('Lagrange gradients', *cput0)

--- a/pyscf/grad/sacasscf.py
+++ b/pyscf/grad/sacasscf.py
@@ -579,6 +579,8 @@ class Gradients (lagrange.Gradients):
         elif eris is None:
             eris = self.eris
         fcasscf_grad = casscf_grad.Gradients (self.make_fcasscf (state))
+        # Mute some misleading messages
+        fcasscf_grad._finalize = lambda: None
         return fcasscf_grad.kernel (mo_coeff=mo, ci=ci[state], atmlst=atmlst, verbose=verbose)
 
     def get_LdotJnuc (self, Lvec, state=None, atmlst=None, verbose=None, mo=None, ci=None,


### PR DESCRIPTION
The output message of SA-CASSCF Gradients is a little bit misleading. This PR screens irrelevant output.
Fix #1668 