### PR TITLE
Fix bug in symm cas methods

### DIFF
--- a/pyscf/mcscf/casci_symm.py
+++ b/pyscf/mcscf/casci_symm.py
@@ -52,7 +52,7 @@ class SymAdaptedCASCI(casci.CASCI):
             mo_coeff = self.mo_coeff
         else: # overwrite self.mo_coeff because it is needed in many methods of this class
             self.mo_coeff = mo_coeff
-            
+
         if ci0 is None:
             ci0 = self.ci
 

--- a/pyscf/mcscf/casci_symm.py
+++ b/pyscf/mcscf/casci_symm.py
@@ -50,6 +50,9 @@ class SymAdaptedCASCI(casci.CASCI):
     def kernel(self, mo_coeff=None, ci0=None, verbose=None):
         if mo_coeff is None:
             mo_coeff = self.mo_coeff
+        else: # overwrite self.mo_coeff because it is needed in many methods of this class
+            self.mo_coeff = mo_coeff
+            
         if ci0 is None:
             ci0 = self.ci
 

--- a/pyscf/mcscf/mc1step_symm.py
+++ b/pyscf/mcscf/mc1step_symm.py
@@ -57,6 +57,8 @@ class SymAdaptedCASSCF(mc1step.CASSCF):
     def kernel(self, mo_coeff=None, ci0=None, callback=None, _kern=None):
         if mo_coeff is None:
             mo_coeff = self.mo_coeff
+        else: # overwrite self.mo_coeff because it is needed in many methods of this class
+            self.mo_coeff = mo_coeff
         if callback is None: callback = self.callback
         if _kern is None: _kern = mc1step.kernel
 

--- a/pyscf/mcscf/newton_casscf_symm.py
+++ b/pyscf/mcscf/newton_casscf_symm.py
@@ -37,6 +37,8 @@ class CASSCF(newton_casscf.CASSCF):
     def kernel(self, mo_coeff=None, ci0=None, callback=None, _kern=None):
         if mo_coeff is None:
             mo_coeff = self.mo_coeff
+        else: # overwrite self.mo_coeff because it is needed in many methods of this class
+            self.mo_coeff = mo_coeff
         if callback is None: callback = self.callback
         if _kern is None: _kern = newton_casscf.kernel
 

--- a/pyscf/mcscf/ucasci.py
+++ b/pyscf/mcscf/ucasci.py
@@ -273,7 +273,7 @@ class UCASCI(casci.CASCI):
             mo_coeff = self.mo_coeff
         else: # overwrite self.mo_coeff because it is needed in many methods of this class
             self.mo_coeff = mo_coeff
-            
+
         if ci0 is None:
             ci0 = self.ci
 

--- a/pyscf/mcscf/ucasci.py
+++ b/pyscf/mcscf/ucasci.py
@@ -271,6 +271,9 @@ class UCASCI(casci.CASCI):
     def kernel(self, mo_coeff=None, ci0=None):
         if mo_coeff is None:
             mo_coeff = self.mo_coeff
+        else: # overwrite self.mo_coeff because it is needed in many methods of this class
+            self.mo_coeff = mo_coeff
+            
         if ci0 is None:
             ci0 = self.ci
 


### PR DESCRIPTION
These methods might raise error if `mo_coeff` not given.