### PR TITLE
fixing a few more typos in gto/ and lo/

### DIFF
--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -17,7 +17,7 @@
 #
 
 '''
-Mole class and helper functions to handle paramters and attributes for GTO
+Mole class and helper functions to handle parameters and attributes for GTO
 integrals. This module serves the interface to the integral library libcint.
 '''
 
@@ -439,7 +439,7 @@ def format_basis(basis_tab):
             Similar to :attr:`Mole.basis`, it **cannot** be a str
 
     Returns:
-        Formated :attr:`~Mole.basis`
+        Formatted :attr:`~Mole.basis`
 
     Examples:
 
@@ -713,7 +713,7 @@ def expand_etb(l, n, alpha, beta):
             Number of GTOs
 
     Returns:
-        Formated :attr:`~Mole.basis`
+        Formatted :attr:`~Mole.basis`
 
     Examples:
 
@@ -728,7 +728,7 @@ def expand_etbs(etbs):
         etbs = [(l, n, alpha, beta), (l, n, alpha, beta),...]
 
     Returns:
-        Formated :attr:`~Mole.basis`
+        Formatted :attr:`~Mole.basis`
 
     Examples:
 
@@ -919,7 +919,7 @@ def make_atm_env(atom, ptr=0, nuclear_model=NUC_POINT, nucprop={}):
 def make_bas_env(basis_add, atom_id=0, ptr=0):
     '''Convert :attr:`Mole.basis` to the argument ``bas`` for ``libcint`` integrals
     '''
-    # First sort basis accroding to l. This is important for method
+    # First sort basis according to l. This is important for method
     # decontract_basis, which assumes that basis functions with the same angular
     # momentum are grouped together
     basis_add = [b for b in basis_add if b]
@@ -1224,7 +1224,7 @@ def loads(molstr):
     from numpy import array  # noqa
     moldic = json.loads(molstr)
     if sys.version_info < (3,):
-        # Convert to utf8 because JSON loads fucntion returns unicode.
+        # Convert to utf8 because JSON loads function returns unicode.
         def byteify(inp):
             if isinstance(inp, dict):
                 return dict([(byteify(k), byteify(v)) for k, v in inp.iteritems()])
@@ -1337,7 +1337,7 @@ def nao_nr_range(mol, bas_id0, bas_id1):
             stop shell id
 
     Returns:
-        tupel of start basis function id and the stop function id
+        tuple of start basis function id and the stop function id
 
     Examples:
 
@@ -1373,7 +1373,7 @@ def nao_2c_range(mol, bas_id0, bas_id1):
             stop shell id, 0-based
 
     Returns:
-        tupel of start basis function id and the stop function id
+        tuple of start basis function id and the stop function id
 
     Examples:
 
@@ -1421,7 +1421,7 @@ def ao_loc_2c(mol):
 
 def time_reversal_map(mol):
     r'''The index to map the spinor functions and its time reversal counterpart.
-    The returned indices have postive or negative values.  For the i-th basis function,
+    The returned indices have positive or negative values.  For the i-th basis function,
     if the returned j = idx[i] < 0, it means :math:`T|i\rangle = -|j\rangle`,
     otherwise :math:`T|i\rangle = |j\rangle`
     '''
@@ -2004,7 +2004,7 @@ def tostring(mol, format='raw'):
     '''Convert molecular geometry to a string of the required format.
 
     Supported output formats:
-        | raw: Each line is  <symobl> <x> <y> <z>
+        | raw: Each line is  <symbol> <x> <y> <z>
         | xyz: XYZ cartesian coordinates format
         | zmat: Z-matrix format
     '''
@@ -2037,7 +2037,7 @@ def tofile(mol, filename, format=None):
     '''Write molecular geometry to a file of the required format.
 
     Supported output formats:
-        | raw: Each line is  <symobl> <x> <y> <z>
+        | raw: Each line is  <symbol> <x> <y> <z>
         | xyz: XYZ cartesian coordinates format
         | zmat: Z-matrix format
     '''
@@ -2054,7 +2054,7 @@ def fromfile(filename, format=None):
     (in testing)
 
     Supported formats:
