### PR TITLE
fix magmom check in mol.copy()

### DIFF
--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -1209,7 +1209,7 @@ def copy(mol, deep=True):
     newmol._ecp    = copy.deepcopy(mol._ecp)
     newmol.pseudo  = copy.deepcopy(mol.pseudo)
     newmol._pseudo = copy.deepcopy(mol._pseudo)
-    if mol.magmom:
+    if mol.magmom is not None:
         newmol.magmom  = list(mol.magmom)
     return newmol
 


### PR DESCRIPTION
If magmom is an np.ndarray,
`if mol.magmom` will raise error.
Need to explicitly use `is not None`