### PR TITLE
Enable numpy array form of mo_coeff and mo_occ in get_k_kpts in df_jk.py

### DIFF
--- a/pyscf/pbc/df/df_jk.py
+++ b/pyscf/pbc/df/df_jk.py
@@ -297,14 +297,14 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None,
     if not mydf.force_dm_kbuild:
         if mo_coeff is not None:
             if isinstance(mo_coeff[0], (list, tuple)) or (isinstance(mo_coeff[0], numpy.ndarray)
-                                                          and mo_coeff[0] == 3):
+                                                          and mo_coeff[0].ndim == 3):
                 mo_coeff = [mo for mo1 in mo_coeff for mo in mo1]
             if len(mo_coeff) != nset*nkpts: # wrong shape
                 log.warn('mo_coeff from dm tag has wrong shape. '
                          'Calculating mo from dm instead.')
                 mo_coeff = None
             elif isinstance(mo_occ[0], (list, tuple)) or (isinstance(mo_occ[0], numpy.ndarray)
-                                                          and mo_occ[0] == 2):
+                                                          and mo_occ[0].ndim == 2):
                 mo_occ = [mo for mo1 in mo_occ for mo in mo1]
         if mo_coeff is not None:
             skmoR, skmoI = _format_mo(mo_coeff, mo_occ, shape=(nset,nkpts), order='F',
@@ -707,14 +707,14 @@ def get_k_kpts_kshift(mydf, dm_kpts, kshift, hermi=0, kpts=numpy.zeros((1,3)), k
     if not mydf.force_dm_kbuild:
         if mo_coeff is not None:
             if isinstance(mo_coeff[0], (list, tuple)) or (isinstance(mo_coeff[0], numpy.ndarray)
-                                                          and mo_coeff[0] == 3):
+                                                          and mo_coeff[0].ndim == 3):
                 mo_coeff = [mo for mo1 in mo_coeff for mo in mo1]
             if len(mo_coeff) != nset*nkpts: # wrong shape
                 log.warn('mo_coeff from dm tag has wrong shape. '
                          'Calculating mo from dm instead.')
                 mo_coeff = None
             elif isinstance(mo_occ[0], (list, tuple)) or (isinstance(mo_occ[0], numpy.ndarray)
-                                                          and mo_occ[0] == 2):
+                                                          and mo_occ[0].ndim == 2):
                 mo_occ = [mo for mo1 in mo_occ for mo in mo1]
         if mo_coeff is not None:
             skmoR, skmoI = _format_mo(mo_coeff, mo_occ, shape=(nset,nkpts), order='F',

--- a/pyscf/pbc/df/df_jk.py
+++ b/pyscf/pbc/df/df_jk.py
@@ -296,15 +296,15 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None,
     skmoR = skmo2R = None
     if not mydf.force_dm_kbuild:
         if mo_coeff is not None:
-            if isinstance(mo_coeff[0], (list, tuple)) or \
-                isinstance(mo_coeff[0], numpy.ndarray and mo_coeff[0] == 3):
+            if isinstance(mo_coeff[0], (list, tuple)) or (isinstance(mo_coeff[0], numpy.ndarray)
+                                                          and mo_coeff[0] == 3):
                 mo_coeff = [mo for mo1 in mo_coeff for mo in mo1]
             if len(mo_coeff) != nset*nkpts: # wrong shape
                 log.warn('mo_coeff from dm tag has wrong shape. '
                          'Calculating mo from dm instead.')
                 mo_coeff = None
-            elif isinstance(mo_occ[0], (list, tuple)) or \
-                isinstance(mo_occ[0], numpy.ndarray and mo_occ[0] == 2):
+            elif isinstance(mo_occ[0], (list, tuple)) or (isinstance(mo_occ[0], numpy.ndarray)
+                                                          and mo_occ[0] == 2):
                 mo_occ = [mo for mo1 in mo_occ for mo in mo1]
         if mo_coeff is not None:
             skmoR, skmoI = _format_mo(mo_coeff, mo_occ, shape=(nset,nkpts), order='F',
@@ -706,15 +706,15 @@ def get_k_kpts_kshift(mydf, dm_kpts, kshift, hermi=0, kpts=numpy.zeros((1,3)), k
     skmoR = skmo2R = None
     if not mydf.force_dm_kbuild:
         if mo_coeff is not None:
-            if isinstance(mo_coeff[0], (list, tuple)) or \
-                isinstance(mo_coeff[0], numpy.ndarray and mo_coeff[0] == 3):
+            if isinstance(mo_coeff[0], (list, tuple)) or (isinstance(mo_coeff[0], numpy.ndarray)
+                                                          and mo_coeff[0] == 3):
                 mo_coeff = [mo for mo1 in mo_coeff for mo in mo1]
             if len(mo_coeff) != nset*nkpts: # wrong shape
                 log.warn('mo_coeff from dm tag has wrong shape. '
                          'Calculating mo from dm instead.')
                 mo_coeff = None
-            elif isinstance(mo_occ[0], (list, tuple)) or \
-                isinstance(mo_occ[0], numpy.ndarray and mo_occ[0] == 2):
+            elif isinstance(mo_occ[0], (list, tuple)) or (isinstance(mo_occ[0], numpy.ndarray)
+                                                          and mo_occ[0] == 2):
                 mo_occ = [mo for mo1 in mo_occ for mo in mo1]
         if mo_coeff is not None:
             skmoR, skmoI = _format_mo(mo_coeff, mo_occ, shape=(nset,nkpts), order='F',

--- a/pyscf/pbc/df/df_jk.py
+++ b/pyscf/pbc/df/df_jk.py
@@ -296,13 +296,15 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None,
     skmoR = skmo2R = None
     if not mydf.force_dm_kbuild:
         if mo_coeff is not None:
-            if isinstance(mo_coeff[0], (list, tuple)):
+            if isinstance(mo_coeff[0], (list, tuple)) or \
+                isinstance(mo_coeff[0], numpy.ndarray and mo_coeff[0] == 3):
                 mo_coeff = [mo for mo1 in mo_coeff for mo in mo1]
             if len(mo_coeff) != nset*nkpts: # wrong shape
                 log.warn('mo_coeff from dm tag has wrong shape. '
                          'Calculating mo from dm instead.')
                 mo_coeff = None
-            elif isinstance(mo_occ[0], (list, tuple)):
+            elif isinstance(mo_occ[0], (list, tuple)) or \
+                isinstance(mo_occ[0], numpy.ndarray and mo_occ[0] == 2):
                 mo_occ = [mo for mo1 in mo_occ for mo in mo1]
         if mo_coeff is not None:
             skmoR, skmoI = _format_mo(mo_coeff, mo_occ, shape=(nset,nkpts), order='F',
@@ -704,13 +706,15 @@ def get_k_kpts_kshift(mydf, dm_kpts, kshift, hermi=0, kpts=numpy.zeros((1,3)), k
     skmoR = skmo2R = None
     if not mydf.force_dm_kbuild:
         if mo_coeff is not None:
-            if isinstance(mo_coeff[0], (list, tuple)):
+            if isinstance(mo_coeff[0], (list, tuple)) or \
+                isinstance(mo_coeff[0], numpy.ndarray and mo_coeff[0] == 3):
                 mo_coeff = [mo for mo1 in mo_coeff for mo in mo1]
             if len(mo_coeff) != nset*nkpts: # wrong shape
                 log.warn('mo_coeff from dm tag has wrong shape. '
                          'Calculating mo from dm instead.')
                 mo_coeff = None
-            elif isinstance(mo_occ[0], (list, tuple)):
+            elif isinstance(mo_occ[0], (list, tuple)) or \
+                isinstance(mo_occ[0], numpy.ndarray and mo_occ[0] == 2):
                 mo_occ = [mo for mo1 in mo_occ for mo in mo1]
         if mo_coeff is not None:
             skmoR, skmoI = _format_mo(mo_coeff, mo_occ, shape=(nset,nkpts), order='F',


### PR DESCRIPTION
Dear all,

I found that if the user gives a set of mo_occ or mo_coeff (in numpy array form) to the kmf with GDF, the current will raise an error.  It assumes the mo_coeff and mo_occ as list or tuple.

This PR fixes this.

Best,
Zhihao