### PR TITLE
Include filename_or_basisname in the error message for basis not found

### DIFF
--- a/pyscf/gto/basis/__init__.py
+++ b/pyscf/gto/basis/__init__.py
@@ -638,7 +638,7 @@ def load(filename_or_basisname, symb, optimize=OPTIMIZE_CONTRACTION):
             else:
                 return bse._orbital_basis(bse_obj)[0]
 
-        raise BasisNotFoundError('Unknown basis format or basis name')
+        raise BasisNotFoundError(f'Unknown basis format or basis name for {filename_or_basisname}')
 
     if 'dat' in basmod:
         b = fload(join(basis_dir, basmod), symb, optimize)


### PR DESCRIPTION
This is a small suggestion to include the user input in the error message when a basis set can not be found.