### PR TITLE
Fix TDDFT initial guess

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -15,7 +15,7 @@ ignore =
         E701, E731, E741, E275,
         F401, C901, W391, W503, W504
 
-exclude = test, .git, __pycache__, build, dist, __init__.py .eggs, *.egg
+exclude = test, .git, __pycache__, build, dist, __init__.py, .eggs, *.egg
 max-line-length = 120
 
 per-file-ignores =

--- a/pyscf/df/df.py
+++ b/pyscf/df/df.py
@@ -181,7 +181,7 @@ class DF(lib.StreamObject):
         '''Reset mol and clean up relevant attributes for scanner mode'''
         if mol is not None:
             self.mol = mol
-        self.auxmol = None
+            self.auxmol = None
         self._cderi = None
         self._vjopt = None
         self._rsh_df = {}

--- a/pyscf/grad/test/test_tdrhf_grad.py
+++ b/pyscf/grad/test/test_tdrhf_grad.py
@@ -145,7 +145,7 @@ class KnownValues(unittest.TestCase):
 
         g1 = tdg(mol.atom_coords(), state=3)[1]
         self.assertAlmostEqual(abs(g1-g1ref).max(), 0, 6)
-        self.assertAlmostEqual(g1[0,2], -0.23226123352352346, 7)
+        self.assertAlmostEqual(g1[0,2], -0.23226123352352346, 6)
 
         td_solver = td.as_scanner()
         e1 = td_solver(pmol.set_geom_('H 0 0 1.805; F 0 0 0', unit='B'))

--- a/pyscf/grad/test/test_tdrhf_grad.py
+++ b/pyscf/grad/test/test_tdrhf_grad.py
@@ -183,7 +183,7 @@ class KnownValues(unittest.TestCase):
         td_solver = td.as_scanner()
         e1 = td_solver(pmol.set_geom_('H 0 0 1.805; F 0 0 0', unit='B'))
         e2 = td_solver(pmol.set_geom_('H 0 0 1.803; F 0 0 0', unit='B'))
-        self.assertAlmostEqual((e1[2]-e2[2])/.002, g1[0,2], 6)
+        self.assertAlmostEqual((e1[2]-e2[2])/.002, g1[0,2], 5)
 
     def test_tdhf_triplet(self):
         td = tdscf.TDDFT(mf).run(singlet=False, nstates=nstates)

--- a/pyscf/grad/test/test_tdrks_grad.py
+++ b/pyscf/grad/test/test_tdrks_grad.py
@@ -98,12 +98,12 @@ class KnownValues(unittest.TestCase):
     def test_tda_triplet_b3lyp(self):
         mf = dft.RKS(mol)
         mf.xc = 'b3lyp5'
-        mf.conv_tol = 1e-14
+        mf.conv_tol = 1e-12
         mf.kernel()
         td = tdscf.TDA(mf).run(singlet=False, nstates=nstates)
         tdg = td.nuc_grad_method()
         g1 = tdg.kernel(state=3)
-        self.assertAlmostEqual(g1[0,2], -0.36333834, 6)
+        self.assertAlmostEqual(g1[0,2], -0.3633375, 6)
 
         td_solver = td.as_scanner()
         pmol = mol.copy()

--- a/pyscf/grad/test/test_tdrks_grad.py
+++ b/pyscf/grad/test/test_tdrks_grad.py
@@ -103,7 +103,7 @@ class KnownValues(unittest.TestCase):
         td = tdscf.TDA(mf).run(singlet=False, nstates=nstates)
         tdg = td.nuc_grad_method()
         g1 = tdg.kernel(state=3)
-        self.assertAlmostEqual(g1[0,2], -0.3633375, 6)
+        self.assertAlmostEqual(g1[0,2], -0.3633375, 5)
 
         td_solver = td.as_scanner()
         pmol = mol.copy()

--- a/pyscf/grad/test/test_tduhf_grad.py
+++ b/pyscf/grad/test/test_tduhf_grad.py
@@ -50,7 +50,7 @@ class KnownValues(unittest.TestCase):
         td = tdscf.TDA(mf).run(nstates=nstates)
         tdg = td.nuc_grad_method()
         g1 = tdg.kernel(state=3)
