### PR TITLE
some fixes for rst syntax in the doc of tdscf

### DIFF
--- a/pyscf/tdscf/common_slow.py
+++ b/pyscf/tdscf/common_slow.py
@@ -24,6 +24,7 @@ if sys.version_info >= (3,):
 def msize(m):
     """
     Checks whether the matrix is square and returns its size.
+
     Args:
         m (numpy.ndarray): the matrix to measure;
 
@@ -39,6 +40,7 @@ def msize(m):
 def full2ab(full, tolerance=1e-12):
     """
     Transforms a full TD matrix into A and B parts.
+
     Args:
         full (numpy.ndarray): the full TD matrix;
         tolerance (float): a tolerance for checking whether the full matrix is in the ABBA-form;
@@ -63,6 +65,7 @@ def full2ab(full, tolerance=1e-12):
 def ab2full(a, b):
     """
     Transforms A and B TD matrices into a full matrix.
+
     Args:
         a (numpy.ndarray): TD A-matrix;
         b (numpy.ndarray): TD B-matrix;
@@ -80,6 +83,7 @@ def ab2full(a, b):
 def ab2mkk(a, b, tolerance=1e-12):
     """
     Transforms A and B TD matrices into MK and K matrices.
+
     Args:
         a (numpy.ndarray): TD A-matrix;
         b (numpy.ndarray): TD B-matrix;
@@ -99,6 +103,7 @@ def ab2mkk(a, b, tolerance=1e-12):
 def mkk2ab(mk, k):
     """
     Transforms MK and M TD matrices into A and B matrices.
+
     Args:
         mk (numpy.ndarray): TD MK-matrix;
         k (numpy.ndarray): TD K-matrix;
@@ -117,6 +122,7 @@ def mkk2ab(mk, k):
 def full2mkk(full):
     """
     Transforms a full TD matrix into MK and K parts.
+
     Args:
         full (numpy.ndarray): the full TD matrix;
 
@@ -129,6 +135,7 @@ def full2mkk(full):
 def mkk2full(mk, k):
     """
     Transforms MK and M TD matrices into a full TD matrix.
+
     Args:
         mk (numpy.ndarray): TD MK-matrix;
         k (numpy.ndarray): TD K-matrix;
@@ -218,6 +225,7 @@ class TDMatrixBlocks(object):
 def mknj2i(item):
     """
     Transforms "mknj" notation into tensor index order for the ERI.
+
     Args:
         item (str): an arbitrary transpose of "mknj" letters;
 
@@ -252,8 +260,9 @@ class TDERIMatrixBlocks(TDMatrixBlocks):
     def tdhf_diag(self, *args):
         """
         Retrieves the diagonal block.
+
         Args:
-            *args: args passed to `__get_mo_energies__`;
+            ``*args``: args passed to `__get_mo_energies__`;
 
         Returns:
             The diagonal block.
@@ -265,9 +274,10 @@ class TDERIMatrixBlocks(TDMatrixBlocks):
     def eri_ov(self, item, *args):
         """
         Retrieves ERI block using 'ov' notation.
+
         Args:
             item (str): a 4-character string of 'o' and 'v' letters;
-            *args: other args passed to `__calc_block__`;
+            ``*args``: other args passed to `__calc_block__`;
 
         Returns:
             The corresponding block of ERI (4-tensor, phys notation).
@@ -295,9 +305,10 @@ class TDERIMatrixBlocks(TDMatrixBlocks):
     def eri_mknj(self, item, *args):
         """
         Retrieves ERI block using 'mknj' notation.
+
         Args:
             item (str): a 4-character string of 'mknj' letters;
-            *args: other arguments passed to `get_block_ov_notation`;
+            ``*args``: other arguments passed to `get_block_ov_notation`;
 
         Returns:
             The corresponding block of ERI (matrix with paired dimensions).
@@ -346,6 +357,7 @@ class TDProxyMatrixBlocks(TDMatrixBlocks):
         """
         This a prototype class for TD calculations based on proxying pyscf classes such as TDDFT. It is a work-around
         class. It accepts a `pyscf.tdscf.*` class and uses its matvec to construct a full-sized TD matrix.
