### PR TITLE
Fix misleading errors caused by Mole and Cell getattr methods

### DIFF
--- a/pyscf/dft/rks.py
+++ b/pyscf/dft/rks.py
@@ -538,5 +538,4 @@ class RKS(KohnShamDFT, hf.RHF):
         obj = lib.to_gpu(hf.SCF.reset(self.view(RKS)))
         # Attributes only defined in gpu4pyscf.RKS
         obj.screen_tol = 1e-14
-        obj.disp = None
         return obj

--- a/pyscf/dft/uks.py
+++ b/pyscf/dft/uks.py
@@ -203,5 +203,4 @@ class UKS(rks.KohnShamDFT, uhf.UHF):
         obj = lib.to_gpu(SCF.reset(self.view(UKS)))
         # Attributes only defined in gpu4pyscf.RKS
         obj.screen_tol = 1e-14
-        obj.disp = None
         return obj

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -3713,7 +3713,7 @@ class Mole(MoleBase):
                      '_repr_mimebundle_'):
             # https://github.com/mewwts/addict/issues/26
             # https://github.com/jupyter/notebook/issues/2014
-            raise AttributeError
+            raise AttributeError(f'Mole object has no attribute {key}')
 
         # Import all available modules. Some methods are registered to other
         # classes/modules when importing modules in __all__.
@@ -3734,8 +3734,10 @@ class Mole(MoleBase):
                 if xc in dft.XC:
                     mf.xc = xc
                     key = 'TDDFT'
-        else:
+        elif 'CI' in key or 'CC' in key or 'CAS' in key or 'MP' in key:
             mf = scf.HF(self)
+        else:
+            raise AttributeError(f'Mole object has no attribute {key}')
 
         method = getattr(mf, key)
 

--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -971,7 +971,7 @@ class Cell(mole.MoleBase):
                      '_repr_mimebundle_'):
             # https://github.com/mewwts/addict/issues/26
             # https://github.com/jupyter/notebook/issues/2014
-            raise AttributeError
+            raise AttributeError(f'Cell object has no attribute {key}')
 
         # Import all available modules. Some methods are registered to other
         # classes/modules when importing modules in __all__.
@@ -994,8 +994,10 @@ class Cell(mole.MoleBase):
                     if xc in XC:
                         mf.xc = xc
                         key = 'KTDDFT'
-            else:
+            elif 'CI' in key or 'CC' in key or 'MP' in key:
                 mf = scf.KHF(self)
+            else:
+                raise AttributeError(f'Cell object has no attribute {key}')
             # Remove prefix 'K' because methods are registered without the leading 'K'
             key = key[1:]
         else:
@@ -1008,8 +1010,10 @@ class Cell(mole.MoleBase):
                     if xc in XC:
                         mf.xc = xc
                         key = 'TDDFT'
-            else:
+            elif 'CI' in key or 'CC' in key or 'MP' in key:
                 mf = scf.HF(self)
+            else:
+                raise AttributeError(f'Cell object has no attribute {key}')
 
         method = getattr(mf, key)
 


### PR DESCRIPTION
The custom `__getattr__` methods of Mole and Cell objects sometimes cause misleading error messages. The supported attributes are explicitly specified in this PR.