### PR TITLE
Implement another variant of the Hückel guess 

### DIFF
--- a/examples/scf/15-initial_guess.py
+++ b/examples/scf/15-initial_guess.py
@@ -78,6 +78,12 @@ mf.kernel()
 mf = scf.RHF(mol)
 mf.init_guess = 'huckel'
 mf.kernel()
+#
+# Another variant also exists, where an updated GWH rule is used
+#
+mf = scf.RHF(mol)
+mf.init_guess = 'mod_huckel'
+mf.kernel()
 
 #
 # Superposition of atomic potentials can be used as initial guess for DFT

--- a/pyscf/pbc/scf/krohf.py
+++ b/pyscf/pbc/scf/krohf.py
@@ -316,6 +316,7 @@ class KROHF(khf.KRHF, pbcrohf.ROHF):
     init_guess_by_minao  = pbcrohf.ROHF.init_guess_by_minao
     init_guess_by_atom   = pbcrohf.ROHF.init_guess_by_atom
     init_guess_by_huckel = pbcrohf.ROHF.init_guess_by_huckel
+    init_guess_by_mod_huckel = pbcrohf.ROHF.init_guess_by_mod_huckel
 
     get_rho = get_rho
 

--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -508,6 +508,7 @@ class KUHF(khf.KSCF, pbcuhf.UHF):
     init_guess_by_minao  = pbcuhf.UHF.init_guess_by_minao
     init_guess_by_atom   = pbcuhf.UHF.init_guess_by_atom
     init_guess_by_huckel = pbcuhf.UHF.init_guess_by_huckel