+
         Args:
             model: a pyscf base model to extract TD matrix from;
         """
@@ -361,6 +373,7 @@ class TDProxyMatrixBlocks(TDMatrixBlocks):
 def format_frozen_mol(frozen, nmo):
     """
     Formats the argument into a mask array of bools where False values correspond to frozen molecular orbitals.
+
     Args:
         frozen (int, Iterable): the number of frozen valence orbitals or the list of frozen orbitals;
         nmo (int): the total number of molecular orbitals;
@@ -447,6 +460,7 @@ class MolecularMFMixin(object):
 def format_frozen_k(frozen, nmo, nk):
     """
     Formats the argument into a mask array of bools where False values correspond to frozen orbitals for each k-point.
+
     Args:
         frozen (int, Iterable): the number of frozen valence orbitals or the list of frozen orbitals for all k-points or
         multiple lists of frozen orbitals for each k-point;
@@ -476,6 +490,7 @@ def format_frozen_k(frozen, nmo, nk):
 def k_nocc(model):
     """
     Retrieves occupation numbers.
+
     Args:
         model (RHF): the model;
 
@@ -488,6 +503,7 @@ def k_nocc(model):
 def k_nmo(model):
     """
     Retrieves number of AOs per k-point.
+
     Args:
         model (RHF): the model;
 
@@ -557,6 +573,7 @@ class VindTracker(object):
     def __init__(self, vind):
         """
         Tracks calls to `vind` (a matrix-vector multiplication density response routine).
+
         Args:
             vind (Callable): a matvec product routine;
         """
@@ -631,6 +648,7 @@ class VindTracker(object):
 def eig(m, driver=None, nroots=None, half=True):
     """
     Eigenvalue problem solver.
+
     Args:
         m (numpy.ndarray): the matrix to diagonalize;
         driver (str): one of the drivers;
@@ -658,12 +676,13 @@ def eig(m, driver=None, nroots=None, half=True):
 def kernel(eri, driver=None, fast=True, nroots=None, **kwargs):
     """
     Calculates eigenstates and eigenvalues of the TDHF problem.
+
     Args:
         eri (TDDFTMatrixBlocks): ERI;
         driver (str): one of the eigenvalue problem drivers;
         fast (bool): whether to run diagonalization on smaller matrixes;
         nroots (int): the number of roots to calculate;
-        **kwargs: arguments to `eri.tdhf_matrix`;
+        ``**kwargs``: arguments to `eri.tdhf_matrix`;
 
     Returns:
         Positive eigenvalues and eigenvectors.
@@ -703,6 +722,7 @@ class TDBase(object):
     def __init__(self, mf, frozen=None):
         """
         Performs TD calculation. Roots and eigenvectors are stored in `self.e`, `self.xy`.
+
         Args:
             mf: the mean-field model;
             frozen (int, Iterable): the number of frozen valence orbitals or the list of frozen orbitals;
@@ -753,6 +773,7 @@ class TDBase(object):
     def vector_to_amplitudes(self, vectors):
         """
         Transforms (reshapes) and normalizes vectors into amplitudes.
+
         Args:
             vectors (numpy.ndarray): raw eigenvectors to transform;
 
@@ -766,6 +787,7 @@ class TDBase(object):
 def format_mask(x):
     """
     Formats a mask into a readable string.
+
     Args:
         x (ndarray): an array with the mask;
 

--- a/pyscf/tdscf/proxy.py
+++ b/pyscf/tdscf/proxy.py
@@ -31,6 +31,7 @@ import numpy
 def molecular_response_ov(vind, space_ov, nocc, nmo, double, log_dest):
     """
     Retrieves a raw response matrix.
+
     Args:
         vind (Callable): a pyscf matvec routine;
         space_ov (ndarray): the active `ov` space mask: either the same mask for both rows and columns (1D array) or
@@ -81,6 +82,7 @@ def molecular_response_ov(vind, space_ov, nocc, nmo, double, log_dest):
 def orb2ov(space, nocc):
     """
     Converts orbital active space specification into ov-pairs space spec.
