### PR TITLE
get rid of TAB characters, and activate check for W191

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install pycodestyle
       run: pip install pycodestyle
     - name: Lint using pycodestyle
-      run: pycodestyle --select=E111 pyscf
+      run: pycodestyle --select=E111,W191 pyscf
 
 #      - name: Static analysis
 #        uses: suo/flake8-github-action@releases/v1

--- a/pyscf/md/test/test_NVTBerendson.py
+++ b/pyscf/md/test/test_NVTBerendson.py
@@ -22,12 +22,13 @@ import pyscf.md as md
 
 CHECK_STABILITY = False
 
+
 def setUpModule():
     global h2o, hf_scanner
     h2o = gto.M(verbose=3,
                 output='/dev/null',
                 atom='''O -2.9103342153    -15.4805607073    -14.9344021104
- 	                H -2.5833611256    -14.8540450112    -15.5615823519
+                        H -2.5833611256    -14.8540450112    -15.5615823519
                        H  -2.7404195919    -16.3470417109    -15.2830799053''',
                 basis='def2-svp')
 
@@ -36,33 +37,35 @@ def setUpModule():
     hf_scanner.conv_tol_grad = 1e-6
     hf_scanner.max_cycle = 700
 
+
 def tearDownModule():
     global h2o, hf_scanner
     hf_scanner.stdout.close()
     del h2o, hf_scanner
 
+
 class KnownValues(unittest.TestCase):
 
     def test_hf_water_init_veloc(self):
         init_veloc = np.array([[-3.00670625e-05, -2.47219610e-04, -2.99235779e-04],
-        			[-5.66022419e-05, -9.83256521e-04, -8.35299245e-04],
-        			[-4.38260913e-04, -3.17970694e-04,  5.07818817e-04]])
+                               [-5.66022419e-05, -9.83256521e-04, -8.35299245e-04],
+                               [-4.38260913e-04, -3.17970694e-04,  5.07818817e-04]])
 
         driver = md.integrators.NVTBerendson(hf_scanner, veloc=init_veloc,
-        				       dt=20, steps=20, T=300, taut=413)
+                                             dt=20, steps=20, T=300, taut=413)
 
         driver.kernel()
         self.assertAlmostEqual(driver.ekin, 4.244286252900E-03, 8)
         self.assertAlmostEqual(driver.epot, -7.596117676337E+01, 8)
 
         final_coord = np.array([[ -5.51486188, -29.3425402,  -28.32832762],
- 				 [ -4.8843336,  -28.48585797, -29.75984939],
- 				 [ -5.30517791, -31.05471672, -28.76717135]])
+                                [ -4.8843336,  -28.48585797, -29.75984939],
+                                [ -5.30517791, -31.05471672, -28.76717135]])
 
         self.assertTrue(np.allclose(driver.mol.atom_coords(), final_coord))
-        
+
         if CHECK_STABILITY:
-           
+
             driver.steps = 990
             driver.kernel()
             self.assertAlmostEqual(driver.temperature(), driver.T, delta=5)

--- a/pyscf/md/test/test_prop.py
+++ b/pyscf/md/test/test_prop.py
@@ -25,7 +25,7 @@ def setUpModule():
     h2o = gto.M(verbose=3,
                 output='/dev/null',
                 atom='''O -2.9103342153    -15.4805607073    -14.9344021104
- 	                H -2.5833611256    -14.8540450112    -15.5615823519
+                        H -2.5833611256    -14.8540450112    -15.5615823519
                        H  -2.7404195919    -16.3470417109    -15.2830799053''',
                 basis='def2-svp')
 
@@ -33,17 +33,18 @@ def setUpModule():
     h2o_scanner.build()
     h2o_scanner.conv_tol_grad = 1e-6
     h2o_scanner.max_cycle = 700
-    
+
     o2 = gto.M(verbose=3,
                output='/dev/null',
                atom='''O 0	0	0.0298162549
-               	O 0	0	1.1701837504''',
+               O 0	0	1.1701837504''',
                basis='def2-svp')
 
     o2_scanner = scf.RHF(o2)
     o2_scanner.build()
     o2_scanner.conv_tol_grad = 1e-6
-    o2_scanner.max_cycle = 700   
+    o2_scanner.max_cycle = 700
+
 
 def tearDownModule():
     global h2o, h2o_scanner, o2, o2_scanner
@@ -51,36 +52,37 @@ def tearDownModule():
     o2_scanner.stdout.close()
     del h2o, h2o_scanner, o2, o2_scanner
 
+
 class KnownValues(unittest.TestCase):
 
     def test_temperature_non_linear(self):
-    	# Property Checked: Non-Linear Molecule Temperature
-    	# unit-converted velocities temp = 298.13 obtained from ORCA
+        # Property Checked: Non-Linear Molecule Temperature
+        # unit-converted velocities temp = 298.13 obtained from ORCA
         init_veloc = np.array([[-3.00670625e-05, -2.47219610e-04, -2.99235779e-04],
-        			[-5.66022419e-05, -9.83256521e-04, -8.35299245e-04],
-        			[-4.38260913e-04, -3.17970694e-04,  5.07818817e-04]])
+                               [-5.66022419e-05, -9.83256521e-04, -8.35299245e-04],
+                               [-4.38260913e-04, -3.17970694e-04,  5.07818817e-04]])
 
         driver = md.integrators.NVTBerendson(h2o_scanner, veloc=init_veloc,
-        				       dt=20, steps=50, T=300, taut=413)
+                                             dt=20, steps=50, T=300, taut=413)
         
         driver._masses = np.array(
-        		[data.elements.COMMON_ISOTOPE_MASSES[m] * data.nist.AMU2AU
-            			for m in driver.mol.atom_charges()])
+                [data.elements.COMMON_ISOTOPE_MASSES[m] * data.nist.AMU2AU
+                 for m in driver.mol.atom_charges()])
         driver.ekin = driver.compute_kinetic_energy()
         self.assertAlmostEqual(driver.temperature(), 298.13, delta=0.2)
         
     def test_temperature_linear(self):
-    	# Property Checked: Linear Molecule Temperature
-    	# unit-converted velocities temp = 468.31 obtained from ORCA
+        # Property Checked: Linear Molecule Temperature
+        # unit-converted velocities temp = 468.31 obtained from ORCA
         init_veloc = np.array([[-0.,          0.,          0.00039058],
-        			[ 0.,         -0.,         -0.00039058]])
+                               [ 0.,         -0.,         -0.00039058]])
 
         driver = md.integrators.NVTBerendson(o2_scanner, veloc=init_veloc,
-        				       dt=20, steps=50, T=300, taut=413)
+                                             dt=20, steps=50, T=300, taut=413)
         
         driver._masses = np.array(
-        		[data.elements.COMMON_ISOTOPE_MASSES[m] * data.nist.AMU2AU
-            			for m in driver.mol.atom_charges()])
+                [data.elements.COMMON_ISOTOPE_MASSES[m] * data.nist.AMU2AU
+                 for m in driver.mol.atom_charges()])
         driver.ekin = driver.compute_kinetic_energy()
         self.assertAlmostEqual(driver.temperature(), 468.31, delta=0.2)
 


### PR DESCRIPTION
this is replacing inappropriate Tab characters in indentation by spaces, and activating the corresponding pycodestyle check W191