### PR TITLE
Fixed small bugs in scf/addons.py

### DIFF
--- a/examples/scf/72-hubbard_finite_temp.py
+++ b/examples/scf/72-hubbard_finite_temp.py
@@ -11,8 +11,6 @@ Half-filled Hubbard model.
 from pyscf import gto, scf , ao2mo
 import numpy
 
-
-
 def _hubbard_hamilts_pbc(L, U):
     h1e = numpy.zeros((L, L))
     g2e = numpy.zeros((L,)*4)
@@ -21,13 +19,11 @@ def _hubbard_hamilts_pbc(L, U):
         g2e[i, i, i, i] = U
     return h1e, g2e
 
-
 L = 10
 U = 4
 
 mol = gto.M()
 mol.nelectron = L
-mol.tot_electrons = lambda *args: L # this function is usually not called
 mol.nao = L
 mol.spin = 0
 mol.incore_anyway = True
@@ -42,13 +38,7 @@ mf.get_ovlp = lambda *args: numpy.eye(L)
 mf.kernel()
 
 # finite temperature 
-# NOTE only works if the addons.py is updated
 from pyscf.scf import addons
 beta = 1
-mf_ft = addons.smearing_(mf, beta, 'fermi', fix_spin=True)
+mf_ft = addons.smearing(mf, sigma=1./beta, method='fermi', fix_spin=True)
 mf_ft.kernel()
-
-
-
-
-

--- a/examples/scf/72-hubbard_finite_temp.py
+++ b/examples/scf/72-hubbard_finite_temp.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#
+# Author: Chong Sun <sunchong137@gmail.com>
+#
+
+'''
+Simulate model systems with HF.
+Half-filled Hubbard model.
+'''
+
+from pyscf import gto, scf , ao2mo
+import numpy
+
+
+
+def _hubbard_hamilts_pbc(L, U):
+    h1e = numpy.zeros((L, L))
+    g2e = numpy.zeros((L,)*4)
+    for i in range(L):
+        h1e[i, (i+1)%L] = h1e[(i+1)%L, i] = -1 
+        g2e[i, i, i, i] = U
+    return h1e, g2e
+
+
+L = 10
+U = 4
+
+mol = gto.M()
+mol.nelectron = L
+mol.tot_electrons = lambda *args: L # this function is usually not called
+mol.nao = L
+mol.spin = 0
+mol.incore_anyway = True
+mol.build()
+
+# set hamiltonian
+h1e, eri = _hubbard_hamilts_pbc(L, U)
+mf = scf.UHF(mol)
+mf.get_hcore = lambda *args: h1e
+mf._eri = ao2mo.restore(1, eri, L)
+mf.get_ovlp = lambda *args: numpy.eye(L)
+mf.kernel()
+
+# finite temperature 
+# NOTE only works if the addons.py is updated
+from pyscf.scf import addons
+beta = 1
+mf_ft = addons.smearing_(mf, beta, 'fermi', fix_spin=True)
+mf_ft.kernel()
+
+
+
+
+

--- a/pyscf/pbc/scf/addons.py
+++ b/pyscf/pbc/scf/addons.py
@@ -121,12 +121,17 @@ class _SmearingKSCF(mol_addons._SmearingSCF):
             if self.mu0 is None:
                 mu_a, occa = mol_addons._smearing_optimize(f_occ, mo_es[0], nocc[0], sigma)
                 mu_b, occb = mol_addons._smearing_optimize(f_occ, mo_es[1], nocc[1], sigma)
-                mu = [mu_a, mu_b]
-                mo_occs = [occa, occb]
             else:
