### PR TITLE
fix and activate pycodestyle W293

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install pycodestyle
       run: pip install pycodestyle
     - name: Lint using pycodestyle
-      run: pycodestyle --select=E111,W191 pyscf
+      run: pycodestyle --select=E111,W191,W293 pyscf
 
 #      - name: Static analysis
 #        uses: suo/flake8-github-action@releases/v1

--- a/pyscf/agf2/__init__.py
+++ b/pyscf/agf2/__init__.py
@@ -118,7 +118,7 @@ def RAGF2(mf, nmom=(None,0), frozen=None, mo_energy=None, mo_coeff=None, mo_occ=
     if nmom != (None,0): # redundant
         if nmom[1] == 0 and nmom[0] != 0:
             nmom = (None,0)
-    
+
     if nmom != (None,0) and getattr(mf, 'with_df', None) is not None:
         raise RuntimeError('AGF2 with custom moment orders does not '
                            'density fitting.')
@@ -141,7 +141,7 @@ def UAGF2(mf, nmom=(None,0), frozen=None, mo_energy=None, mo_coeff=None, mo_occ=
     if nmom != (None,0): # redundant
         if nmom[1] == 0 and nmom[0] != 0:
             nmom = (None,0)
-    
+
     if nmom != (None,0) and getattr(mf, 'with_df', None) is not None:
         raise RuntimeError('AGF2 with custom moment orders does not '
                            'density fitting.')

--- a/pyscf/agf2/test/test_c_agf2.py
+++ b/pyscf/agf2/test/test_c_agf2.py
@@ -78,7 +78,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(np.max(np.absolute(vv1-vv2)), 0.0, 10)
         self.assertAlmostEqual(np.max(np.absolute(vev1-vev2)), 0.0, 10)
 
-        
+
 if __name__ == '__main__':
     print('AGF2 C implementations')
     unittest.main()

--- a/pyscf/agf2/test/test_dfuagf2_beh.py
+++ b/pyscf/agf2/test/test_dfuagf2_beh.py
@@ -36,7 +36,7 @@ class KnownValues(unittest.TestCase):
     @classmethod
     def tearDownClass(self):
         del self.mol, self.mf, self.gf2
-        
+
     def test_dfuagf2_beh_ground_state(self):
         # tests the ground state AGF2 energies for BeH/cc-pvdz
         self.assertTrue(self.gf2.converged)

--- a/pyscf/lib/test/test_scipy_helper.py
+++ b/pyscf/lib/test/test_scipy_helper.py
@@ -53,7 +53,7 @@ class KnownValues(unittest.TestCase):
             self.assertTrue(numpy.allclose(L, L_ref, atol=1.0e-14))
             self.assertTrue(numpy.array_equal(piv, piv_ref))
             self.assertEqual(rank, 1)
-    
+
     def test_pivoted_cholesky_10x10(self):
         for func in self.pivoted_cholesky:
             # Positive-definite 10x10 matrix A
@@ -78,7 +78,7 @@ class KnownValues(unittest.TestCase):
                 for j in range(i+1, 10):
                     self.assertEqual(L[i, j], 0)
             self.assertTrue(numpy.allclose(LtL, PtAP, atol=1.0e-12))
-    
+
     def test_10x10_singular(self):
         for func in self.pivoted_cholesky:
             # Positive-semidefinite 10x10 matrix A with rank 7

--- a/pyscf/mcscf/__init__.py
+++ b/pyscf/mcscf/__init__.py
@@ -140,7 +140,7 @@ The Following attributes are used for CASSCF
         can affect the accuracy and performance of CASSCF solver.  Lower
         ``ah_conv_tol`` and ``ah_lindep`` can improve the accuracy of CASSCF
         optimization, but slow down the performance.
-        
+
         >>> from pyscf import gto, scf, mcscf
         >>> mol = gto.M(atom='N 0 0 0; N 0 0 1', basis='ccpvdz', verbose=0)
         >>> mf = scf.UHF(mol)

--- a/pyscf/mcscf/test/test_apc.py
+++ b/pyscf/mcscf/test/test_apc.py
@@ -6,7 +6,7 @@ from pyscf.mcscf import apc
 APC_VERBOSE = 5
 
 class KnownValues(unittest.TestCase):
-        
+
     def test_water(self):
         mol = gto.Mole()
         mol.atom = [('O', [0.0, 0.0, -0.13209669380597672]),
@@ -15,10 +15,10 @@ class KnownValues(unittest.TestCase):
         mol.basis = "6-31g"
         mol.unit = "bohr"
         mol.build()
-            
+
         mf = scf.RHF(mol)
         mf.kernel()
-        
+
         #With (nelec,ncas) size constraint:
         myapc = apc.APC(mf,max_size=(10,10),verbose=APC_VERBOSE)
         ncas,nelecas,casorbs = myapc.kernel()
@@ -27,7 +27,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(na, 4)
         self.assertAlmostEqual(nb, 4)
         self.assertAlmostEqual(lib.fp(np.abs(casorbs)),1.7403225684990318,4)
-        
+
         #With ncas size constraint:
         myapc = apc.APC(mf,max_size=12,verbose=APC_VERBOSE)
         ncas,nelecas,casorbs = myapc.kernel()
@@ -36,7 +36,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(na, 4)
         self.assertAlmostEqual(nb, 4)
         self.assertAlmostEqual(lib.fp(np.abs(casorbs)),3.405630497055709,4)
-        
+
         #With n=0
         myapc = apc.APC(mf,max_size=(2,2),n=0,verbose=APC_VERBOSE)
         ncas,nelecas,casorbs = myapc.kernel()
@@ -56,7 +56,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(na, 3)
         self.assertAlmostEqual(nb, 3)
         self.assertAlmostEqual(lib.fp(np.abs(casorbs)),-2.449707369711791,4)
-        
+
         #With user-input mos:
         mf2 = scf.RKS(mol) #example: dft MOs
         mf2.kernel()
@@ -68,7 +68,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(na, 4)
         self.assertAlmostEqual(nb, 4)
         self.assertAlmostEqual(lib.fp(np.abs(casorbs)),0.15825224792265288,4)
-        
+
     def test_vinyl(self):
         mol = gto.Mole()
         mol.atom = [('C', [0.0, 1.16769663781575, -0.043031463808524656]),
@@ -80,7 +80,7 @@ class KnownValues(unittest.TestCase):
         mol.unit = "bohr"
         mol.spin = 1
         mol.build()
-        
+
         #With ROHF:
         mf = scf.ROHF(mol)
         mf.kernel()
@@ -91,7 +91,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(na, 6)
         self.assertAlmostEqual(nb, 5)
         self.assertAlmostEqual(lib.fp(np.abs(casorbs)),-4.619108890673209,4)
-        
+
         #With UHF:
         mf = scf.UHF(mol)
         mf.max_cycle = 100

--- a/pyscf/md/test/test_prop.py
+++ b/pyscf/md/test/test_prop.py
@@ -64,13 +64,13 @@ class KnownValues(unittest.TestCase):
 
         driver = md.integrators.NVTBerendson(h2o_scanner, veloc=init_veloc,
                                              dt=20, steps=50, T=300, taut=413)
-        
+
         driver._masses = np.array(
                 [data.elements.COMMON_ISOTOPE_MASSES[m] * data.nist.AMU2AU
                  for m in driver.mol.atom_charges()])
         driver.ekin = driver.compute_kinetic_energy()
         self.assertAlmostEqual(driver.temperature(), 298.13, delta=0.2)
-        
+
     def test_temperature_linear(self):
         # Property Checked: Linear Molecule Temperature
         # unit-converted velocities temp = 468.31 obtained from ORCA
@@ -79,7 +79,7 @@ class KnownValues(unittest.TestCase):
 
         driver = md.integrators.NVTBerendson(o2_scanner, veloc=init_veloc,
                                              dt=20, steps=50, T=300, taut=413)
-        
+
         driver._masses = np.array(
                 [data.elements.COMMON_ISOTOPE_MASSES[m] * data.nist.AMU2AU
                  for m in driver.mol.atom_charges()])

--- a/pyscf/mp/test/test_dfmp2_native.py
+++ b/pyscf/mp/test/test_dfmp2_native.py
@@ -77,7 +77,7 @@ class KnownValues(unittest.TestCase):
             pt.kernel()
             self.assertAlmostEqual(pt.e_corr, -0.274767743344, delta=1.0e-8)
             self.assertAlmostEqual(pt.e_tot, -78.252218528769, delta=1.0e-8)
-    
+
     def test_energy_fclist(self):
         for arr in self.mf.mo_coeff.T, self.mf.mo_occ, self.mf.mo_energy:
             arr[[0, 2]] = arr[[2, 0]]
@@ -86,7 +86,7 @@ class KnownValues(unittest.TestCase):
             pt.kernel()
             self.assertAlmostEqual(pt.e_corr, -0.274767743344, delta=1.0e-8)
             self.assertAlmostEqual(pt.e_tot, -78.252218528769, delta=1.0e-8)
-    
+
     def test_natorbs(self):
         mol = self.mf.mol
         with DFMP2(self.mf) as pt:
@@ -100,7 +100,7 @@ class KnownValues(unittest.TestCase):
             self.assertAlmostEqual(natocc[7], 1.9384231532, delta=1.0e-7)
             self.assertAlmostEqual(natocc[8], 0.0459829060, delta=1.0e-7)
             self.assertAlmostEqual(natocc[47], 0.0000761012, delta=1.0e-7)
-    
+
     def test_natorbs_fc(self):
         mol = self.mf.mol
         with DFMP2(self.mf, frozen=2) as pt:
@@ -116,7 +116,7 @@ class KnownValues(unittest.TestCase):
             self.assertAlmostEqual(natocc[7], 1.9384836199, delta=1.0e-7)
             self.assertAlmostEqual(natocc[8], 0.0459325459, delta=1.0e-7)
             self.assertAlmostEqual(natocc[47], 0.0000751662, delta=1.0e-7)
-    
+
     def test_natorbs_fclist(self):
         for arr in self.mf.mo_coeff.T, self.mf.mo_occ, self.mf.mo_energy:
             arr[[0, 5]] = arr[[5, 0]]
@@ -187,7 +187,7 @@ class KnownValues(unittest.TestCase):
             self.assertAlmostEqual(natocc[7], 1.9402044334, delta=1.0e-7)
             self.assertAlmostEqual(natocc[8], 0.0459829060, delta=1.0e-7)
             self.assertAlmostEqual(natocc[47], 0.0000658464, delta=1.0e-7)
-    
+
     def test_natorbs_relaxed_fc(self):
         mol = self.mf.mol
         with DFMP2(self.mf, frozen=2) as pt:

--- a/pyscf/mp/test/test_dfump2_native.py
+++ b/pyscf/mp/test/test_dfump2_native.py
@@ -100,7 +100,7 @@ class KnownValues(unittest.TestCase):
             self.assertAlmostEqual(natocc[8], 1.0168954406, delta=1.0e-7)
             self.assertAlmostEqual(natocc[9], 0.0478262909, delta=1.0e-7)
             self.assertAlmostEqual(natocc[27], 0.0002326288, delta=1.0e-7)
-            
+
     def test_natorbs_fc(self):
         mol = self.mf.mol
         with DFUMP2(self.mf, frozen=2) as pt:
@@ -118,7 +118,7 @@ class KnownValues(unittest.TestCase):
             self.assertAlmostEqual(natocc[8], 1.0168965649, delta=1.0e-7)
             self.assertAlmostEqual(natocc[9], 0.0477790944, delta=1.0e-7)
             self.assertAlmostEqual(natocc[27], 0.0002307322, delta=1.0e-7)
-    
+
     def test_natorbs_fclist(self):
         self.mf.mo_coeff[0, :, [1, 3]] = self.mf.mo_coeff[0, :, [3, 1]]
         self.mf.mo_energy[0, [1, 3]] = self.mf.mo_energy[0, [3, 1]]

--- a/pyscf/mrpt/test/test_nevpt2.py
+++ b/pyscf/mrpt/test/test_nevpt2.py
@@ -186,7 +186,7 @@ class KnownValues(unittest.TestCase):
         mc.fcisolver=fci.solver(mol,singlet=True)
         mc.fcisolver.nroots=2
         mc.kernel(orbital)
-        
+
         # Ground State
         mp0 = nevpt2.NEVPT(mc, root=0)
         mp0.kernel()

--- a/pyscf/pbc/scf/test/test_khf_ksym.py
+++ b/pyscf/pbc/scf/test/test_khf_ksym.py
@@ -122,7 +122,7 @@ class KnownValues(unittest.TestCase):
     def test_krhf_df(self):
         kpts0 = He.make_kpts(nk)
         kmf0 = khf.KRHF(He, kpts=kpts0).density_fit().run()
-        
+
         kpts = He.make_kpts(nk, space_group_symmetry=True,time_reversal_symmetry=True)
         kmf = pscf.KRHF(He, kpts=kpts).density_fit().run()
         self.assertAlmostEqual(kmf.e_tot, kmf0.e_tot, 7)

--- a/pyscf/solvent/test/test_ddcosmo.py
+++ b/pyscf/solvent/test/test_ddcosmo.py
@@ -491,7 +491,6 @@ class KnownValues(unittest.TestCase):
         td = mf.TDA().ddCOSMO().run(equilibrium_solvation=True)
         ref = numpy.array([0.30124900879, 0.358722766464, 0.3950184783571])
         self.assertAlmostEqual(abs(ref - td.e).max(), 0, 7)
-        
 
         # TDA without equilibrium_solvation
         mf = mol.RHF().ddCOSMO().run(conv_tol=1e-10)


### PR DESCRIPTION
This is fixing the pycodestyle warning W293 about spaces in empty lines, and adding the check to the linter.