### PR TITLE
Remove deprecated keyword from scipy.linalg.solve

### DIFF
--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -244,7 +244,7 @@ def get_j(mf_grad, mol=None, dm=None, hermi=0):
 
     # (P|Q)
     int2c = auxmol.intor('int2c2e', aosym='s1')
-    rhoj = scipy.linalg.solve(int2c, rhoj.T, sym_pos=True).T
+    rhoj = scipy.linalg.solve(int2c, rhoj.T, assume_a='pos').T
     int2c = None
 
     # (d/dX i,j|P)

--- a/pyscf/lib/linalg_helper.py
+++ b/pyscf/lib/linalg_helper.py
@@ -1461,7 +1461,7 @@ def cho_solve(a, b, strict_sym_pos=True):
             on matrix a
     '''
     try:
-        return scipy.linalg.solve(a, b, sym_pos=True)
+        return scipy.linalg.solve(a, b, assume_a='pos')
     except numpy.linalg.LinAlgError:
         if strict_sym_pos:
             raise

--- a/pyscf/mcscf/avas.py
+++ b/pyscf/mcscf/avas.py
@@ -131,7 +131,7 @@ def _kernel(avas_obj):
         s2 = pmol.intor_symmetric('int1e_ovlp')[baslst][:,baslst]
         s21 = gto.intor_cross('int1e_ovlp', pmol, mol)[baslst]
         s21 = numpy.dot(s21, mo_coeff[:, ncore:])
-    sa = s21.T.dot(scipy.linalg.solve(s2, s21, sym_pos=True))
+    sa = s21.T.dot(scipy.linalg.solve(s2, s21, assume_a='pos'))
 
     threshold = avas_obj.threshold
     if avas_obj.openshell_option == 2:

--- a/pyscf/mp/mp2f12_slow.py
+++ b/pyscf/mp/mp2f12_slow.py
@@ -43,7 +43,7 @@ def find_cabs(mol, auxmol, lindep=1e-8):
     nao = mol.nao_nr()
     s = cabs_mol.intor_symmetric('int1e_ovlp')
 
-    ls12 = scipy.linalg.solve(s[:nao,:nao], s[:nao,nao:], sym_pos=True)
+    ls12 = scipy.linalg.solve(s[:nao,:nao], s[:nao,nao:], assume_a='pos')
     s[nao:,nao:] -= s[nao:,:nao].dot(ls12)
     w, v = scipy.linalg.eigh(s[nao:,nao:])
     c2 = v[:,w>lindep]/numpy.sqrt(w[w>lindep])

--- a/pyscf/pbc/scf/addons.py
+++ b/pyscf/pbc/scf/addons.py
@@ -48,10 +48,10 @@ def project_mo_nr2nr(cell1, mo1, cell2, kpts=None):
     s22 = cell2.pbc_intor('int1e_ovlp', hermi=1, kpts=kpts)
     s21 = pbcgto.intor_cross('int1e_ovlp', cell2, cell1, kpts=kpts)
     if kpts is None or numpy.shape(kpts) == (3,):  # A single k-point
-        return scipy.linalg.solve(s22, s21.dot(mo1), sym_pos=True)
+        return scipy.linalg.solve(s22, s21.dot(mo1), assume_a='pos')
     else:
         assert (len(kpts) == len(mo1))
-        return [scipy.linalg.solve(s22[k], s21[k].dot(mo1[k]), sym_pos=True)
+        return [scipy.linalg.solve(s22[k], s21[k].dot(mo1[k]), assume_a='pos')
                 for k, kpt in enumerate(kpts)]
 
 


### PR DESCRIPTION
* The `sym_pos` keyword will be removed in SciPy 1.11, use `assume_a` instead
  See https://docs.scipy.org/doc/scipy/reference/generated/scipy.linalg.solve.html
* SciPy 1.11 could release soon since there is already a second release candidate
* The assume_a keyword exists at least since SciPy 1.0, so there should be no compatibility issue