### PR TITLE
To gpu

### DIFF
--- a/pyscf/adc/__init__.py
+++ b/pyscf/adc/__init__.py
@@ -46,7 +46,7 @@ def ADC(mf, frozen=None, mo_coeff=None, mo_occ=None):
     #elif isinstance(mf, scf.rohf.ROHF):
     #    lib.logger.warn(mf, 'RADC method does not support ROHF reference. ROHF object '
     #                    'is converted to UHF object and UADC method is called.')
-    #    mf = scf.addons.convert_to_uhf(mf)
+    #    mf = mf.to_uhf(mf)
     #    return UADC(mf, frozen, mo_coeff, mo_occ)
     # TODO add ROHF functionality
     elif isinstance(mf, scf.rhf.RHF):
@@ -64,8 +64,10 @@ def UADC(mf, frozen=None, mo_coeff=None, mo_occ=None):
 
     from pyscf.soscf import newton_ah
 
-    if isinstance(mf, newton_ah._CIAH_SOSCF) or not isinstance(mf, scf.uhf.UHF):
-        mf = scf.addons.convert_to_uhf(mf)
+    if not isinstance(mf, scf.uhf.UHF):
+        mf = mf.to_uhf()
+    if isinstance(mf, newton_ah._CIAH_SOSCF):
+        mf = mf.undo_soscf()
 
     return uadc.UADC(mf, frozen, mo_coeff, mo_occ)
 
@@ -79,8 +81,10 @@ def RADC(mf, frozen=None, mo_coeff=None, mo_occ=None):
 
     from pyscf.soscf import newton_ah
 
-    if isinstance(mf, newton_ah._CIAH_SOSCF) or not isinstance(mf, scf.rhf.RHF):
-        mf = scf.addons.convert_to_rhf(mf)
+    if not isinstance(mf, scf.rhf.RHF):
+        mf = mf.to_rhf()
+    if isinstance(mf, newton_ah._CIAH_SOSCF):
+        mf = mf.undo_soscf()
 
     return radc.RADC(mf, frozen, mo_coeff, mo_occ)
 

--- a/pyscf/adc/__init__.py
+++ b/pyscf/adc/__init__.py
@@ -61,12 +61,9 @@ def UADC(mf, frozen=None, mo_coeff=None, mo_occ=None):
     if not (frozen is None or frozen == 0):
         raise NotImplementedError
 
-    from pyscf.soscf import newton_ah
-
+    mf = mf.remove_soscf()
     if not mf.istype('UHF'):
         mf = mf.to_uhf()
-    if isinstance(mf, newton_ah._CIAH_SOSCF):
-        mf = mf.undo_soscf()
 
     return uadc.UADC(mf, frozen, mo_coeff, mo_occ)
 
@@ -78,12 +75,9 @@ def RADC(mf, frozen=None, mo_coeff=None, mo_occ=None):
     if not (frozen is None or frozen == 0):
         raise NotImplementedError
 
-    from pyscf.soscf import newton_ah
-
+    mf = mf.remove_soscf()
     if not mf.istype('RHF'):
         mf = mf.to_rhf()
-    if isinstance(mf, newton_ah._CIAH_SOSCF):
-        mf = mf.undo_soscf()
 
     return radc.RADC(mf, frozen, mo_coeff, mo_occ)
 

