### PR TITLE
Update linalg_helper.py to comply with scipy 1.11

### DIFF
--- a/pyscf/lib/linalg_helper.py
+++ b/pyscf/lib/linalg_helper.py
@@ -1461,7 +1461,7 @@ def cho_solve(a, b, strict_sym_pos=True):
             on matrix a
     '''
     try:
-        return scipy.linalg.solve(a, b, sym_pos=True)
+        return scipy.linalg.solve(a, b, assume_a="pos")
     except numpy.linalg.LinAlgError:
         if strict_sym_pos:
             raise


### PR DESCRIPTION
keyword sym_pos in scipy.linalg.solve deprecated since 0.19. 
In version 1.11 it can't be used anymore and leads to crashes in pyscf. 
Replaced with assume_a="pos" following official scipy deprecation warning.
Should be backward compatible to at least scipy 0.19.