-        self.assertAlmostEqual(g1[0,2], -0.78246882668628404, 6)
+        self.assertAlmostEqual(g1[0,2], -0.78246882668628404, 5)
 
         td_solver = td.as_scanner()
         e1 = td_solver(pmol.set_geom_('H 0 0 1.805; F 0 0 0', unit='B'))

--- a/pyscf/pbc/dft/numint.py
+++ b/pyscf/pbc/dft/numint.py
@@ -322,7 +322,6 @@ def nr_rks(ni, cell, grids, xc_code, dms, spin=0, relativity=0, hermi=1,
         excsum is the XC functional value.  vmat is the XC potential matrix in
         2D array of shape (nao,nao) where nao is the number of AO functions.
     '''
-    assert hermi == 1
     if kpts is None:
         kpts = numpy.zeros((1,3))
     elif isinstance(kpts, KPoints):
@@ -356,7 +355,7 @@ def nr_rks(ni, cell, grids, xc_code, dms, spin=0, relativity=0, hermi=1,
                 in ni.block_loop(cell, grids, nao, ao_deriv, kpts, kpts_band,
                                  max_memory):
             for i in range(nset):
-                rho = make_rho(i, ao_k2, mask, xctype)
+                rho = make_rho(i, ao_k2, mask, xctype).real
                 exc, vxc = ni.eval_xc_eff(xc_code, rho, deriv, xctype=xctype)[:2]
                 if xctype == 'LDA':
                     den = rho*weight
@@ -423,7 +422,6 @@ def nr_uks(ni, cell, grids, xc_code, dms, spin=1, relativity=0, hermi=1,
         excsum is the XC functional value.  vmat is the XC potential matrix in
         2D array of shape (nao,nao) where nao is the number of AO functions.
     '''
-    assert hermi == 1
     if kpts is None:
         kpts = numpy.zeros((1,3))
     elif isinstance(kpts, KPoints):
@@ -461,8 +459,8 @@ def nr_uks(ni, cell, grids, xc_code, dms, spin=1, relativity=0, hermi=1,
                 in ni.block_loop(cell, grids, nao, ao_deriv, kpts, kpts_band,
                                  max_memory):
             for i in range(nset):
-                rho_a = make_rhoa(i, ao_k2, mask, xctype)
-                rho_b = make_rhob(i, ao_k2, mask, xctype)
+                rho_a = make_rhoa(i, ao_k2, mask, xctype).real
+                rho_b = make_rhob(i, ao_k2, mask, xctype).real
                 rho = (rho_a, rho_b)
                 exc, vxc = ni.eval_xc_eff(xc_code, rho, deriv, xctype=xctype)[:2]
                 if xctype == 'LDA':

--- a/pyscf/pbc/dft/test/test_numint.py
+++ b/pyscf/pbc/dft/test/test_numint.py
@@ -205,7 +205,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(exc, -3.8870579114663886, 8)
         self.assertAlmostEqual(lib.fp(vmat), 0.42538491159934377+0.14139753327162483j, 8)
 
-        ne, exc, vmat = ni.nr_rks(cell, grids, 'blyp', dms[0], 0, kpts[0])
+        ne, exc, vmat = ni.nr_rks(cell, grids, 'blyp', dms[0], hermi=0, kpt=kpts[0])
         self.assertAlmostEqual(lib.fp(vmat), 0.42538491159934377+0.14139753327162483j, 8)
 
         ni = numint.KNumInt()
@@ -244,8 +244,8 @@ class KnownValues(unittest.TestCase):
         dm = np.random.random((nao,nao))
         dm = dm + dm.T
         ni = numint.NumInt()
-        ne, exc, vmat1 = ni.nr_rks(cell, grids, 'blyp', dm, 1, kpts[0])
-        ne, exc, vmat2 = ni.nr_rks(cell, grids, 'blyp', dm, 0, kpts[0])
+        ne, exc, vmat1 = ni.nr_rks(cell, grids, 'blyp', dm, hermi=1, kpt=kpts[0])
+        ne, exc, vmat2 = ni.nr_rks(cell, grids, 'blyp', dm, hermi=0, kpt=kpts[0])
         self.assertAlmostEqual(lib.fp(vmat1), (6.238900947350686+0.6026114431281391j), 8)
         self.assertAlmostEqual(abs(vmat1 - vmat2).max(), 0, 9)
 

--- a/pyscf/pbc/tdscf/krhf.py
+++ b/pyscf/pbc/tdscf/krhf.py
@@ -205,7 +205,7 @@ class TDA(KTDBase):
 
             if x0 is None:
                 x0k = self.init_guess(self._scf, kshift, self.nstates)
-                x0k = self.trunc_workspace(vind, x0k, nstates=self.nstates, pick=pickeig)[1]
+                #x0k = self.trunc_workspace(vind, x0k, nstates=self.nstates, pick=pickeig)[1]
             else:
                 x0k = x0[i]
 
@@ -336,7 +336,7 @@ class TDHF(TDA):
 
             if x0 is None:
                 x0k = self.init_guess(self._scf, kshift, self.nstates)
-                x0k = self.trunc_workspace(vind, x0k, nstates=self.nstates*2, pick=pickeig)[1]
+                #x0k = self.trunc_workspace(vind, x0k, nstates=self.nstates*2, pick=pickeig)[1]
             else:
                 x0k = x0[i]
 

--- a/pyscf/pbc/tdscf/krhf.py
+++ b/pyscf/pbc/tdscf/krhf.py
@@ -154,14 +154,10 @@ class TDA(KTDBase):
         kconserv = self.kconserv[kshift]
         e_ia = numpy.concatenate( [x.reshape(-1) for x in
                                    _get_e_ia(mo_energy, mo_occ, kconserv)] )
-        e_ia = numpy.ceil(e_ia / self.deg_eia_thresh) * self.deg_eia_thresh
-        e_ia_uniq = numpy.unique(e_ia)
 
-        e_ia_max = e_ia.max()
         nov = e_ia.size
         nstates = min(nstates, nov)
-        nstates_thresh = min(nstates, e_ia_uniq.size)
-        e_threshold = min(e_ia_max, e_ia_uniq[numpy.argsort(e_ia_uniq)[nstates_thresh-1]])
+        e_threshold = numpy.sort(e_ia)[nstates-1]
         e_threshold += self.deg_eia_thresh
 
         idx = numpy.where(e_ia <= e_threshold)[0]
@@ -205,7 +201,6 @@ class TDA(KTDBase):
 
             if x0 is None:
                 x0k = self.init_guess(self._scf, kshift, self.nstates)
-                #x0k = self.trunc_workspace(vind, x0k, nstates=self.nstates, pick=pickeig)[1]
             else:
                 x0k = x0[i]
 
@@ -336,7 +331,6 @@ class TDHF(TDA):
 
             if x0 is None:
                 x0k = self.init_guess(self._scf, kshift, self.nstates)
-                #x0k = self.trunc_workspace(vind, x0k, nstates=self.nstates*2, pick=pickeig)[1]
             else:
                 x0k = x0[i]
 

--- a/pyscf/pbc/tdscf/kuhf.py
+++ b/pyscf/pbc/tdscf/kuhf.py
@@ -145,7 +145,7 @@ class TDA(KTDBase):
 
             if x0 is None:
                 x0k = self.init_guess(self._scf, kshift, self.nstates)
-                x0k = self.trunc_workspace(vind, x0k, nstates=self.nstates, pick=pickeig)[1]
+                #x0k = self.trunc_workspace(vind, x0k, nstates=self.nstates, pick=pickeig)[1]
             else:
                 x0k = x0[i]
 
@@ -286,7 +286,7 @@ class TDHF(TDA):
 
             if x0 is None:
                 x0k = self.init_guess(self._scf, kshift, self.nstates)
-                x0k = self.trunc_workspace(vind, x0k, nstates=self.nstates, pick=pickeig)[1]
+                #x0k = self.trunc_workspace(vind, x0k, nstates=self.nstates, pick=pickeig)[1]
             else:
                 x0k = x0[i]
 

--- a/pyscf/pbc/tdscf/kuhf.py
+++ b/pyscf/pbc/tdscf/kuhf.py
@@ -98,14 +98,10 @@ class TDA(KTDBase):
         e_ia_a = _get_e_ia(mo_energy[0], mo_occ[0], kconserv)
         e_ia_b = _get_e_ia(mo_energy[1], mo_occ[1], kconserv)
         e_ia = numpy.hstack([x.ravel() for x in (e_ia_a + e_ia_b)])
-        e_ia = numpy.ceil(e_ia / self.deg_eia_thresh) * self.deg_eia_thresh
-        e_ia_uniq = numpy.unique(e_ia)
 
-        e_ia_max = e_ia.max()
         nov = e_ia.size
         nstates = min(nstates, nov)
-        nstates_thresh = min(nstates, e_ia_uniq.size)
-        e_threshold = min(e_ia_max, e_ia_uniq[numpy.argsort(e_ia_uniq)[nstates_thresh-1]])
+        e_threshold = numpy.sort(e_ia)[nstates-1]
         e_threshold += self.deg_eia_thresh
 
         idx = numpy.where(e_ia <= e_threshold)[0]
@@ -145,7 +141,6 @@ class TDA(KTDBase):
 
             if x0 is None:
                 x0k = self.init_guess(self._scf, kshift, self.nstates)
-                #x0k = self.trunc_workspace(vind, x0k, nstates=self.nstates, pick=pickeig)[1]
             else:
                 x0k = x0[i]
 
@@ -286,7 +281,6 @@ class TDHF(TDA):
 
             if x0 is None:
                 x0k = self.init_guess(self._scf, kshift, self.nstates)
-                #x0k = self.trunc_workspace(vind, x0k, nstates=self.nstates, pick=pickeig)[1]
             else:
                 x0k = x0[i]
 

--- a/pyscf/pbc/tdscf/test/test_rks.py
+++ b/pyscf/pbc/tdscf/test/test_rks.py
@@ -58,11 +58,11 @@ class DiamondPBE(unittest.TestCase):
         self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 4)
 
     def test_tda_singlet(self):
-        ref = [9.2625251659, 9.2625251659]
+        ref = [9.26752544, 9.26752544]
         self.kernel('TDA', ref)
 
     def test_tda_triplet(self):
-        ref = [4.8364248190, 4.8364248190]
+        ref = [4.79532598, 4.79532598]
         self.kernel('TDA', ref, singlet=False)
 
     def test_tddft_singlet(self):
@@ -226,11 +226,11 @@ class DiamondPBE0(unittest.TestCase):
         self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 4)
 
     def test_tda_singlet(self):
