### PR TITLE
Fix chunking dimension for pol_embed in  _compute_multipole_potential…

### DIFF
--- a/pyscf/solvent/pol_embed.py
+++ b/pyscf/solvent/pol_embed.py
@@ -386,7 +386,7 @@ class PolEmbed(lib.StreamObject):
                                       implemented for order > 2.""")
 
         op = 0
-        for p0, p1 in lib.prange_split(all_sites.size, n_chunks):
+        for p0, p1 in lib.prange_split(all_sites.shape[0], n_chunks):
             sites = all_sites[p0:p1]
             orders = all_orders[p0:p1]
             moments = all_moments[p0:p1]


### PR DESCRIPTION
There was a problem with the dimensions for chunking of the static multipole integrals.
The dimensions were determined from all_sites.size (3*n_sites), which only will work when n_chunks = 1, since in that case, the list slicing past the boundary just returns the full list anyway.

Previously, with n_chunks > 1, the slicing could give empty lists, and the later einsums would fail with something like:

```
File ~/Programs/pyscf/pyscf/scf/hf.py:1718, in SCF.scf(self, dm0, **kwargs)
   1713 self.build(self.mol)
   1715 if self.max_cycle > 0 or self.mo_coeff is None:
   1716     self.converged, self.e_tot, \
   1717             self.mo_energy, self.mo_coeff, self.mo_occ = \
-> 1718             kernel(self, self.conv_tol, self.conv_tol_grad,
   1719                    dm0=dm0, callback=self.callback,
   1720                    conv_check=self.conv_check, **kwargs)
   1721 else:
   1722     # Avoid to update SCF orbitals in the non-SCF initialization
   1723     # (issue #495).  But run regular SCF for initial guess if SCF was
   1724     # not initialized.
   1725     self.e_tot = kernel(self, self.conv_tol, self.conv_tol_grad,
   1726                         dm0=dm0, callback=self.callback,
   1727                         conv_check=self.conv_check, **kwargs)[1]

File ~/Programs/pyscf/pyscf/scf/hf.py:124, in kernel(mf, conv_tol, conv_tol_grad, dump_chk, dm0, callback, conv_check, **kwargs)
    121     dm = dm0
    123 h1e = mf.get_hcore(mol)
--> 124 vhf = mf.get_veff(mol, dm)
    125 e_tot = mf.energy_tot(dm, h1e, vhf)
    126 logger.info(mf, 'init E= %.15g', e_tot)

File ~/Programs/pyscf/pyscf/solvent/_attach_solvent.py:85, in SCFWithSolvent.get_veff(self, mol, dm, *args, **kwargs)
     83 with_solvent = self.with_solvent
     84 if not with_solvent.frozen:
---> 85     with_solvent.e, with_solvent.v = with_solvent.kernel(dm)
     86 e_solvent, v_solvent = with_solvent.e, with_solvent.v
     88 # NOTE: v_solvent should not be added to vhf in this place. This is
     89 # because vhf is used as the reference for direct_scf in the next
     90 # iteration. If v_solvent is added here, it may break direct SCF.

File ~/Programs/pyscf/pyscf/solvent/pol_embed.py:259, in PolEmbed.kernel(self, dm, elec_only)
    255 if not (isinstance(dm, numpy.ndarray) and dm.ndim == 2):
    256     # spin-traced DM for UHF or ROHF
    257     dm = dm[0] + dm[1]
--> 259 e, v = self._exec_cppe(dm, elec_only)
    260 logger.info(self, 'Polarizable embedding energy = %.15g', e)
    262 self.e = e

File ~/Programs/pyscf/pyscf/solvent/pol_embed.py:311, in PolEmbed._exec_cppe(self, dm, elec_only)
    309     orders.append(m.k)
    310     moments.append(p_moments)
--> 311 self.V_es = self._compute_multipole_potential_integrals(
    312     positions, orders, moments, n_chunks_el
    313 )
    314 if self.do_ecp:
    315     self.V_ecp = self.ecpmol.intor("ECPscalar")

File ~/Programs/pyscf/pyscf/solvent/pol_embed.py:402, in PolEmbed._compute_multipole_potential_integrals(self, all_sites, all_orders, all_moments, n_chunks)
    400 integral0 = df.incore.aux_e2(self.mol, fakemol, intor='int3c2e')
    401 moments_0 = numpy.array([m[0] for m in moments])
--> 402 op += numpy.einsum('ijg,ga->ij', integral0, moments_0 * cppe.prefactors(0))
    404 # order 1
    405 if numpy.any(orders >= 1):

File <__array_function__ internals>:200, in einsum(*args, **kwargs)

File ~/miniconda3/lib/python3.8/site-packages/numpy/core/einsumfunc.py:1371, in einsum(out, optimize, *operands, **kwargs)
   1369     if specified_out:
   1370         kwargs['out'] = out
-> 1371     return c_einsum(*operands, **kwargs)
   1373 # Check the kwargs to avoid a more cryptic error later, without having to
   1374 # repeat default values here
   1375 valid_einsum_kwargs = ['dtype', 'order', 'casting']

ValueError: einstein sum subscripts string contains too many subscripts for operand 1

```
 