-        | raw: Each line is  <symobl> <x> <y> <z>
+        | raw: Each line is  <symbol> <x> <y> <z>
         | xyz: XYZ cartesian coordinates format
         | zmat: Z-matrix format
     '''
@@ -2071,7 +2071,7 @@ def fromstring(string, format='xyz'):
     (in testing)
 
     Supported formats:
-        | raw: Each line is  <symobl> <x> <y> <z>
+        | raw: Each line is  <symbol> <x> <y> <z>
         | xyz: XYZ cartesian coordinates format
         | zmat: Z-matrix format
     '''
@@ -2096,7 +2096,7 @@ def fromstring(string, format='xyz'):
         raise NotImplementedError
 
 def is_au(unit):
-    '''Return whether the unit is recogized as A.U. or not
+    '''Return whether the unit is recognized as A.U. or not
     '''
     return unit.upper().startswith(('B', 'AU'))
 
@@ -2106,7 +2106,7 @@ def is_au(unit):
 #    .atom (input) <=>  ._atom (for python) <=> ._atm (for libcint)
 #   .basis (input) <=> ._basis (for python) <=> ._bas (for libcint)
 # input layer does not talk to libcint directly.  Data are held in python
-# internal fomrat layer.  Most of methods defined in this class only operates
+# internal format layer.  Most of methods defined in this class only operates
 # on the internal format.  Exceptions are make_env, make_atm_env, make_bas_env,
 # set_common_orig_, set_rinv_orig_ which are used to manipulate the libcint arguments.
 #
@@ -2200,12 +2200,12 @@ class Mole(lib.StreamObject):
 
         _atm :
             :code:`[[charge, ptr-of-coord, nuc-model, ptr-zeta, 0, 0], [...]]`
-            each element reperesents one atom
+            each element represents one atom
         natm :
             number of atoms
         _bas :
             :code:`[[atom-id, angular-momentum, num-primitive-GTO, num-contracted-GTO, 0, ptr-of-exps, ptr-of-contract-coeff, 0], [...]]`
-            each element reperesents one shell
+            each element represents one shell
         nbas :
             number of shells
         _env :
@@ -2406,7 +2406,7 @@ class Mole(lib.StreamObject):
 #        cls = self.__class__
 #        newmol = cls.__new__(cls)
 #        newmol = ...
-# do not use __copy__ to aovid iteratively call copy.copy
+# do not use __copy__ to avoid iteratively call copy.copy
     copy = copy
 
     pack = pack
@@ -2452,7 +2452,7 @@ class Mole(lib.StreamObject):
             output : str or None
                 Output file.  If given, overwrite :attr:`Mole.output`
             max_memory : int, float
-                Allowd memory in MB.  If given, overwrite :attr:`Mole.max_memory`
+                Allowed memory in MB.  If given, overwrite :attr:`Mole.max_memory`
             atom : list or str
                 To define molecluar structure.
             basis : dict or str
@@ -2835,7 +2835,7 @@ class Mole(lib.StreamObject):
     set_common_origin_ = set_common_orig  # for backward compatibility
 
     def with_common_origin(self, coord):
-        '''Return a temporary mol context which has the rquired common origin.
+        '''Return a temporary mol context which has the required common origin.
         The required common origin has no effects out of the temporary context.
         See also :func:`mol.set_common_origin`
 
@@ -2864,7 +2864,7 @@ class Mole(lib.StreamObject):
     set_rinv_origin_ = set_rinv_orig  # for backward compatibility
 
     def with_rinv_origin(self, coord):
-        '''Return a temporary mol context which has the rquired origin of 1/r
+        '''Return a temporary mol context which has the required origin of 1/r
         operator.  The required origin has no effects out of the temporary
         context.  See also :func:`mol.set_rinv_origin`
 
@@ -2960,7 +2960,7 @@ class Mole(lib.StreamObject):
     set_rinv_zeta_ = set_rinv_zeta  # for backward compatibility
 
     def with_rinv_zeta(self, zeta):
-        '''Return a temporary mol context which has the rquired Gaussian charge
+        '''Return a temporary mol context which has the required Gaussian charge
         distribution placed at "rinv_origin": rho(r) = Norm * exp(-zeta * r^2).
         See also :func:`mol.set_rinv_zeta`
 
@@ -2999,7 +2999,7 @@ class Mole(lib.StreamObject):
     with_rinv_as_nucleus = with_rinv_at_nucleus  # For backward compatibility
 
     def with_integral_screen(self, threshold):
-        '''Return a temporary mol context which has the rquired integral
+        '''Return a temporary mol context which has the required integral
         screen threshold
         '''
         if threshold is None:

