### PR TITLE
Assume 46 and 78 core configurations to be f-in-valence

### DIFF
--- a/pyscf/gto/ecp.py
+++ b/pyscf/gto/ecp.py
@@ -145,10 +145,12 @@ def core_configuration(nelec_core, atom_symbol=None):
     elements_4f = ELEMENTS[57:71]
     elements_5f = ELEMENTS[89:103]
     if atom_symbol in elements_4f:
-        for i in range(46, 60):
+        # TODO: fix La3+ and Ce4+ ECP46MWB f-in-core ECPs
+        for i in range(47, 59):
             conf_dic[i] = '4s3p2d1f'
     if atom_symbol in elements_5f:
-        for i in range(78, 92):
+        # TODO: fix Ac3+, Th4+, Pa5+ and U6+ ECP78MWB f-in-core ECPs
+        for i in range(79, 91):
             conf_dic[i] = '5s4p3d2f'
     if nelec_core not in conf_dic:
         raise RuntimeError('Core configuration for %d core electrons is not available.' % nelec_core)

--- a/pyscf/gto/test/test_ecp.py
+++ b/pyscf/gto/test/test_ecp.py
@@ -376,8 +376,18 @@ Eu F
 2      5.3988000000      -63.6010500000
                     ''')}, charge=2, verbose=0)
         mf = scf.RHF(mol)
+        mf.get_init_guess()
         self.assertEqual(mol.ao_labels()[0], '0 Eu1 5s    ')
         self.assertAlmostEqual(lib.fp(mf.get_hcore()), 22.59028455662168)
+
+    def test_ecp_f_in_valence(self):
+        mol = gto.M(atom='U, 0.00, 0.00, 0.00',
+                    basis={'U': 'crenbl'}, ecp={'U': 'crenbl'},
+                    charge=3, spin=3, verbose=0)
+        mf = scf.ROHF(mol)
+        mf.get_init_guess()
+        self.assertEqual(mol.ao_labels()[40], '0 U 5f-3  ')
+        self.assertAlmostEqual(lib.fp(mf.get_hcore()), -55.38627201912257)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is a reasonable default and should fix  #1889. I added a test with `mf.get_init_guess()` to catch the error.

What should be the way to introduce another core configuration to the same element and number of electrons? 
An `f_in_core`  attribute should be added somewhere.