--- a/pyscf/adc/__init__.py
+++ b/pyscf/adc/__init__.py
@@ -23,7 +23,6 @@ Algebraic Diagrammatic Construction
 ===================================
 '''
 
-from pyscf import scf
 from pyscf import lib
 from pyscf.adc import uadc
 from pyscf.adc import radc
@@ -41,7 +40,7 @@ def ADC(mf, frozen=None, mo_coeff=None, mo_occ=None):
     if not (frozen is None or frozen == 0):
         raise NotImplementedError
 
-    if isinstance(mf, scf.uhf.UHF):
+    if mf.istype('UHF'):
         return UADC(mf, frozen, mo_coeff, mo_occ)
     #elif isinstance(mf, scf.rohf.ROHF):
     #    lib.logger.warn(mf, 'RADC method does not support ROHF reference. ROHF object '
@@ -49,7 +48,7 @@ def ADC(mf, frozen=None, mo_coeff=None, mo_occ=None):
     #    mf = mf.to_uhf(mf)
     #    return UADC(mf, frozen, mo_coeff, mo_occ)
     # TODO add ROHF functionality
-    elif isinstance(mf, scf.rhf.RHF):
+    elif mf.istype('RHF'):
         return RADC(mf, frozen, mo_coeff, mo_occ)
     else :
         raise RuntimeError('ADC code only supports RHF, ROHF, and UHF references')
@@ -64,7 +63,7 @@ def UADC(mf, frozen=None, mo_coeff=None, mo_occ=None):
 
     from pyscf.soscf import newton_ah
 
-    if not isinstance(mf, scf.uhf.UHF):
+    if not mf.istype('UHF'):
         mf = mf.to_uhf()
     if isinstance(mf, newton_ah._CIAH_SOSCF):
         mf = mf.undo_soscf()
@@ -81,7 +80,7 @@ def RADC(mf, frozen=None, mo_coeff=None, mo_occ=None):
 
     from pyscf.soscf import newton_ah
 
-    if not isinstance(mf, scf.rhf.RHF):
+    if not mf.istype('RHF'):
         mf = mf.to_rhf()
     if isinstance(mf, newton_ah._CIAH_SOSCF):
         mf = mf.undo_soscf()

--- a/pyscf/agf2/__init__.py
+++ b/pyscf/agf2/__init__.py
@@ -102,7 +102,7 @@ def AGF2(mf, nmom=(None,0), frozen=None, mo_energy=None, mo_coeff=None, mo_occ=N
     elif isinstance(mf, scf.rohf.ROHF):
         lib.logger.warn(mf, 'RAGF2 method does not support ROHF reference. '
                             'Converting to UHF and using UAGF2.')
-        mf = scf.addons.convert_to_uhf(mf)
+        mf = mf.to_uhf()
         return UAGF2(mf, nmom, frozen, mo_energy, mo_coeff, mo_occ)
 
     elif isinstance(mf, scf.rhf.RHF):

--- a/pyscf/cc/__init__.py
+++ b/pyscf/cc/__init__.py
@@ -79,9 +79,9 @@ from pyscf.cc import momgfccsd
 from pyscf import scf
 
 def CCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    if isinstance(mf, scf.uhf.UHF):
+    if mf.istype('UHF'):
         return UCCSD(mf, frozen, mo_coeff, mo_occ)
-    elif isinstance(mf, scf.ghf.GHF):
+    elif mf.istype('GHF'):
         return GCCSD(mf, frozen, mo_coeff, mo_occ)
     else:
         return RCCSD(mf, frozen, mo_coeff, mo_occ)
@@ -93,21 +93,24 @@ scf.hf.SCF.CCSD = CCSD
 def RCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     import numpy
     from pyscf import lib
+    from pyscf.df.df_jk import _DFHF
     from pyscf.soscf import newton_ah
     from pyscf.cc import dfccsd
 
-    if isinstance(mf, scf.uhf.UHF):
+    if mf.istype('UHF'):
         raise RuntimeError('RCCSD cannot be used with UHF method.')
-    elif isinstance(mf, scf.rohf.ROHF):
+    elif mf.istype('ROHF'):
         lib.logger.warn(mf, 'RCCSD method does not support ROHF method. ROHF object '
                         'is converted to UHF object and UCCSD method is called.')
-        mf = scf.addons.convert_to_uhf(mf)
+        mf = mf.to_uhf()
         return UCCSD(mf, frozen, mo_coeff, mo_occ)
 
-    if isinstance(mf, newton_ah._CIAH_SOSCF) or not isinstance(mf, scf.hf.RHF):
-        mf = scf.addons.convert_to_rhf(mf)
+    if not mf.istype('RHF'):
+        mf = mf.to_rhf()
+    if isinstance(mf, newton_ah._CIAH_SOSCF):
+        mf = mf.undo_soscf()
 
-    if getattr(mf, 'with_df', None):
+    if isinstance(mf, _DFHF) and mf.with_df:
         return dfccsd.RCCSD(mf, frozen, mo_coeff, mo_occ)
 
     elif numpy.iscomplexobj(mo_coeff) or numpy.iscomplexobj(mf.mo_coeff):
@@ -119,12 +122,15 @@ RCCSD.__doc__ = ccsd.CCSD.__doc__
 
 
 def UCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
+    from pyscf.df.df_jk import _DFHF
     from pyscf.soscf import newton_ah
 
-    if isinstance(mf, newton_ah._CIAH_SOSCF) or not isinstance(mf, scf.uhf.UHF):
-        mf = scf.addons.convert_to_uhf(mf)
+    if not mf.istype('UHF'):
+        mf = mf.to_uhf()
+    if isinstance(mf, newton_ah._CIAH_SOSCF):
+        mf = mf.undo_soscf()
 
-    if getattr(mf, 'with_df', None):
+    if isinstance(mf, _DFHF) and mf.with_df:
         # TODO: DF-UCCSD with memory-efficient particle-particle ladder,
         # similar to dfccsd.RCCSD
         return uccsd.UCCSD(mf, frozen, mo_coeff, mo_occ)
@@ -134,12 +140,15 @@ UCCSD.__doc__ = uccsd.UCCSD.__doc__
 
 
 def GCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
+    from pyscf.df.df_jk import _DFHF
     from pyscf.soscf import newton_ah
 
-    if isinstance(mf, newton_ah._CIAH_SOSCF) or not isinstance(mf, scf.ghf.GHF):
-        mf = scf.addons.convert_to_ghf(mf)
+    if not mf.istype('GHF'):
+        mf = mf.to_ghf()
+    if isinstance(mf, newton_ah._CIAH_SOSCF):
+        mf = mf.undo_soscf()
 
-    if getattr(mf, 'with_df', None):
+    if isinstance(mf, _DFHF) and mf.with_df:
         raise NotImplementedError('DF-GCCSD')
     else:
         return gccsd.GCCSD(mf, frozen, mo_coeff, mo_occ)
@@ -147,9 +156,9 @@ GCCSD.__doc__ = gccsd.GCCSD.__doc__
 
 
 def QCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    if isinstance(mf, scf.uhf.UHF):
+    if mf.istype('UHF'):
         raise NotImplementedError
-    elif isinstance(mf, scf.ghf.GHF):
+    elif mf.istype('GHF'):
         raise NotImplementedError
     else:
         return RQCISD(mf, frozen, mo_coeff, mo_occ)
@@ -162,16 +171,17 @@ def RQCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     from pyscf import lib
     from pyscf.soscf import newton_ah
 
-    if isinstance(mf, scf.uhf.UHF):
+    if mf.istype('UHF'):
         raise RuntimeError('RQCISD cannot be used with UHF method.')
-    elif isinstance(mf, scf.rohf.ROHF):
+    elif mf.istype('ROHF'):
         lib.logger.warn(mf, 'RQCISD method does not support ROHF method. ROHF object '
                         'is converted to UHF object and UQCISD method is called.')
-        mf = scf.addons.convert_to_uhf(mf)
         raise NotImplementedError
 
-    if isinstance(mf, newton_ah._CIAH_SOSCF) or not isinstance(mf, scf.hf.RHF):
-        mf = scf.addons.convert_to_rhf(mf)
+    if not mf.istype('RHF'):
+        mf = mf.to_rhf()
+    if isinstance(mf, newton_ah._CIAH_SOSCF):
+        mf = mf.undo_soscf()
 
     elif numpy.iscomplexobj(mo_coeff) or numpy.iscomplexobj(mf.mo_coeff):
         raise NotImplementedError

--- a/pyscf/cc/__init__.py
+++ b/pyscf/cc/__init__.py
@@ -94,7 +94,6 @@ def RCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     import numpy
     from pyscf import lib
     from pyscf.df.df_jk import _DFHF
-    from pyscf.soscf import newton_ah
     from pyscf.cc import dfccsd
 
     if mf.istype('UHF'):
@@ -105,10 +104,9 @@ def RCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
         mf = mf.to_uhf()
         return UCCSD(mf, frozen, mo_coeff, mo_occ)
 
+    mf = mf.remove_soscf()
     if not mf.istype('RHF'):
         mf = mf.to_rhf()
-    if isinstance(mf, newton_ah._CIAH_SOSCF):
-        mf = mf.undo_soscf()
 
     if isinstance(mf, _DFHF) and mf.with_df:
         return dfccsd.RCCSD(mf, frozen, mo_coeff, mo_occ)
@@ -123,12 +121,10 @@ RCCSD.__doc__ = ccsd.CCSD.__doc__
 
 def UCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     from pyscf.df.df_jk import _DFHF
-    from pyscf.soscf import newton_ah
 
+    mf = mf.remove_soscf()
     if not mf.istype('UHF'):
         mf = mf.to_uhf()
-    if isinstance(mf, newton_ah._CIAH_SOSCF):
-        mf = mf.undo_soscf()
 
     if isinstance(mf, _DFHF) and mf.with_df:
         # TODO: DF-UCCSD with memory-efficient particle-particle ladder,
@@ -141,12 +137,10 @@ UCCSD.__doc__ = uccsd.UCCSD.__doc__
 
 def GCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     from pyscf.df.df_jk import _DFHF
-    from pyscf.soscf import newton_ah
 
+    mf = mf.remove_soscf()
     if not mf.istype('GHF'):
         mf = mf.to_ghf()
-    if isinstance(mf, newton_ah._CIAH_SOSCF):
-        mf = mf.undo_soscf()
 
     if isinstance(mf, _DFHF) and mf.with_df:
         raise NotImplementedError('DF-GCCSD')
@@ -169,7 +163,6 @@ scf.hf.SCF.QCISD = QCISD
 def RQCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     import numpy
     from pyscf import lib
-    from pyscf.soscf import newton_ah
 
     if mf.istype('UHF'):
         raise RuntimeError('RQCISD cannot be used with UHF method.')
@@ -178,10 +171,9 @@ def RQCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
                         'is converted to UHF object and UQCISD method is called.')
         raise NotImplementedError
 
+    mf = mf.remove_soscf()
     if not mf.istype('RHF'):
         mf = mf.to_rhf()
-    if isinstance(mf, newton_ah._CIAH_SOSCF):
-        mf = mf.undo_soscf()
 
     elif numpy.iscomplexobj(mo_coeff) or numpy.iscomplexobj(mf.mo_coeff):
         raise NotImplementedError

--- a/pyscf/cc/addons.py
+++ b/pyscf/cc/addons.py
@@ -122,14 +122,13 @@ def spin2spatial(tx, orbspin):
         return t2aa,t2ab,t2bb
 
 def convert_to_uccsd(mycc):
-    from pyscf import scf
     from pyscf.cc import uccsd, gccsd
     if isinstance(mycc, uccsd.UCCSD):
         return mycc
     elif isinstance(mycc, gccsd.GCCSD):
         raise NotImplementedError
 
-    mf = scf.addons.convert_to_uhf(mycc._scf)
+    mf = mycc._scf.to_uhf()
     ucc = uccsd.UCCSD(mf)
     assert (mycc._nocc is None)
     assert (mycc._nmo is None)
@@ -143,12 +142,11 @@ def convert_to_uccsd(mycc):
     return ucc
 
 def convert_to_gccsd(mycc):
-    from pyscf import scf
     from pyscf.cc import gccsd
     if isinstance(mycc, gccsd.GCCSD):
         return mycc
 
-    mf = scf.addons.convert_to_ghf(mycc._scf)
+    mf = mycc._scf.to_ghf()
     gcc = gccsd.GCCSD(mf)
     assert (mycc._nocc is None)
     assert (mycc._nmo is None)

--- a/pyscf/cc/ccsd.py
+++ b/pyscf/cc/ccsd.py
@@ -1496,6 +1496,8 @@ def _make_eris_incore(mycc, mo_coeff=None):
     return eris
 
 def _make_eris_outcore(mycc, mo_coeff=None):
+    from pyscf.scf.hf import RHF
+    assert isinstance(mycc._scf, RHF)
     cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(mycc.stdout, mycc.verbose)
     eris = _ChemistsERIs()

--- a/pyscf/cc/dfccsd.py
+++ b/pyscf/cc/dfccsd.py
@@ -121,6 +121,7 @@ class _ChemistsERIs(ccsd._ChemistsERIs):
         return _contract_vvvv_t2(mycc, self.mol, self.vvL, t2, out, verbose)
 
 def _make_df_eris(cc, mo_coeff=None):
+    assert cc._scf.istype('RHF')
     eris = _ChemistsERIs()
     eris._common_init_(cc, mo_coeff)
     nocc = eris.nocc

--- a/pyscf/cc/gccsd.py
+++ b/pyscf/cc/gccsd.py
@@ -117,7 +117,6 @@ class GCCSD(ccsd.CCSDBase):
     conv_tol_normt = getattr(__config__, 'cc_gccsd_GCCSD_conv_tol_normt', 1e-6)
 
     def __init__(self, mf, frozen=None, mo_coeff=None, mo_occ=None):
-        assert (isinstance(mf, scf.ghf.GHF))
         ccsd.CCSDBase.__init__(self, mf, frozen, mo_coeff, mo_occ)
 
     def init_amps(self, eris=None):
@@ -385,6 +384,8 @@ def _make_eris_incore(mycc, mo_coeff=None, ao2mofn=None):
     return eris
 
 def _make_eris_outcore(mycc, mo_coeff=None):
+    from pyscf.scf.ghf import GHF
+    assert isinstance(mycc._scf, GHF)
     cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(mycc.stdout, mycc.verbose)
 

--- a/pyscf/cc/gccsd_t.py
+++ b/pyscf/cc/gccsd_t.py
@@ -91,7 +91,7 @@ if __name__ == '__main__':
 
     numpy.random.seed(1)
     mf.mo_coeff = numpy.random.random(mf.mo_coeff.shape) - .9
-    mycc = cc.GCCSD(scf.addons.convert_to_ghf())
+    mycc = cc.GCCSD(mf.to_ghf())
     eris = mycc.ao2mo()
     nocc = 10
     nvir = mol.nao_nr() * 2 - nocc

--- a/pyscf/cc/gccsd_t.py
+++ b/pyscf/cc/gccsd_t.py
@@ -85,13 +85,13 @@ if __name__ == '__main__':
     mycc = cc.CCSD(mf).set(conv_tol=1e-11).run()
     et = mycc.ccsd_t()
 
-    mycc = cc.GCCSD(scf.addons.convert_to_ghf(mf)).set(conv_tol=1e-11).run()
+    mycc = cc.GCCSD(mf.to_ghf()).set(conv_tol=1e-11).run()
     eris = mycc.ao2mo()
     print(kernel(mycc, eris) - et)
 
     numpy.random.seed(1)
     mf.mo_coeff = numpy.random.random(mf.mo_coeff.shape) - .9
-    mycc = cc.GCCSD(scf.addons.convert_to_ghf(mf))
+    mycc = cc.GCCSD(scf.addons.convert_to_ghf())
     eris = mycc.ao2mo()
     nocc = 10
     nvir = mol.nao_nr() * 2 - nocc

--- a/pyscf/cc/gccsd_t_rdm.py
+++ b/pyscf/cc/gccsd_t_rdm.py
@@ -120,7 +120,7 @@ if __name__ == '__main__':
     mol.basis = '631g'
     mol.build()
     mf0 = mf = scf.RHF(mol).run(conv_tol=1.)
-    mf = scf.addons.convert_to_ghf(mf)
+    mf = mf.to_ghf()
 
     from pyscf.cc import ccsd_t_lambda_slow as ccsd_t_lambda
     from pyscf.cc import ccsd_t_rdm_slow as ccsd_t_rdm

--- a/pyscf/cc/rccsd.py
+++ b/pyscf/cc/rccsd.py
@@ -259,6 +259,8 @@ def _make_eris_incore(mycc, mo_coeff=None, ao2mofn=None):
     return eris
 
 def _make_eris_outcore(mycc, mo_coeff=None):
+    from pyscf.scf.hf import RHF
+    assert isinstance(mycc._scf, RHF)
     cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(mycc.stdout, mycc.verbose)
     eris = _ChemistsERIs()

--- a/pyscf/cc/uccsd.py
+++ b/pyscf/cc/uccsd.py
@@ -547,7 +547,7 @@ class UCCSD(ccsd.CCSDBase):
 # * A pair of list : First list is the orbital indices to be frozen for alpha
 #       orbitals, second list is for beta orbitals
     def __init__(self, mf, frozen=None, mo_coeff=None, mo_occ=None):
-        assert isinstance(mf, scf.uhf.UHF)
+        assert mf.istype('UHF')
         ccsd.CCSDBase.__init__(self, mf, frozen, mo_coeff, mo_occ)
 
     get_nocc = get_nocc
@@ -942,6 +942,7 @@ def _make_eris_incore(mycc, mo_coeff=None, ao2mofn=None):
     return eris
 
 def _make_df_eris_outcore(mycc, mo_coeff=None):
+    assert mycc._scf.istype('UHF')
     cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(mycc.stdout, mycc.verbose)
     eris = _ChemistsERIs()
@@ -1059,6 +1060,8 @@ def _make_df_eris_outcore(mycc, mo_coeff=None):
     return eris
 
 def _make_eris_outcore(mycc, mo_coeff=None):
+    from pyscf.scf.uhf import UHF
+    assert isinstance(mycc._scf, UHF)
     eris = _ChemistsERIs()
     eris._common_init_(mycc, mo_coeff)
 

--- a/pyscf/cc/uccsd.py
+++ b/pyscf/cc/uccsd.py
@@ -547,7 +547,6 @@ class UCCSD(ccsd.CCSDBase):
 # * A pair of list : First list is the orbital indices to be frozen for alpha
 #       orbitals, second list is for beta orbitals
     def __init__(self, mf, frozen=None, mo_coeff=None, mo_occ=None):
-        assert mf.istype('UHF')
         ccsd.CCSDBase.__init__(self, mf, frozen, mo_coeff, mo_occ)
 
     get_nocc = get_nocc

--- a/pyscf/ci/__init__.py
+++ b/pyscf/ci/__init__.py
@@ -52,6 +52,7 @@ def RCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
 RCISD.__doc__ = cisd.RCISD.__doc__
 
 def UCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
+    from pyscf.df.df_jk import _DFHF
     from pyscf.soscf import newton_ah
 
     if not mf.istype('UHF'):
@@ -70,6 +71,7 @@ UCISD.__doc__ = ucisd.UCISD.__doc__
 
 
 def GCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
+    from pyscf.df.df_jk import _DFHF
     from pyscf.soscf import newton_ah
 
     if not mf.istype('GHF'):

--- a/pyscf/ci/__init__.py
+++ b/pyscf/ci/__init__.py
@@ -20,8 +20,6 @@ from pyscf.ci import gcisd
 from pyscf.cc import qcisd
 
 def CISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    from pyscf.soscf import newton_ah
-
     if mf.istype('UHF'):
         return UCISD(mf, frozen, mo_coeff, mo_occ)
     elif mf.istype('ROHF'):
@@ -35,12 +33,10 @@ CISD.__doc__ = cisd.CISD.__doc__
 
 def RCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     from pyscf.df.df_jk import _DFHF
-    from pyscf.soscf import newton_ah
 
+    mf = mf.remove_soscf()
     if not mf.istype('RHF'):
         mf = mf.to_rhf()
-    if isinstance(mf, newton_ah._CIAH_SOSCF):
-        mf = mf.undo_soscf()
 
     if isinstance(mf, _DFHF) and mf.with_df:
         from pyscf import lib
@@ -53,12 +49,10 @@ RCISD.__doc__ = cisd.RCISD.__doc__
 
 def UCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     from pyscf.df.df_jk import _DFHF
-    from pyscf.soscf import newton_ah
 
+    mf = mf.remove_soscf()
     if not mf.istype('UHF'):
         mf = mf.to_uhf()
-    if isinstance(mf, newton_ah._CIAH_SOSCF):
-        mf = mf.undo_soscf()
 
     if isinstance(mf, _DFHF) and mf.with_df:
         from pyscf import lib
@@ -72,12 +66,10 @@ UCISD.__doc__ = ucisd.UCISD.__doc__
 
 def GCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     from pyscf.df.df_jk import _DFHF
-    from pyscf.soscf import newton_ah
 
+    mf = mf.remove_soscf()
     if not mf.istype('GHF'):
         mf = mf.to_ghf()
-    if isinstance(mf, newton_ah._CIAH_SOSCF):
-        mf = mf.undo_soscf()
 
     if isinstance(mf, _DFHF) and mf.with_df:
         raise NotImplementedError('DF-GCISD')
@@ -100,7 +92,6 @@ scf.hf.SCF.QCISD = QCISD
 def RQCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     import numpy
     from pyscf import lib
-    from pyscf.soscf import newton_ah
 
     if mf.istype('UHF'):
         raise RuntimeError('RQCISD cannot be used with UHF method.')
@@ -109,10 +100,9 @@ def RQCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
                         'is converted to UHF object and UQCISD method is called.')
         raise NotImplementedError
 
+    mf = mf.remove_soscf()
     if not mf.istype('RHF'):
         mf = mf.to_rhf()
-    if isinstance(mf, newton_ah._CIAH_SOSCF):
-        mf = mf.undo_soscf()
 
     elif numpy.iscomplexobj(mo_coeff) or numpy.iscomplexobj(mf.mo_coeff):
         raise NotImplementedError

--- a/pyscf/ci/__init__.py
+++ b/pyscf/ci/__init__.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pyscf import lib
 from pyscf import scf
 from pyscf.ci import cisd
 from pyscf.ci import ucisd
@@ -23,9 +22,10 @@ from pyscf.cc import qcisd
 def CISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     from pyscf.soscf import newton_ah
 
-    if isinstance(mf, scf.uhf.UHF):
+    if mf.istype('UHF'):
         return UCISD(mf, frozen, mo_coeff, mo_occ)
-    elif isinstance(mf, scf.rohf.ROHF):
+    elif mf.istype('ROHF'):
+        from pyscf import lib
         lib.logger.warn(mf, 'RCISD method does not support ROHF method. ROHF object '
                         'is converted to UHF object and UCISD method is called.')
         return UCISD(mf, frozen, mo_coeff, mo_occ)
@@ -34,12 +34,18 @@ def CISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
 CISD.__doc__ = cisd.CISD.__doc__
 
 def RCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
+    from pyscf.df.df_jk import _DFHF
     from pyscf.soscf import newton_ah
 
-    if isinstance(mf, newton_ah._CIAH_SOSCF) or not isinstance(mf, scf.hf.RHF):
-        mf = scf.addons.convert_to_rhf(mf)
+    if not mf.istype('RHF'):
+        mf = mf.to_rhf()
+    if isinstance(mf, newton_ah._CIAH_SOSCF):
+        mf = mf.undo_soscf()
 
-    if getattr(mf, 'with_df', None):
+    if isinstance(mf, _DFHF) and mf.with_df:
+        from pyscf import lib
+        lib.logger.warn(mf, f'DF-RCISD for DFHF method {mf} is not available. '
+                        'Normal RCISD method is called.')
         return cisd.RCISD(mf, frozen, mo_coeff, mo_occ)
     else:
         return cisd.RCISD(mf, frozen, mo_coeff, mo_occ)
@@ -48,10 +54,15 @@ RCISD.__doc__ = cisd.RCISD.__doc__
 def UCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     from pyscf.soscf import newton_ah
 
-    if isinstance(mf, newton_ah._CIAH_SOSCF) or not isinstance(mf, scf.uhf.UHF):
-        mf = scf.addons.convert_to_uhf(mf)
+    if not mf.istype('UHF'):
+        mf = mf.to_uhf()
+    if isinstance(mf, newton_ah._CIAH_SOSCF):
+        mf = mf.undo_soscf()
 
-    if getattr(mf, 'with_df', None):
+    if isinstance(mf, _DFHF) and mf.with_df:
+        from pyscf import lib
+        lib.logger.warn(mf, f'DF-UCISD for DFHF method {mf} is not available. '
+                        'Normal UCISD method is called.')
         return ucisd.UCISD(mf, frozen, mo_coeff, mo_occ)
     else:
         return ucisd.UCISD(mf, frozen, mo_coeff, mo_occ)
@@ -61,10 +72,12 @@ UCISD.__doc__ = ucisd.UCISD.__doc__
 def GCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     from pyscf.soscf import newton_ah
 
-    if isinstance(mf, newton_ah._CIAH_SOSCF) or not isinstance(mf, scf.ghf.GHF):
-        mf = scf.addons.convert_to_ghf(mf)
+    if not mf.istype('GHF'):
+        mf = mf.to_ghf()
+    if isinstance(mf, newton_ah._CIAH_SOSCF):
+        mf = mf.undo_soscf()
 
-    if getattr(mf, 'with_df', None):
+    if isinstance(mf, _DFHF) and mf.with_df:
         raise NotImplementedError('DF-GCISD')
     else:
         return gcisd.GCISD(mf, frozen, mo_coeff, mo_occ)
@@ -72,9 +85,9 @@ GCISD.__doc__ = gcisd.GCISD.__doc__
 
 
 def QCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    if isinstance(mf, scf.uhf.UHF):
+    if mf.istype('UHF'):
         raise NotImplementedError
-    elif isinstance(mf, scf.ghf.GHF):
+    elif mf.istype('GHF'):
         raise NotImplementedError
     else:
         return RQCISD(mf, frozen, mo_coeff, mo_occ)
@@ -87,16 +100,17 @@ def RQCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
     from pyscf import lib
     from pyscf.soscf import newton_ah
 
-    if isinstance(mf, scf.uhf.UHF):
+    if mf.istype('UHF'):
         raise RuntimeError('RQCISD cannot be used with UHF method.')
-    elif isinstance(mf, scf.rohf.ROHF):
+    elif mf.istype('ROHF'):
         lib.logger.warn(mf, 'RQCISD method does not support ROHF method. ROHF object '
                         'is converted to UHF object and UQCISD method is called.')
-        mf = scf.addons.convert_to_uhf(mf)
         raise NotImplementedError
 
-    if isinstance(mf, newton_ah._CIAH_SOSCF) or not isinstance(mf, scf.hf.RHF):
-        mf = scf.addons.convert_to_rhf(mf)
+    if not mf.istype('RHF'):
+        mf = mf.to_rhf()
+    if isinstance(mf, newton_ah._CIAH_SOSCF):
+        mf = mf.undo_soscf()
 
     elif numpy.iscomplexobj(mo_coeff) or numpy.iscomplexobj(mf.mo_coeff):
         raise NotImplementedError

--- a/pyscf/ci/addons.py
+++ b/pyscf/ci/addons.py
@@ -17,14 +17,13 @@
 #
 
 import numpy as np
-from pyscf import scf
 
 def convert_to_gcisd(myci):
     from pyscf.ci import gcisd
     if isinstance(myci, gcisd.GCISD):
         return myci
 
-    mf = scf.addons.convert_to_ghf(myci._scf)
+    mf = myci._scf.to_ghf()
     gci = gcisd.GCISD(mf)
     assert (myci._nocc is None)
     assert (myci._nmo is None)

--- a/pyscf/df/df.py
+++ b/pyscf/df/df.py
@@ -181,7 +181,7 @@ class DF(lib.StreamObject):
         '''Reset mol and clean up relevant attributes for scanner mode'''
         if mol is not None:
             self.mol = mol
-        self.auxmol = None
+            self.auxmol = None
         self._cderi = None
         self._vjopt = None
         self._rsh_df = {}
@@ -307,6 +307,10 @@ class DF(lib.StreamObject):
             mol.omega = mol_omega
             if auxmol_omega is not None:
                 auxmol.omega = auxmol_omega
+
+    def to_gpu(self):
+        from gpu4pyscf.df.df import DF as DF
+        return to_gpu(self.__class__.reset(self.view(DF)))
 
 GDF = DF
 

--- a/pyscf/df/df.py
+++ b/pyscf/df/df.py
@@ -310,7 +310,7 @@ class DF(lib.StreamObject):
 
     def to_gpu(self):
         from gpu4pyscf.df.df import DF as DF
-        return to_gpu(self.__class__.reset(self.view(DF)))
+        return lib.to_gpu(self.__class__.reset(self.view(DF)))
 
 GDF = DF
 

--- a/pyscf/df/df_jk.py
+++ b/pyscf/df/df_jk.py
@@ -227,6 +227,11 @@ class _DFHF:
         from pyscf import mcscf
         return mcscf.DFCASSCF(self, ncas, nelecas, auxbasis, ncore, frozen)
 
+    def to_gpu(self):
+        obj = self.undo_df().to_gpu().density_fit()
+        obj.__dict__.update(self.__dict__)
+        return lib.to_gpu(self.__class__.reset(obj))
+
 
 def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
     assert (with_j or with_k)

--- a/pyscf/df/df_jk.py
+++ b/pyscf/df/df_jk.py
@@ -237,7 +237,7 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
     assert (with_j or with_k)
     if (not with_k and not dfobj.mol.incore_anyway and
         # 3-center integral tensor is not initialized
-        dfobj._cderi is None):
+        dfobj.with_df._cderi is None):
         return get_j(dfobj, dm, hermi, direct_scf_tol), None
 
     t0 = t1 = (logger.process_clock(), logger.perf_counter())

--- a/pyscf/df/df_jk.py
+++ b/pyscf/df/df_jk.py
@@ -237,7 +237,7 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
     assert (with_j or with_k)
     if (not with_k and not dfobj.mol.incore_anyway and
         # 3-center integral tensor is not initialized
-        dfobj.with_df._cderi is None):
+        dfobj._cderi is None):
         return get_j(dfobj, dm, hermi, direct_scf_tol), None
 
     t0 = t1 = (logger.process_clock(), logger.perf_counter())

--- a/pyscf/df/df_jk.py
+++ b/pyscf/df/df_jk.py
@@ -123,8 +123,7 @@ class _DFHF:
     def undo_df(self):
         '''Remove the DFHF Mixin'''
         obj = lib.view(self, lib.drop_class(self.__class__, _DFHF))
-        del obj.with_df
-        del obj.only_dfj
+        del obj.with_df, obj.only_dfj
         return obj
 
     def reset(self, mol=None):
@@ -230,7 +229,7 @@ class _DFHF:
     def to_gpu(self):
         obj = self.undo_df().to_gpu().density_fit()
         obj.__dict__.update(self.__dict__)
-        return lib.to_gpu(self.__class__.reset(obj))
+        return lib.to_gpu(obj)
 
 
 def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):

--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -523,6 +523,6 @@ class Gradients(rhf_grad.Gradients):
 
     def to_gpu(self):
         from gpu4pyscf.df.grad.rhf import Gradients
-        return lib.to_gpu(obj.view(Gradients))
+        return lib.to_gpu(self.view(Gradients))
 
 Grad = Gradients

--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -521,4 +521,8 @@ class Gradients(rhf_grad.Gradients):
         else:
             return 0
 
+    def to_gpu(self):
+        from gpu4pyscf.df.grad.rhf import Gradients
+        return lib.to_gpu(obj.view(Gradients))
+
 Grad = Gradients

--- a/pyscf/df/grad/rks.py
+++ b/pyscf/df/grad/rks.py
@@ -123,4 +123,8 @@ class Gradients(rks_grad.Gradients):
             e1 += envs['vhf'].aux[atom_id]
         return e1
 
+    def to_gpu(self):
+        from gpu4pyscf.df.grad.rks import Gradients
+        return lib.to_gpu(obj.view(Gradients))
+
 Grad = Gradients

--- a/pyscf/df/grad/rks.py
+++ b/pyscf/df/grad/rks.py
@@ -125,6 +125,6 @@ class Gradients(rks_grad.Gradients):
 
     def to_gpu(self):
         from gpu4pyscf.df.grad.rks import Gradients
-        return lib.to_gpu(obj.view(Gradients))
+        return lib.to_gpu(self.view(Gradients))
 
 Grad = Gradients

--- a/pyscf/df/hessian/rhf.py
+++ b/pyscf/df/hessian/rhf.py
@@ -483,7 +483,7 @@ class Hessian(rhf_hess.Hessian):
 
     def to_gpu(self):
         from gpu4pyscf.df.hessian.rhf import Hessian
-        return lib.to_gpu(obj.view(Hessian))
+        return lib.to_gpu(self.view(Hessian))
 
 #TODO: Insert into DF class
 

--- a/pyscf/df/hessian/rhf.py
+++ b/pyscf/df/hessian/rhf.py
@@ -481,6 +481,10 @@ class Hessian(rhf_hess.Hessian):
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
 
+    def to_gpu(self):
+        from gpu4pyscf.df.hessian.rhf import Hessian
+        return lib.to_gpu(obj.view(Hessian))
+
 #TODO: Insert into DF class
 
 

--- a/pyscf/df/hessian/rks.py
+++ b/pyscf/df/hessian/rks.py
@@ -127,6 +127,10 @@ class Hessian(rks_hess.Hessian):
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
 
+    def to_gpu(self):
+        from gpu4pyscf.df.hessian.rks import Hessian
+        return lib.to_gpu(obj.view(Hessian))
+
 
 if __name__ == '__main__':
     from pyscf import gto

--- a/pyscf/df/hessian/rks.py
+++ b/pyscf/df/hessian/rks.py
@@ -129,7 +129,7 @@ class Hessian(rks_hess.Hessian):
 
     def to_gpu(self):
         from gpu4pyscf.df.hessian.rks import Hessian
-        return lib.to_gpu(obj.view(Hessian))
+        return lib.to_gpu(self.view(Hessian))
 
 
 if __name__ == '__main__':

--- a/pyscf/dft/gen_grid.py
+++ b/pyscf/dft/gen_grid.py
@@ -626,6 +626,10 @@ class Grids(lib.StreamObject):
             self.screen_index = self.non0tab
         return self
 
+    def to_gpu(self):
+        from gpu4pyscf.dft.gen_grid import Grids
+        return lib.to_gpu(self.view(Grids))
+
 
 def _default_rad(nuc, level=3):
     '''Number of radial grids '''

--- a/pyscf/dft/gks.py
+++ b/pyscf/dft/gks.py
@@ -178,12 +178,7 @@ class GKS(rks.KohnShamDFT, ghf.GHF):
         return self._transfer_attrs_(self.mol.GHF())
 
     def to_gpu(self):
-        from gpu4pyscf.dft.gks import GKS
-        obj = lib.to_gpu(self.__class__.reset(self.view(GKS)))
-        # Attributes only defined in gpu4pyscf.RKS
-        obj.screen_tol = 1e-14
-        obj.disp = None
-        return obj
+        raise NotImplementedError
 
 
 if __name__ == '__main__':

--- a/pyscf/dft/gks.py
+++ b/pyscf/dft/gks.py
@@ -177,6 +177,14 @@ class GKS(rks.KohnShamDFT, ghf.GHF):
         '''Convert to GHF object.'''
         return self._transfer_attrs_(self.mol.GHF())
 
+    def to_gpu(self):
+        from gpu4pyscf.dft.gks import GKS
+        obj = lib.to_gpu(self.__class__.reset(self.view(GKS)))
+        # Attributes only defined in gpu4pyscf.RKS
+        obj.screen_tol = 1e-14
+        obj.disp = None
+        return obj
+
 
 if __name__ == '__main__':
     from pyscf import gto

--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -2881,6 +2881,11 @@ class NumInt(lib.StreamObject, LibXCMixin):
                                      with_lapl)
         return make_rho, ndms, nao
 
+    def to_gpu(self):
+        from gpu4pyscf.dft.numint import NumInt
+        # Note: gpu4pyscf NumInt initializes additional things in __init__.py
+        return NumInt()
+
 _NumInt = NumInt
 
 

--- a/pyscf/dft/rks.py
+++ b/pyscf/dft/rks.py
@@ -484,6 +484,9 @@ class KohnShamDFT(object):
             t0 = logger.timer(self, 'setting up nlc grids', *t0)
         return self
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 # Update the KohnShamDFT label in scf.hf module
 hf.KohnShamDFT = KohnShamDFT
 
@@ -529,3 +532,11 @@ class RKS(KohnShamDFT, hf.RHF):
     def to_hf(self):
         '''Convert to RHF object.'''
         return self._transfer_attrs_(self.mol.RHF())
+
+    def to_gpu(self):
+        from gpu4pyscf.dft.rks import RKS
+        obj = lib.to_gpu(self.__class__.reset(self.view(RKS)))
+        # Attributes only defined in gpu4pyscf.RKS
+        obj.screen_tol = 1e-14
+        obj.disp = None
+        return obj

--- a/pyscf/dft/rks.py
+++ b/pyscf/dft/rks.py
@@ -535,7 +535,7 @@ class RKS(KohnShamDFT, hf.RHF):
 
     def to_gpu(self):
         from gpu4pyscf.dft.rks import RKS
-        obj = lib.to_gpu(self.__class__.reset(self.view(RKS)))
+        obj = lib.to_gpu(hf.SCF.reset(self.view(RKS)))
         # Attributes only defined in gpu4pyscf.RKS
         obj.screen_tol = 1e-14
         obj.disp = None

--- a/pyscf/dft/roks.py
+++ b/pyscf/dft/roks.py
@@ -66,8 +66,9 @@ class ROKS(rks.KohnShamDFT, rohf.ROHF):
         return self._transfer_attrs_(self.mol.ROHF())
 
     def to_gpu(self):
-        from gpu4pyscf.dft.uks import UKS
-        obj = lib.to_gpu(self.__class__.reset(self.view(UKS)))
+        from pyscf.scf.hf import SCF
+        from gpu4pyscf.dft.roks import ROKS
+        obj = lib.to_gpu(SCF.reset(self.view(ROKS)))
         # Attributes only defined in gpu4pyscf.RKS
         obj.screen_tol = 1e-14
         obj.disp = None

--- a/pyscf/dft/roks.py
+++ b/pyscf/dft/roks.py
@@ -65,6 +65,14 @@ class ROKS(rks.KohnShamDFT, rohf.ROHF):
         '''Convert to ROHF object.'''
         return self._transfer_attrs_(self.mol.ROHF())
 
+    def to_gpu(self):
+        from gpu4pyscf.dft.uks import UKS
+        obj = lib.to_gpu(self.__class__.reset(self.view(UKS)))
+        # Attributes only defined in gpu4pyscf.RKS
+        obj.screen_tol = 1e-14
+        obj.disp = None
+        return obj
+
 
 if __name__ == '__main__':
     from pyscf import gto

--- a/pyscf/dft/uks.py
+++ b/pyscf/dft/uks.py
@@ -24,7 +24,7 @@ Non-relativistic Unrestricted Kohn-Sham
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
-from pyscf.scf import uhf
+from pyscf.scf import hf, uhf
 from pyscf.dft import rks
 
 def get_veff(ks, mol=None, dm=None, dm_last=0, vhf_last=0, hermi=1):
@@ -198,8 +198,9 @@ class UKS(rks.KohnShamDFT, uhf.UHF):
         return self._transfer_attrs_(self.mol.UHF())
 
     def to_gpu(self):
+        from pyscf.scf.hf import SCF
         from gpu4pyscf.dft.uks import UKS
-        obj = lib.to_gpu(self.__class__.reset(self.view(UKS)))
+        obj = lib.to_gpu(SCF.reset(self.view(UKS)))
         # Attributes only defined in gpu4pyscf.RKS
         obj.screen_tol = 1e-14
         obj.disp = None

--- a/pyscf/dft/uks.py
+++ b/pyscf/dft/uks.py
@@ -196,3 +196,11 @@ class UKS(rks.KohnShamDFT, uhf.UHF):
     def to_hf(self):
         '''Convert to UHF object.'''
         return self._transfer_attrs_(self.mol.UHF())
+
+    def to_gpu(self):
+        from gpu4pyscf.dft.uks import UKS
+        obj = lib.to_gpu(self.__class__.reset(self.view(UKS)))
+        # Attributes only defined in gpu4pyscf.RKS
+        obj.screen_tol = 1e-14
+        obj.disp = None
+        return obj

--- a/pyscf/grad/rhf.py
+++ b/pyscf/grad/rhf.py
@@ -438,6 +438,9 @@ class GradientsBase(lib.StreamObject):
         to be split into alpha,beta in DF-ROHF subclass'''
         return lib.tag_array (dm, mo_coeff=mo_coeff, mo_occ=mo_occ)
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 # export the symbol GradientsMixin for backward compatibility.
 # GradientsMixin should be dropped in the future.
 GradientsMixin = GradientsBase