--- a/pyscf/gto/moleintor.py
+++ b/pyscf/gto/moleintor.py
@@ -18,7 +18,7 @@
 
 '''
 A low level interface to libcint library. It's recommended to use the
-Mole.intor method to drive the integral evaluation funcitons.
+Mole.intor method to drive the integral evaluation functions.
 '''
 
 import warnings

--- a/pyscf/lo/boys.py
+++ b/pyscf/lo/boys.py
@@ -166,7 +166,7 @@ class Boys(ciah.CIAHOptimizer):
         max_iters : int
             The max. number of iterations in each macro iteration. Default 20
         max_stepsize : float
-            The step size for orbital rotation.  Small step (0.005 - 0.05) is prefered.
+            The step size for orbital rotation.  Small step (0.005 - 0.05) is preferred.
             Default 0.03.
         init_guess : str or None
             Initial guess for optimization. If set to None, orbitals defined

--- a/pyscf/lo/ibo.py
+++ b/pyscf/lo/ibo.py
@@ -178,7 +178,7 @@ def ibo_loc(mol, orbocc, iaos, s, exponent, grad_tol, max_iter,
                     continue
                     #this saves us from replacing already fine orbitals
                 else:
-                    #THE BELOW IS TAKEN DIRECLTY FROMG KNIZIA's FREE CODE
+                    #THE BELOW IS TAKEN DIRECTLY FROMG KNIZIA's FREE CODE
                     # Calculate 2x2 rotation angle phi.
                     # This correspond to [2] (12)-(15), re-arranged and simplified.
                     phi = .25*numpy.arctan2(Bij,-Aij)
@@ -235,7 +235,7 @@ def PipekMezey(mol, orbocc, iaos, s, exponent, minao=MINAO):
     '''
 
     # Note: PM with Lowdin-orth IAOs is implemented in pipek.PM class
-    # TODO: Merge the implemenation here to pipek.PM
+    # TODO: Merge the implementation here to pipek.PM
 
     cs = numpy.dot(iaos.T.conj(), s)
     s_iao = numpy.dot(cs, iaos)

--- a/pyscf/lo/nao.py
+++ b/pyscf/lo/nao.py
@@ -35,7 +35,7 @@ from pyscf.data import elements
 from pyscf import __config__
 
 # Note the valence space for Li, Be may need include 2p, Al..Cl may need 3d ...
-# This is No. of shells, not the atomic configuations
+# This is No. of shells, not the atomic configurations
 #     core       core+valence
 # core+valence = lambda nuc, l: \
 #            int(numpy.ceil(elements.CONFIGURATION[nuc][l]/(4*l+2.)))
@@ -196,7 +196,7 @@ def _core_val_ryd_list(mol):
 
 @lru_cache(10)
 def _cart_averge_wt(l):
-    '''Weight matrix for spherical symmetry averaging in Cartensian GTOs'''
+    '''Weight matrix for spherical symmetry averaging in Cartesian GTOs'''
     c = mole.cart2sph(l, normalized='sp')
     return numpy.einsum('pi,qi->pq', c, c)
 

--- a/pyscf/lo/pipek.py
+++ b/pyscf/lo/pipek.py
@@ -153,7 +153,7 @@ class PipekMezey(boys.Boys):
         max_iters : int
             The max. number of iterations in each macro iteration. Default 20
         max_stepsize : float
-            The step size for orbital rotation.  Small step (0.005 - 0.05) is prefered.
+            The step size for orbital rotation.  Small step (0.005 - 0.05) is preferred.
             Default 0.03.
         init_guess : str or None
             Initial guess for optimization. If set to None, orbitals defined


### PR DESCRIPTION
just fixing a few more typos, found using

`codespell -L nd,ket,te pyscf/gto/`