+    init_guess_by_mod_huckel = pbcuhf.UHF.init_guess_by_mod_huckel
 
     @lib.with_doc(mulliken_meta.__doc__)
     def mulliken_meta(self, cell=None, dm=None, verbose=logger.DEBUG,

--- a/pyscf/pbc/scf/rohf.py
+++ b/pyscf/pbc/scf/rohf.py
@@ -128,6 +128,7 @@ class ROHF(pbchf.RHF, mol_rohf.ROHF):
     init_guess_by_minao  = mol_rohf.ROHF.init_guess_by_minao
     init_guess_by_atom   = mol_rohf.ROHF.init_guess_by_atom
     init_guess_by_huckel = mol_rohf.ROHF.init_guess_by_huckel
+    init_guess_by_mod_huckel = mol_rohf.ROHF.init_guess_by_mod_huckel
 
     analyze = mol_rohf.ROHF.analyze
     canonicalize = mol_rohf.ROHF.canonicalize

--- a/pyscf/pbc/scf/uhf.py
+++ b/pyscf/pbc/scf/uhf.py
@@ -231,6 +231,7 @@ class UHF(pbchf.SCF, mol_uhf.UHF):
     init_guess_by_minao  = mol_uhf.UHF.init_guess_by_minao
     init_guess_by_atom   = mol_uhf.UHF.init_guess_by_atom
     init_guess_by_huckel = mol_uhf.UHF.init_guess_by_huckel
+    init_guess_by_mod_huckel = mol_uhf.UHF.init_guess_by_mod_huckel
 
     analyze = mol_uhf.UHF.analyze
     mulliken_pop = mol_uhf.UHF.mulliken_pop

--- a/pyscf/scf/dhf.py
+++ b/pyscf/scf/dhf.py
@@ -226,7 +226,8 @@ def init_guess_by_huckel(mol):
     return _proj_dmll(mol, dm, mol)
 
 def init_guess_by_mod_huckel(mol):
-    '''Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089, employing the updated GWH rule from doi:10.1021/ja00480a005.'''
+    '''Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089,
+    employing the updated GWH rule from doi:10.1021/ja00480a005.'''
     dm = hf.init_guess_by_mod_huckel(mol)
     return _proj_dmll(mol, dm, mol)
 
@@ -504,7 +505,8 @@ class DHF(hf.SCF):
     @lib.with_doc(hf.SCF.init_guess_by_mod_huckel.__doc__)
     def init_guess_by_mod_huckel(self, mol=None):
         if mol is None: mol = self.mol
-        logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089, employing the updated GWH rule from doi:10.1021/ja00480a005.')
+        logger.info(self, '''Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089,
+employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         return init_guess_by_mod_huckel(mol)
 
     def init_guess_by_chkfile(self, chkfile=None, project=None):

--- a/pyscf/scf/dhf.py
+++ b/pyscf/scf/dhf.py
@@ -225,6 +225,11 @@ def init_guess_by_huckel(mol):
     dm = hf.init_guess_by_huckel(mol)
     return _proj_dmll(mol, dm, mol)
 
+def init_guess_by_mod_huckel(mol):
+    '''Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089, employing the updated GWH rule from doi:10.1021/ja00480a005.'''
+    dm = hf.init_guess_by_mod_huckel(mol)
+    return _proj_dmll(mol, dm, mol)
+
 def init_guess_by_chkfile(mol, chkfile_name, project=None):
     '''Read SCF chkfile and make the density matrix for 4C-DHF initial guess.
 
@@ -283,7 +288,7 @@ def get_init_guess(mol, key='minao'):
 
     Kwargs:
         key : str
-            One of 'minao', 'atom', 'huckel', 'hcore', '1e', 'chkfile'.
+            One of 'minao', 'atom', 'huckel', 'mod_huckel', 'hcore', '1e', 'chkfile'.
     '''
     return UHF(mol).get_init_guess(mol, key)
 
@@ -495,6 +500,12 @@ class DHF(hf.SCF):
         if mol is None: mol = self.mol
         logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089.')
         return init_guess_by_huckel(mol)
+
+    @lib.with_doc(hf.SCF.init_guess_by_mod_huckel.__doc__)
+    def init_guess_by_mod_huckel(self, mol=None):
+        if mol is None: mol = self.mol
+        logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089, employing the updated GWH rule from doi:10.1021/ja00480a005.')
+        return init_guess_by_mod_huckel(mol)
 
     def init_guess_by_chkfile(self, chkfile=None, project=None):
         if chkfile is None: chkfile = self.chkfile

--- a/pyscf/scf/ghf.py
+++ b/pyscf/scf/ghf.py
@@ -435,7 +435,8 @@ class GHF(hf.SCF):
     @lib.with_doc(hf.SCF.init_guess_by_mod_huckel.__doc__)
     def init_guess_by_mod_huckel(self, mol=None):
         if mol is None: mol = self.mol
-        logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089, employing the updated GWH rule from doi:10.1021/ja00480a005.')
+        logger.info(self, '''Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089,
+employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         return _from_rhf_init_dm(hf.init_guess_by_mod_huckel(mol))
 
     @lib.with_doc(hf.SCF.init_guess_by_chkfile.__doc__)

--- a/pyscf/scf/ghf.py
+++ b/pyscf/scf/ghf.py
@@ -432,6 +432,12 @@ class GHF(hf.SCF):
         logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089.')
         return _from_rhf_init_dm(hf.init_guess_by_huckel(mol))
 
+    @lib.with_doc(hf.SCF.init_guess_by_mod_huckel.__doc__)
+    def init_guess_by_mod_huckel(self, mol=None):
+        if mol is None: mol = self.mol
+        logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089, employing the updated GWH rule from doi:10.1021/ja00480a005.')
+        return _from_rhf_init_dm(hf.init_guess_by_mod_huckel(mol))
+
     @lib.with_doc(hf.SCF.init_guess_by_chkfile.__doc__)
     def init_guess_by_chkfile(self, chkfile=None, project=None):
         if chkfile is None: chkfile = self.chkfile

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -1623,7 +1623,8 @@ class SCF(lib.StreamObject):
     @lib.with_doc(init_guess_by_mod_huckel.__doc__)
     def init_guess_by_mod_huckel(self, updated_rule, mol=None):
         if mol is None: mol = self.mol
-        logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089, employing the updated GWH rule from doi:10.1021/ja00480a005.')
+        logger.info(self, '''Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089,
+employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         mo_energy, mo_coeff = _init_guess_huckel_orbitals(mol, updated_rule=True)
         mo_occ = self.get_occ(mo_energy, mo_coeff)
         return self.make_rdm1(mo_coeff, mo_occ)

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -522,22 +522,52 @@ def init_guess_by_huckel(mol):
     Returns:
         Density matrix, 2D ndarray
     '''
-    mo_energy, mo_coeff = _init_guess_huckel_orbitals(mol)
+    mo_energy, mo_coeff = _init_guess_huckel_orbitals(mol, updated_rule = False)
     mo_occ = get_occ(SCF(mol), mo_energy, mo_coeff)
     return make_rdm1(mo_coeff, mo_occ)
 
-def _init_guess_huckel_orbitals(mol):
+def init_guess_by_mod_huckel(mol):
     '''Generate initial guess density matrix from a Huckel calculation based
     on occupancy averaged atomic RHF calculations, doi:10.1021/acs.jctc.8b01089
+
+    In contrast to init_guess_by_huckel, this routine employs the
+    updated GWH rule from doi:10.1021/ja00480a005 to form the guess.
+
+    Returns:
+        Density matrix, 2D ndarray
+
+    '''
+    mo_energy, mo_coeff = _init_guess_huckel_orbitals(mol, updated_rule = True)
+    mo_occ = get_occ(SCF(mol), mo_energy, mo_coeff)
+    return make_rdm1(mo_coeff, mo_occ)
+
+def Kgwh(Ei, Ej, updated_rule=False):
+    '''Computes the generalized Wolfsberg-Helmholtz parameter'''
+
+    # GWH parameter value
+    k = 1.75
+
+    if updated_rule:
+        '''Updated scheme from J. Am. Chem. Soc. 100, 3686 (1978); doi:10.1021/ja00480a005'''
+        Delta = (Ei-Ej)/(Ei+Ej)
+        return k + Delta**2 + Delta**4 * (1 - k)
+    else:
+        '''Original rule'''
+        return k
+
+def _init_guess_huckel_orbitals(mol, updated_rule = False):
+    '''Generate initial guess density matrix from a Huckel calculation based
+    on occupancy averaged atomic RHF calculations, doi:10.1021/acs.jctc.8b01089
+
+    Arguments:
+        mol, the molecule
+        updated_rule, boolean triggering use of the updated GWH rule from doi:10.1021/ja00480a005
 
     Returns:
         An 1D array for Huckel orbital energies and an 2D array for orbital coefficients
     '''
     from pyscf.scf import atom_hf
     atm_scf = atom_hf.get_atm_nrhf(mol)
-
-    # GWH parameter value
-    Kgwh = 1.75
 
     # Run atomic SCF calculations to get orbital energies, coefficients and occupations
     at_e = []
@@ -610,7 +640,7 @@ def _init_guess_huckel_orbitals(mol):
         orb_H[io,io] = orb_E[io]
         for jo in range(io):
             # Off-diagonal is given by GWH approximation
-            orb_H[io,jo] = 0.5*Kgwh*orb_S[io,jo]*(orb_E[io]+orb_E[jo])
+            orb_H[io,jo] = 0.5*Kgwh(orb_E[io],orb_E[jo],updated_rule=updated_rule)*orb_S[io,jo]*(orb_E[io]+orb_E[jo])
             orb_H[jo,io] = orb_H[io,jo]
 
     # Energies and coefficients in the minimal orbital basis
@@ -1586,7 +1616,15 @@ class SCF(lib.StreamObject):
     def init_guess_by_huckel(self, mol=None):
         if mol is None: mol = self.mol
         logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089.')
-        mo_energy, mo_coeff = _init_guess_huckel_orbitals(mol)
+        mo_energy, mo_coeff = _init_guess_huckel_orbitals(mol, updated_rule=False)
+        mo_occ = self.get_occ(mo_energy, mo_coeff)
+        return self.make_rdm1(mo_coeff, mo_occ)
+
+    @lib.with_doc(init_guess_by_mod_huckel.__doc__)
+    def init_guess_by_mod_huckel(self, updated_rule, mol=None):
+        if mol is None: mol = self.mol
+        logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089, employing the updated GWH rule from doi:10.1021/ja00480a005.')
+        mo_energy, mo_coeff = _init_guess_huckel_orbitals(mol, updated_rule=True)
         mo_occ = self.get_occ(mo_energy, mo_coeff)
         return self.make_rdm1(mo_coeff, mo_occ)
 
@@ -1623,6 +1661,8 @@ class SCF(lib.StreamObject):
             dm = self.init_guess_by_1e(mol)
         elif key == 'huckel':
             dm = self.init_guess_by_huckel(mol)
+        elif key == 'mod_huckel':
+            dm = self.init_guess_by_mod_huckel(mol)
         elif getattr(mol, 'natm', 0) == 0:
             logger.info(self, 'No atom found in mol. Use 1e initial guess')
             dm = self.init_guess_by_1e(mol)

--- a/pyscf/scf/rohf.py
+++ b/pyscf/scf/rohf.py
@@ -48,6 +48,7 @@ def init_guess_by_atom(mol):
     return dm
 
 init_guess_by_huckel = uhf.init_guess_by_huckel
+init_guess_by_mod_huckel = uhf.init_guess_by_mod_huckel
 init_guess_by_chkfile = uhf.init_guess_by_chkfile
 
 def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
@@ -366,6 +367,11 @@ class ROHF(hf.RHF):
         if mol is None: mol = self.mol
         logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089.')
         return init_guess_by_huckel(mol)
+
+    def init_guess_by_mod_huckel(self, mol=None):
+        if mol is None: mol = self.mol
+        logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089, employing the updated GWH rule from doi:10.1021/ja00480a005.')
+        return init_guess_by_mod_huckel(mol)
 
     def init_guess_by_1e(self, mol=None):
         if mol is None: mol = self.mol

--- a/pyscf/scf/rohf.py
+++ b/pyscf/scf/rohf.py
@@ -370,7 +370,8 @@ class ROHF(hf.RHF):
 
     def init_guess_by_mod_huckel(self, mol=None):
         if mol is None: mol = self.mol
-        logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089, employing the updated GWH rule from doi:10.1021/ja00480a005.')
+        logger.info(self, '''Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089,
+employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         return init_guess_by_mod_huckel(mol)
 
     def init_guess_by_1e(self, mol=None):

--- a/pyscf/scf/test/test_dhf.py
+++ b/pyscf/scf/test/test_dhf.py
@@ -66,6 +66,10 @@ class KnownValues(unittest.TestCase):
         dm = scf.dhf.DHF(mol).get_init_guess(mol, key='huckel')
         self.assertAlmostEqual(lib.fp(dm), (-0.6090467376579871-0.08968155321478456j), 8)
 
+    def test_init_guess_mod_huckel(self):
+        dm = scf.dhf.DHF(mol).get_init_guess(mol, key='mod_huckel')
+        self.assertAlmostEqual(lib.fp(dm), (-0.5563045659111319-0.0897593233637678j), 8)
+
     def test_get_hcore(self):
         h = mf.get_hcore()
         self.assertAlmostEqual(numpy.linalg.norm(h), 129.81389477933607, 7)

--- a/pyscf/scf/test/test_ghf.py
+++ b/pyscf/scf/test/test_ghf.py
@@ -131,6 +131,10 @@ class KnownValues(unittest.TestCase):
         dm = scf.GHF(mol).get_init_guess(mol, key='huckel')
         self.assertAlmostEqual(lib.fp(dm), 1.0574099243527206, 7)
 
+    def test_init_guess_mod_huckel(self):
+        dm = scf.GHF(mol).get_init_guess(mol, key='mod_huckel')
+        self.assertAlmostEqual(lib.fp(dm), 1.1466144161440015, 7)
+
     def test_ghf_complex(self):
         mf1 = scf.GHF(mol)
         dm = mf1.init_guess_by_1e(mol) + 0j

--- a/pyscf/scf/test/test_rhf.py
+++ b/pyscf/scf/test/test_rhf.py
@@ -239,6 +239,13 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(lib.fp(dm), 2.01095497354225, 5)
         self.assertAlmostEqual(numpy.einsum('ij,ji->', dm, mol1.intor('int1e_ovlp')), 20, 9)
 
+    def test_init_guess_huckel(self):
+        dm = scf.hf.RHF(mol).get_init_guess(mol, key='mod_huckel')
+        self.assertAlmostEqual(lib.fp(dm), 3.233072986208057, 5)
+
+        dm = scf.ROHF(mol).init_guess_by_mod_huckel()
+        self.assertAlmostEqual(lib.fp(dm[0]), 3.233072986208057/2, 5)
+
     def test_1e(self):
         mf = scf.rohf.HF1e(mol)
         self.assertAlmostEqual(mf.scf(), -23.867818585778764, 9)

--- a/pyscf/scf/test/test_uhf.py
+++ b/pyscf/scf/test/test_uhf.py
@@ -96,6 +96,12 @@ class KnownValues(unittest.TestCase):
         dm2 = scf.uhf.UHF(mol).get_init_guess(mol, key='huckel')
         self.assertAlmostEqual(lib.fp(dm2), 0.6174062069308063, 7)
 
+    def test_init_guess_mod_huckel(self):
+        dm1 = mf.init_guess_by_mod_huckel(mol, breaksym=False)
+        self.assertAlmostEqual(lib.fp(dm1), 0.575004422279537, 7)
+        dm2 = scf.uhf.UHF(mol).get_init_guess(mol, key='mod_huckel')
+        self.assertAlmostEqual(lib.fp(dm2), 0.601086728278398, 7)
+
     def test_1e(self):
         mf = scf.uhf.HF1e(mol)
         self.assertAlmostEqual(mf.scf(), -23.867818585778764, 9)

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -59,6 +59,9 @@ def init_guess_by_atom(mol, breaksym=BREAKSYM):
 def init_guess_by_huckel(mol, breaksym=BREAKSYM):
     return UHF(mol).init_guess_by_huckel(mol, breaksym)
 
+def init_guess_by_mod_huckel(mol, breaksym=BREAKSYM):
+    return UHF(mol).init_guess_by_mod_huckel(mol, breaksym)
+
 def init_guess_by_chkfile(mol, chkfile_name, project=None):
     '''Read SCF chkfile and make the density matrix for UHF initial guess.
 
@@ -863,7 +866,22 @@ class UHF(hf.SCF):
         if user_set_breaksym is not None:
             breaksym = user_set_breaksym
         logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089.')
-        mo_energy, mo_coeff = hf._init_guess_huckel_orbitals(mol)
+        mo_energy, mo_coeff = hf._init_guess_huckel_orbitals(mol, updated_rule = False)
+        mo_energy = (mo_energy, mo_energy)
+        mo_coeff = (mo_coeff, mo_coeff)
+        mo_occ = self.get_occ(mo_energy, mo_coeff)
+        dma, dmb = self.make_rdm1(mo_coeff, mo_occ)
+        if breaksym:
+            dma, dmb = _break_dm_spin_symm(mol, (dma, dmb))
+        return numpy.array((dma,dmb))
+
+    def init_guess_by_mod_huckel(self, mol=None, breaksym=BREAKSYM):
+        if mol is None: mol = self.mol
+        user_set_breaksym = getattr(self, "init_guess_breaksym", None)
+        if user_set_breaksym is not None:
+            breaksym = user_set_breaksym
+        logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089, employing the updated GWH rule from doi:10.1021/ja00480a005.')
+        mo_energy, mo_coeff = hf._init_guess_huckel_orbitals(mol, updated_rule = True)
         mo_energy = (mo_energy, mo_energy)
         mo_coeff = (mo_coeff, mo_coeff)
         mo_occ = self.get_occ(mo_energy, mo_coeff)

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -880,7 +880,8 @@ class UHF(hf.SCF):
         user_set_breaksym = getattr(self, "init_guess_breaksym", None)
         if user_set_breaksym is not None:
             breaksym = user_set_breaksym
-        logger.info(self, 'Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089, employing the updated GWH rule from doi:10.1021/ja00480a005.')
+        logger.info(self, '''Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089,
+employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         mo_energy, mo_coeff = hf._init_guess_huckel_orbitals(mol, updated_rule = True)
         mo_energy = (mo_energy, mo_energy)
         mo_coeff = (mo_coeff, mo_coeff)


### PR DESCRIPTION
Implements another variant of the Hückel guess based on the updated GWH rule from [doi:10.1021/ja00480a005](https://doi.org/10.1021/ja00480a005)