### PR TITLE
Update periodic GW init and add example

### DIFF
--- a/examples/pbc/22-k_points_gw.py
+++ b/examples/pbc/22-k_points_gw.py
@@ -39,5 +39,5 @@ print("KRGW energies =", mygw.mo_energy)
 # With CD frequency integration
 #mygw = gw.KRGW(kmf, freq_int='cd')
 #mygw.kernel()
-#print("KRGW-AC energies =", mygw.mo_energy)
+#print("KRGW-CD energies =", mygw.mo_energy)
 

--- a/examples/pbc/22-k_points_gw.py
+++ b/examples/pbc/22-k_points_gw.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+'''
+G0W0 with k-points sampling
+'''
+
+from functools import reduce
+import numpy
+from pyscf.pbc import gto, scf, gw
+
+cell = gto.Cell()
+cell.atom='''
+C 0.000000000000   0.000000000000   0.000000000000
+C 1.685068664391   1.685068664391   1.685068664391
+'''
+cell.basis = 'gth-szv'
+cell.pseudo = 'gth-pade'
+cell.a = '''
+0.000000000, 3.370137329, 3.370137329
+3.370137329, 0.000000000, 3.370137329
+3.370137329, 3.370137329, 0.000000000'''
+cell.unit = 'B'
+cell.verbose = 5
+cell.build()
+
+#
+# KDFT and KGW with 2x2x2 k-points
+#
+kpts = cell.make_kpts([2,2,2])
+kmf = scf.KRKS(cell).density_fit()
+kmf.kpts = kpts
+emf = kmf.kernel()
+
+# Default is AC frequency integration
+mygw = gw.KRGW(kmf)
+mygw.kernel()
+print("KRGW energies =", mygw.mo_energy)
+
+# With CD frequency integration
+#mygw = gw.KRGW(kmf, freq_int='cd')
+#mygw.kernel()
+#print("KRGW-AC energies =", mygw.mo_energy)
+

