### PR TITLE
smearing for ROHF and fix_spin=True

### DIFF
--- a/pyscf/pbc/scf/addons.py
+++ b/pyscf/pbc/scf/addons.py
@@ -57,7 +57,7 @@ def project_mo_nr2nr(cell1, mo1, cell2, kpts=None):
 
 def smearing_(mf, sigma=None, method=SMEARING_METHOD, mu0=None, fix_spin=False):
     '''Fermi-Dirac or Gaussian smearing'''
-    from pyscf.scf import uhf
+    from pyscf.scf import uhf, rohf
     from pyscf.scf import ghf
     from pyscf.pbc.scf import khf
     mf_class = mf.__class__
@@ -65,9 +65,12 @@ def smearing_(mf, sigma=None, method=SMEARING_METHOD, mu0=None, fix_spin=False):
     is_ghf = isinstance(mf, ghf.GHF)
     is_rhf = (not is_uhf) and (not is_ghf)
     is_khf = isinstance(mf, khf.KSCF)
+    is_rohf = isinstance(mf, rohf.ROHF)
+    if is_rohf:
+        is_rhf = False 
 
-    if fix_spin and not is_uhf:
-        raise KeyError("fix_spin only supports UHF.")
+    if fix_spin and not (is_uhf or is_rohf):
+        raise KeyError("fix_spin only supports UHF and ROHF.")
     if fix_spin and mu0 is not None:
         raise KeyError("fix_spin does not support fix mu0")
 
@@ -93,6 +96,8 @@ def smearing_(mf, sigma=None, method=SMEARING_METHOD, mu0=None, fix_spin=False):
 
         This is a k-point version of scf.hf.SCF.get_occ
         '''
+        if is_rohf and fix_spin:
+            mo_energy_kpts=(mo_energy_kpts,mo_energy_kpts)
         kpts = getattr(mf, 'kpts', None)
         if isinstance(kpts, KPoints):
             mo_energy_kpts = kpts.transform_mo_energy(mo_energy_kpts)
@@ -113,7 +118,7 @@ def smearing_(mf, sigma=None, method=SMEARING_METHOD, mu0=None, fix_spin=False):
             nelectron = mf.mol.tot_electrons(nkpts)
         else:
             nelectron = mf.mol.tot_electrons()
-        if is_uhf:
+        if is_uhf or (is_rohf and fix_spin):
             nocc = nelectron
             if fix_spin:
                 nocc = mf.nelec
@@ -150,7 +155,7 @@ def smearing_(mf, sigma=None, method=SMEARING_METHOD, mu0=None, fix_spin=False):
         if mu0 is None:
             def nelec_cost_fn(m, _mo_es, _nelectron):
                 mo_occ_kpts = f_occ(m, _mo_es, sigma)
-                if is_rhf:
+                if is_rhf and not is_rohf:
                     mo_occ_kpts *= 2
                 return (mo_occ_kpts.sum() - _nelectron)**2
             if fix_spin:
@@ -244,6 +249,8 @@ def smearing_(mf, sigma=None, method=SMEARING_METHOD, mu0=None, fix_spin=False):
             tools.print_mo_energy_occ_kpts(mf,mo_energy_kpts,mo_occ_kpts,is_uhf)
         else:
             tools.print_mo_energy_occ(mf,mo_energy_kpts,mo_occ_kpts,is_uhf)
+        if is_rohf and fix_spin:
+            mo_occ_kpts=mo_occ_kpts[0]+mo_occ_kpts[1]
         return mo_occ_kpts
 
     def get_grad_tril(mo_coeff_kpts, mo_occ_kpts, fock):

--- a/pyscf/pbc/scf/addons.py
+++ b/pyscf/pbc/scf/addons.py
@@ -67,7 +67,7 @@ def smearing_(mf, sigma=None, method=SMEARING_METHOD, mu0=None, fix_spin=False):
     is_khf = isinstance(mf, khf.KSCF)
     is_rohf = isinstance(mf, rohf.ROHF)
     if is_rohf:
-        is_rhf = False 
+        is_rhf = False
 
     if fix_spin and not (is_uhf or is_rohf):
         raise KeyError("fix_spin only supports UHF and ROHF.")

--- a/pyscf/pbc/scf/test/test_addons.py
+++ b/pyscf/pbc/scf/test/test_addons.py
@@ -376,13 +376,12 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(kmf.e_free, 1.3942942592412, 9)
         self.assertAlmostEqual(lib.fp(kmf.mo_occ), 0.035214493032250, 9)
 
-
     def test_rohf_smearing(self):
         from pyscf import gto, scf
         import sys
         # Fe2 from https://doi.org/10.1021/acs.jpca.1c05769
         mol = gto.M(
-        atom='''
+            atom='''
         Fe       0. 0. 0.
         Fe       2.01 0. 0.
         ''', basis="lanl2dz", ecp="lanl2dz", symmetry=False, unit='Angstrom',
