### PR TITLE
fix cc example 20

### DIFF
--- a/examples/cc/20-ip_ea_eom_ccsd.py
+++ b/examples/cc/20-ip_ea_eom_ccsd.py
@@ -51,7 +51,7 @@ eea,cea = mycc.eaccsd(nroots=1)
 
 # EOM-GCCSD
 mf = mf.to_ghf()
-mycc = mf.GCCSD()
+mycc = mf.CCSD()
 ecc, t1, t2 = mycc.kernel()
 e,v = mycc.ipccsd(nroots=6)
 e,v = mycc.eaccsd(nroots=6)


### PR DESCRIPTION
I believe that this should fix example 20. When running CC via an mf object, it seems that only CCSD can be used, not GCCSD, etc, see https://github.com/pyscf/pyscf/blob/14d88828cd1f18f1e5358da1445355bde55322a1/pyscf/cc/__init__.py#L90 

fixes issue #1948