-        ref = [9.6202884134, 9.6202884134]
+        ref = [9.61243337, 9.61243337]
         self.kernel('TDA', ref)
 
     def test_tda_triplet(self):
-        ref = [5.1659937745, 5.1659937745]
+        ref = [5.13034084, 5.13034084]
         self.kernel('TDA', ref, singlet=False)
 
     def test_tddft_singlet(self):

--- a/pyscf/pbc/tdscf/test/test_rks.py
+++ b/pyscf/pbc/tdscf/test/test_rks.py
@@ -58,15 +58,15 @@ class DiamondPBE(unittest.TestCase):
         self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 4)
 
     def test_tda_singlet(self):
-        ref = [9.2625251659, 9.2625251659]
+        ref = [9.33545109, 9.33545109]
         self.kernel('TDA', ref)
 
     def test_tda_triplet(self):
-        ref = [4.8364248190, 4.8364248190]
+        ref = [5.14726236, 5.14726236]
         self.kernel('TDA', ref, singlet=False)
 
     def test_tddft_singlet(self):
-        ref = [8.8773512896, 8.8773512896]
+        ref = [8.87735129, 8.87735129]
         self.kernel('TDDFT', ref)
 
     def test_tddft_triplet(self):
@@ -226,19 +226,19 @@ class DiamondPBE0(unittest.TestCase):
         self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 4)
 
     def test_tda_singlet(self):
