### PR TITLE
Parsing of command line arguments disabled by default

### DIFF
--- a/pyscf/__config__.py
+++ b/pyscf/__config__.py
@@ -10,6 +10,7 @@ DEBUG = False
 MAX_MEMORY = int(os.environ.get('PYSCF_MAX_MEMORY', 4000)) # MB
 TMPDIR = os.environ.get('TMPDIR', '.')
 TMPDIR = os.environ.get('PYSCF_TMPDIR', TMPDIR)
+ARGPARSE = bool(os.getenv('PYSCF_ARGPARSE', False))
 
 VERBOSE = 3  # default logger level (logger.NOTE)
 UNIT = 'angstrom'

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2430,7 +2430,7 @@ class Mole(lib.StreamObject):
         self.__dict__.update(loads(molstr).__dict__)
         return self
 
-    def build(self, dump_input=True, parse_arg=True,
+    def build(self, dump_input=True, parse_arg=False,
               verbose=None, output=None, max_memory=None,
               atom=None, basis=None, unit=None, nucmod=None, ecp=None,
               charge=None, spin=0, symmetry=None, symmetry_subgroup=None,

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -103,6 +103,7 @@ DISABLE_EVAL = getattr(__config__, 'DISABLE_EVAL', False)
 # Whether to disable the explicit call to gc.collect(). gc.collect() may cause
 # non-negligible overhead (https://github.com/pyscf/pyscf/issues/1038).
 DISABLE_GC = getattr(__config__, 'DISABLE_GC', False)
+ARGPARSE = getattr(__config__, 'ARGPARSE', False)
 
 def M(**kwargs):
     r'''This is a shortcut to build up Mole object.
@@ -2430,7 +2431,7 @@ class Mole(lib.StreamObject):
         self.__dict__.update(loads(molstr).__dict__)
         return self
 
-    def build(self, dump_input=True, parse_arg=False,
+    def build(self, dump_input=True, parse_arg=ARGPARSE,
               verbose=None, output=None, max_memory=None,
               atom=None, basis=None, unit=None, nucmod=None, ecp=None,
               charge=None, spin=0, symmetry=None, symmetry_subgroup=None,

--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -1288,7 +1288,7 @@ class Cell(mole.Mole):
         return mesh1
 
 #Note: Exculde dump_input, parse_arg, basis from kwargs to avoid parsing twice
-    def build(self, dump_input=True, parse_arg=True,
+    def build(self, dump_input=True, parse_arg=False,
               a=None, mesh=None, ke_cutoff=None, precision=None, nimgs=None,
               pseudo=None, basis=None, h=None, dimension=None, rcut= None,
               ecp=None, low_dim_ft_type=None,

--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -1288,7 +1288,7 @@ class Cell(mole.Mole):
         return mesh1
 
 #Note: Exculde dump_input, parse_arg, basis from kwargs to avoid parsing twice
-    def build(self, dump_input=True, parse_arg=False,
+    def build(self, dump_input=True, parse_arg=mole.ARGPARSE,
               a=None, mesh=None, ke_cutoff=None, precision=None, nimgs=None,
               pseudo=None, basis=None, h=None, dimension=None, rcut= None,
               ecp=None, low_dim_ft_type=None,


### PR DESCRIPTION
Changed the default value of `parse_arg` to `False` in `Mole.build()` and `Cell.build()`.