### PR TITLE
DIIS with damping

### DIFF
--- a/pyscf/pbc/scf/krohf.py
+++ b/pyscf/pbc/scf/krohf.py
@@ -51,7 +51,8 @@ def make_rdm1(mo_coeff_kpts, mo_occ_kpts, **kwargs):
     return lib.tag_array((dma, dmb), mo_coeff=mo_coeff_kpts, mo_occ=mo_occ_kpts)
 
 def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
-             diis_start_cycle=None, level_shift_factor=None, damp_factor=None):
+             diis_start_cycle=None, level_shift_factor=None, damp_factor=None,
+             fock_last=None):
     h1e_kpts, s_kpts, vhf_kpts, dm_kpts = h1e, s1e, vhf, dm
     if h1e_kpts is None: h1e_kpts = mf.get_hcore()
     if vhf_kpts is None: vhf_kpts = mf.get_veff(mf.cell, dm_kpts)
@@ -71,10 +72,10 @@ def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
     if dm_kpts is None: dm_kpts = mf.make_rdm1()
 
     dm_sf = dm_kpts[0] + dm_kpts[1]
-    if 0 <= cycle < diis_start_cycle-1 and abs(damp_factor) > 1e-4:
+    if 0 <= cycle < diis_start_cycle-1 and abs(damp_factor) > 1e-4 and fock_last is not None:
         raise NotImplementedError('ROHF Fock-damping')
     if diis and cycle >= diis_start_cycle:
-        f_kpts = diis.update(s_kpts, dm_sf, f_kpts, mf, h1e_kpts, vhf_kpts)
+        f_kpts = diis.update(s_kpts, dm_sf, f_kpts, mf, h1e_kpts, vhf_kpts, f_prev=fock_last)
     if abs(level_shift_factor) > 1e-4:
         f_kpts = [mol_hf.level_shift(s, dm_sf[k]*.5, f_kpts[k], level_shift_factor)
                   for k, s in enumerate(s_kpts)]

--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -59,7 +59,8 @@ def make_rdm1(mo_coeff_kpts, mo_occ_kpts, **kwargs):
     return lib.tag_array(dm, mo_coeff=mo_coeff_kpts, mo_occ=mo_occ_kpts)
 
 def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
-             diis_start_cycle=None, level_shift_factor=None, damp_factor=None):
+             diis_start_cycle=None, level_shift_factor=None, damp_factor=None,
+             fock_last=None):
     h1e_kpts, s_kpts, vhf_kpts, dm_kpts = h1e, s1e, vhf, dm
     if h1e_kpts is None: h1e_kpts = mf.get_hcore()
     if vhf_kpts is None: vhf_kpts = mf.get_veff(mf.cell, dm_kpts)
@@ -85,15 +86,15 @@ def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
     else:
         dampa = dampb = damp_factor
 
-    if 0 <= cycle < diis_start_cycle-1 and abs(dampa)+abs(dampb) > 1e-4:
+    if 0 <= cycle < diis_start_cycle-1 and abs(dampa)+abs(dampb) > 1e-4 and fock_last is not None:
         f_a = []
         f_b = []
-        for k, s1e in enumerate(s_kpts):
-            f_a.append(mol_hf.damping(s1e, dm_kpts[0][k], f_kpts[0][k], dampa))
-            f_b.append(mol_hf.damping(s1e, dm_kpts[1][k], f_kpts[1][k], dampb))
+        for k in range(len(s_kpts)):
+            f_a.append(mol_hf.damping(f_kpts[0][k], fock_last[0][k], dampa))
+            f_b.append(mol_hf.damping(f_kpts[1][k], fock_last[1][k], dampa))
         f_kpts = [f_a, f_b]
     if diis and cycle >= diis_start_cycle:
-        f_kpts = diis.update(s_kpts, dm_kpts, f_kpts, mf, h1e_kpts, vhf_kpts)
+        f_kpts = diis.update(s_kpts, dm_kpts, f_kpts, mf, h1e_kpts, vhf_kpts, f_prev=fock_last)
     if abs(level_shift_factor) > 1e-4:
         f_kpts =([mol_hf.level_shift(s, dm_kpts[0,k], f_kpts[0,k], shifta)
                   for k, s in enumerate(s_kpts)],

--- a/pyscf/pbc/scf/test/test_khf.py
+++ b/pyscf/pbc/scf/test/test_khf.py
@@ -292,23 +292,14 @@ class KnownValues(unittest.TestCase):
     def test_damping(self):
         nao = cell.nao
         np.random.seed(1)
-        s = kmf.get_ovlp()
-        d = np.random.random((len(kpts),nao,nao))
-        d = (d + d.transpose(0,2,1)) * 2
-        vhf = 0
-        f = khf.get_fock(kmf, kmf.get_hcore(), s, vhf, d, cycle=0,
-                         diis_start_cycle=2, damp_factor=0.5)
-        self.assertAlmostEqual(np.linalg.norm(f[0]), 95.32749551722966, 6)
-        self.assertAlmostEqual(np.linalg.norm(f[1]), 73.9231303798864, 6)
-        self.assertAlmostEqual(np.linalg.norm(f[2]), 58.973290554565196, 6)
-
-        vhf = np.zeros((2,len(kpts),nao,nao))
-        d1 = np.asarray([d/2, d/2])
-        f1 = kuhf.get_fock(kumf, kumf.get_hcore(), s, vhf, d1, cycle=0,
-                             diis_start_cycle=2, damp_factor=0.5)
+        f = kmf.get_hcore()
+        df  = np.random.rand(len(kpts),nao,nao)
+        f_prev = f + df
+        damp = 0.3
+        f_damp = khf.get_fock(kmf, h1e=0, s1e=0, vhf=f, dm=0, cycle=0,
+                              diis_start_cycle=2, damp_factor=damp, fock_last=f_prev)
         for k in range(len(kpts)):
-            self.assertAlmostEqual(abs(f[k] - f1[0,k]).max(), 0, 9)
-            self.assertAlmostEqual(abs(f[k] - f1[1,k]).max(), 0, 9)
+            self.assertAlmostEqual(abs(f_damp[k] - (f[k]*(1-damp) + f_prev[k]*damp)).max(), 0, 9)
 
 if __name__ == '__main__':
     print("Full Tests for pbc.scf.khf")

--- a/pyscf/scf/addons.py
+++ b/pyscf/scf/addons.py
@@ -406,7 +406,8 @@ def dynamic_level_shift_(mf, factor=1.):
     old_get_fock = mf.get_fock
     mf._last_e = None
     def get_fock(h1e, s1e, vhf, dm, cycle=-1, diis=None,
-                 diis_start_cycle=None, level_shift_factor=None, damp_factor=None):
+                 diis_start_cycle=None, level_shift_factor=None, damp_factor=None,
+                 fock_last=None):
         if cycle > 0 or diis is not None:
             if 'exc' in mf.scf_summary:  # DFT
                 e_tot = mf.scf_summary['e1'] + mf.scf_summary['coul'] + mf.scf_summary['exc']
@@ -417,7 +418,7 @@ def dynamic_level_shift_(mf, factor=1.):
                 logger.info(mf, 'Set level shift to %g', level_shift_factor)
             mf._last_e = e_tot
         return old_get_fock(h1e, s1e, vhf, dm, cycle, diis, diis_start_cycle,
-                            level_shift_factor, damp_factor)
+                            level_shift_factor, damp_factor, fock_last=fock_last)
     mf.get_fock = get_fock
     return mf
 dynamic_level_shift = dynamic_level_shift_

--- a/pyscf/scf/rohf.py
+++ b/pyscf/scf/rohf.py
@@ -73,7 +73,8 @@ def init_guess_by_chkfile(mol, chkfile_name, project=None):
     return lib.tag_array(dm, mo_coeff=mo_coeff, mo_occ=mo_occ)
 
 def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
