### PR TITLE
Fix changelog and warn message about B3LYP

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@ PySCF 2.3.0 (2023-07-04)
   - TDDFT gradients for triplet states
   - Support complex-valued h1e in fci_slow.absorb_h1e
 * Improved
-  - Update B3LYP functional to make it behave the same to Gaussian
+  - Update B3LYP functional to correspond to the original definition
   - Disable CLI parser by default
   - Accuracy and performance of RSDF, GDF and RSJK methods
   - get_lattice_Ls, and energy cutoff estimation

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@ PySCF 2.3.0 (2023-07-04)
   - TDDFT gradients for triplet states
   - Support complex-valued h1e in fci_slow.absorb_h1e
 * Improved
-  - Update B3LYP functional to make it behave the same to ORCA
+  - Update B3LYP functional to make it behave the same to Gaussian
   - Disable CLI parser by default
   - Accuracy and performance of RSDF, GDF and RSJK methods
   - get_lattice_Ls, and energy cutoff estimation

--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -770,7 +770,7 @@ XC_CODES.update({
 # Issue 1480
 if not hasattr(__config__, 'B3LYP_WITH_VWN5'):
     warnings.warn('Since PySCF-2.3, B3LYP (and B3P86) are changed to the VWN-RPA variant, '
-                  'the same to the B3LYP functional in Gaussian and ORCA (issue 1480). '
+                  'the same to the B3LYP functional in Gaussian (issue 1480). '
                   'To restore the VWN5 definition, you can put the setting '
                   '"B3LYP_WITH_VWN5 = True" in pyscf_conf.py')
 elif getattr(__config__, 'B3LYP_WITH_VWN5', False):

--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -770,7 +770,8 @@ XC_CODES.update({
 # Issue 1480
 if not hasattr(__config__, 'B3LYP_WITH_VWN5'):
     warnings.warn('Since PySCF-2.3, B3LYP (and B3P86) are changed to the VWN-RPA variant, '
-                  'the same to the B3LYP functional in Gaussian (issue 1480). '
+                  'corresponding to the original definition by Stephens et al. (issue 1480) '
+                  'and the same as the B3LYP functional in Gaussian. '
                   'To restore the VWN5 definition, you can put the setting '
                   '"B3LYP_WITH_VWN5 = True" in pyscf_conf.py')
 elif getattr(__config__, 'B3LYP_WITH_VWN5', False):


### PR DESCRIPTION
After #1481, current PySCF choice of B3LYP (the same as Gaussian's) is different with ORCA. See ORCA manual 9.4.2.1

> In ORCA VWN5 is chosen for the local correlation part. This choice is consistent with the TurboMole
program but not with the Gaussian program. 

https://github.com/pyscf/pyscf/blob/fc9995cad1318409303ba939d230d02196aa8109/pyscf/dft/libxc.py#L737-L739

So the changelog and libxc.py stating that PySCF's B3LYP is the same to ORCA's should be corrected.