-                mu = self.mu0
-                mo_occs = f_occ(mu[0], mo_es[0], sigma)
-                mo_occs = f_occ(mu[1], mo_es[1], sigma)
+                if numpy.isscalar(self.mu0):
+                    mu_a = mu_b = self.mu0
+                elif len(self.mu0) == 2:
+                    mu_a, mu_b = self.mu0
+                else:
+                    raise TypeError('Unsupported mu0: {self.mu0}')
+                occa = f_occ(mu_a, mo_es[0], sigma)
+                occb = f_occ(mu_b, mo_es[1], sigma)
+            mu = [mu_a, mu_b]
+            mo_occs = [occa, occb]
             self.entropy  = self._get_entropy(mo_es[0], mo_occs[0], mu[0])
             self.entropy += self._get_entropy(mo_es[1], mo_occs[1], mu[1])
             self.entropy /= nkpts
@@ -163,6 +168,7 @@ class _SmearingKSCF(mol_addons._SmearingSCF):
             else:
                 # If mu0 is given, fix mu instead of electron number. XXX -Chong Sun
                 mu = self.mu0
+                assert numpy.isscalar(mu)
                 mo_occs = f_occ(mu, mo_es, sigma)
             self.entropy = self._get_entropy(mo_es, mo_occs, mu) / nkpts
             if is_rhf:

--- a/pyscf/pbc/scf/addons.py
+++ b/pyscf/pbc/scf/addons.py
@@ -127,7 +127,7 @@ class _SmearingKSCF(mol_addons._SmearingSCF):
                 elif len(self.mu0) == 2:
                     mu_a, mu_b = self.mu0
                 else:
-                    raise TypeError('Unsupported mu0: {self.mu0}')
+                    raise TypeError(f'Unsupported mu0: {self.mu0}')
                 occa = f_occ(mu_a, mo_es[0], sigma)
                 occb = f_occ(mu_b, mo_es[1], sigma)
             mu = [mu_a, mu_b]

--- a/pyscf/scf/addons.py
+++ b/pyscf/scf/addons.py
@@ -146,7 +146,7 @@ class _SmearingSCF:
                 elif len(self.mu0) == 2:
                     mu_a, mu_b = self.mu0
                 else:
-                    raise TypeError('Unsupported mu0: {self.mu0}')
+                    raise TypeError(f'Unsupported mu0: {self.mu0}')
                 occa = f_occ(mu_a, mo_es[0], sigma)
                 occb = f_occ(mu_b, mo_es[1], sigma)
             mu = [mu_a, mu_b]

--- a/pyscf/scf/addons.py
+++ b/pyscf/scf/addons.py
@@ -144,8 +144,12 @@ class _SmearingSCF:
                 mo_occs = [occa, occb]
             else:
                 mu = self.mu0
-                mo_occs = f_occ(mu[0], mo_es[0], sigma)
-                mo_occs = f_occ(mu[1], mo_es[1], sigma)
+                try:
+                    mu_a, mu_b = mu 
+                except:
+                    mu = [mu, mu] 
+                mo_occs = [f_occ(mu[0], mo_es[0], sigma)]
+                mo_occs.append(f_occ(mu[1], mo_es[1], sigma))
             self.entropy  = self._get_entropy(mo_es[0], mo_occs[0], mu[0])
             self.entropy += self._get_entropy(mo_es[1], mo_occs[1], mu[1])
             fermi = (_get_fermi(mo_es[0], nocc[0]), _get_fermi(mo_es[1], nocc[1]))
@@ -164,6 +168,9 @@ class _SmearingSCF:
                 mo_occs = mo_occs[0] + mo_occs[1]
         else: # all orbitals treated with the same fermi level
             nocc = nelectron = self.mol.tot_electrons()
+            if abs(nocc) < 1:
+                # model systems don't have atoms 
+                nocc = nelectron = numpy.sum(self.mol.nelec)
             if is_uhf:
                 mo_es = numpy.hstack(mo_energy)
             else:


### PR DESCRIPTION
Hi there,

Here are the changes I made:

1. Fixed a small bug regarding given mu0 in the `get_occ()` function of the `_SmearingSCF` class. 
2. Still in the `get_occ()` function of the `_SmearingSCF` class: In model systems, the `mol.tot_electrons()` might not be defined, so I added a line to get electron number from `mol.nelec` if the original approach fails.
3. Added an example of running UHF for the Hubbard model.

Please let me know if this works!
Chong