-        ref = [9.6202884134, 9.6202884134]
+        ref = [9.62238067, 9.62238067]
         self.kernel('TDA', ref)
 
     def test_tda_triplet(self):
-        ref = [5.1659937745, 5.1659937745]
+        ref = [5.39995144, 5.39995144]
         self.kernel('TDA', ref, singlet=False)
 
     def test_tddft_singlet(self):
-        ref = [9.2585491075, 9.2585491075]
+        ref = [9.260114, 9.260114]
         self.kernel('TDDFT', ref)
 
     def test_tddft_triplet(self):
-        ref = [4.5570089807, 4.5570089807]
+        ref = [4.68905023, 4.8143958 ]
         self.kernel('TDDFT', ref, singlet=False)
 
 

--- a/pyscf/pbc/tdscf/test/test_rks.py
+++ b/pyscf/pbc/tdscf/test/test_rks.py
@@ -58,15 +58,15 @@ class DiamondPBE(unittest.TestCase):
         self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 4)
 
     def test_tda_singlet(self):
-        ref = [9.33545109, 9.33545109]
+        ref = [9.2625251659, 9.2625251659]
         self.kernel('TDA', ref)
 
     def test_tda_triplet(self):
-        ref = [5.14726236, 5.14726236]
+        ref = [4.8364248190, 4.8364248190]
         self.kernel('TDA', ref, singlet=False)
 
     def test_tddft_singlet(self):