@@ -457,6 +460,10 @@ class Gradients(GradientsBase):
         return make_rdm1e(mo_energy, mo_coeff, mo_occ)
 
     grad_elec = grad_elec
+
+    def to_gpu(self):
+        from gpu4pyscf.grad.rhf import Gradients
+        return lib.to_gpu(self.view(Gradients))
 
 Grad = Gradients
 

--- a/pyscf/grad/rks.py
+++ b/pyscf/grad/rks.py
@@ -622,6 +622,10 @@ class Gradients(rhf_grad.Gradients):
         else:
             return 0
 
+    def to_gpu(self):
+        from gpu4pyscf.grad.rks import Gradients
+        return lib.to_gpu(self.view(Gradients))
+
 Grad = Gradients
 
 from pyscf import dft

--- a/pyscf/grad/uhf.py
+++ b/pyscf/grad/uhf.py
@@ -106,6 +106,9 @@ class Gradients(rhf_grad.GradientsBase):
 
     grad_elec = grad_elec
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 Grad = Gradients
 
 from pyscf import scf

--- a/pyscf/grad/uks.py
+++ b/pyscf/grad/uks.py
@@ -275,6 +275,9 @@ class Gradients(uhf_grad.Gradients):
         else:
             return 0
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 Grad = Gradients
 
 from pyscf import dft