-             diis_start_cycle=None, level_shift_factor=None, damp_factor=None):
+             diis_start_cycle=None, level_shift_factor=None, damp_factor=None,
+             fock_last=None):
     '''Build fock matrix based on Roothaan's effective fock.
     See also :func:`get_roothaan_fock`
     '''
@@ -100,10 +101,10 @@ def get_fock(mf, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1, diis=None,
         damp_factor = mf.damp
 
     dm_tot = dm[0] + dm[1]
-    if 0 <= cycle < diis_start_cycle-1 and abs(damp_factor) > 1e-4:
+    if 0 <= cycle < diis_start_cycle-1 and abs(damp_factor) > 1e-4 and fock_last is not None:
         raise NotImplementedError('ROHF Fock-damping')
     if diis and cycle >= diis_start_cycle:
-        f = diis.update(s1e, dm_tot, f, mf, h1e, vhf)
+        f = diis.update(s1e, dm_tot, f, mf, h1e, vhf, f_prev=fock_last)
     if abs(level_shift_factor) > 1e-4:
         f = hf.level_shift(s1e, dm_tot*.5, f, level_shift_factor)
     f = lib.tag_array(f, focka=focka, fockb=fockb)

--- a/pyscf/scf/test/test_rhf.py
+++ b/pyscf/scf/test/test_rhf.py
@@ -416,11 +416,14 @@ class KnownValues(unittest.TestCase):
     def test_damping(self):
         nao = mol.nao_nr()
         numpy.random.seed(1)
-        s = scf.hf.get_ovlp(mol)
-        d = numpy.random.random((nao,nao))
-        d = d + d.T
-        f = scf.hf.damping(s, d, scf.hf.get_hcore(mol), .5)
-        self.assertAlmostEqual(numpy.linalg.norm(f), 23361.854064083178, 9)
+        f = scf.hf.get_hcore(mol)
+        df  = numpy.random.rand(nao,nao)
+        df += df.T
+        f_prev = f + df
+        damp = 0.3
+        f_damp = scf.hf.get_fock(mf, h1e=0, s1e=0, vhf=f, dm=0, cycle=0,
+                                 diis_start_cycle=2, damp_factor=damp, fock_last=f_prev)
+        self.assertAlmostEqual(abs(f_damp - (f*(1-damp) + f_prev*damp)).max(), 0, 9)
 
     def test_level_shift(self):
         nao = mol.nao_nr()

--- a/pyscf/scf/test/test_uhf.py
+++ b/pyscf/scf/test/test_uhf.py
@@ -399,14 +399,14 @@ H     0    0.757    0.587'''
     def test_damping(self):
         nao = mol.nao_nr()
         numpy.random.seed(1)
-        s = scf.hf.get_ovlp(mol)
-        d = numpy.random.random((nao,nao))
-        d = (d + d.T) * 2
-        vhf = 0
-        f = scf.uhf.get_fock(mf, scf.hf.get_hcore(mol), s, vhf, d, cycle=0,
-                             diis_start_cycle=2, damp_factor=0.5)
-        self.assertAlmostEqual(numpy.linalg.norm(f[0]), 23361.854064083178, 9)
-        self.assertAlmostEqual(numpy.linalg.norm(f[1]), 23361.854064083178, 9)
+        f = np.asarray([scf.hf.get_hcore(mol)]*2)
+        df  = numpy.random.rand(2,nao,nao)
+        f_prev = f + df
+        damp = 0.3
+        f_damp = scf.uhf.get_fock(mf, h1e=0, s1e=0, vhf=f, dm=0, cycle=0,
+                                 diis_start_cycle=2, damp_factor=damp, fock_last=f_prev)
+        self.assertAlmostEqual(abs(f_damp[0] - (f[0]*(1-damp) + f_prev[0]*damp)).max(), 0, 9)
+        self.assertAlmostEqual(abs(f_damp[1] - (f[1]*(1-damp) + f_prev[1]*damp)).max(), 0, 9)
 
     def test_get_irrep_nelec(self):
         fock = n2mf.get_fock()

--- a/pyscf/scf/test/test_uhf.py
+++ b/pyscf/scf/test/test_uhf.py
@@ -399,7 +399,7 @@ H     0    0.757    0.587'''
     def test_damping(self):
         nao = mol.nao_nr()
         numpy.random.seed(1)
-        f = np.asarray([scf.hf.get_hcore(mol)]*2)
+        f = numpy.asarray([scf.hf.get_hcore(mol)]*2)
         df  = numpy.random.rand(2,nao,nao)
         f_prev = f + df
         damp = 0.3

--- a/pyscf/solvent/_attach_solvent.py
+++ b/pyscf/solvent/_attach_solvent.py
@@ -92,14 +92,15 @@ class SCFWithSolvent(_Solvation):
 
     def get_fock(self, h1e=None, s1e=None, vhf=None, dm=None, cycle=-1,
                  diis=None, diis_start_cycle=None,
-                 level_shift_factor=None, damp_factor=None):
+                 level_shift_factor=None, damp_factor=None, fock_last=None):
         # DIIS was called inside super().get_fock. v_solvent, as a function of
         # dm, should be extrapolated as well. To enable it, v_solvent has to be
         # added to the fock matrix before DIIS was called.
         if getattr(vhf, 'v_solvent', None) is None:
             vhf = self.get_veff(self.mol, dm)
         return super().get_fock(h1e, s1e, vhf+vhf.v_solvent, dm, cycle, diis,
-                                diis_start_cycle, level_shift_factor, damp_factor)
+                                diis_start_cycle, level_shift_factor, damp_factor,
+                                fock_last)
 
     def energy_elec(self, dm=None, h1e=None, vhf=None):
         if dm is None:


### PR DESCRIPTION
## Highlight
Many of us have found SCF convergence issues for metallic systems with DIIS in PySCF even when smearing is used. By contrast, most other codes (QE, VASP, FHI-aims) do not have such a problem. The main reason is found to be the use of damping on top of DIIS in other codes. See e.g.,
- Eqn 92 in [10.1016/0927-0256(96)00008-0](https://doi.org/10.1016/0927-0256(96)00008-0) for VASP
- Eqn 43 in [10.1016/j.cpc.2009.06.022](https://doi.org/10.1016/j.cpc.2009.06.022) for FHI-aims

This PR modifies the current DIIS implementation in PySCF to enable using damping by simply
```
mf.diis_damp = 0.9
```
The SCF convergence for metallic systems is significantly improved as demonstrated in the plots below for two representative systems: ethylene carbonate adsorption on lithium and CO adsorption on copper. In both cases, the regular DIIS (black) struggles with converging SCF, while simple linear damping (blue) shows monotonic convergence at a very slow rate. By contrast, DIIS with damping (green) converges as fast as in many gapped systems.

<img width="600" alt="scf_conv_compare" src="https://github.com/pyscf/pyscf/assets/12220457/2d017f37-4835-4ba1-9901-07a422efcdc1">

Note: the `damping` function is also updated to be the simple linear damping, i.e.,
```
F = Fnew * (1-damp) + Fold * damp
```

## Math

For a fixed point problem
```
f(x) = x
```
The regular DIIS as currently employed in PySCF mixes `h` previous output vectors
```
x_{m+1} = \sum_{i=m-h}^{m} c_i f(x_i)
```
while the damped DIIS also mixes the input vectors with a factor `damp`
```
x_{m+1} = \sum_{i=m-h}^{m} c_i [ f(x_i) * (1 - damp) + x_i * damp ]
```
---
Many thanks to @tberkel, @welltemperedpaprika, and @minyez for helpful discussion and @sohangkundu and @zhutianyu1991 for suggestions on test systems.