@@ -390,15 +389,17 @@ class KnownValues(unittest.TestCase):
         myhf = scf.ROHF(mol).newton()
         myhf.kernel()
         # -244.96420350069377 on python 3.8 and 3.9
-        # -244.37255692969057 on python 3.7 
+        # -244.37255692969057 on macos py3.7 (github CI)
+        # -244.37254314207422 on macos py3.7 (github CI), repeat
+        # -244.3724387756635 on linux-build py3.7 (github CI)
         if sys.version_info.minor == 7:
-            self.assertAlmostEqual(myhf.e_tot, -244.3725569, 6)
+            self.assertAlmostEqual(myhf.e_tot, -244.3725, 3)
         else:
             self.assertAlmostEqual(myhf.e_tot, -244.9642035, 6)
         myhf_s = scf.ROHF(mol)
         myhf_s = pscf.addons.smearing_(myhf_s, sigma=0.01, method='gaussian', fix_spin=True)
         myhf_s.kernel()
-        self.assertAlmostEqual(myhf_s.e_tot, -242.4828982, 6)
+        self.assertAlmostEqual(myhf_s.e_tot, -242.4828, 4)
         self.assertAlmostEqual(myhf_s.entropy, 0.45197, 4)
         myhf2 = scf.ROHF(mol)
         myhf2.max_cycle = 600
@@ -406,7 +407,6 @@ class KnownValues(unittest.TestCase):
         myhf2.kernel(myhf_s.make_rdm1())
         # note 16mHa lower energy than myhf
         self.assertAlmostEqual(myhf2.e_tot, -244.9808750, 6)
-        
 
 
 if __name__ == '__main__':

--- a/pyscf/pbc/scf/test/test_addons.py
+++ b/pyscf/pbc/scf/test/test_addons.py
@@ -379,6 +379,7 @@ class KnownValues(unittest.TestCase):
 
     def test_rohf_smearing(self):
         from pyscf import gto, scf