--- a/pyscf/hessian/rhf.py
+++ b/pyscf/hessian/rhf.py
@@ -467,7 +467,7 @@ def gen_hop(hobj, mo_energy=None, mo_coeff=None, mo_occ=None, verbose=None):
     return h_op, hdiag
 
 
-class Hessian(lib.StreamObject):
+class HessianBase(lib.StreamObject):
     '''Non-relativistic restricted Hartree-Fock hessian'''
 
     _keys = set((
@@ -485,9 +485,11 @@ class Hessian(lib.StreamObject):
         self.atmlst = range(self.mol.natm)
         self.de = numpy.zeros((0,0,3,3))  # (A,B,dR_A,dR_B)
 
-    partial_hess_elec = partial_hess_elec
-    hess_elec = hess_elec
-    make_h1 = make_h1
+    def hess_elec(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def make_h1(self, *args, **kwargs):
+        raise NotImplementedError
 
     def get_hcore(self, mol=None):
         if mol is None: mol = self.mol
@@ -585,6 +587,20 @@ class Hessian(lib.StreamObject):
     hess = kernel
 
     gen_hop = gen_hop
+
+    def to_gpu(self):
+        raise NotImplementedError
+
+
+class Hessian(HessianBase):
+
+    partial_hess_elec = partial_hess_elec
+    hess_elec = hess_elec
+    make_h1 = make_h1
+
+    def to_gpu(self):
+        from gpu4pyscf.hessian.rhf import Hessian
+        return lib.to_gpu(self.view(Hessian))
 
 # Inject to RHF class
 from pyscf import scf

--- a/pyscf/hessian/rks.py
+++ b/pyscf/hessian/rks.py
@@ -548,7 +548,7 @@ def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
     return vmat
 
 
-class Hessian(rhf_hess.Hessian):
+class Hessian(rhf_hess.HessianBase):
     '''Non-relativistic RKS hessian'''
 
     _keys = set(['grids', 'grid_response'])
@@ -559,7 +559,12 @@ class Hessian(rhf_hess.Hessian):
         self.grid_response = False
 
     partial_hess_elec = partial_hess_elec
+    hess_elec = rhf_hess.hess_elec
     make_h1 = make_h1
+
+    def to_gpu(self):
+        from gpu4pyscf.hessian.rks import Hessian
+        return lib.to_gpu(self.view(Hessian))
 
 from pyscf import dft
 dft.rks.RKS.Hessian = dft.rks_symm.RKS.Hessian = lib.class_as_method(Hessian)

--- a/pyscf/hessian/uhf.py
+++ b/pyscf/hessian/uhf.py
@@ -438,8 +438,9 @@ def gen_hop(hobj, mo_energy=None, mo_coeff=None, mo_occ=None, verbose=None):
     return h_op, hdiag
 
 
-class Hessian(rhf_hess.Hessian):
+class Hessian(rhf_hess.HessianBase):
     '''Non-relativistic UHF hessian'''
+
     partial_hess_elec = partial_hess_elec
     hess_elec = hess_elec
     make_h1 = make_h1
@@ -449,6 +450,9 @@ class Hessian(rhf_hess.Hessian):
                   fx=None, atmlst=None, max_memory=4000, verbose=None):
         return solve_mo1(self.base, mo_energy, mo_coeff, mo_occ, h1ao_or_chkfile,
                          fx, atmlst, max_memory, verbose)
+
+    def to_gpu(self):
+        raise NotImplementedError
 
 from pyscf import scf
 scf.uhf.UHF.Hessian = lib.class_as_method(Hessian)

--- a/pyscf/hessian/uks.py
+++ b/pyscf/hessian/uks.py
@@ -653,7 +653,7 @@ def _get_vxc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
     return vmata, vmatb
 
 
-class Hessian(uhf_hess.Hessian):
+class Hessian(rhf_hess.HessianBase):
     '''Non-relativistic UKS hessian'''
 
     _keys = set(['grids', 'grid_response'])
@@ -663,8 +663,14 @@ class Hessian(uhf_hess.Hessian):
         self.grids = None
         self.grid_response = False
 
+    hess_elec = uhf_hess.hess_elec
+    gen_hop = uhf_hess.gen_hop
+    solve_mo1 = uhf_hess.Hessian.solve_mo1
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
+
+    def to_gpu(self):
+        raise NotImplementedError
 
 from pyscf import dft
 dft.uks.UKS.Hessian = dft.uks_symm.UKS.Hessian = lib.class_as_method(Hessian)

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -1331,3 +1331,14 @@ def isintsequence(obj):
         for i in obj:
             are_ints = are_ints and isinteger(i)
         return are_ints
+
+def to_gpu(method):
+    '''Recursively converts all attributes of a method to cupy objects or
+    gpu4pyscf objects.
+    '''
+    for key, val in method.__dict__.items():
+        if isinstance(val, numpy.ndarray):
+            setattr(method, key, cupy.asarray(val))
+        elif hasattr(val, 'to_gpu'):
+            setattr(method, key, val.to_gpu())
+    return method

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -1336,6 +1336,7 @@ def to_gpu(method):
     '''Recursively converts all attributes of a method to cupy objects or
     gpu4pyscf objects.
     '''
+    import cupy
     for key, val in method.__dict__.items():
         if isinstance(val, numpy.ndarray):
             setattr(method, key, cupy.asarray(val))

--- a/pyscf/mcscf/test/test_ucasci.py
+++ b/pyscf/mcscf/test/test_ucasci.py
@@ -95,7 +95,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(eri1[2]-eri2[2]).max(), 0, 12)
 
     def test_get_veff(self):
-        mc1 = mcscf.UCASCI(m.view(dft.rks.RKS), 5, (4,2))
+        mc1 = mcscf.UCASCI(m.to_rks(), 5, (4,2))
         nao = mol.nao_nr()
         dm = numpy.random.random((2,nao,nao))
         dm = dm + dm.transpose(0,2,1)

--- a/pyscf/mp/__init__.py
+++ b/pyscf/mp/__init__.py
@@ -34,7 +34,6 @@ MP2.__doc__ = mp2.MP2.__doc__
 
 def RMP2(mf, frozen=None, mo_coeff=None, mo_occ=None):
     from pyscf import lib
-    from pyscf.soscf import newton_ah
 
     if mf.istype('UHF'):
         raise RuntimeError('RMP2 cannot be used with UHF method.')
@@ -43,10 +42,9 @@ def RMP2(mf, frozen=None, mo_coeff=None, mo_occ=None):
                         'is converted to UHF object and UMP2 method is called.')
         return UMP2(mf, frozen, mo_coeff, mo_occ)
 
+    mf = mf.remove_soscf()
     if not mf.istype('RHF'):
         mf = mf.to_rhf()
-    if isinstance(mf, newton_ah._CIAH_SOSCF):
-        mf = mf.undo_soscf()
 
     if getattr(mf, 'with_df', None):
         return dfmp2.DFMP2(mf, frozen, mo_coeff, mo_occ)
