### PR TITLE
Fix lz_adaptation example; needs to run in D2h symmetry to work

### DIFF
--- a/examples/symm/33-lz_adaption.py
+++ b/examples/symm/33-lz_adaption.py
@@ -40,7 +40,7 @@ def lz_adapt_(mol):
         mol.symm_orb[Ex] = lz_plus   # x+iy
     return mol
 
-mol = gto.M(atom='Ne', basis='ccpvtz', symmetry=True)
+mol = gto.M(atom='Ne', basis='ccpvtz', symmetry='d2h')
 mol = lz_adapt_(mol)
 mf = scf.RHF(mol)
 mf.run()


### PR DESCRIPTION
The example `symm/33-lz_adaption.py` does not work and gives the error
```
$ python 33-lz_adaption.py 
mol.irrep_id [0, 106, 105, 107, 211, 203, 200, 202, 210, 316, 314, 306, 305, 307, 315, 317]
Traceback (most recent call last):
  File "/home/work/pyscf/examples/symm/33-lz_adaption.py", line 44, in <module>
    mol = lz_adapt_(mol)
          ^^^^^^^^^^^^^^
  File "/home/work/pyscf/examples/symm/33-lz_adaption.py", line 22, in lz_adapt_
    Ey = mol.irrep_id.index(ir+1)
         ^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: 201 is not in list
```
This is likely since the symmetry code now defaults to using `Dooh` symmetry for atoms. Changing the argument from `symmetry = True` to `symmetry = 'D2h'` appears to fix the issue.