+
     Args:
         space (ndarray): the obital space;
         nocc (int): the number of occupied orbitals;
@@ -97,6 +99,7 @@ def orb2ov(space, nocc):
 def molecular_response(vind, space, nocc, nmo, double, log_dest):
     """
     Retrieves a raw response matrix.
+
     Args:
         vind (Callable): a pyscf matvec routine;
         space (ndarray): the active orbital space mask: either the same mask for both rows and columns (1D array) or
@@ -126,6 +129,7 @@ def molecular_response(vind, space, nocc, nmo, double, log_dest):
 def mk_make_canonic(m, o, v, return_ov=False, space_ov=None):
     """
     Makes the output of pyscf TDDFT matrix (MK form) to be canonic.
+
     Args:
         m (ndarray): the TDDFT matrix;
         o (ndarray): occupied orbital energies;
@@ -172,6 +176,7 @@ class PhysERI(MolecularMFMixin, TDProxyMatrixBlocks):
     def proxy_is_double(self):
         """
         Determines if double-sized matrices are proxied.
+
         Returns:
             True if double-sized matrices are proxied.
         """
@@ -194,6 +199,7 @@ class PhysERI(MolecularMFMixin, TDProxyMatrixBlocks):
     def proxy_response(self):
         """
         A raw response matrix.
+
         Returns:
             A raw response matrix.
         """
@@ -233,6 +239,7 @@ class TDProxy(TDBase):
     def __init__(self, mf, proxy, frozen=None):
         """
         Performs TD calculation. Roots and eigenvectors are stored in `self.e`, `self.xy`.
+
         Args:
             mf: the base restricted mean-field model;
             proxy: a pyscf proxy with TD response function, one of 'hf', 'dft';

--- a/pyscf/tdscf/rhf.py
+++ b/pyscf/tdscf/rhf.py
@@ -604,13 +604,13 @@ def as_scanner(td):
 
     Examples::
 
-    >>> from pyscf import gto, scf, tdscf
-    >>> mol = gto.M(atom='H 0 0 0; F 0 0 1')
-    >>> td_scanner = tdscf.TDHF(scf.RHF(mol)).as_scanner()
-    >>> de = td_scanner(gto.M(atom='H 0 0 0; F 0 0 1.1'))
-    [ 0.34460866  0.34460866  0.7131453 ]
-    >>> de = td_scanner(gto.M(atom='H 0 0 0; F 0 0 1.5'))
-    [ 0.14844013  0.14844013  0.47641829]
+        >>> from pyscf import gto, scf, tdscf
+        >>> mol = gto.M(atom='H 0 0 0; F 0 0 1')
+        >>> td_scanner = tdscf.TDHF(scf.RHF(mol)).as_scanner()
+        >>> de = td_scanner(gto.M(atom='H 0 0 0; F 0 0 1.1'))
+        [ 0.34460866  0.34460866  0.7131453 ]
+        >>> de = td_scanner(gto.M(atom='H 0 0 0; F 0 0 1.5'))
+        [ 0.14844013  0.14844013  0.47641829]
     '''
     if isinstance(td, lib.SinglePointScanner):
         return td

--- a/pyscf/tdscf/rhf_slow.py
+++ b/pyscf/tdscf/rhf_slow.py
@@ -48,6 +48,7 @@ class PhysERI(MolecularMFMixin, TDERIMatrixBlocks):
     def ao2mo(self, coeff):
         """
         Phys ERI in MO basis.
+
         Args:
             coeff (Iterable): MO orbitals;
 
@@ -130,6 +131,7 @@ class PhysERI8(PhysERI4):
 def vector_to_amplitudes(vectors, nocc, nmo):
     """
     Transforms (reshapes) and normalizes vectors into amplitudes.
+
     Args:
         vectors (numpy.ndarray): raw eigenvectors to transform;
         nocc (int): number of occupied orbitals;


### PR DESCRIPTION
this fixes all issues with `rst` syntax in the doc of `tdscf` folder