@@ -55,12 +53,9 @@ def RMP2(mf, frozen=None, mo_coeff=None, mo_occ=None):
 RMP2.__doc__ = mp2.RMP2.__doc__
 
 def UMP2(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    from pyscf.soscf import newton_ah
-
+    mf = mf.remove_soscf()
     if mf.istype('UHF'):
         mf = mf.to_uhf()
-    if isinstance(mf, newton_ah._CIAH_SOSCF):
-        mf = mf.undo_soscf()
 
     if getattr(mf, 'with_df', None):
         #raise NotImplementedError('DF-UMP2')
@@ -70,12 +65,9 @@ def UMP2(mf, frozen=None, mo_coeff=None, mo_occ=None):
 UMP2.__doc__ = ump2.UMP2.__doc__
 
 def GMP2(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    from pyscf.soscf import newton_ah
-
+    mf = mf.remove_soscf()
     if not mf.istype('GHF'):
         mf = mf.to_ghf()
-    if isinstance(mf, newton_ah._CIAH_SOSCF):
-        mf = mf.undo_soscf()
 
     if getattr(mf, 'with_df', None):
         return dfgmp2.DFGMP2(mf, frozen, mo_coeff, mo_occ)

--- a/pyscf/mp/dfgmp2.py
+++ b/pyscf/mp/dfgmp2.py
@@ -85,6 +85,7 @@ def kernel(mp, mo_energy=None, mo_coeff=None, eris=None, with_t2=WITH_T2,
 
 class DFGMP2(dfmp2.DFMP2):
     def loop_ao2mo(self, mo_coeff, nocc, orbspin):
+        assert self._scf.istype('GHF')
         nao, nmo = mo_coeff.shape
         complex_orb = mo_coeff.dtype == np.complex128
         if orbspin is None:

--- a/pyscf/mp/dfmp2_native.py
+++ b/pyscf/mp/dfmp2_native.py
@@ -41,8 +41,6 @@ class DFRMP2(lib.StreamObject):
             auxbasis : name of auxiliary basis set, otherwise determined automatically
         '''
 
-        if not isinstance(mf, scf.rhf.RHF):
-            raise TypeError('Class initialization with non-RHF object')
         self.mo_coeff = mf.mo_coeff
         self.mo_energy = mf.mo_energy
         self.nocc = np.count_nonzero(mf.mo_occ)
@@ -204,6 +202,8 @@ class DFRMP2(lib.StreamObject):
         '''
         Calculates the three center integrals for MP2.
         '''
+        if not isinstance(self._scf, scf.rhf.RHF):
+            raise TypeError('Class initialization with non-RHF object')
         Co = self.mo_coeff[:, self.occ_mask]
         Cv = self.mo_coeff[:, self.nocc:]
         logger = lib.logger.new_logger(self)

--- a/pyscf/mp/dfump2_native.py
+++ b/pyscf/mp/dfump2_native.py
@@ -40,9 +40,6 @@ class DFUMP2(DFRMP2):
             auxbasis : name of auxiliary basis set, otherwise determined automatically
         '''
 
-        if not isinstance(mf, scf.uhf.UHF):
-            raise TypeError('Class initialization with non-UHF object')
-
         # UHF quantities are stored as numpy arrays
         self.mo_coeff = np.array(mf.mo_coeff)
         self.mo_energy = np.array(mf.mo_energy)
@@ -205,6 +202,8 @@ class DFUMP2(DFRMP2):
         '''
         Calculates the three center integrals for MP2.
         '''
+        if not isinstance(self._scf, scf.uhf.UHF):
+            raise TypeError('Class initialization with non-UHF object')
         intsfile = []
         logger = lib.logger.new_logger(self)
         logger.info('')

--- a/pyscf/mp/gmp2.py
+++ b/pyscf/mp/gmp2.py
@@ -175,7 +175,6 @@ def make_rdm2(mp, t2=None, ao_repr=False):
 
 class GMP2(mp2.MP2):
     def __init__(self, mf, frozen=None, mo_coeff=None, mo_occ=None):
-        assert (isinstance(mf, scf.ghf.GHF))
         mp2.MP2.__init__(self, mf, frozen, mo_coeff, mo_occ)
 
     def ao2mo(self, mo_coeff=None):
@@ -302,6 +301,8 @@ def _make_eris_incore(mp, mo_coeff=None, ao2mofn=None, verbose=None):
     return eris
 
 def _make_eris_outcore(mp, mo_coeff=None, verbose=None):
+    from pyscf.scf.ghf import GHF
+    assert isinstance(mp._scf, GHF)
     cput0 = (logger.process_clock(), logger.perf_counter())
     log = logger.Logger(mp.stdout, mp.verbose)
     eris = _PhysicistsERIs()

--- a/pyscf/mp/mp2.py
+++ b/pyscf/mp/mp2.py
@@ -756,6 +756,8 @@ def _make_eris(mp, mo_coeff=None, ao2mofn=None, verbose=None):
 #   or    => (ij|ol) => (oj|ol) => (oj|ov) => (ov|ov)
 #
 def _ao2mo_ovov(mp, orbo, orbv, feri, max_memory=2000, verbose=None):
+    from pyscf.scf.hf import RHF
+    assert isinstance(mp._scf, RHF)
     time0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mp, verbose)
 

--- a/pyscf/mp/ump2.py
+++ b/pyscf/mp/ump2.py
@@ -558,6 +558,8 @@ def _make_eris(mp, mo_coeff=None, ao2mofn=None, verbose=None):
     return eris
 
 def _ao2mo_ovov(mp, orbs, feri, max_memory=2000, verbose=None):
+    from pyscf.scf.uhf import UHF
+    assert isinstance(mp._scf, UHF)
     time0 = (logger.process_clock(), logger.perf_counter())
     log = logger.new_logger(mp, verbose)
     orboa = numpy.asarray(orbs[0], order='F')

--- a/pyscf/pbc/adc/__init__.py
+++ b/pyscf/pbc/adc/__init__.py
@@ -21,5 +21,5 @@ from pyscf.pbc.adc import kadc_rhf_ea
 def KRADC(mf, frozen=None, mo_coeff=None, mo_occ=None):
     from pyscf.pbc.adc import kadc_rhf
     if not isinstance(mf, scf.khf.KRHF):
-        mf = scf.addons.convert_to_rhf(mf)
+        mf = mf.to_rhf()
     return kadc_rhf.RADC(mf, frozen, mo_coeff, mo_occ)

--- a/pyscf/pbc/cc/__init__.py
+++ b/pyscf/pbc/cc/__init__.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pyscf.pbc import scf
 from pyscf.pbc.cc import ccsd
 from pyscf.pbc.cc import kccsd_rhf as krccsd
 from pyscf.pbc.cc import kccsd_uhf as kuccsd
@@ -24,31 +23,35 @@ from pyscf.pbc.cc import eom_kccsd_ghf
 from pyscf.pbc.cc.kccsd_rhf_ksymm import KsymAdaptedRCCSD
 
 def RCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    mf = scf.addons.convert_to_rhf(mf)
+    mf = mf.to_rhf()
     return ccsd.RCCSD(mf, frozen, mo_coeff, mo_occ)
 
 CCSD = RCCSD
 
 def UCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    mf = scf.addons.convert_to_uhf(mf)
+    mf = mf.to_uhf()
     return ccsd.UCCSD(mf, frozen, mo_coeff, mo_occ)
 
 def GCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    mf = scf.addons.convert_to_ghf(mf)
+    mf = mf.to_ghf()
     return ccsd.GCCSD(mf, frozen, mo_coeff, mo_occ)
 
 def KGCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    mf = scf.addons.convert_to_ghf(mf)
+    mf = mf.to_ghf()
     return kgccsd.GCCSD(mf, frozen, mo_coeff, mo_occ)
 
 def KRCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
+    from pyscf.pbc import scf
+    assert isinstance(mf, scf.khf.KSCF)
     if not isinstance(mf, scf.khf.KRHF):
-        mf = scf.addons.convert_to_rhf(mf)
+        mf = mf.to_rhf()
     return krccsd.RCCSD(mf, frozen, mo_coeff, mo_occ)
 
 KCCSD = KRCCSD
 
 def KUCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
+    from pyscf.pbc import scf
+    assert isinstance(mf, scf.khf.KSCF)
     if not isinstance(mf, scf.kuhf.KUHF):
-        mf = scf.addons.convert_to_uhf(mf)
+        mf = mf.to_uhf()
     return kuccsd.UCCSD(mf, frozen, mo_coeff, mo_occ)

--- a/pyscf/pbc/cc/kccsd.py
+++ b/pyscf/pbc/cc/kccsd.py
@@ -333,7 +333,7 @@ class GCCSD(gccsd.GCCSD):
     def __init__(self, mf, frozen=None, mo_coeff=None, mo_occ=None):
         assert (isinstance(mf, scf.khf.KSCF))
         if not isinstance(mf, scf.kghf.KGHF):
-            mf = scf.addons.convert_to_ghf(mf)
+            mf = mf.to_ghf()
         self.kpts = mf.kpts
         self.khelper = kpts_helper.KptsHelper(mf.cell, mf.kpts)
         gccsd.GCCSD.__init__(self, mf, frozen, mo_coeff, mo_occ)

--- a/pyscf/pbc/ci/__init__.py
+++ b/pyscf/pbc/ci/__init__.py
@@ -16,21 +16,21 @@ from pyscf.pbc import scf
 from pyscf.pbc.ci import cisd, kcis_rhf
 
 def RCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    mf = scf.addons.convert_to_rhf(mf)
+    mf = mf.to_rhf()
     return cisd.RCISD(mf, frozen, mo_coeff, mo_occ)
 
 CISD = RCISD
 
 def UCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    mf = scf.addons.convert_to_uhf(mf)
+    mf = mf.to_uhf()
     return cisd.UCISD(mf, frozen, mo_coeff, mo_occ)
 
 def GCISD(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    mf = scf.addons.convert_to_ghf(mf)
+    mf = mf.to_ghf()
     return cisd.GCISD(mf, frozen, mo_coeff, mo_occ)
 
 def KCIS(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    mf = scf.addons.convert_to_rhf(mf)
+    mf = mf.to_rhf()
     return kcis_rhf.KCIS(mf, frozen, mo_coeff, mo_occ)
 
 CIS = KCIS

--- a/pyscf/pbc/dft/gks.py
+++ b/pyscf/pbc/dft/gks.py
@@ -143,3 +143,6 @@ class GKS(rks.KohnShamDFT, pbcghf.GHF):
         '''Convert to GHF object.'''
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.GHF(self.cell, self.kpt))
+
+    def to_gpu(self):
+        raise NotImplementedError

--- a/pyscf/pbc/dft/gks.py
+++ b/pyscf/pbc/dft/gks.py
@@ -143,6 +143,3 @@ class GKS(rks.KohnShamDFT, pbcghf.GHF):
         '''Convert to GHF object.'''
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.GHF(self.cell, self.kpt))
-
-    def to_gpu(self):
-        raise NotImplementedError

--- a/pyscf/pbc/dft/rks.py
+++ b/pyscf/pbc/dft/rks.py
@@ -346,9 +346,6 @@ class RKS(KohnShamDFT, pbchf.RHF):
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.RHF(self.cell, self.kpt))
 
-    def to_gpu(self):
-        raise NotImplementedError
-
 
 if __name__ == '__main__':
     from pyscf.pbc import gto

--- a/pyscf/pbc/dft/rks.py
+++ b/pyscf/pbc/dft/rks.py
@@ -312,6 +312,9 @@ class KohnShamDFT(mol_ks.KohnShamDFT):
             t0 = logger.timer(self, 'setting up nlc grids', *t0)
         return self
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 # Update the KohnShamDFT label in pbc.scf.hf module
 pbchf.KohnShamDFT = KohnShamDFT
 
@@ -342,6 +345,9 @@ class RKS(KohnShamDFT, pbchf.RHF):
         '''Convert to RHF object.'''
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.RHF(self.cell, self.kpt))
+
+    def to_gpu(self):
+        raise NotImplementedError
 
 
 if __name__ == '__main__':

--- a/pyscf/pbc/dft/roks.py
+++ b/pyscf/pbc/dft/roks.py
@@ -68,6 +68,9 @@ class ROKS(rks.KohnShamDFT, rohf.ROHF):
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.ROHF(self.cell, self.kpt))
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 
 if __name__ == '__main__':
     from pyscf.pbc import gto

--- a/pyscf/pbc/dft/roks.py
+++ b/pyscf/pbc/dft/roks.py
@@ -68,9 +68,6 @@ class ROKS(rks.KohnShamDFT, rohf.ROHF):
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.ROHF(self.cell, self.kpt))
 
-    def to_gpu(self):
-        raise NotImplementedError
-
 
 if __name__ == '__main__':
     from pyscf.pbc import gto

--- a/pyscf/pbc/dft/uks.py
+++ b/pyscf/pbc/dft/uks.py
@@ -144,6 +144,9 @@ class UKS(rks.KohnShamDFT, pbcuhf.UHF):
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.UHF(self.cell, self.kpt))
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 
 if __name__ == '__main__':
     from pyscf.pbc import gto

--- a/pyscf/pbc/dft/uks.py
+++ b/pyscf/pbc/dft/uks.py
@@ -144,9 +144,6 @@ class UKS(rks.KohnShamDFT, pbcuhf.UHF):
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.UHF(self.cell, self.kpt))
 
-    def to_gpu(self):
-        raise NotImplementedError
-
 
 if __name__ == '__main__':
     from pyscf.pbc import gto

