### PR TITLE
Support complex-valued h1e in fci_slow.absorb_h1e

### DIFF
--- a/pyscf/fci/direct_nosym.py
+++ b/pyscf/fci/direct_nosym.py
@@ -118,7 +118,7 @@ def absorb_h1e(h1e, eri, norb, nelec, fac=1):
     '''
     if not isinstance(nelec, (int, numpy.number)):
         nelec = sum(nelec)
-    h2e = ao2mo.restore(1, eri.copy(), norb)
+    h2e = ao2mo.restore(1, eri.copy(), norb).astype(h1e.dtype, copy=False)
     f1e = h1e - numpy.einsum('jiik->jk', h2e) * .5
     f1e = f1e * (1./(nelec+1e-100))
     for k in range(norb):

--- a/pyscf/fci/fci_slow.py
+++ b/pyscf/fci/fci_slow.py
@@ -131,7 +131,7 @@ def absorb_h1e(h1e, eri, norb, nelec, fac=1):
     '''
     if not isinstance(nelec, (int, numpy.integer)):
         nelec = sum(nelec)
-    h2e = ao2mo.restore(1, eri.copy(), norb)
+    h2e = ao2mo.restore(1, eri.copy(), norb).astype(h1e.dtype, copy=False)
     f1e = h1e - numpy.einsum('jiik->jk', h2e) * .5
     f1e = f1e * (1./(nelec+1e-100))
     for k in range(norb):

--- a/pyscf/fci/test/test_direct_nosym.py
+++ b/pyscf/fci/test/test_direct_nosym.py
@@ -65,6 +65,11 @@ class KnownValues(unittest.TestCase):
         h1 = fci.direct_nosym.absorb_h1e(h1e, h2e, norb, nelec)
         self.assertTrue(numpy.allclose(href, h1))
 
+    def test_absorb_h1e_complex(self):
+        href = fci_slow.absorb_h1e(h1e.astype(complex), h2e, norb, nelec)
+        h1 = fci.direct_nosym.absorb_h1e(h1e.astype(complex), h2e, norb, nelec)
+        self.assertTrue(numpy.allclose(href, h1))
+
     def test_kernel(self):
         h1 = h1e + h1e.T
         eri = .5* ao2mo.restore(1, ao2mo.restore(8, h2e, norb), norb)


### PR DESCRIPTION
Makes `fci_slow.absorb_h1e` accept a complex-valued `h1e`. I made the same change to `direct_nosym.absorb_h1e`. May I ask, why do both functions exist? They appear identical.