### PR TITLE
Fixed the numerical issue in df hessian when the overlap matrix is ill-conditioned

### DIFF
--- a/pyscf/df/hessian/rhf.py
+++ b/pyscf/df/hessian/rhf.py
@@ -174,15 +174,7 @@ def _partial_hess_ejk(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
         get_int3c_ipip2 = _int3c_wrapper(mol, auxmol, 'int3c2e_ipip2', 's1')
         rhok0_P__ = lib.einsum('plj,li->pij', rhok0_Pl_, mocc_2)
         rho2c_0 = lib.einsum('pij,qji->pq', rhok0_P__, rhok0_P__)
-
-        try:
-            int2c_inv = np.linalg.inv(int2c)
-        except scipy.linalg.LinAlgError:
-            w, v = scipy.linalg.eigh(int2c)
-            mask = w > LINEAR_DEP_THRESHOLD
-            v1 = v[:,mask]
-            int2c_inv = lib.dot(v1/w[mask], v1.conj().T)
-            v1 = None
+        int2c_inv = numpy.linalg.pinv(int2c, rcond=LINEAR_DEP_THRESHOLD)
         int2c_ipip1 = auxmol.intor('int2c2e_ipip1', aosym='s1')
         int2c_ip_ip  = lib.einsum('xpq,qr,ysr->xyps', int2c_ip1, int2c_inv, int2c_ip1)
         int2c_ip_ip -= auxmol.intor('int2c2e_ip1ip2', aosym='s1').reshape(3,3,naux,naux)

--- a/pyscf/df/hessian/uhf.py
+++ b/pyscf/df/hessian/uhf.py
@@ -197,15 +197,7 @@ def _partial_hess_ejk(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
         rhok0b_P__ = lib.einsum('plj,li->pij', rhok0b_Pl_, moccb)
         rho2c_0  = lib.einsum('pij,qij->pq', rhok0a_P__, rhok0a_P__)
         rho2c_0 += lib.einsum('pij,qij->pq', rhok0b_P__, rhok0b_P__)
-
-        try:
-            int2c_inv = np.linalg.inv(int2c)
-        except scipy.linalg.LinAlgError:
-            w, v = scipy.linalg.eigh(int2c)
-            mask = w > LINEAR_DEP_THRESHOLD
-            v1 = v[:,mask]
-            int2c_inv = lib.dot(v1/w[mask], v1.conj().T)
-            v1 = None
+        int2c_inv = numpy.linalg.pinv(int2c, rcond=LINEAR_DEP_THRESHOLD)
         int2c_ipip1 = auxmol.intor('int2c2e_ipip1', aosym='s1')
         int2c_ip_ip  = lib.einsum('xpq,qr,ysr->xyps', int2c_ip1, int2c_inv, int2c_ip1)
         int2c_ip_ip -= auxmol.intor('int2c2e_ip1ip2', aosym='s1').reshape(3,3,naux,naux)

--- a/pyscf/df/test/test_df_hessian.py
+++ b/pyscf/df/test/test_df_hessian.py
@@ -62,21 +62,35 @@ class KnownValues(unittest.TestCase):
         h1 = df_h.kernel()
         self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
+    def test_rks_mgga_hess(self):
+        href = mol.RKS.run(xc='m06').Hessian().kernel()
+        df_h = mol.RKS.density_fit().run(xc='m06').Hessian()
+        df_h.auxbasis_response = 2
+        h1 = df_h.kernel()
+        self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
+
     def test_rks_rsh_hess(self):
         href = mol.RKS.run(xc='camb3lyp').Hessian().kernel()
-        h1 = mol.RKS.density_fit().run(xc='camb3lyp').Hessian().kernel()
-        self.assertAlmostEqual(abs(href - h1).max(), 0, 3)
+        df_h = mol.RKS.density_fit().run(xc='camb3lyp').Hessian()
+        df_h.auxbasis_response = 2
+        h1 = df_h.kernel()
+        self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
     def test_uhf_hess(self):
         href = scf.UHF(mol).run().Hessian().kernel()
-        h1 = scf.UHF(mol).density_fit().run().Hessian().kernel()
-        self.assertAlmostEqual(abs(href - h1).max(), 0, 3)
+        df_h = scf.UHF(mol).density_fit().run().Hessian()
+        df_h.auxbasis_response = 2
+        h1 = df_h.kernel()
+        self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
     def test_uks_hess(self):
         href = mol.UKS.run(xc='camb3lyp').Hessian().kernel()
-        h1 = mol.UKS.density_fit().run(xc='camb3lyp').Hessian().kernel()
-        self.assertAlmostEqual(abs(href - h1).max(), 0, 3)
+        df_h = mol.UKS.density_fit().run(xc='camb3lyp').Hessian()
+        df_h.auxbasis_response = 2
+        h1 = df_h.kernel()
+        self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
 if __name__ == "__main__":
     print("Full Tests for df.hessian")
     unittest.main()
+


### PR DESCRIPTION
- The overlap matrix of the auxiliary basis is highly ill-conditioned, especially when omega is not zero. The ill-condition error was not raise with np.linalg.inv. Using pinv instead.
- The test cases are updated accordingly. Because of this improvement, the test case of range-separated hybrid functional with auxbasis_response = 2 can pass. And the agreement with hessian w/o df is improved from 1e-3 to 1e-4.