### PR TITLE
add nr_nlc_vxc to NumInt

### DIFF
--- a/pyscf/pbc/dft/numint.py
+++ b/pyscf/pbc/dft/numint.py
@@ -1069,6 +1069,7 @@ class NumInt(lib.StreamObject, numint.LibXCMixin):
     nr_rks_fxc = nr_rks_fxc
     nr_uks_fxc = nr_uks_fxc
     nr_rks_fxc_st = nr_rks_fxc_st
+    nr_nlc_vxc = nr_nlc_vxc
 
     make_mask = staticmethod(make_mask)
     eval_ao = staticmethod(eval_ao)


### PR DESCRIPTION
The function `nr_nlc_vxc` in `pbc/dft/numint.py` is not linked to the `NumInt` class. As a result, when running PBC DFT with nlc functional like VV10 the following error is triggered:
```
Traceback (most recent call last):
  File "run_nlc.py", line 29, in <module>
    mf.kernel()
  File "<string>", line 2, in kernel
  File "/Users/hzye/local/opt/pyscf/pyscf/scf/hf.py", line 1726, in scf
    conv_check=self.conv_check, **kwargs)
  File "/Users/hzye/local/opt/pyscf/pyscf/scf/hf.py", line 124, in kernel
    vhf = mf.get_veff(mol, dm)
  File "/Users/hzye/local/opt/pyscf/pyscf/pbc/dft/rks.py", line 97, in get_veff
    n, enlc, vnlc = ni.nr_nlc_vxc(cell, ks.nlcgrids, xc, dm, 0, hermi, kpt,
AttributeError: 'NumInt' object has no attribute 'nr_nlc_vxc'
```
This PR fixes the bug. DFT calculations on a single water molecule using wb97x-v are verified to give very similar results using both molecular code and pbc code with a large box.
```
mol wb97x-v energy: -76.3916331204099
pbc wb97x-v energy: -76.3921126437242
```

### Minimal working example
``` Python
import numpy as np

from pyscf import gto, scf
from pyscf.pbc import gto as pbcgto, scf as pbcscf, dft as pbcdft


if __name__ == '__main__':
    atom = '''
    O          0.00000        0.00000        0.11779
    H          0.00000        0.75545       -0.47116
    H          0.00000       -0.75545       -0.47116
    '''
    basis = 'cc-pvdz'
    a = np.eye(3) * 20
    xc = 'wb97x-v'

    mol = gto.M(atom=atom, basis=basis)

    mf = scf.RKS(mol).density_fit()
    mf.xc = xc
    mf.nlcgrids.level = 1
    mf.kernel()

    cell = pbcgto.M(atom=atom, a=a, basis=basis)
    mf = pbcdft.RKS(cell, xc=xc).rs_density_fit()
    mf.with_df.omega = 0.1
    mf.nlcgrids.level = 1
    mf.kernel()

```