### PR TITLE
fixing frozen for FNO

### DIFF
--- a/pyscf/cc/__init__.py
+++ b/pyscf/cc/__init__.py
@@ -195,17 +195,11 @@ def FNOCCSD(mf, thresh=1e-6, pct_occ=None, nvir_act=None, frozen=None):
             Number of virtual NOs to keep. Default is None. If present, overrides `thresh` and `pct_occ`.
     """
     import numpy
-    if frozen is None:
-        frozenocc = 0
-    else:
-        assert(isinstance(frozen, (int,numpy.int64)))
-        frozenocc = frozen
     from pyscf import mp
-    pt = mp.MP2(mf).set(verbose=0).run()
+    pt = mp.MP2(mf, frozen=frozen).set(verbose=2).run()
     frozen, no_coeff = pt.make_fno(thresh=thresh, pct_occ=pct_occ, nvir_act=nvir_act)
-    frozen = numpy.hstack([numpy.arange(frozenocc),frozen])
     if len(frozen) == 0: frozen = None
-    pt_no = mp.MP2(mf, frozen=frozen, mo_coeff=no_coeff).set(verbose=0).run()
+    pt_no = mp.MP2(mf, frozen=frozen, mo_coeff=no_coeff).set(verbose=2).run()
     mycc = CCSD(mf, frozen=frozen, mo_coeff=no_coeff)
     mycc.delta_emp2 = pt.e_corr - pt_no.e_corr
     from pyscf.lib import logger

--- a/pyscf/mp/mp2.py
+++ b/pyscf/mp/mp2.py
@@ -229,13 +229,18 @@ def make_fno(mp, thresh=1e-6, pct_occ=None, nvir_act=None, t2=None):
     n,v = numpy.linalg.eigh(dm[nocc:,nocc:])
     idx = numpy.argsort(n)[::-1]
     n,v = n[idx], v[:,idx]
+    logger.debug1(mp, 'make_fno: noon = %s', n)
 
     if nvir_act is None:
         if pct_occ is None:
             nvir_act = numpy.count_nonzero(n>thresh)
         else:
-            print(numpy.cumsum(n/numpy.sum(n)))
-            nvir_act = numpy.count_nonzero(numpy.cumsum(n/numpy.sum(n))<pct_occ)
+            pct_occ_sum = numpy.cumsum(n/numpy.sum(n))
+            logger.debug1(mp, 'make_fno: pctsum(noon) = %s', pct_occ_sum)
+            nvir_act = numpy.count_nonzero(pct_occ_sum<pct_occ)
+
+    if nvir_act == 0:
+        logger.warn(mp, 'make_fno: nvir_act = 0')
 
     fvv = numpy.diag(mf.mo_energy[nocc:])
     fvv_no = numpy.dot(v.T, numpy.dot(fvv, v))
@@ -245,7 +250,11 @@ def make_fno(mp, thresh=1e-6, pct_occ=None, nvir_act=None, t2=None):
     no_coeff_2 = numpy.dot(mf.mo_coeff[:,nocc:], v[:,nvir_act:])
     no_coeff = numpy.concatenate((mf.mo_coeff[:,:nocc], no_coeff_1, no_coeff_2), axis=1)
 
-    return numpy.arange(nocc+nvir_act,nmo), no_coeff
+    frozen_mask = mp.get_frozen_mask()
+    frozen_mask[numpy.where(frozen_mask)[0][numpy.arange(nocc+nvir_act,nmo)]] = False
+    frozen = numpy.where(~frozen_mask)[0]
+
+    return frozen, no_coeff
 
 
 def make_rdm2(mp, t2=None, eris=None, ao_repr=False):


### PR DESCRIPTION
In a previous PR (#1893), the `frozen` variable in FNOCCSD was not used in the full-system MP2 calculation. As a result,
1. natural orbitals are selected based on non-frozen MP2 rdm1, leading to suboptimal active-space NOs
2. MP2 composite correction includes the core correlation energy, making the final FNOCCSD energy include a MP2-level core correlation and thus not approximate frozen-core CCSD.

Both problems are fixed in this PR. The `make_fno` function in MP2/UMP2 now supports general `frozen` pattern. The unit tests are updated for frozen-core tests. New tests for a UHF reference are added.

@sunqm The reason why previous tests not passing is likely because the reference values were generated using all-e potential while the tests themselves used a pseudopotential (likely a copy-paste error when I wrote the test file). Once I turned off the pseudopotential, all tests that do not use `frozen` (thus not affecting by this PR) can pass.