+        import sys
         # Fe2 from https://doi.org/10.1021/acs.jpca.1c05769
         mol = gto.M(
         atom='''
@@ -388,18 +389,23 @@ class KnownValues(unittest.TestCase):
             spin=6, charge=0, verbose=0)
         myhf = scf.ROHF(mol).newton()
         myhf.kernel()
-        self.assertAlmostEqual(myhf.e_tot, -244.96420350069377, 6)
+        # -244.96420350069377 on python 3.8 and 3.9
+        # -244.37255692969057 on python 3.7 
+        if sys.version_info.minor == 7:
+            self.assertAlmostEqual(myhf.e_tot, -244.9642035, 6)
+        else:
+            self.assertAlmostEqual(myhf.e_tot, -244.3725569, 6)
         myhf_s = scf.ROHF(mol)
         myhf_s = pscf.addons.smearing_(myhf_s, sigma=0.01, method='gaussian', fix_spin=True)
         myhf_s.kernel()
-        self.assertAlmostEqual(myhf_s.e_tot, -242.48289824695684, 6)
-        self.assertAlmostEqual(myhf_s.entropy, 0.45197250690850654, 4)
+        self.assertAlmostEqual(myhf_s.e_tot, -242.4828982, 6)
+        self.assertAlmostEqual(myhf_s.entropy, 0.45197, 4)
         myhf2 = scf.ROHF(mol)
         myhf2.max_cycle = 600
         myhf2 = myhf2.newton()
         myhf2.kernel(myhf_s.make_rdm1())
         # note 16mHa lower energy than myhf
-        self.assertAlmostEqual(myhf2.e_tot, -244.98087503558844, 6)
+        self.assertAlmostEqual(myhf2.e_tot, -244.9808750, 6)
         
 
 

--- a/pyscf/pbc/scf/test/test_addons.py
+++ b/pyscf/pbc/scf/test/test_addons.py
@@ -392,9 +392,9 @@ class KnownValues(unittest.TestCase):
         # -244.96420350069377 on python 3.8 and 3.9
         # -244.37255692969057 on python 3.7 
         if sys.version_info.minor == 7:
-            self.assertAlmostEqual(myhf.e_tot, -244.9642035, 6)
-        else:
             self.assertAlmostEqual(myhf.e_tot, -244.3725569, 6)
+        else:
+            self.assertAlmostEqual(myhf.e_tot, -244.9642035, 6)
         myhf_s = scf.ROHF(mol)
         myhf_s = pscf.addons.smearing_(myhf_s, sigma=0.01, method='gaussian', fix_spin=True)
         myhf_s.kernel()

--- a/pyscf/pbc/scf/test/test_addons.py
+++ b/pyscf/pbc/scf/test/test_addons.py
@@ -399,7 +399,9 @@ class KnownValues(unittest.TestCase):
         myhf_s = scf.ROHF(mol)
         myhf_s = pscf.addons.smearing_(myhf_s, sigma=0.01, method='gaussian', fix_spin=True)
         myhf_s.kernel()
-        self.assertAlmostEqual(myhf_s.e_tot, -242.4828, 4)
+        # macos py3.7 CI -242.4828982467762
+        # linux py3.11 CI -242.48289824670388
+        self.assertAlmostEqual(myhf_s.e_tot, -242.482898246, 6)
         self.assertAlmostEqual(myhf_s.entropy, 0.45197, 4)
         myhf2 = scf.ROHF(mol)
         myhf2.max_cycle = 600

--- a/pyscf/pbc/scf/test/test_addons.py
+++ b/pyscf/pbc/scf/test/test_addons.py
@@ -397,7 +397,7 @@ class KnownValues(unittest.TestCase):
         myhf2 = scf.ROHF(mol)
         myhf2.max_cycle = 600
         myhf2 = myhf2.newton()
-        myhf2.kernel(myhf.make_rdm1())
+        myhf2.kernel(myhf_s.make_rdm1())
         # note 16mHa lower energy than myhf
         self.assertAlmostEqual(myhf2.e_tot, -244.98087503558844, 6)
         


### PR DESCRIPTION
For ROHF and spin>0, PySCF's smearing function produces incorrect results (and drives spin to 0), because it assumes the meaning of the occupation vector as in RHF. I propose a solution where the smearing function is applied separately to alpha and beta occupations which are later added up to produce the ROHF occupation vector. This is obviously wrong for low multiplicities and high smearing sigma, but it's "almost" accurate for high enough multiplicity and low enough sigma.
This is my test case:
```
from pyscf import gto, scf
from pyscf.scf.addons import smearing_

mol = gto.M(
    atom = '''
Fe      -1.301259682     -0.271152073      0.000000000
Fe       0.741101210     -0.199078285      1.084788423
Fe       0.741101210     -0.199078285     -1.084788423

''',basis="lanl2dz",ecp="lanl2dz",symmetry=False,unit='Angstrom',
            spin=4,charge=0,verbose=4)
myhf = scf.ROHF(mol)
myhf.max_cycle = 600 

smearhf = smearing_(myhf, sigma=0.005, fix_spin=True)
smearhf.kernel()
```