### PR TITLE
Bug fix for PBC DF

### DIFF
--- a/pyscf/pbc/df/rsdf_helper.py
+++ b/pyscf/pbc/df/rsdf_helper.py
@@ -36,6 +36,20 @@ from pyscf.pbc.tools import k2gamma
 
 """ General helper functions
 """
+class MoleNoBasSort(mol_gto.mole.Mole):
+    def build(self, **kwargs):
+        mol_gto.mole.Mole.build(self, **kwargs)
+
+        # sort self._bas
+        _bas = []
+        for iatm in range(self.natm):
+            atm = self.atom_symbol(iatm)
+            basin = self._basis[atm]
+            bas_ls = [b[0] for b in basin]
+            ls_uniq, ls_inv = np.unique(bas_ls, return_inverse=True)
+            order = np.argsort(np.concatenate([np.where(ls_inv==l)[0] for l in ls_uniq]))
+            _bas.append( self._bas[np.where(self._bas[:,0] == iatm)[0][order]] )
+        self._bas = np.vstack(_bas).astype(np.int32)
 def _remove_exp_basis_(bold, amin, amax):
     bnew = []
     for b in bold:
@@ -385,8 +399,8 @@ def _get_schwartz_data(bas_lst, omega, dijs_lst=None, keep1ctr=True, safe=True):
     if keep1ctr:
         bas_lst = get1ctr(bas_lst)
     if dijs_lst is None:
-        mol = mol_gto.Mole()
-        mol.build(False, False, atom="H 0 0 0", basis=bas_lst, spin=None)
+        mol = MoleNoBasSort()
+        mol.build(dump_input=False, parse_arg=False, atom="H 0 0 0", basis=bas_lst, spin=None)
         nbas = mol.nbas
         intor = "int2c2e"
         Qs = np.zeros(nbas)
@@ -400,8 +414,8 @@ def _get_schwartz_data(bas_lst, omega, dijs_lst=None, keep1ctr=True, safe=True):
             return _get_norm(
                         _fintor_sreri(mol, intor, shls_slice, omega, safe)
                     )**0.5
-        mol = mol_gto.Mole()
-        mol.build(False, False, atom="H 0 0 0; H 0 0 0", basis=bas_lst, spin=None)
+        mol = MoleNoBasSort()
+        mol.build(dump_input=False, parse_arg=False, atom="H 0 0 0", basis=bas_lst, spin=None)
         nbas = mol.nbas//2
         n2 = nbas*(nbas+1)//2
         if len(dijs_lst) != n2:
@@ -428,8 +442,8 @@ def _get_schwartz_dcut(bas_lst, omega, precision, r0=None, safe=True):
     Return:
         1d array of length nbas*(nbas+1)//2 with nbas=len(bas_lst).
     """
-    mol = mol_gto.Mole()
-    mol.build(False, False, atom="H 0 0 0; H 0 0 0", basis=bas_lst)
+    mol = MoleNoBasSort()
+    mol.build(dump_input=False, parse_arg=False, atom="H 0 0 0; H 0 0 0", basis=bas_lst)
     nbas = len(bas_lst)
     n2 = nbas*(nbas+1)//2
 
@@ -664,15 +678,15 @@ def _get_3c2e_Rcuts(bas_lst_or_mol, auxbas_lst_or_auxmol, dijs_lst, omega,
         mol = bas_lst_or_mol
     else:
         bas_lst = bas_lst_or_mol
-        mol = mol_gto.Mole()
-        mol.build(False, False, atom="H 0 0 0", basis=bas_lst, spin=None)
+        mol = MoleNoBasSort()
+        mol.build(dump_input=False, parse_arg=False, atom="H 0 0 0", basis=bas_lst, spin=None)
 
     if isinstance(auxbas_lst_or_auxmol, mol_gto.mole.Mole):
         auxmol = auxbas_lst_or_auxmol
     else:
         auxbas_lst = auxbas_lst_or_auxmol
-        auxmol = mol_gto.Mole()
-        auxmol.build(False, False, atom="H 0 0 0", basis=auxbas_lst, spin=None)
+        auxmol = MoleNoBasSort()
+        auxmol.build(dump_input=False, parse_arg=False, atom="H 0 0 0", basis=auxbas_lst, spin=None)
 
     nbas = mol.nbas
 


### PR DESCRIPTION
Two bugs are fixed in this PR:
1. In PR #[1620](https://github.com/pyscf/pyscf/pull/1620), the default behavior of Mole was changed to sort the input basis sets by angular momentum for each atom, which makes `mol._bas` and `mol._basis` not necessarily agree with each other. The mismatch causes bugs in various places in `pbc/df/rsdf_helper.py`, leading to inaccurate DF integrals when using RSDF. This PR fixes the bug. A minimal demo is provided below.
2. The PBC DF-based J-build has a bug in [L129](https://github.com/pyscf/pyscf/blob/master/pyscf/pbc/df/df_jk.py#L129). When an non-Hermitian density matrix is input, the J matrix is not Hermitian and aosymm must be False in the DF loop function. This leads to failure in e.g., k-based TDDFT calculations. This PR fixes the bug.

PBE total energy for water in a box (details below) with different DF methods.
| DF methods | Energy |
| ------------ | ------- |
| RSDF (before fix) | -76.3338831107 |
| RSDF (after fix) | -76.3338642530 |
| GDF (RS builder) | -76.3338642530 |
| GDF (CC builder) | -76.3338642530 |

``` Python
atom = '''
O          0.00000        0.00000        0.11779
H          0.00000        0.75545       -0.47116
H          0.00000       -0.75545       -0.47116
'''
basis = 'cc-pvdz'
a = np.eye(3) * 6
kmesh = [3,1,1]
cell = gto.M(atom=atom, a=a, basis=basis)
cell.precision = 1e-12
```