--- a/pyscf/pbc/gw/__init__.py
+++ b/pyscf/pbc/gw/__init__.py
@@ -1,1 +1,44 @@
-from .kgw_slow import GW as KRGW
+# Copyright 2014-2018 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Periodic G0W0 approximation
+'''
+
+from pyscf.pbc.gw import krgw_ac
+from pyscf.pbc.gw import kugw_ac
+from pyscf.pbc.gw import krgw_cd
+from pyscf.pbc import scf
+
+def KRGW(mf, freq_int='ac', frozen=None):
+    mf = mf.to_rhf()
+    if freq_int.lower() == 'ac':
+        return krgw_ac.KRGWAC(mf, frozen)
+    elif freq_int.lower() == 'cd':
+        return krgw_cd.KRGWCD(mf, frozen)
+    else:
+        raise RuntimeError("GW frequency integration method %s not recognized. "
+                           "With PBC, options are 'ac' and 'cd'."%(freq_int))
+
+def KUGW(mf, freq_int='ac', frozen=None):
+    mf = mf.to_uhf()
+    if freq_int.lower() == 'ac':
+        return kugw_ac.KUGWAC(mf, frozen)
+    elif freq_int.lower() == 'cd':
+        raise RuntimeError('GWCD does not support UHF or UKS methods.')
+    else:
+        raise RuntimeError("GW frequency integration method %s not recognized. "
+                           "With PBC, options are 'ac' and 'cd'."%(freq_int))
+
+KGW = KRGW

--- a/pyscf/pbc/gw/__init__.py
+++ b/pyscf/pbc/gw/__init__.py
@@ -22,7 +22,7 @@ from pyscf.pbc.gw import krgw_cd
 from pyscf.pbc import scf
 
 def KRGW(mf, freq_int='ac', frozen=None):
-    mf = mf.to_rhf()
+    # mf = mf.to_rhf()
     if freq_int.lower() == 'ac':
         return krgw_ac.KRGWAC(mf, frozen)
     elif freq_int.lower() == 'cd':
@@ -32,7 +32,7 @@ def KRGW(mf, freq_int='ac', frozen=None):
                            "With PBC, options are 'ac' and 'cd'."%(freq_int))
 
 def KUGW(mf, freq_int='ac', frozen=None):
-    mf = mf.to_uhf()
+    # mf = mf.to_uhf()
     if freq_int.lower() == 'ac':
         return kugw_ac.KUGWAC(mf, frozen)
     elif freq_int.lower() == 'cd':

--- a/pyscf/pbc/gw/krgw_ac.py
+++ b/pyscf/pbc/gw/krgw_ac.py
@@ -546,7 +546,7 @@ class KRGWAC(lib.StreamObject):
         'kpts', 'nkpts', 'mo_energy', 'mo_coeff', 'mo_occ', 'sigma',
     }
 
-    def __init__(self, mf, frozen=0):
+    def __init__(self, mf, frozen=None):
         self.mol = mf.mol
         self._scf = mf
         self.verbose = self.mol.verbose
@@ -554,7 +554,7 @@ class KRGWAC(lib.StreamObject):
         self.max_memory = mf.max_memory
 
         #TODO: implement frozen orbs
-        if frozen > 0:
+        if frozen is not None and frozen > 0:
             raise NotImplementedError
         self.frozen = frozen
 

--- a/pyscf/pbc/gw/krgw_cd.py
+++ b/pyscf/pbc/gw/krgw_cd.py
@@ -607,7 +607,7 @@ class KRGWCD(lib.StreamObject):
         'kpts', 'nkpts', 'mo_energy', 'mo_coeff', 'mo_occ', 'sigma',
     }
 
-    def __init__(self, mf, frozen=0):
+    def __init__(self, mf, frozen=None):
         self.mol = mf.mol
         self._scf = mf
         self.verbose = self.mol.verbose
@@ -615,7 +615,7 @@ class KRGWCD(lib.StreamObject):
         self.max_memory = mf.max_memory
 
         #TODO: implement frozen orbs
-        if frozen > 0:
+        if frozen is not None and frozen > 0:
             raise NotImplementedError
         self.frozen = frozen
 

--- a/pyscf/pbc/gw/kugw_ac.py
+++ b/pyscf/pbc/gw/kugw_ac.py
@@ -609,7 +609,7 @@ class KUGWAC(lib.StreamObject):
         'kpts', 'nkpts', 'mo_energy', 'mo_coeff', 'mo_occ', 'sigma',
     }
 
-    def __init__(self, mf, frozen=0):
+    def __init__(self, mf, frozen=None):
         self.mol = mf.mol
         self._scf = mf
         self.verbose = self.mol.verbose
@@ -617,7 +617,7 @@ class KUGWAC(lib.StreamObject):
         self.max_memory = mf.max_memory
 
         #TODO: implement frozen orbs
-        if frozen > 0:
+        if frozen is not None and frozen > 0:
             raise NotImplementedError
         self.frozen = frozen
 


### PR DESCRIPTION
This should improve the PBC GW interface in response to, e.g., issue #1966. But I think the KUGW is broken and might need to be looked at by @zhutianyu1991 or someone else. I get the below error if I try KUKS + KUGW,
```
Traceback (most recent call last):
  File "/Users/tberkelbach/bin/pyscf/examples/pbc/22-k_points_gw.py", line 36, in <module>
    mygw.kernel()
  File "/Users/tberkelbach/bin/pyscf/pyscf/pbc/gw/kugw_ac.py", line 705, in kernel
    kernel(self, mo_energy, mo_coeff, orbs=orbs,
  File "/Users/tberkelbach/bin/pyscf/pyscf/pbc/gw/kugw_ac.py", line 89, in kernel
    vk = uhf.get_veff(gw.mol,dm_kpts=dm)
  File "/Users/tberkelbach/bin/pyscf/pyscf/pbc/scf/kuhf.py", line 442, in get_veff
    vj, vk = self.get_jk(cell, dm_kpts, hermi, kpts, kpts_band)
  File "/Users/tberkelbach/bin/pyscf/pyscf/pbc/scf/khf.py", line 529, in get_jk
    vj, vk = self.with_df.get_jk(dm_kpts, hermi, kpts, kpts_band,
  File "/Users/tberkelbach/bin/pyscf/pyscf/pbc/df/df.py", line 443, in get_jk
    vk = df_jk.get_k_kpts(self, dm, hermi, kpts, kpts_band, exxdiv)
  File "/Users/tberkelbach/bin/pyscf/pyscf/pbc/df/df_jk.py", line 611, in get_k_kpts
    make_kpt(ki, kj, True)
  File "/Users/tberkelbach/bin/pyscf/pyscf/pbc/df/df_jk.py", line 444, in make_kpt
    for LpqR, LpqI, sign in mydf.sr_loop((kpti,kptj), max_memory, False):
  File "/Users/tberkelbach/bin/pyscf/pyscf/pbc/df/df.py", line 355, in sr_loop
    with _load3c(self._cderi, self._dataname, kpti_kptj) as j3c:
  File "/Users/tberkelbach/bin/pyscf/pyscf/pbc/df/df.py", line 692, in __enter__
    return self.getitem(*self.kpti_kptj)
  File "/Users/tberkelbach/bin/pyscf/pyscf/pbc/df/df.py", line 746, in getitem
    raise KeyError(f'Key {key} not found')
KeyError: 'Key j3c/2 not found'
```