--- a/pyscf/pbc/mp/__init__.py
+++ b/pyscf/pbc/mp/__init__.py
@@ -20,17 +20,17 @@ from pyscf.pbc.mp import kmp2_ksymm
 from pyscf.pbc.lib import kpts as libkpts
 
 def RMP2(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    mf = scf.addons.convert_to_rhf(mf)
+    mf = mf.to_rhf()
     return mp2.RMP2(mf, frozen, mo_coeff, mo_occ)
 
 MP2 = RMP2
 
 def UMP2(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    mf = scf.addons.convert_to_uhf(mf)
+    mf = mf.to_uhf()
     return mp2.UMP2(mf, frozen, mo_coeff, mo_occ)
 
 def GMP2(mf, frozen=None, mo_coeff=None, mo_occ=None):
-    mf = scf.addons.convert_to_ghf(mf)
+    mf = mf.to_ghf()
     return mp2.GMP2(mf, frozen, mo_coeff, mo_occ)
 
 def KRMP2(mf, frozen=None, mo_coeff=None, mo_occ=None):

--- a/pyscf/pbc/mpicc/__init__.py
+++ b/pyscf/pbc/mpicc/__init__.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 from pyscf.pbc.cc import ccsd
-from pyscf.pbc import scf
 
 def KRCCSD(mf, frozen=None, mo_coeff=None, mo_occ=None):
+    from pyscf.pbc import scf
     from pyscf.pbc.mpicc import kccsd_rhf
-    mf = scf.addons.convert_to_rhf(mf)
+    assert isinstance(mf, scf.khf.KSCF)
+    if not isinstance(mf, scf.khf.KRHF):
+        mf = mf.to_rhf()
     return kccsd_rhf.RCCSD(mf, frozen)
 
 KCCSD = KRCCSD

--- a/pyscf/pbc/scf/addons.py
+++ b/pyscf/pbc/scf/addons.py
@@ -394,7 +394,7 @@ def convert_to_ghf(mf, out=None):
         else:
             assert (not isinstance(out, scf.khf.KSCF))
 
-    if isinstance(mf, (scf.ghf.GHF, scf.ghf.KGHF)):
+    if isinstance(mf, (scf.ghf.GHF, scf.kghf.KGHF)):
         if out is None:
             return mf.copy()
         else:

--- a/pyscf/pbc/scf/addons.py
+++ b/pyscf/pbc/scf/addons.py
@@ -91,15 +91,13 @@ class _SmearingKSCF(mol_addons._SmearingSCF):
 
         This is a k-point version of scf.hf.SCF.get_occ
         '''
-        from pyscf.scf import uhf, rohf, ghf
         if (self.sigma == 0) or (not self.sigma) or (not self.smearing_method):
             mo_occ_kpts = super().get_occ(mo_energy_kpts, mo_coeff_kpts)
             return mo_occ_kpts
 
-        is_uhf = isinstance(self, uhf.UHF)
-        is_ghf = isinstance(self, ghf.GHF)
-        is_rhf = (not is_uhf) and (not is_ghf)
-        is_rohf = isinstance(self, rohf.ROHF)
+        is_uhf = self.istype('KUHF')
+        is_rhf = self.istype('KRHF')
+        is_rohf = self.istype('KROHF')
 
         sigma = self.sigma
         if self.smearing_method.lower() == 'fermi':
@@ -196,14 +194,13 @@ class _SmearingKSCF(mol_addons._SmearingSCF):
         return mo_occ_kpts
 
     def get_grad(self, mo_coeff_kpts, mo_occ_kpts, fock=None):
-        from pyscf.scf import uhf
         if (self.sigma == 0) or (not self.sigma) or (not self.smearing_method):
             return super().get_grad(mo_coeff_kpts, mo_occ_kpts, fock)
 
         if fock is None:
             dm1 = self.make_rdm1(mo_coeff_kpts, mo_occ_kpts)
             fock = self.get_hcore() + self.get_veff(self.mol, dm1)
-        if isinstance(self, uhf.UHF):
+        if self.istype('KUHF'):
             ga = _get_grad_tril(mo_coeff_kpts[0], mo_occ_kpts[0], fock[0])
             gb = _get_grad_tril(mo_coeff_kpts[1], mo_occ_kpts[1], fock[1])
             return numpy.hstack((ga,gb))
@@ -288,7 +285,7 @@ def convert_to_uhf(mf, out=None):
         if isinstance(mf, (scf.uhf.UHF, scf.kuhf.KUHF)):
             return mf.copy()
         else:
-            if isinstance(mf, scf.kghf.KGHF):
+            if isinstance(mf, (scf.ghf.GHF, scf.kghf.KGHF)):
                 raise NotImplementedError(
                     f'No conversion from {mf.__class__} to uhf object')
 
@@ -339,7 +336,7 @@ def convert_to_rhf(mf, out=None):
             assert (not isinstance(out, scf.khf.KSCF))
         out = mol_addons._update_mf_without_soscf(mf, out, False)
 
-    elif nelec[0] != nelec[1] and isinstance(mf, scf.rohf.ROHF):
+    elif nelec[0] != nelec[1] and isinstance(mf, (scf.rohf.ROHF, scf.krohf.KROHF)):
         if getattr(mf, '_scf', None):
             return mol_addons._update_mf_without_soscf(mf, mf._scf.copy(), False)
         else:
@@ -349,7 +346,7 @@ def convert_to_rhf(mf, out=None):
         if isinstance(mf, (scf.hf.RHF, scf.khf.KRHF)):
             return mf.copy()
         else:
-            if isinstance(mf, scf.kghf.KGHF):
+            if isinstance(mf, (scf.ghf.GHF, scf.kghf.KGHF)):
                 raise NotImplementedError(
                     f'No conversion from {mf.__class__} to rhf object')
 
@@ -397,7 +394,7 @@ def convert_to_ghf(mf, out=None):
         else:
             assert (not isinstance(out, scf.khf.KSCF))
 
-    if isinstance(mf, scf.ghf.GHF):
+    if isinstance(mf, (scf.ghf.GHF, scf.ghf.KGHF)):
         if out is None:
             return mf.copy()
         else:
@@ -416,7 +413,7 @@ def convert_to_ghf(mf, out=None):
                     nkpts = mf.kpts.nkpts_ibz
                 else:
                     nkpts = len(mf.kpts)
-                is_rhf = isinstance(mf, scf.hf.RHF)
+                is_rhf = mf.istype('KRHF')
                 for k in range(nkpts):
                     if is_rhf:
                         mo_a = mo_b = mf.mo_coeff[k]
@@ -472,6 +469,7 @@ def convert_to_kscf(mf, out=None):
     '''
     from pyscf.pbc import scf, dft
     if not isinstance(mf, scf.khf.KSCF):
+        assert isinstance(mf, scf.hf.SCF)
         known_cls = {
             dft.uks.UKS   : dft.kuks.KUKS  ,
             dft.roks.ROKS : dft.kroks.KROKS,
@@ -484,7 +482,7 @@ def convert_to_kscf(mf, out=None):
         }
         mf = mol_addons._object_without_soscf(mf, known_cls, False)
         if mf.mo_energy is not None:
-            if isinstance(mf, scf.uhf.UHF):
+            if mf.istype('UHF'):
                 mf.mo_occ = mf.mo_occ[:,numpy.newaxis]
                 mf.mo_coeff = mf.mo_coeff[:,numpy.newaxis]
                 mf.mo_energy = mf.mo_energy[:,numpy.newaxis]

--- a/pyscf/pbc/scf/ghf.py
+++ b/pyscf/pbc/scf/ghf.py
@@ -165,6 +165,9 @@ class GHF(pbchf.SCF, mol_ghf.GHF):
         addons.convert_to_ghf(mf, self)
         return self
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 
 if __name__ == '__main__':
     from pyscf.pbc import gto

--- a/pyscf/pbc/scf/ghf.py
+++ b/pyscf/pbc/scf/ghf.py
@@ -97,7 +97,7 @@ def get_jk(mf, cell=None, dm=None, hermi=0, kpt=None, kpts_band=None,
 
     return vj, vk
 
-class GHF(pbchf.SCF, mol_ghf.GHF):
+class GHF(pbchf.SCF):
     '''GHF class for PBCs.
     '''
 
@@ -164,9 +164,6 @@ class GHF(pbchf.SCF, mol_ghf.GHF):
         '''Convert given mean-field object to GHF'''
         addons.convert_to_ghf(mf, self)
         return self
-
-    def to_gpu(self):
-        raise NotImplementedError
 
 
 if __name__ == '__main__':

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -901,6 +901,9 @@ class RHF(SCF, mol_hf.RHF):
         addons.convert_to_rhf(mf, self)
         return self
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 
 def _format_jks(vj, dm, kpts_band):
     if kpts_band is None:

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -870,6 +870,9 @@ class SCF(mol_hf.SCF):
         logger.debug1(self, 'Apply %s for J, %s for K, %s for nuc', J, K, nuc)
         return self
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 
 class KohnShamDFT:
     '''A mock DFT base class
@@ -881,7 +884,7 @@ class KohnShamDFT:
     '''
 
 
-class RHF(SCF, mol_hf.RHF):
+class RHF(SCF):
 
     analyze = mol_hf.RHF.analyze
     spin_square = mol_hf.RHF.spin_square
@@ -900,9 +903,6 @@ class RHF(SCF, mol_hf.RHF):
         '''Convert given mean-field object to RHF/ROHF'''
         addons.convert_to_rhf(mf, self)
         return self
-
-    def to_gpu(self):
-        raise NotImplementedError
 
 
 def _format_jks(vj, dm, kpts_band):

--- a/pyscf/pbc/scf/kghf.py
+++ b/pyscf/pbc/scf/kghf.py
@@ -278,6 +278,9 @@ class KGHF(khf.KSCF, pbcghf.GHF):
         from pyscf.pbc import dft
         return self._transfer_attrs_(dft.KGKS(self.cell, self.kpts, xc=xc))
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 del (WITH_META_LOWDIN, PRE_ORTH_METHOD)
 
 if __name__ == '__main__':

--- a/pyscf/pbc/scf/kghf.py
+++ b/pyscf/pbc/scf/kghf.py
@@ -183,7 +183,7 @@ def _cast_mol_init_guess(fn):
         'guess DM ' + fn.__doc__)
     return fn_init_guess
 
-class KGHF(khf.KSCF, pbcghf.GHF):
+class KGHF(khf.KSCF):
     '''GHF class for PBCs.
     '''
     def __init__(self, cell, kpts=np.zeros((1,3)),
@@ -277,9 +277,6 @@ class KGHF(khf.KSCF, pbcghf.GHF):
         '''
         from pyscf.pbc import dft
         return self._transfer_attrs_(dft.KGKS(self.cell, self.kpts, xc=xc))
-
-    def to_gpu(self):
-        raise NotImplementedError
 
 del (WITH_META_LOWDIN, PRE_ORTH_METHOD)
 

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -687,7 +687,7 @@ class KSCF(pbchf.SCF):
     def convert_from_(self, mf):
         raise NotImplementedError
 
-class KRHF(KSCF, pbchf.RHF):
+class KRHF(KSCF):
 
     analyze = analyze
     spin_square = mol_hf.RHF.spin_square
@@ -755,6 +755,3 @@ class KRHF(KSCF, pbchf.RHF):
         '''Convert given mean-field object to KRHF/KROHF'''
         addons.convert_to_rhf(mf, self)
         return self
-
-    def to_gpu(self):
-        raise NotImplementedError

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -755,3 +755,6 @@ class KRHF(KSCF, pbchf.RHF):
         '''Convert given mean-field object to KRHF/KROHF'''
         addons.convert_to_rhf(mf, self)
         return self
+
+    def to_gpu(self):
+        raise NotImplementedError

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -654,9 +654,6 @@ class KSCF(pbchf.SCF):
         from pyscf.pbc.scf import newton_ah
         return newton_ah.newton(self)
 
-    def remove_soscf(self):
-        raise NotImplementedError
-
     def sfx2c1e(self):
         from pyscf.pbc.x2c import sfx2c1e
         return sfx2c1e.sfx2c1e(self)

--- a/pyscf/pbc/scf/krohf.py
+++ b/pyscf/pbc/scf/krohf.py
@@ -255,7 +255,7 @@ def canonicalize(mf, mo_coeff_kpts, mo_occ_kpts, fock=None):
 
 init_guess_by_chkfile = kuhf.init_guess_by_chkfile
 
-class KROHF(khf.KRHF, pbcrohf.ROHF):
+class KROHF(khf.KRHF):
     '''UHF class with k-point sampling.
     '''
     conv_tol_grad = getattr(__config__, 'pbc_scf_KSCF_conv_tol_grad', None)

--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -572,3 +572,6 @@ class KUHF(khf.KSCF, pbcuhf.UHF):
         '''Convert given mean-field object to KUHF'''
         addons.convert_to_uhf(mf, self)
         return self
+
+    def to_gpu(self):
+        raise NotImplementedError

--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -364,7 +364,7 @@ def dip_moment(cell, dm_kpts, unit='Debye', verbose=logger.NOTE,
 
 get_rho = khf.get_rho
 
-class KUHF(khf.KSCF, pbcuhf.UHF):
+class KUHF(khf.KSCF):
     '''UHF class with k-point sampling.
     '''
     conv_tol_grad = getattr(__config__, 'pbc_scf_KSCF_conv_tol_grad', None)
@@ -572,6 +572,3 @@ class KUHF(khf.KSCF, pbcuhf.UHF):
         '''Convert given mean-field object to KUHF'''
         addons.convert_to_uhf(mf, self)
         return self
-
-    def to_gpu(self):
-        raise NotImplementedError

--- a/pyscf/pbc/scf/rohf.py
+++ b/pyscf/pbc/scf/rohf.py
@@ -132,3 +132,6 @@ class ROHF(pbchf.RHF, mol_rohf.ROHF):
         '''
         from pyscf.pbc import dft
         return self._transfer_attrs_(dft.ROKS(self.cell, self.kpt, xc=xc))
+
+    def to_gpu(self):
+        raise NotImplementedError

--- a/pyscf/pbc/scf/rohf.py
+++ b/pyscf/pbc/scf/rohf.py
@@ -40,7 +40,7 @@ energy_elec = mol_rohf.energy_elec
 dip_moment = pbcuhf.dip_moment
 get_rho = pbcuhf.get_rho
 
-class ROHF(pbchf.RHF, mol_rohf.ROHF):
+class ROHF(pbchf.RHF):
     '''ROHF class for PBCs.
     '''
 
@@ -132,6 +132,3 @@ class ROHF(pbchf.RHF, mol_rohf.ROHF):
         '''
         from pyscf.pbc import dft
         return self._transfer_attrs_(dft.ROKS(self.cell, self.kpt, xc=xc))
-
-    def to_gpu(self):
-        raise NotImplementedError

--- a/pyscf/pbc/scf/uhf.py
+++ b/pyscf/pbc/scf/uhf.py
@@ -258,3 +258,6 @@ class UHF(pbchf.SCF, mol_uhf.UHF):
         '''Convert given mean-field object to UHF'''
         addons.convert_to_uhf(mf, self)
         return self
+
+    def to_gpu(self):
+        raise NotImplementedError

--- a/pyscf/pbc/scf/uhf.py
+++ b/pyscf/pbc/scf/uhf.py
@@ -104,7 +104,7 @@ def dip_moment(cell, dm, unit='Debye', verbose=logger.NOTE,
 
 get_rho = pbchf.get_rho
 
-class UHF(pbchf.SCF, mol_uhf.UHF):
+class UHF(pbchf.SCF):
     '''UHF class for PBCs.
     '''
     _keys = set(["init_guess_breaksym"])
@@ -258,6 +258,3 @@ class UHF(pbchf.SCF, mol_uhf.UHF):
         '''Convert given mean-field object to UHF'''
         addons.convert_to_uhf(mf, self)
         return self
-
-    def to_gpu(self):
-        raise NotImplementedError

--- a/pyscf/pbc/tdscf/__init__.py
+++ b/pyscf/pbc/tdscf/__init__.py
@@ -31,22 +31,20 @@ except (ImportError, IOError):
     pass
 
 def TDHF(mf):
-    import numpy
     if isinstance(mf, scf.khf.KSCF):
         return KTDHF(mf)
     if isinstance(mf, scf.hf.KohnShamDFT):
         raise RuntimeError('TDHF does not support DFT object %s' % mf)
-    #TODO: mf = mf.remove_soscf()
+    mf = mf.remove_soscf()
     if isinstance(mf, scf.rohf.ROHF):
         # Is it correct to call TDUHF for ROHF?
         mf = mf.to_uhf()
     return mf.TDHF()
 
 def TDA(mf):
-    import numpy
     if isinstance(mf, scf.khf.KSCF):
         return KTDA(mf)
-    #TODO: mf = mf.remove_soscf()
+    mf = mf.remove_soscf()
     if isinstance(mf, scf.rohf.ROHF):
         if isinstance(mf, scf.hf.KohnShamDFT):
             mf = mf.to_uks()
@@ -55,11 +53,10 @@ def TDA(mf):
     return mf.TDA()
 
 def TDDFT(mf):
-    import numpy
     if isinstance(mf, scf.khf.KSCF):
         return KTDDFT(mf)
     if isinstance(mf, scf.hf.KohnShamDFT):
-        #TODO: mf = mf.remove_soscf()
+        mf = mf.remove_soscf()
         if isinstance(mf, scf.rohf.ROHF):
             mf = mf.to_uks()
         return mf.TDDFT()
@@ -69,13 +66,13 @@ def TDDFT(mf):
 def KTDHF(mf):
     if isinstance(mf, scf.hf.KohnShamDFT):
         raise RuntimeError('TDHF does not support DFT object %s' % mf)
-    #TODO: mf = mf.remove_soscf()
+    mf = mf.remove_soscf()
     if isinstance(mf, scf.rohf.ROHF):
         mf = mf.to_uhf()
     return mf.TDHF()
 
 def KTDA(mf):
-    #TODO: mf = mf.remove_soscf()
+    mf = mf.remove_soscf()
     if isinstance(mf, scf.rohf.ROHF):
         if isinstance(mf, scf.hf.KohnShamDFT):
             mf = mf.to_uks()
@@ -85,7 +82,7 @@ def KTDA(mf):
 
 def KTDDFT(mf):
     if isinstance(mf, scf.hf.KohnShamDFT):
-        #TODO: mf = mf.remove_soscf()
+        mf = mf.remove_soscf()
         if isinstance(mf, scf.rohf.ROHF):
             mf = mf.to_uks()
         return mf.TDDFT()

--- a/pyscf/scf/_response_functions.py
+++ b/pyscf/scf/_response_functions.py
@@ -36,7 +36,7 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
             orbital hessian or CPHF will be generated. If singlet is boolean,
             it is used in TDDFT response kernel.
     '''
-    assert (not isinstance(mf, (uhf.UHF, rohf.ROHF)))
+    assert isinstance(mf, hf.RHF) and not isinstance(mf, (uhf.UHF, rohf.ROHF))
 
     if mo_coeff is None: mo_coeff = mf.mo_coeff
     if mo_occ is None: mo_occ = mf.mo_occ
@@ -148,6 +148,7 @@ def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None,
     '''Generate a function to compute the product of UHF response function and
     UHF density matrices.
     '''
+    assert isinstance(mf, (uhf.UHF, rohf.ROHF))
     if mo_coeff is None: mo_coeff = mf.mo_coeff
     if mo_occ is None: mo_occ = mf.mo_occ
     mol = mf.mol

--- a/pyscf/scf/addons.py
+++ b/pyscf/scf/addons.py
@@ -25,7 +25,6 @@ from pyscf import lib
 from pyscf.gto import mole
 from pyscf.lib import logger
 from pyscf.lib.scipy_helper import pivoted_cholesky
-from pyscf.scf import hf
 from pyscf import __config__
 
 LINEAR_DEP_THRESHOLD = getattr(__config__, 'scf_addons_remove_linear_dep_threshold', 1e-8)
@@ -44,6 +43,7 @@ def smearing(mf, sigma=None, method=SMEARING_METHOD, mu0=None, fix_spin=False):
         mf.fix_spin = fix_spin
         return mf
 
+    assert not mf.istype('KSCF')
     return lib.set_class(_SmearingSCF(mf, sigma, method, mu0, fix_spin),
                          (_SmearingSCF, mf.__class__))
 
@@ -116,16 +116,14 @@ class _SmearingSCF:
     def get_occ(self, mo_energy=None, mo_coeff=None):
         '''Label the occupancies for each orbital
         '''
-        from pyscf.scf import uhf, rohf, ghf
         from pyscf.pbc.tools import print_mo_energy_occ
         if (self.sigma == 0) or (not self.sigma) or (not self.smearing_method):
             mo_occ = super().get_occ(mo_energy, mo_coeff)
             return mo_occ
 
-        is_uhf = isinstance(self, uhf.UHF)
-        is_ghf = isinstance(self, ghf.GHF)
-        is_rhf = (not is_uhf) and (not is_ghf)
-        is_rohf = isinstance(self, rohf.ROHF)
+        is_uhf = self.istype('UHF')
+        is_rhf = self.istype('RHF')
+        is_rohf = self.istype('ROHF')
 
         sigma = self.sigma
         if self.smearing_method.lower() == 'fermi':
@@ -207,14 +205,13 @@ class _SmearingSCF:
         return entropy
 
     def get_grad(self, mo_coeff, mo_occ, fock=None):
-        from pyscf.scf import uhf
         if (self.sigma == 0) or (not self.sigma) or (not self.smearing_method):
             return super().get_grad(mo_coeff, mo_occ, fock)
 
         if fock is None:
             dm1 = self.make_rdm1(mo_coeff, mo_occ)
             fock = self.get_hcore() + self.get_veff(self.mol, dm1)
-        if isinstance(self, uhf.UHF):
+        if self.istype('UHF'):
             ga = _get_grad_tril(mo_coeff[0], mo_occ[0], fock[0])
             gb = _get_grad_tril(mo_coeff[1], mo_occ[1], fock[1])
             return numpy.hstack((ga,gb))
@@ -241,7 +238,7 @@ def frac_occ_(mf, tol=1e-3):
         >>> mf = scf.addons.frac_occ(mf)
         >>> mf.run()
     '''
-    from pyscf.scf import hf, uhf, rohf
+    from pyscf.scf import uhf, rohf
     old_get_occ = mf.get_occ
     mol = mf.mol
 
@@ -263,7 +260,7 @@ def frac_occ_(mf, tol=1e-3):
             frac_occ_lst = numpy.zeros_like(mo_energy, dtype=bool)
         return mo_occ, numpy.where(frac_occ_lst)[0], homo, lumo
 
-    if isinstance(mf, uhf.UHF):
+    if mf.istype('UHF'):
         def get_occ(mo_energy, mo_coeff=None):
             nocca, noccb = mol.nelec
             mo_occa, frac_lsta, homoa, lumoa = guess_occ(mo_energy[0], nocca)
@@ -289,7 +286,7 @@ def frac_occ_(mf, tol=1e-3):
                 mo_occ = old_get_occ(mo_energy, mo_coeff)
             return mo_occ
 
-    elif isinstance(mf, rohf.ROHF):
+    elif mf.istype('ROHF'):
         def get_occ(mo_energy, mo_coeff=None):
             nocca, noccb = mol.nelec
             mo_occa, frac_lsta, homoa, lumoa = guess_occ(mo_energy, nocca)
@@ -336,7 +333,7 @@ def frac_occ_(mf, tol=1e-3):
             g[uniq_var_b] += fockb[uniq_var_b]
             return g[uniq_var_a | uniq_var_b]
 
-    elif isinstance(mf, hf.RHF):
+    elif mf.istype('RHF'):
         def get_occ(mo_energy, mo_coeff=None):
             nocc = (mol.nelectron+1) // 2  # n_docc + n_socc
             mo_occ, frac_lst, homo, lumo = guess_occ(mo_energy, nocc)
@@ -379,7 +376,7 @@ def dynamic_occ_(mf, tol=1e-3):
     '''
     Dynamically adjust the occupancy to avoid degeneracy between HOMO and LUMO
     '''
-    assert (isinstance(mf, hf.RHF))
+    assert mf.istype('RHF')
     old_get_occ = mf.get_occ
     def get_occ(mo_energy, mo_coeff=None):
         mol = mf.mol
@@ -431,7 +428,7 @@ def float_occ_(mf):
     Determine occupation of alpha and beta electrons based on energy spectrum
     '''
     from pyscf.scf import uhf
-    assert (isinstance(mf, uhf.UHF))
+    assert mf.istype('UHF')
     def get_occ(mo_energy, mo_coeff=None):
         mol = mf.mol
         ee = numpy.sort(numpy.hstack(mo_energy))
@@ -477,10 +474,10 @@ def mom_occ_(mf, occorb, setocc):
     iteration.'''
     from pyscf.scf import uhf, rohf
     log = logger.Logger(mf.stdout, mf.verbose)
-    if isinstance(mf, uhf.UHF):
+    if mf.istype('UHF'):
         coef_occ_a = occorb[0][:, setocc[0]>0]
         coef_occ_b = occorb[1][:, setocc[1]>0]
-    elif isinstance(mf, rohf.ROHF):
+    elif mf.istype('ROHF'):
         if mf.mol.spin != (numpy.sum(setocc[0]) - numpy.sum(setocc[1])):
             raise ValueError('Wrong occupation setting for restricted open-shell calculation.')
         coef_occ_a = occorb[:, setocc[0]>0]
@@ -488,11 +485,11 @@ def mom_occ_(mf, occorb, setocc):
     else: # GHF, and DHF
         assert setocc.ndim == 1
 
-    if isinstance(mf, (uhf.UHF, rohf.ROHF)):
+    if mf.istype('UHF') or mf.istype('ROHF'):
         def get_occ(mo_energy=None, mo_coeff=None):
             if mo_energy is None: mo_energy = mf.mo_energy
             if mo_coeff is None: mo_coeff = mf.mo_coeff
-            if isinstance(mf, rohf.ROHF):
+            if mf.istype('ROHF'):
                 mo_coeff = numpy.array([mo_coeff, mo_coeff])
             mo_occ = numpy.zeros_like(setocc)
             nocc_a = int(numpy.sum(setocc[0]))
@@ -521,7 +518,7 @@ def mom_occ_(mf, occorb, setocc):
                           nocc_b, int(numpy.sum(mo_occ[1])))
 
             #output 1-dimension occupation number for restricted open-shell
-            if isinstance(mf, rohf.ROHF): mo_occ = mo_occ[0, :] + mo_occ[1, :]
+            if mf.istype('ROHF'): mo_occ = mo_occ[0, :] + mo_occ[1, :]
             return mo_occ
     else:
         def get_occ(mo_energy=None, mo_coeff=None):
@@ -780,18 +777,18 @@ def convert_to_uhf(mf, out=None, remove_df=False):
     '''
     from pyscf import scf
     from pyscf import dft
-    assert (isinstance(mf, hf.SCF))
+    assert (isinstance(mf, scf.hf.SCF))
 
     logger.debug(mf, 'Converting %s to UHF', mf.__class__)
 
-    if isinstance(mf, scf.ghf.GHF):
+    if mf.istype('GHF'):
         raise NotImplementedError
 
     elif out is not None:
-        assert (isinstance(out, scf.uhf.UHF))
+        assert out.istype('UHF')
         out = _update_mf_without_soscf(mf, out, remove_df)
 
-    elif isinstance(mf, scf.uhf.UHF):
+    elif mf.istype('UHF'):
         # Remove with_df for SOSCF method because the post-HF code checks the
         # attribute .with_df to identify whether an SCF object is DF-SCF method.
         # with_df in SOSCF is used in orbital hessian approximation only.  For the
@@ -884,7 +881,7 @@ def convert_to_rhf(mf, out=None, remove_df=False):
     '''
     from pyscf import scf
     from pyscf import dft
-    assert (isinstance(mf, hf.SCF))
+    assert (isinstance(mf, scf.hf.SCF))
 
     logger.debug(mf, 'Converting %s to RHF', mf.__class__)
 
@@ -893,15 +890,15 @@ def convert_to_rhf(mf, out=None, remove_df=False):
     else:
         nelec = mf.nelec
 
-    if isinstance(mf, scf.ghf.GHF):
+    if mf.istype('GHF'):
         raise NotImplementedError
 
     elif out is not None:
-        assert (isinstance(out, scf.hf.RHF))
+        assert out.istype('RHF')
         out = _update_mf_without_soscf(mf, out, remove_df)
 
-    elif (isinstance(mf, scf.hf.RHF) or
-          (nelec[0] != nelec[1] and isinstance(mf, scf.rohf.ROHF))):
+    elif (mf.istype('RHF') or
+          (nelec[0] != nelec[1] and mf.istype('ROHF'))):
         if getattr(mf, '_scf', None):
             return _update_mf_without_soscf(mf, mf._scf.copy(), remove_df)
         else:
@@ -951,15 +948,15 @@ def convert_to_ghf(mf, out=None, remove_df=False):
     '''
     from pyscf import scf
     from pyscf import dft
-    assert (isinstance(mf, hf.SCF))
+    assert (isinstance(mf, scf.hf.SCF))
 
     logger.debug(mf, 'Converting %s to GHF', mf.__class__)
 
     if out is not None:
-        assert (isinstance(out, scf.ghf.GHF))
+        assert out.istype('GHF')
         out = _update_mf_without_soscf(mf, out, remove_df)
 
-    elif isinstance(mf, scf.ghf.GHF):
+    elif mf.istype('GHF'):
         if getattr(mf, '_scf', None):
             return _update_mf_without_soscf(mf, mf._scf.copy(), remove_df)
         else:
@@ -985,11 +982,10 @@ def convert_to_ghf(mf, out=None, remove_df=False):
     return _update_mo_to_ghf_(mf, out)
 
 def _update_mo_to_uhf_(mf, mf1):
-    from pyscf import scf
     if mf.mo_energy is None:
         return mf1
 
-    if isinstance(mf, scf.uhf.UHF):
+    if mf.istype('UHF') or mf.istype('KUHF'):
         mf1.mo_occ = mf.mo_occ
         mf1.mo_coeff = mf.mo_coeff
         mf1.mo_energy = mf.mo_energy
@@ -1011,11 +1007,10 @@ def _update_mo_to_uhf_(mf, mf1):
     return mf1
 
 def _update_mo_to_rhf_(mf, mf1):
-    from pyscf import scf
     if mf.mo_energy is None:
         return mf1
 
-    if isinstance(mf, scf.hf.RHF): # RHF/ROHF/KRHF/KROHF
+    if mf.istype('RHF') or mf.istype('KRHF'): # RHF/ROHF/KRHF/KROHF
         mf1.mo_occ = mf.mo_occ
         mf1.mo_coeff = mf.mo_coeff
         mf1.mo_energy = mf.mo_energy
@@ -1034,11 +1029,12 @@ def _update_mo_to_rhf_(mf, mf1):
     return mf1
 
 def _update_mo_to_ghf_(mf, mf1):
-    from pyscf import scf
     if mf.mo_energy is None:
         return mf1
 
-    if isinstance(mf, scf.hf.RHF): # RHF
+    if mf.istype('KSCF'):
+        raise NotImplementedError('KSCF')
+    elif mf.istype('RHF'):
         nao, nmo = mf.mo_coeff.shape
         orbspin = get_ghf_orbspin(mf.mo_energy, mf.mo_occ, True)
 

--- a/pyscf/scf/addons.py
+++ b/pyscf/scf/addons.py
@@ -819,11 +819,7 @@ def _object_without_soscf(mf, known_class, remove_df=False):
     from pyscf.soscf import newton_ah
     from pyscf.df.df_jk import _DFHF
     if isinstance(mf, newton_ah._CIAH_SOSCF):
-        base_scf = mf._scf
         mf = mf.undo_soscf()
-        if isinstance(mf, _DFHF) and not isinstance(base_scf, _DFHF):
-            # where density fitting is only applied on SOSCF hessian
-            mf = mf.undo_df()
 
     if remove_df and isinstance(mf, _DFHF):
         mf = mf.undo_df()

--- a/pyscf/scf/ghf.py
+++ b/pyscf/scf/ghf.py
@@ -541,6 +541,10 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         from pyscf import dft
         return self._transfer_attrs_(dft.GKS(self.mol, xc=xc))
 
+    def to_gpu(self):
+        from gpu4pyscf.scf import GHF
+        return lib.to_gpu(self.__class__.reset(self.view(GHF)))
+
 def _from_rhf_init_dm(dm, breaksym=True):
     dma = dm * .5
     dm = scipy.linalg.block_diag(dma, dma)

--- a/pyscf/scf/ghf.py
+++ b/pyscf/scf/ghf.py
@@ -543,7 +543,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
 
     def to_gpu(self):
         from gpu4pyscf.scf import GHF
-        return lib.to_gpu(self.__class__.reset(self.view(GHF)))
+        return lib.to_gpu(hf.SCF.reset(self.view(GHF)))
 
 def _from_rhf_init_dm(dm, breaksym=True):
     dma = dm * .5

--- a/pyscf/scf/ghf_symm.py
+++ b/pyscf/scf/ghf_symm.py
@@ -281,6 +281,9 @@ class SymAdaptedGHF(ghf.GHF):
         return numpy.asarray(get_orbsym(self.mol, mo_coeff, s))
     orbsym = property(get_orbsym)
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 GHF = SymAdaptedGHF
 
 

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -2002,6 +2002,11 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         dst.converged = False
         return dst
 
+    def to_gpu(self):
+        '''Converts to the object with GPU support.
+        '''
+        raise NotImplementedError
+
 
 class KohnShamDFT:
     '''A mock DFT base class
@@ -2111,6 +2116,11 @@ class RHF(SCF):
         '''
         from pyscf import dft
         return self._transfer_attrs_(dft.RKS(self.mol, xc=xc))
+
+    def to_gpu(self):
+        # FIXME: consider the density_fit, x2c and soscf decoration
+        from gpu4pyscf.scf import RHF
+        return lib.to_gpu(self.__class__.reset(self.view(RHF)))
 
 def _hf1e_scf(mf, *args):
     logger.info(mf, '\n')

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -2007,6 +2007,20 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         '''
         raise NotImplementedError
 
+    def istype(self, type_code):
+        '''
+        Checks if the object is an instance of the class specified by the type_code.
+        type_code can be a class or a str. If the type_code is a class, it is
+        equivalent to the Python built-in function `isinstance`. If the type_code
+        is a str, it checks the type_code against the names of the object and all
+        its parent classes.
+        '''
+        if isinstance(type_code, type):
+            # type_code is a class
+            return isinstance(self, type_code)
+
+        return any(type_code == t.__name__ for t in self.__class__.__mro__)
+
 
 class KohnShamDFT:
     '''A mock DFT base class

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -2120,7 +2120,8 @@ class RHF(SCF):
     def to_gpu(self):
         # FIXME: consider the density_fit, x2c and soscf decoration
         from gpu4pyscf.scf import RHF
-        return lib.to_gpu(self.__class__.reset(self.view(RHF)))
+        obj = SCF.reset(self.view(RHF))
+        return lib.to_gpu(obj)
 
 def _hf1e_scf(mf, *args):
     logger.info(mf, '\n')

--- a/pyscf/scf/hf_symm.py
+++ b/pyscf/scf/hf_symm.py
@@ -572,6 +572,10 @@ class SymAdaptedRHF(hf.RHF):
     wfnsym = property(get_wfnsym)
 
     canonicalize = canonicalize
+
+    def to_gpu(self):
+        raise NotImplementedError
+
 RHF = SymAdaptedRHF
 
 
@@ -929,6 +933,9 @@ class SymAdaptedROHF(rohf.ROHF):
 
     get_wfnsym = get_wfnsym
     wfnsym = property(get_wfnsym)
+
+    def to_gpu(self):
+        raise NotImplementedError
 
 ROHF = SymAdaptedROHF
 

--- a/pyscf/scf/rohf.py
+++ b/pyscf/scf/rohf.py
@@ -501,7 +501,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
 
     def to_gpu(self):
         from gpu4pyscf.scf import ROHF
-        return lib.to_gpu(self.__class__.reset(self.view(ROHF)))
+        return lib.to_gpu(hf.SCF.reset(self.view(ROHF)))
 
 
 class HF1e(ROHF):

--- a/pyscf/scf/rohf.py
+++ b/pyscf/scf/rohf.py
@@ -499,6 +499,10 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         from pyscf import dft
         return self._transfer_attrs_(dft.ROKS(self.mol, xc=xc))
 
+    def to_gpu(self):
+        from gpu4pyscf.scf import ROHF
+        return lib.to_gpu(self.__class__.reset(self.view(ROHF)))
+
 
 class HF1e(ROHF):
     scf = hf._hf1e_scf

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -1071,6 +1071,10 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         from pyscf import dft
         return self._transfer_attrs_(dft.UKS(self.mol, xc=xc))
 
+    def to_gpu(self):
+        from gpu4pyscf.scf import UHF
+        return lib.to_gpu(self.__class__.reset(self.view(UHF)))
+
 def _hf1e_scf(mf, *args):
     logger.info(mf, '\n')
     logger.info(mf, '******** 1 electron system ********')

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -1073,7 +1073,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
 
     def to_gpu(self):
         from gpu4pyscf.scf import UHF
-        return lib.to_gpu(self.__class__.reset(self.view(UHF)))
+        return lib.to_gpu(hf.SCF.reset(self.view(UHF)))
 
 def _hf1e_scf(mf, *args):
     logger.info(mf, '\n')

--- a/pyscf/scf/uhf_symm.py
+++ b/pyscf/scf/uhf_symm.py
@@ -565,6 +565,9 @@ class SymAdaptedUHF(uhf.UHF):
 
     canonicalize = canonicalize
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 UHF = SymAdaptedUHF
 
 

--- a/pyscf/soscf/newton_ah.py
+++ b/pyscf/soscf/newton_ah.py
@@ -925,15 +925,15 @@ def newton(mf):
 
     assert isinstance(mf, hf.SCF)
 
-    if isinstance(mf, rohf.ROHF):
+    if mf.istype('ROHF'):
         cls = _SecondOrderROHF
-    elif isinstance(mf, uhf.UHF):
+    elif mf.istype('UHF'):
         cls = _SecondOrderUHF
-    elif isinstance(mf, scf.ghf.GHF):
+    elif mf.istype('GHF'):
         cls = _SecondOrderGHF
-    elif isinstance(mf, scf.dhf.RDHF):
+    elif mf.istype('RDHF'):
         cls = _SecondOrderRDHF
-    elif isinstance(mf, scf.dhf.DHF):
+    elif mf.istype('DHF'):
         cls = _SecondOrderDHF
     else:
         cls = _SecondOrderRHF

--- a/pyscf/soscf/newton_ah.py
+++ b/pyscf/soscf/newton_ah.py
@@ -656,8 +656,16 @@ class _CIAH_SOSCF(object):
 
     def undo_soscf(self):
         '''Remove the SOSCF Mixin'''
-        obj = lib.view(self, lib.drop_class(self.__class__, _CIAH_SOSCF))
+        from pyscf.df.df_jk import _DFHF
+        if isinstance(self, _DFHF) and not isinstance(self._scf, _DFHF):
+            # where density fitting is only applied on the SOSCF hessian
+            mf = self.undo_df()
+        else:
+            mf = self
+        obj = lib.view(mf, lib.drop_class(mf.__class__, _CIAH_SOSCF))
         del obj._scf
+        # When both self and self._scf are DF objects, they may be different df
+        # objects. The DF object of the base scf object should be used.
         if hasattr(self._scf, 'with_df'):
             obj.with_df = self._scf.with_df
         return obj

--- a/pyscf/soscf/test/test_newton_ah.py
+++ b/pyscf/soscf/test/test_newton_ah.py
@@ -320,14 +320,14 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(mf._eri is None)
         self.assertTrue(mf._scf._eri is None)
         self.assertAlmostEqual(mf.e_tot, -75.983944727996, 9)
+        self.assertEqual(mf.__class__.__name__, 'SecondOrderDFRHF')
 
         mf = scf.RHF(h2o_z0).newton().density_fit().run()
         self.assertTrue(mf._eri is None)
         self.assertTrue(mf._scf._eri is not None)
         self.assertAlmostEqual(mf.e_tot, -75.9839484980661, 9)
-
         mf = mf.undo_newton()
-        self.assertEqual(mf.__class__.__name__, 'DFRHF')
+        self.assertEqual(mf.__class__.__name__, 'RHF')
 
     def test_rohf_dinfh(self):
         mol = gto.M(atom='Ti 0 0 0; O 0 0 1.9',


### PR DESCRIPTION
* Add to_gpu method for some mean-field methods. It converts pyscf objects to its GPU variant
* Change the mean-field class inheritance hierarchy. The mean-field classes of molecule, Gamma-point PBC, k-point PBC are independent classes now. Refactor the initialization functions of cc, tddft, etc regarding to this change.
* Add an istype method for mean-field class to test if a mean-field class subject to the molecule or gamma-point PBC class.
* Fix the undo_soscf method when it works with density fitting model