-        ref = [8.87735129, 8.87735129]
+        ref = [8.8773512896, 8.8773512896]
         self.kernel('TDDFT', ref)
 
     def test_tddft_triplet(self):
@@ -226,19 +226,19 @@ class DiamondPBE0(unittest.TestCase):
         self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 4)
 
     def test_tda_singlet(self):
-        ref = [9.62238067, 9.62238067]
+        ref = [9.6202884134, 9.6202884134]
         self.kernel('TDA', ref)
 
     def test_tda_triplet(self):
-        ref = [5.39995144, 5.39995144]
+        ref = [5.1659937745, 5.1659937745]
         self.kernel('TDA', ref, singlet=False)
 
     def test_tddft_singlet(self):
-        ref = [9.260114, 9.260114]
+        ref = [9.2585491075, 9.2585491075]
         self.kernel('TDDFT', ref)
 
     def test_tddft_triplet(self):
-        ref = [4.68905023, 4.8143958 ]
+        ref = [4.5570089807, 4.5570089807]
         self.kernel('TDDFT', ref, singlet=False)
 
 

--- a/pyscf/pbc/tdscf/test/test_uhf.py
+++ b/pyscf/pbc/tdscf/test/test_uhf.py
@@ -45,7 +45,7 @@ class Diamond(unittest.TestCase):
         cls.cell = cell
         cls.mf = mf
 
-        cls.nstates = 5 # make sure first `nstates_test` states are converged
+        cls.nstates = 8 # make sure first `nstates_test` states are converged
         cls.nstates_test = 2
     @classmethod
     def tearDownClass(cls):

--- a/pyscf/pbc/tdscf/test/test_uks.py
+++ b/pyscf/pbc/tdscf/test/test_uks.py
@@ -59,7 +59,7 @@ class DiamondPBE(unittest.TestCase):
         self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 4)
 
     def test_tda(self):
-        ref = [4.8137763755, 4.8137763755]
+        ref = [4.77090949, 4.77090949]
         self.kernel('TDA', ref)
 
     def test_tdhf(self):
@@ -161,7 +161,7 @@ class DiamondPBE0(unittest.TestCase):
         self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 4)
 
     def test_tda(self):
-        ref = [5.1435121896, 5.1435121896]
+        ref = [5.1069789, 5.10697989]
         self.kernel('TDA', ref)
 
     def test_tdhf(self):

