### PR TITLE
Bug fix in interactive solver for non-canonical UMP2

### DIFF
--- a/pyscf/mp/ump2.py
+++ b/pyscf/mp/ump2.py
@@ -154,9 +154,9 @@ def update_amps(mp, t2, eris):
     eris_ovov = numpy.asarray(eris.ovov).reshape(nocca,nvira,nocca,nvira).conj() * .5
     eris_OVOV = numpy.asarray(eris.OVOV).reshape(noccb,nvirb,noccb,nvirb).conj() * .5
     eris_ovOV = numpy.asarray(eris.ovOV).reshape(nocca,nvira,noccb,nvirb).conj().copy()
-    u2aa = eris_ovov.transpose(0,2,1,3) - eris_ovov.transpose(0,2,3,1)
-    u2bb = eris_OVOV.transpose(0,2,1,3) - eris_OVOV.transpose(0,2,3,1)
-    u2ab = eris_ovOV.transpose(0,2,1,3)
+    u2aa += eris_ovov.transpose(0,2,1,3) - eris_ovov.transpose(0,2,3,1)
+    u2bb += eris_OVOV.transpose(0,2,1,3) - eris_OVOV.transpose(0,2,3,1)
+    u2ab += eris_ovOV.transpose(0,2,1,3)
     u2aa = u2aa + u2aa.transpose(1,0,3,2)
     u2bb = u2bb + u2bb.transpose(1,0,3,2)
 


### PR DESCRIPTION
 This PR fixes a bug in the iterative non-canonical UMP2 calculation (described in  #1988), causing discrepancy in UMP2 and RMP2 for a close-shell carbon atom.