### PR TITLE
make str2addr fail on large address

### DIFF
--- a/pyscf/fci/cistring.py
+++ b/pyscf/fci/cistring.py
@@ -380,6 +380,8 @@ def str2addr(norb, nelec, string):
     '''Convert string to CI determinant address'''
     if norb >= 64:
         raise NotImplementedError('norb >= 64')
+    if num_strings(norb, nelec) >= 2**31:
+        raise NotImplementedError('Large address')
 
     if isinstance(string, str):
         assert (string.count('1') == nelec)


### PR DESCRIPTION
Closes https://github.com/pyscf/pyscf/issues/1886.

Looks like this change was missed in https://github.com/pyscf/pyscf/pull/1971.