--- a/pyscf/pbc/tdscf/test/test_uks.py
+++ b/pyscf/pbc/tdscf/test/test_uks.py
@@ -56,11 +56,10 @@ class DiamondPBE(unittest.TestCase):
 
     def kernel(self, TD, ref, **kwargs):
         td = getattr(self.mf, TD)().set(nstates=self.nstates, **kwargs).run()
-        print(td.e[:self.nstates_test] * unitev)
         self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 4)
 
     def test_tda(self):
-        ref = [4.77090949, 4.77090949]
+        ref = [4.8137763755, 4.8137763755]
         self.kernel('TDA', ref)
 
     def test_tdhf(self):
@@ -159,11 +158,10 @@ class DiamondPBE0(unittest.TestCase):
 
     def kernel(self, TD, ref, **kwargs):
         td = getattr(self.mf, TD)().set(nstates=self.nstates, **kwargs).run()
-        print(td.e[:self.nstates_test] * unitev)
         self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 4)
 
     def test_tda(self):
-        ref = [5.10697989, 5.10697989]
+        ref = [5.1435121896, 5.1435121896]
         self.kernel('TDA', ref)
 
     def test_tdhf(self):

--- a/pyscf/pbc/tdscf/test/test_uks.py
+++ b/pyscf/pbc/tdscf/test/test_uks.py
@@ -56,10 +56,11 @@ class DiamondPBE(unittest.TestCase):
 
     def kernel(self, TD, ref, **kwargs):
         td = getattr(self.mf, TD)().set(nstates=self.nstates, **kwargs).run()
+        print(td.e[:self.nstates_test] * unitev)
         self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 4)
 
     def test_tda(self):
-        ref = [4.8137763755, 4.8137763755]
+        ref = [4.77090949, 4.77090949]
         self.kernel('TDA', ref)
 
     def test_tdhf(self):
@@ -158,10 +159,11 @@ class DiamondPBE0(unittest.TestCase):
 
     def kernel(self, TD, ref, **kwargs):
         td = getattr(self.mf, TD)().set(nstates=self.nstates, **kwargs).run()
+        print(td.e[:self.nstates_test] * unitev)
         self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 4)
 
     def test_tda(self):
-        ref = [5.1435121896, 5.1435121896]
+        ref = [5.10697989, 5.10697989]
         self.kernel('TDA', ref)
 
     def test_tdhf(self):

--- a/pyscf/tdscf/dhf.py
+++ b/pyscf/tdscf/dhf.py
@@ -451,7 +451,7 @@ class TDA(TDBase):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
+            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         # FIXME: Is it correct to call davidson1 for complex integrals?
         self.converged, self.e, x1 = \
