### PR TITLE
fix chemcore bug when ecp exists

### DIFF
--- a/examples/cc/11-frozen_core.py
+++ b/examples/cc/11-frozen_core.py
@@ -69,13 +69,13 @@ print('CCSD correlation energy', mycc.e_corr)
 # number of elec screened by ECP > number of chemical core electrons
 #
 mol = gto.M(
-    atom = 'Mg 0 0 0',
-    basis = 'def2-svp')
+    atom = 'Xe 0 0 0',
+    basis = 'cc-pvtz-dk')
 mf = scf.RHF(mol).run()
 mycc = cc.CCSD(mf)
 mycc.set_frozen()
 print('Number of core orbital frozen: %d' % mycc.frozen)
-mol.set(basis='lanl2dz', ecp='lanl2dz').build()
+mol.set(basis='def2-svp', ecp='def2-svp').build()
 mf = scf.RHF(mol).run()
 mycc = cc.CCSD(mf)
 mycc.set_frozen()

--- a/pyscf/data/elements.py
+++ b/pyscf/data/elements.py
@@ -1102,13 +1102,12 @@ def chemcore(mol, spinorb=False):
         atm_nelec = mol.atom_charge(a)
         atm_z = charge(mol.atom_symbol(a))
         ne_ecp = atm_z - atm_nelec
+        ncore_ecp = ne_ecp // 2
         atm_ncore = chemcore_atm[atm_z]
-        if ne_ecp == 0:
-            core += atm_ncore
-        elif ne_ecp > atm_ncore:
+        if ncore_ecp > atm_ncore:
             core += 0
         else:
-            core += atm_ncore - ne_ecp
+            core += atm_ncore - ncore_ecp
 
     if spinorb:
         core *= 2


### PR DESCRIPTION
There's a bug in the previous pr #1311. `ne_ecp` should be divided by 2 to give the number of core orbitals screened by ecp.