### PR TITLE
Switch off sparse algorithm in DFT numerical integration for small systems

### DIFF
--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -2802,7 +2802,7 @@ class NumInt(lib.StreamObject, LibXCMixin):
         screen_index = non0tab
 
         # the xxx_sparse() functions require ngrids 8-byte aligned
-        allow_sparse = ngrids % ALIGNMENT_UNIT == 0
+        allow_sparse = ngrids % ALIGNMENT_UNIT == 0 and nao > SWITCH_SIZE
 
         if buf is None:
             buf = _empty_aligned(comp * blksize * nao)

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2100,7 +2100,7 @@ def tofile(mol, filename, format=None):
     if format is None:  # Guess format based on filename
         format = os.path.splitext(filename)[1][1:]
     string = tostring(mol, format)
-    with open(filename, 'w') as f:
+    with open(filename, 'w', encoding='utf-8') as f:
         f.write(string)
         f.write('\n')
     return string
@@ -2516,9 +2516,9 @@ class MoleBase(lib.StreamObject):
                     print('output file: %s' % self.output)
 
             if self.output == '/dev/null':
-                self.stdout = open(os.devnull, 'w')
+                self.stdout = open(os.devnull, 'w', encoding='utf-8')
             else:
-                self.stdout = open(self.output, 'w')
+                self.stdout = open(self.output, 'w', encoding='utf-8')
 
         if self.verbose >= logger.WARN:
             self.check_sanity()


### PR DESCRIPTION
* Sparse numerical integration algorithm is slower than the dense one based on np.dot in small systems.
* Fix the encoding problem for cuda environment caused by issue https://github.com/NVIDIA/cuda-python/issues/29