### PR TITLE
GHF density fitting

### DIFF
--- a/pyscf/cc/test/test_gccsd.py
+++ b/pyscf/cc/test/test_gccsd.py
@@ -181,6 +181,7 @@ class KnownValues(unittest.TestCase):
     def test_rdm_real(self):
         nocc = 6
         nvir = 10
+        mol = gto.M()
         mf = scf.GHF(mol)
         nmo = nocc + nvir
         npair = nmo*(nmo//2+1)//4

--- a/pyscf/df/df_jk.py
+++ b/pyscf/df/df_jk.py
@@ -124,8 +124,16 @@ def density_fit(mf, auxbasis=None, with_df=None, only_dfj=False):
             with_dfk = with_k and not self.only_dfj
             if isinstance(self, scf.ghf.GHF):
                 def jkbuild(mol, dm, hermi, with_j, with_k, omega=None):
-                    return self.with_df.get_jk(dm, hermi, with_j, with_k,
-                                               self.direct_scf_tol, omega)
+                    vj, vk = self.with_df.get_jk(dm.real, hermi, with_j, with_k,
+                                                 self.direct_scf_tol, omega)
+                    if dm.dtype == numpy.complex128:
+                        vjI, vkI = self.with_df.get_jk(dm.imag, hermi, with_j, with_k,
+                                                       self.direct_scf_tol, omega)
+                        if with_j:
+                            vj = vj + vjI * 1j
+                        if with_k:
+                            vk = vk + vkI * 1j
+                    return vj, vk
                 vj, vk = scf.ghf.get_jk(mol, dm, hermi, with_j, with_dfk,
                                         jkbuild, omega)
             else:

--- a/pyscf/scf/ghf.py
+++ b/pyscf/scf/ghf.py
@@ -442,7 +442,8 @@ class GHF(hf.SCF):
         if dm is None: dm = self.make_rdm1()
         nao = mol.nao
         dm = numpy.asarray(dm)
-        if dm.shape[-1] != nao * 2:
+        # nao = 0 for HF with custom Hamiltonian
+        if dm.shape[-1] != nao * 2 and nao != 0:
             raise ValueError('Dimension inconsistent '
                              f'dm.shape = {dm.shape}, mol.nao = {nao}')
 

--- a/pyscf/scf/ghf.py
+++ b/pyscf/scf/ghf.py
@@ -442,20 +442,14 @@ class GHF(hf.SCF):
         if dm is None: dm = self.make_rdm1()
         nao = mol.nao
         dm = numpy.asarray(dm)
+        if dm.shape[-1] != nao * 2:
+            raise ValueError('Dimension inconsistent '
+                             f'dm.shape = {dm.shape}, mol.nao = {nao}')
 
         def jkbuild(mol, dm, hermi, with_j, with_k, omega=None):
-            if (not omega and
-                (self._eri is not None or mol.incore_anyway or self._is_mem_enough())):
-                if self._eri is None:
-                    self._eri = mol.intor('int2e', aosym='s8')
-                return hf.dot_eri_dm(self._eri, dm, hermi, with_j, with_k)
-            else:
-                return hf.SCF.get_jk(self, mol, dm, hermi, with_j, with_k, omega)
+            return hf.RHF.get_jk(self, mol, dm, hermi, with_j, with_k, omega)
 
-        if nao == dm.shape[-1]:
-            vj, vk = jkbuild(mol, dm, hermi, with_j, with_k, omega)
-        else:  # GHF density matrix, shape (2N,2N)
-            vj, vk = get_jk(mol, dm, hermi, with_j, with_k, jkbuild, omega)
+        vj, vk = get_jk(mol, dm, hermi, with_j, with_k, jkbuild, omega)
         return vj, vk
 
     def get_veff(self, mol=None, dm=None, dm_last=0, vhf_last=0, hermi=1):
@@ -554,29 +548,3 @@ def _from_rhf_init_dm(dm, breaksym=True):
 
 class HF1e(GHF):
     scf = hf._hf1e_scf
-
-
-del (PRE_ORTH_METHOD)
-
-
-if __name__ == '__main__':
-    mol = gto.Mole()
-    mol.verbose = 3
-    mol.atom = 'H 0 0 0; H 0 0 1; O .5 .6 .2'
-    mol.basis = 'ccpvdz'
-    mol.build()
-
-    mf = GHF(mol)
-    mf.kernel()
-
-    dm = mf.init_guess_by_1e(mol)
-    dm = dm + 0j
-    nao = mol.nao_nr()
-    numpy.random.seed(12)
-    dm[:nao,nao:] = numpy.random.random((nao,nao)) * .1j
-    dm[nao:,:nao] = dm[:nao,nao:].T.conj()
-    mf.kernel(dm)
-    mf.canonicalize(mf.mo_coeff, mf.mo_occ)
-    mf.analyze()
-    print(mf.spin_square())
-    print(mf.e_tot - -75.9125824421352)

--- a/pyscf/scf/test/test_ghf.py
+++ b/pyscf/scf/test/test_ghf.py
@@ -140,6 +140,7 @@ class KnownValues(unittest.TestCase):
         dm[nao:,:nao] = dm[:nao,nao:].T.conj()
         mf1.kernel(dm)
         self.assertAlmostEqual(mf1.e_tot, mf.e_tot, 9)
+        self.assertAlmostEqual(mf1.e_tot, -76.02676567312, 9)
 
     def test_get_veff(self):
         nao = mol.nao_nr()*2
@@ -229,6 +230,9 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(ss, 3.9543837879512358, 9)
         ssref = spin_square(mol, mo)
         self.assertAlmostEqual(ssref, ss, 9)
+
+        # Test the call to spin_square() in ghf.analyze()
+        mf.analyze()
 
     def test_canonicalize(self):
         mo = mf.mo_coeff + 0j

--- a/pyscf/scf/test/test_ghf.py
+++ b/pyscf/scf/test/test_ghf.py
@@ -193,17 +193,6 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(lib.fp(vj), 254.68614111766146+0j, 9)
         self.assertAlmostEqual(lib.fp(vk), 62.08832587927003-8.640597547171135j, 9)
 
-        nao = mol.nao_nr()
-        numpy.random.seed(1)
-        d1 = numpy.random.random((nao,nao))
-        d2 = numpy.random.random((nao,nao))
-        d = (d1+d1.T, d2+d2.T)
-        vj, vk = mf.get_jk(mol, d)
-        self.assertEqual(vj.shape, (2,nao,nao))
-        self.assertEqual(vk.shape, (2,nao,nao))
-        self.assertAlmostEqual(lib.fp(vj), -388.17756605981504, 9)
-        self.assertAlmostEqual(lib.fp(vk), -84.276190743451622, 9)
-
     def test_spin_square(self):
         nao = mol.nao_nr()
         s = mol.intor('int1e_ovlp')

--- a/pyscf/scf/test/test_h2o.py
+++ b/pyscf/scf/test/test_h2o.py
@@ -106,6 +106,11 @@ class KnownValues(unittest.TestCase):
         uhf.conv_tol = 1e-11
         self.assertAlmostEqual(uhf.scf(), -75.983210886950, 9)
 
+    def test_nr_df_ghf(self):
+        mf = mol.GHF().density_fit(auxbasis='weigend')
+        mf.conv_tol = 1e-11
+        self.assertAlmostEqual(mf.scf(), -75.983210886950, 9)
+
     def test_nr_rhf_no_mem(self):
         rhf = scf.RHF(mol)
         rhf.conv_tol = 1e-11


### PR DESCRIPTION
This PR fixes a few bugs related to matrix and tensor shape in GHF method:
* GHF density fitting crashes due to shape mismatch;
* GHF.as_scanner method fails to use initial guess from previous results.