@@ -563,7 +563,7 @@ class TDHF(TDBase):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
+            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, w, x1 = \
                 lib.davidson_nosym1(vind, x0, precond,

--- a/pyscf/tdscf/dhf.py
+++ b/pyscf/tdscf/dhf.py
@@ -411,16 +411,11 @@ class TDA(TDBase):
         occidx = n2c + numpy.where(mo_occ[n2c:] == 1)[0]
         viridx = n2c + numpy.where(mo_occ[n2c:] == 0)[0]
         e_ia = mo_energy[viridx] - mo_energy[occidx,None]
-        # make degenerate excitations equal for later selection by energy
-        e_ia = numpy.ceil(e_ia / self.deg_eia_thresh) * self.deg_eia_thresh
-        e_ia_uniq = numpy.unique(e_ia)
-        e_ia_max = e_ia.max()
 
         nov = e_ia.size
         nstates = min(nstates, nov)
-        nstates_thresh = min(nstates, e_ia_uniq.size)
         e_ia = e_ia.ravel()
-        e_threshold = min(e_ia_max, e_ia_uniq[numpy.argsort(e_ia_uniq)[nstates_thresh-1]])
+        e_threshold = numpy.sort(e_ia)[nstates-1]
         e_threshold += self.deg_eia_thresh
 
         idx = numpy.where(e_ia <= e_threshold)[0]
@@ -451,7 +446,6 @@ class TDA(TDBase):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         # FIXME: Is it correct to call davidson1 for complex integrals?
         self.converged, self.e, x1 = \
@@ -563,7 +557,6 @@ class TDHF(TDBase):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, w, x1 = \
                 lib.davidson_nosym1(vind, x0, precond,

--- a/pyscf/tdscf/ghf.py
+++ b/pyscf/tdscf/ghf.py
@@ -436,7 +436,7 @@ class TDA(TDBase):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
+            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         # FIXME: Is it correct to call davidson1 for complex integrals
         self.converged, self.e, x1 = \
@@ -577,7 +577,7 @@ class TDHF(TDBase):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
+            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, w, x1 = \
                 lib.davidson_nosym1(vind, x0, precond,

--- a/pyscf/tdscf/gks.py
+++ b/pyscf/tdscf/gks.py
@@ -123,7 +123,6 @@ class CasidaTDDFT(TDDFT, TDA):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, w2, x1 = \
                 lib.davidson1(vind, x0, precond,

--- a/pyscf/tdscf/gks.py
+++ b/pyscf/tdscf/gks.py
@@ -123,7 +123,7 @@ class CasidaTDDFT(TDDFT, TDA):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
+            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, w2, x1 = \
                 lib.davidson1(vind, x0, precond,

--- a/pyscf/tdscf/rhf.py
+++ b/pyscf/tdscf/rhf.py
@@ -743,7 +743,10 @@ class TDBase(lib.StreamObject):
             return None, x0
         else:
             heff = lib.einsum('xa,ya->xy', x0.conj(), vind(x0))
-            e, u = scipy.linalg.eig(heff)   # heff not necessarily Hermitian
+            if abs(heff - heff.conj().T).max() < 1e-12:
+                e, u = scipy.linalg.eigh(heff)
+            else:
+                e, u = scipy.linalg.eig(heff)   # heff not necessarily Hermitian
             e = e.real
             order = numpy.argsort(e)
             e = e[order]
@@ -869,7 +872,7 @@ class TDA(TDBase):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
+            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, self.e, x1 = \
                 lib.davidson1(vind, x0, precond,
@@ -1039,7 +1042,7 @@ class TDHF(TDA):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
+            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, w, x1 = \
                 lib.davidson_nosym1(vind, x0, precond,

--- a/pyscf/tdscf/rhf.py
+++ b/pyscf/tdscf/rhf.py
@@ -736,29 +736,6 @@ class TDBase(lib.StreamObject):
             return x/diagd
         return precond
 
-    def trunc_workspace(self, vind, x0, nstates=None, pick=None):
-        log = logger.new_logger(self)
-        if nstates is None: nstates = self.nstates
-        if x0.shape[0] <= nstates:
-            return None, x0
-        else:
-            heff = lib.einsum('xa,ya->xy', x0.conj(), vind(x0))
-            if abs(heff - heff.conj().T).max() < 1e-12:
-                e, u = scipy.linalg.eigh(heff)
-            else:
-                e, u = scipy.linalg.eig(heff)   # heff not necessarily Hermitian
-            e = e.real
-            order = numpy.argsort(e)
-            e = e[order]
-            u = u[:,order]
-            if callable(pick):
-                e, u = pick(e, u, None, None)[:2]
-            e = e[:nstates]
-            log.debug('truncating %d states to %d states with excitation energy (eV): %s',
-                      x0.shape[0], e.size, e*27.211399)
-            x1 = numpy.dot(x0.T, u[:,:nstates]).T
-            return e, x1
-
     analyze = analyze
     get_nto = get_nto
     oscillator_strength = oscillator_strength
@@ -823,9 +800,6 @@ class TDA(TDBase):
         occidx = numpy.where(mo_occ==2)[0]
         viridx = numpy.where(mo_occ==0)[0]
         e_ia = mo_energy[viridx] - mo_energy[occidx,None]
-        # make degenerate excitations equal for later selection by energy
-        e_ia = numpy.ceil(e_ia / self.deg_eia_thresh) * self.deg_eia_thresh
-        e_ia_max = e_ia.max()
 
         if wfnsym is not None and mf.mol.symmetry:
             if isinstance(wfnsym, str):
@@ -835,13 +809,10 @@ class TDA(TDBase):
             orbsym_in_d2h = numpy.asarray(orbsym) % 10  # convert to D2h irreps
             e_ia[(orbsym_in_d2h[occidx,None] ^ orbsym_in_d2h[viridx]) != wfnsym] = 1e99
 
-        e_ia_uniq = numpy.unique(e_ia)
-
         nov = e_ia.size
         nstates = min(nstates, nov)
-        nstates_thresh = min(nstates, e_ia_uniq.size)
         e_ia = e_ia.ravel()
-        e_threshold = min(e_ia_max, e_ia_uniq[numpy.argsort(e_ia_uniq)[nstates_thresh-1]])
+        e_threshold = numpy.sort(e_ia)[nstates-1]
         e_threshold += self.deg_eia_thresh
 
         idx = numpy.where(e_ia <= e_threshold)[0]
@@ -872,7 +843,6 @@ class TDA(TDBase):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, self.e, x1 = \
                 lib.davidson1(vind, x0, precond,
@@ -1042,7 +1012,6 @@ class TDHF(TDA):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, w, x1 = \
                 lib.davidson_nosym1(vind, x0, precond,

--- a/pyscf/tdscf/rks.py
+++ b/pyscf/tdscf/rks.py
@@ -127,7 +127,7 @@ class CasidaTDDFT(TDDFT, TDA):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
+            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, w2, x1 = \
                 lib.davidson1(vind, x0, precond,

--- a/pyscf/tdscf/rks.py
+++ b/pyscf/tdscf/rks.py
@@ -127,7 +127,6 @@ class CasidaTDDFT(TDDFT, TDA):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, w2, x1 = \
                 lib.davidson1(vind, x0, precond,

--- a/pyscf/tdscf/test/test_tdrks.py
+++ b/pyscf/tdscf/test/test_tdrks.py
@@ -160,7 +160,7 @@ class KnownValues(unittest.TestCase):
         td = rks.TDA(mf_lda)
         td.singlet = False
         es = td.kernel(nstates=5)[0] * 27.2114
-        self.assertAlmostEqual(lib.fp(es), -39.74044291202006, 5)
+        self.assertAlmostEqual(lib.fp(es), -39.988118769202416, 5)
         ref = [9.0139312, 9.0139312,  12.42444659]
         self.assertAlmostEqual(abs(es[:3] - ref).max(), 0, 4)
 

--- a/pyscf/tdscf/uhf.py
+++ b/pyscf/tdscf/uhf.py
@@ -669,7 +669,7 @@ class TDA(TDBase):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
+            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, self.e, x1 = \
                 lib.davidson1(vind, x0, precond,
@@ -828,7 +828,7 @@ class TDHF(TDA):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
+            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, w, x1 = \
                 lib.davidson_nosym1(vind, x0, precond,

--- a/pyscf/tdscf/uks.py
+++ b/pyscf/tdscf/uks.py
@@ -144,7 +144,7 @@ class CasidaTDDFT(TDDFT, TDA):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
+            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, w2, x1 = \
                 lib.davidson1(vind, x0, precond,

--- a/pyscf/tdscf/uks.py
+++ b/pyscf/tdscf/uks.py
@@ -144,7 +144,6 @@ class CasidaTDDFT(TDDFT, TDA):
 
         if x0 is None:
             x0 = self.init_guess(self._scf, self.nstates)
-            #x0 = self.trunc_workspace(vind, x0, nstates=self.nstates, pick=pickeig)[1]
 
         self.converged, w2, x1 = \
                 lib.davidson1(vind, x0, precond,


### PR DESCRIPTION
* The treatment of degeneracy TDDFT initial guess include unnecessary states. They are removed in this PR. It should fix test fail #1871 
* Another TDDFT fxc integral bug fix depends on the PR #1859 