### PR TITLE
Improve to_gpu

### DIFF
--- a/pyscf/cc/ccsd.py
+++ b/pyscf/cc/ccsd.py
@@ -1365,6 +1365,8 @@ class CCSD(CCSDBase):
         if t2 is None: t2 = self.t2
         return get_d2_diagnostic(t2)
 
+    to_gpu = lib.to_gpu
+
 CC = RCCSD = CCSD
 
 

--- a/pyscf/cc/dfccsd.py
+++ b/pyscf/cc/dfccsd.py
@@ -48,6 +48,8 @@ class RCCSD(ccsd.CCSD):
         assert (not self.direct)
         return ccsd.CCSD._add_vvvv(self, t1, t2, eris, out, with_ovvv, t2sym)
 
+    to_gpu = lib.to_gpu
+
 
 def _contract_vvvv_t2(mycc, mol, vvL, t2, out=None, verbose=None):
     '''Ht2 = numpy.einsum('ijcd,acdb->ijab', t2, vvvv)

--- a/pyscf/cc/gccsd.py
+++ b/pyscf/cc/gccsd.py
@@ -289,6 +289,8 @@ class GCCSD(ccsd.CCSDBase):
                 orbspin = orbspin[self.get_frozen_mask()]
         return spin2spatial(tx, orbspin)
 
+    to_gpu = lib.to_gpu
+
 CCSD = GCCSD
 
 

--- a/pyscf/cc/uccsd.py
+++ b/pyscf/cc/uccsd.py
@@ -758,6 +758,8 @@ class UCCSD(ccsd.CCSDBase):
     def amplitudes_from_rccsd(self, t1, t2):
         return amplitudes_from_rccsd(t1, t2)
 
+    to_gpu = lib.to_gpu
+
 CCSD = UCCSD
 
 

--- a/pyscf/ci/cisd.py
+++ b/pyscf/ci/cisd.py
@@ -1131,6 +1131,8 @@ class CISD(lib.StreamObject):
         from pyscf.grad import cisd
         return cisd.Gradients(self)
 
+    to_gpu = lib.to_gpu
+
 class RCISD(CISD):
     pass
 

--- a/pyscf/df/addons.py
+++ b/pyscf/df/addons.py
@@ -152,7 +152,7 @@ def make_auxbasis(mol, mp2fit=False):
         _basis.update(mol.basis)
         del (_basis['default'])
     else:
-        _basis = mol._basis
+        _basis = mol._basis or {}
 
     auxbasis = {}
     for k in _basis:

--- a/pyscf/df/df.py
+++ b/pyscf/df/df.py
@@ -308,9 +308,7 @@ class DF(lib.StreamObject):
             if auxmol_omega is not None:
                 auxmol.omega = auxmol_omega
 
-    def to_gpu(self):
-        from gpu4pyscf.df.df import DF as DF
-        return lib.to_gpu(self.__class__.reset(self.view(DF)))
+    to_gpu = lib.to_gpu
 
 GDF = DF
 

--- a/pyscf/df/df_jk.py
+++ b/pyscf/df/df_jk.py
@@ -228,8 +228,7 @@ class _DFHF:
 
     def to_gpu(self):
         obj = self.undo_df().to_gpu().density_fit()
-        obj.__dict__.update(self.__dict__)
-        return lib.to_gpu(obj)
+        return lib.to_gpu(self, obj)
 
 
 def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):

--- a/pyscf/df/grad/casscf.py
+++ b/pyscf/df/grad/casscf.py
@@ -224,6 +224,8 @@ class Gradients(casci_grad.Gradients):
 
     as_scanner = as_scanner
 
+    to_gpu = lib.to_gpu
+
 Grad = Gradients
 
 #from pyscf import mcscf

--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -482,11 +482,13 @@ class Gradients(rhf_grad.Gradients):
     _keys = {'with_df', 'auxbasis_response'}
 
     def __init__(self, mf):
-        assert isinstance(mf, df.df_jk._DFHF)
         # Whether to include the response of DF auxiliary basis when computing
         # nuclear gradients of J/K matrices
         self.auxbasis_response = True
         rhf_grad.Gradients.__init__(self, mf)
+
+    def check_sanity(self):
+        assert isinstance(self.base, df.df_jk._DFHF)
 
     def get_jk(self, mol=None, dm=None, hermi=0, with_j=True, with_k=True,
                omega=None):
@@ -521,8 +523,6 @@ class Gradients(rhf_grad.Gradients):
         else:
             return 0
 
-    def to_gpu(self):
-        from gpu4pyscf.df.grad.rhf import Gradients
-        return lib.to_gpu(self.view(Gradients))
+    to_gpu = lib.to_gpu
 
 Grad = Gradients

--- a/pyscf/df/grad/rks.py
+++ b/pyscf/df/grad/rks.py
@@ -123,8 +123,6 @@ class Gradients(rks_grad.Gradients):
             e1 += envs['vhf'].aux[atom_id]
         return e1
 
-    def to_gpu(self):
-        from gpu4pyscf.df.grad.rks import Gradients
-        return lib.to_gpu(self.view(Gradients))
+    to_gpu = lib.to_gpu
 
 Grad = Gradients

--- a/pyscf/df/grad/sacasscf.py
+++ b/pyscf/df/grad/sacasscf.py
@@ -370,3 +370,5 @@ class Gradients (sacasscf_grad.Gradients):
     def get_LdotJnuc (self, Lvec, **kwargs):
         with lib.temporary_env (sacasscf_grad, Lci_dot_dgci_dx=Lci_dot_dgci_dx, Lorb_dot_dgorb_dx=Lorb_dot_dgorb_dx):
             return sacasscf_grad.Gradients.get_LdotJnuc (self, Lvec, **kwargs)
+
+    to_gpu = lib.to_gpu

--- a/pyscf/df/grad/uhf.py
+++ b/pyscf/df/grad/uhf.py
@@ -60,4 +60,6 @@ class Gradients(uhf_grad.Gradients):
         else:
             return 0
 
+    to_gpu = lib.to_gpu
+
 Grad = Gradients

--- a/pyscf/df/grad/uks.py
+++ b/pyscf/df/grad/uks.py
@@ -124,4 +124,6 @@ class Gradients(uks_grad.Gradients):
             e1 += envs['vhf'].aux[atom_id]
         return e1
 
+    to_gpu = lib.to_gpu
+
 Grad = Gradients

--- a/pyscf/df/hessian/rhf.py
+++ b/pyscf/df/hessian/rhf.py
@@ -480,10 +480,7 @@ class Hessian(rhf_hess.Hessian):
 
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
-
-    def to_gpu(self):
-        from gpu4pyscf.df.hessian.rhf import Hessian
-        return lib.to_gpu(self.view(Hessian))
+    to_gpu = lib.to_gpu
 
 #TODO: Insert into DF class
 

--- a/pyscf/df/hessian/rks.py
+++ b/pyscf/df/hessian/rks.py
@@ -126,10 +126,7 @@ class Hessian(rks_hess.Hessian):
 
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
-
-    def to_gpu(self):
-        from gpu4pyscf.df.hessian.rks import Hessian
-        return lib.to_gpu(self.view(Hessian))
+    to_gpu = lib.to_gpu
 
 
 if __name__ == '__main__':

--- a/pyscf/df/hessian/uhf.py
+++ b/pyscf/df/hessian/uhf.py
@@ -531,6 +531,7 @@ class Hessian(uhf_hess.Hessian):
 
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
+    to_gpu = lib.to_gpu
 
 #TODO: Insert into DF class
 

--- a/pyscf/df/hessian/uks.py
+++ b/pyscf/df/hessian/uks.py
@@ -139,6 +139,7 @@ class Hessian(uks_hess.Hessian):
 
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
+    to_gpu = lib.to_gpu
 
 
 if __name__ == '__main__':

--- a/pyscf/dft/dks.py
+++ b/pyscf/dft/dks.py
@@ -143,6 +143,8 @@ class DKS(KohnShamDFT, dhf.DHF):
         return x2chf
     x2c = x2c1e
 
+    to_gpu = lib.to_gpu
+
 UKS = UDKS = DKS
 
 class RDKS(DKS, dhf.RDHF):

--- a/pyscf/dft/gen_grid.py
+++ b/pyscf/dft/gen_grid.py
@@ -587,9 +587,7 @@ class Grids(lib.StreamObject):
             self.screen_index = self.non0tab
         return self
 
-    def to_gpu(self):
-        from gpu4pyscf.dft.gen_grid import Grids
-        return lib.to_gpu(self.view(Grids))
+    to_gpu = lib.to_gpu
 
 
 def _default_rad(nuc, level=3):

--- a/pyscf/dft/gks.py
+++ b/pyscf/dft/gks.py
@@ -177,8 +177,7 @@ class GKS(rks.KohnShamDFT, ghf.GHF):
         '''Convert to GHF object.'''
         return self._transfer_attrs_(self.mol.GHF())
 
-    def to_gpu(self):
-        raise NotImplementedError
+    to_gpu = lib.to_gpu
 
 
 if __name__ == '__main__':

--- a/pyscf/dft/gks_symm.py
+++ b/pyscf/dft/gks_symm.py
@@ -57,6 +57,8 @@ class GKS(rks.KohnShamDFT, ghf_symm.GHF):
     def nuc_grad_method(self):
         raise NotImplementedError
 
+    to_gpu = lib.to_gpu
+
 
 if __name__ == '__main__':
     import numpy

--- a/pyscf/dft/gks_symm.py
+++ b/pyscf/dft/gks_symm.py
@@ -20,6 +20,7 @@
 Generalized Kohn-Sham
 '''
 
+from pyscf import lib
 from pyscf.lib import logger
 from pyscf.scf import ghf_symm
 from pyscf.dft import gks

--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -2865,10 +2865,7 @@ class NumInt(lib.StreamObject, LibXCMixin):
                                      with_lapl)
         return make_rho, ndms, nao
 
-    def to_gpu(self):
-        from gpu4pyscf.dft.numint import NumInt
-        # Note: gpu4pyscf NumInt initializes additional things in __init__.py
-        return NumInt()
+    to_gpu = lib.to_gpu
 
 _NumInt = NumInt
 

--- a/pyscf/dft/rks.py
+++ b/pyscf/dft/rks.py
@@ -531,9 +531,4 @@ class RKS(KohnShamDFT, hf.RHF):
         '''Convert to RHF object.'''
         return self._transfer_attrs_(self.mol.RHF())
 
-    def to_gpu(self):
-        from gpu4pyscf.dft.rks import RKS
-        obj = lib.to_gpu(hf.SCF.reset(self.view(RKS)))
-        # Attributes only defined in gpu4pyscf.RKS
-        obj.screen_tol = 1e-14
-        return obj
+    to_gpu = lib.to_gpu

--- a/pyscf/dft/rks_symm.py
+++ b/pyscf/dft/rks_symm.py
@@ -20,6 +20,7 @@
 Non-relativistic Restricted Kohn-Sham
 '''
 
+from pyscf import lib
 from pyscf.scf import hf_symm
 from pyscf.dft import rks
 from pyscf.dft import uks

--- a/pyscf/dft/rks_symm.py
+++ b/pyscf/dft/rks_symm.py
@@ -46,12 +46,14 @@ class SymAdaptedRKS(rks.KohnShamDFT, hf_symm.SymAdaptedRHF):
         from pyscf.grad import rks
         return rks.Gradients(self)
 
+    to_gpu = lib.to_gpu
+
 RKS = SymAdaptedRKS
 
 
 class SymAdaptedROKS(rks.KohnShamDFT, hf_symm.SymAdaptedROHF):
     ''' Restricted Kohn-Sham '''
-    def __init__(self, mol, xc='LDA,VWN'):
+    def __init__(self, mol=None, xc='LDA,VWN'):
         hf_symm.ROHF.__init__(self, mol)
         rks.KohnShamDFT.__init__(self, xc)
 
@@ -69,6 +71,8 @@ class SymAdaptedROKS(rks.KohnShamDFT, hf_symm.SymAdaptedROHF):
     def nuc_grad_method(self):
         from pyscf.grad import roks
         return roks.Gradients(self)
+
+    to_gpu = lib.to_gpu
 
 ROKS = SymAdaptedROKS
 

--- a/pyscf/dft/roks.py
+++ b/pyscf/dft/roks.py
@@ -65,14 +65,7 @@ class ROKS(rks.KohnShamDFT, rohf.ROHF):
         '''Convert to ROHF object.'''
         return self._transfer_attrs_(self.mol.ROHF())
 
-    def to_gpu(self):
-        from pyscf.scf.hf import SCF
-        from gpu4pyscf.dft.roks import ROKS
-        obj = lib.to_gpu(SCF.reset(self.view(ROKS)))
-        # Attributes only defined in gpu4pyscf.RKS
-        obj.screen_tol = 1e-14
-        obj.disp = None
-        return obj
+    to_gpu = lib.to_gpu
 
 
 if __name__ == '__main__':

--- a/pyscf/dft/uks.py
+++ b/pyscf/dft/uks.py
@@ -197,10 +197,4 @@ class UKS(rks.KohnShamDFT, uhf.UHF):
         '''Convert to UHF object.'''
         return self._transfer_attrs_(self.mol.UHF())
 
-    def to_gpu(self):
-        from pyscf.scf.hf import SCF
-        from gpu4pyscf.dft.uks import UKS
-        obj = lib.to_gpu(SCF.reset(self.view(UKS)))
-        # Attributes only defined in gpu4pyscf.RKS
-        obj.screen_tol = 1e-14
-        return obj
+    to_gpu = lib.to_gpu

--- a/pyscf/dft/uks_symm.py
+++ b/pyscf/dft/uks_symm.py
@@ -20,6 +20,7 @@
 Non-relativistic Unrestricted Kohn-Sham
 '''
 
+from pyscf import lib
 from pyscf.lib import logger
 from pyscf.scf import uhf_symm
 from pyscf.dft import uks

--- a/pyscf/dft/uks_symm.py
+++ b/pyscf/dft/uks_symm.py
@@ -47,6 +47,8 @@ class SymAdaptedUKS(rks.KohnShamDFT, uhf_symm.UHF):
         from pyscf.grad import uks
         return uks.Gradients(self)
 
+    to_gpu = lib.to_gpu
+
 UKS = SymAdaptedUKS
 
 

--- a/pyscf/fci/direct_spin1.py
+++ b/pyscf/fci/direct_spin1.py
@@ -727,13 +727,7 @@ class FCIBase(lib.StreamObject):
 
     def __init__(self, mol=None):
         if mol is None:
-            self.stdout = sys.stdout
-            self.verbose = logger.NOTE
-            self.max_memory = lib.param.MAX_MEMORY
-        else:
-            self.stdout = mol.stdout
-            self.verbose = mol.verbose
-            self.max_memory = mol.max_memory
+            mol = lib.omniobj
         self.mol = mol
         self.nroots = 1
         self.spin = None
@@ -942,6 +936,8 @@ class FCISolver(FCIBase):
     def transform_ci_for_orbital_rotation(self, fcivec, norb, nelec, u):
         nelec = _unpack_nelec(nelec, self.spin)
         return addons.transform_ci_for_orbital_rotation(fcivec, norb, nelec, u)
+
+    to_gpu = lib.to_gpu
 
 FCI = FCISolver
 

--- a/pyscf/fci/direct_spin1.py
+++ b/pyscf/fci/direct_spin1.py
@@ -727,7 +727,13 @@ class FCIBase(lib.StreamObject):
 
     def __init__(self, mol=None):
         if mol is None:
-            mol = lib.omniobj
+            self.stdout = sys.stdout
+            self.verbose = logger.NOTE
+            self.max_memory = lib.param.MAX_MEMORY
+        else:
+            self.stdout = mol.stdout
+            self.verbose = mol.verbose
+            self.max_memory = mol.max_memory
         self.mol = mol
         self.nroots = 1
         self.spin = None

--- a/pyscf/grad/casci.py
+++ b/pyscf/grad/casci.py
@@ -342,6 +342,8 @@ class Gradients(rhf_grad.GradientsBase):
 
     as_scanner = as_scanner
 
+    to_gpu = lib.to_gpu
+
 Grad = Gradients
 
 from pyscf import mcscf

--- a/pyscf/grad/casscf.py
+++ b/pyscf/grad/casscf.py
@@ -220,6 +220,8 @@ class Gradients(casci_grad.Gradients):
 
     as_scanner = as_scanner
 
+    to_gpu = lib.to_gpu
+
 Grad = Gradients
 
 from pyscf import mcscf

--- a/pyscf/grad/ccsd.py
+++ b/pyscf/grad/ccsd.py
@@ -456,6 +456,8 @@ class Gradients(rhf_grad.GradientsBase):
 
     as_scanner = as_scanner
 
+    to_gpu = lib.to_gpu
+
 Grad = Gradients
 
 ccsd.CCSD.Gradients = lib.class_as_method(Gradients)

--- a/pyscf/grad/cisd.py
+++ b/pyscf/grad/cisd.py
@@ -203,6 +203,8 @@ class Gradients(rhf_grad.GradientsBase):
 
     as_scanner = as_scanner
 
+    to_gpu = lib.to_gpu
+
 Grad = Gradients
 
 cisd.CISD.Gradients = lib.class_as_method(Gradients)

--- a/pyscf/grad/dhf.py
+++ b/pyscf/grad/dhf.py
@@ -217,6 +217,8 @@ class Gradients(GradientsBase):
 
     as_scanner = rhf_grad.as_scanner
 
+    to_gpu = lib.to_gpu
+
 Grad = Gradients
 
 from pyscf import scf

--- a/pyscf/grad/mp2.py
+++ b/pyscf/grad/mp2.py
@@ -309,6 +309,8 @@ class Gradients(rhf_grad.GradientsBase):
 
     as_scanner = as_scanner
 
+    to_gpu = lib.to_gpu
+
 Grad = Gradients
 
 # Inject to RMP2 class

--- a/pyscf/grad/rhf.py
+++ b/pyscf/grad/rhf.py
@@ -463,9 +463,7 @@ class Gradients(GradientsBase):
 
     grad_elec = grad_elec
 
-    def to_gpu(self):
-        from gpu4pyscf.grad.rhf import Gradients
-        return lib.to_gpu(self.view(Gradients))
+    to_gpu = lib.to_gpu
 
 Grad = Gradients
 

--- a/pyscf/grad/rks.py
+++ b/pyscf/grad/rks.py
@@ -622,9 +622,7 @@ class Gradients(rhf_grad.Gradients):
         else:
             return 0
 
-    def to_gpu(self):
-        from gpu4pyscf.grad.rks import Gradients
-        return lib.to_gpu(self.view(Gradients))
+    to_gpu = lib.to_gpu
 
 Grad = Gradients
 

--- a/pyscf/grad/tdrhf.py
+++ b/pyscf/grad/tdrhf.py
@@ -325,6 +325,8 @@ class Gradients(rhf_grad.GradientsBase):
 
     as_scanner = as_scanner
 
+    to_gpu = lib.to_gpu
+
 Grad = Gradients
 
 from pyscf import tdscf

--- a/pyscf/grad/uhf.py
+++ b/pyscf/grad/uhf.py
@@ -106,8 +106,7 @@ class Gradients(rhf_grad.GradientsBase):
 
     grad_elec = grad_elec
 
-    def to_gpu(self):
-        raise NotImplementedError
+    to_gpu = lib.to_gpu
 
 Grad = Gradients
 

--- a/pyscf/grad/uks.py
+++ b/pyscf/grad/uks.py
@@ -275,8 +275,7 @@ class Gradients(uhf_grad.Gradients):
         else:
             return 0
 
-    def to_gpu(self):
-        raise NotImplementedError
+    to_gpu = lib.to_gpu
 
 Grad = Gradients
 

--- a/pyscf/hessian/rhf.py
+++ b/pyscf/hessian/rhf.py
@@ -487,9 +487,9 @@ class HessianBase(lib.StreamObject):
         self.verbose = scf_method.verbose
         self.stdout = scf_method.stdout
         self.mol = scf_method.mol
-        self.base = scf_method
         self.chkfile = scf_method.chkfile
         self.max_memory = self.mol.max_memory
+        self.base = scf_method
         self.atmlst = range(self.mol.natm)
         self.de = numpy.zeros((0,0,3,3))  # (A,B,dR_A,dR_B)
 
@@ -608,10 +608,7 @@ class Hessian(HessianBase):
     partial_hess_elec = partial_hess_elec
     hess_elec = hess_elec
     make_h1 = make_h1
-
-    def to_gpu(self):
-        from gpu4pyscf.hessian.rhf import Hessian
-        return lib.to_gpu(self.view(Hessian))
+    to_gpu = lib.to_gpu
 
 # Inject to RHF class
 from pyscf import scf

--- a/pyscf/hessian/rks.py
+++ b/pyscf/hessian/rks.py
@@ -590,10 +590,7 @@ class Hessian(rhf_hess.HessianBase):
     partial_hess_elec = partial_hess_elec
     hess_elec = rhf_hess.hess_elec
     make_h1 = make_h1
-
-    def to_gpu(self):
-        from gpu4pyscf.hessian.rks import Hessian
-        return lib.to_gpu(self.view(Hessian))
+    to_gpu = lib.to_gpu
 
 from pyscf import dft
 dft.rks.RKS.Hessian = dft.rks_symm.RKS.Hessian = lib.class_as_method(Hessian)

--- a/pyscf/hessian/uhf.py
+++ b/pyscf/hessian/uhf.py
@@ -454,8 +454,7 @@ class Hessian(rhf_hess.HessianBase):
                          fx, atmlst, max_memory, verbose,
                          max_cycle=self.max_cycle, level_shift=self.level_shift)
 
-    def to_gpu(self):
-        raise NotImplementedError
+    to_gpu = lib.to_gpu
 
 from pyscf import scf
 scf.uhf.UHF.Hessian = lib.class_as_method(Hessian)

--- a/pyscf/hessian/uks.py
+++ b/pyscf/hessian/uks.py
@@ -667,9 +667,7 @@ class Hessian(rhf_hess.HessianBase):
     solve_mo1 = uhf_hess.Hessian.solve_mo1
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
-
-    def to_gpu(self):
-        raise NotImplementedError
+    to_gpu = lib.to_gpu
 
 from pyscf import dft
 dft.uks.UKS.Hessian = dft.uks_symm.UKS.Hessian = lib.class_as_method(Hessian)

--- a/pyscf/lib/diis.py
+++ b/pyscf/lib/diis.py
@@ -334,6 +334,8 @@ class DIIS:
         self._H[1:nd+1,1:nd+1] = e_mat
         return self
 
+    to_gpu = lib.to_gpu
+
 
 def restore(filename):
     '''Restore/construct diis object based on a diis file'''

--- a/pyscf/lib/diis.py
+++ b/pyscf/lib/diis.py
@@ -334,7 +334,7 @@ class DIIS:
         self._H[1:nd+1,1:nd+1] = e_mat
         return self
 
-    to_gpu = lib.to_gpu
+    to_gpu = misc.to_gpu
 
 
 def restore(filename):

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -843,10 +843,7 @@ def invalid_method(name):
 
 @functools.lru_cache(None)
 def _define_class(name, bases):
-    cls = type(name, bases, {})
-    # Register the dynamic class to the corresponding module
-    setattr(bases[0], name, cls)
-    return cls
+    return type(name, bases, {})
 
 def make_class(bases, name=None, attrs=None):
     '''
@@ -1406,6 +1403,10 @@ def to_gpu(method, out=None):
                   '    pip install gpu4pyscf-cuda11x\n'
                   'See more installation info at https://github.com/pyscf/gpu4pyscf')
             raise
+
+        # TODO: Is it necessary to implement scanner in gpu4pyscf?
+        if isinstance(method, (SinglePointScanner, GradScanner)):
+            method = method.undo_scanner()
 
         import import_module
         mod = import_module(method.__module__.replace('pyscf', 'gpu4pyscf'))

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -843,7 +843,10 @@ def invalid_method(name):
 
 @functools.lru_cache(None)
 def _define_class(name, bases):
-    return type(name, bases, {})
+    cls = type(name, bases, {})
+    # Register the dynamic class to the corresponding module
+    setattr(bases[0], name, cls)
+    return cls
 
 def make_class(bases, name=None, attrs=None):
     '''
@@ -1360,17 +1363,69 @@ def isintsequence(obj):
             are_ints = are_ints and isinteger(i)
         return are_ints
 
-def to_gpu(method):
-    '''Recursively converts all attributes of a method to cupy objects or
-    gpu4pyscf objects.
+class _OmniObject:
+    '''Class with default attributes. When accessing an attribute that is not
+    initialized, a default value will be returned than raising an AttributeError.
+    '''
+    verbose = 0
+    max_memory = param.MAX_MEMORY
+    stdout = sys.stdout
+
+    def __init__(self, default_factory=None):
+        self._default = default_factory
+
+    def __getattr__(self, key):
+        return self._default
+
+# Many methods requires a mol or mf object in initialization.
+# These objects can be as the default arguments for these methods.
+# Then class can be instantiated easily like cls(omniobj) in the following
+# to_gpu function.
+omniobj = _OmniObject()
+omniobj.mol = omniobj
+omniobj._scf = omniobj
+omniobj.base = omniobj
+
+def to_gpu(method, out=None):
+    '''Convert a method to its corresponding GPU variant, and recursively
+    converts all attributes of a method to cupy objects or gpu4pyscf objects.
     '''
     import cupy
     from pyscf import gto
-    for key, val in method.__dict__.items():
-        if isinstance(val, gto.MoleBase):
-            continue
+
+    # If a GPU class inherits a CPU code, the "to_gpu" method may be resolved
+    # and available in the GPU class. Skip the conversion in this case.
+    if method.__module__.startswith('gpu4pyscf'):
+        return method
+
+    if out is None:
+        try:
+            import gpu4pyscf
+        except ImportError:
+            print('Library gpu4pyscf not found. You can install this package via\n'
+                  '    pip install gpu4pyscf-cuda11x\n'
+                  'See more installation info at https://github.com/pyscf/gpu4pyscf')
+            raise
+
+        import import_module
+        mod = import_module(method.__module__.replace('pyscf', 'gpu4pyscf'))
+        cls = getattr(mod, method.__class__.__name__)
+        # A temporary GPU instance. This ensures to initialize private
+        # attributes that are only available for GPU code.
+        out = cls(omniobj)
+
+    # Convert only the keys that are defined in the corresponding GPU class
+    cls_keys = [getattr(cls, '_keys', ()) for cls in out.__class__.__mro__[:-1]]
+    out_keys = set(out.__dict__).union(*cls_keys)
+    # Only overwrite the attributes of the same name.
+    keys = set(method.__dict__).intersection(out_keys)
+
+    for key in keys:
+        val = getattr(method, key)
         if isinstance(val, numpy.ndarray):
-            setattr(method, key, cupy.asarray(val))
+            val = cupy.asarray(val)
         elif hasattr(val, 'to_gpu'):
-            setattr(method, key, val.to_gpu())
-    return method
+            val = val.to_gpu()
+        setattr(out, key, val)
+    out.reset()
+    return out

--- a/pyscf/mcscf/casci.py
+++ b/pyscf/mcscf/casci.py
@@ -770,7 +770,7 @@ class CASBase(lib.StreamObject):
         'e_tot', 'e_cas', 'ci', 'mo_coeff', 'mo_energy', 'mo_occ', 'converged',
     }
 
-    def __init__(self, mf_or_mol, ncas, nelecas, ncore=None):
+    def __init__(self, mf_or_mol, ncas=0, nelecas=0, ncore=None):
         if isinstance(mf_or_mol, gto.Mole):
             mf = scf.RHF(mf_or_mol)
         else:
@@ -1169,6 +1169,8 @@ class CASCI(CASBase):
     def nuc_grad_method(self):
         from pyscf.grad import casci
         return casci.Gradients(self)
+
+    to_gpu = lib.to_gpu
 
 scf.hf.RHF.CASCI = scf.rohf.ROHF.CASCI = lib.class_as_method(CASCI)
 scf.uhf.UHF.CASCI = None

--- a/pyscf/mcscf/casci_symm.py
+++ b/pyscf/mcscf/casci_symm.py
@@ -28,7 +28,7 @@ from pyscf.mcscf import addons
 from pyscf.scf.hf_symm import map_degeneracy
 
 class SymAdaptedCASCI(casci.CASCI):
-    def __init__(self, mf_or_mol, ncas, nelecas, ncore=None):
+    def __init__(self, mf_or_mol, ncas=0, nelecas=0, ncore=None):
         casci.CASCI.__init__(self, mf_or_mol, ncas, nelecas, ncore)
 
         assert (self.mol.symmetry)
@@ -73,6 +73,8 @@ class SymAdaptedCASCI(casci.CASCI):
         if mo_coeff is None: mo_coeff = self.mo_coeff
         return addons.sort_mo_by_irrep(self, mo_coeff, cas_irrep_nocc,
                                        cas_irrep_ncore, s)
+
+    to_gpu = lib.to_gpu
 
 CASCI = SymAdaptedCASCI
 

--- a/pyscf/mcscf/mc1step.py
+++ b/pyscf/mcscf/mc1step.py
@@ -755,7 +755,7 @@ class CASSCF(casci.CASBase):
         'mo_energy', 'converged',
     }
 
-    def __init__(self, mf_or_mol, ncas, nelecas, ncore=None, frozen=None):
+    def __init__(self, mf_or_mol, ncas=0, nelecas=0, ncore=None, frozen=None):
         casci.CASBase.__init__(self, mf_or_mol, ncas, nelecas, ncore)
         self.frozen = frozen
 
@@ -1295,6 +1295,8 @@ To enable the solvent model for CASSCF, the following code needs to be called
     def reset(self, mol=None):
         casci.CASBase.reset(self, mol=mol)
         self._max_stepsize = None
+
+    to_gpu = lib.to_gpu
 
 scf.hf.RHF.CASSCF = scf.rohf.ROHF.CASSCF = lib.class_as_method(CASSCF)
 scf.uhf.UHF.CASSCF = None

--- a/pyscf/mcscf/newton_casscf_symm.py
+++ b/pyscf/mcscf/newton_casscf_symm.py
@@ -27,7 +27,7 @@ from pyscf import fci
 
 class CASSCF(newton_casscf.CASSCF):
     __doc__ = newton_casscf.CASSCF.__doc__
-    def __init__(self, mf_or_mol, ncas, nelecas, ncore=None, frozen=None):
+    def __init__(self, mf_or_mol, ncas=0, nelecas=0, ncore=None, frozen=None):
         newton_casscf.CASSCF.__init__(self, mf_or_mol, ncas, nelecas, ncore, frozen)
         assert (self.mol.symmetry)
         self.fcisolver = fci.solver(self.mol, False, True)

--- a/pyscf/mcscf/ucasci.py
+++ b/pyscf/mcscf/ucasci.py
@@ -119,7 +119,7 @@ def kernel(casci, mo_coeff=None, ci0=None, verbose=logger.NOTE, envs=None):
 
 class UCASBase(CASBase):
     # nelecas is tuple of (nelecas_alpha, nelecas_beta)
-    def __init__(self, mf_or_mol, ncas, nelecas, ncore=None):
+    def __init__(self, mf_or_mol, ncas=0, nelecas=0, ncore=None):
         #assert ('UHF' == mf.__class__.__name__)
         if isinstance(mf_or_mol, gto.Mole):
             mf = scf.UHF(mf_or_mol)

--- a/pyscf/mcscf/umc1step.py
+++ b/pyscf/mcscf/umc1step.py
@@ -379,7 +379,7 @@ class UCASSCF(ucasci.UCASBase):
         'canonicalization', 'sorting_mo_energy',
     }
 
-    def __init__(self, mf_or_mol, ncas, nelecas, ncore=None, frozen=None):
+    def __init__(self, mf_or_mol, ncas=0, nelecas=0, ncore=None, frozen=None):
         ucasci.UCASBase.__init__(self, mf_or_mol, ncas, nelecas, ncore)
         self.frozen = frozen
 

--- a/pyscf/mp/dfmp2.py
+++ b/pyscf/mp/dfmp2.py
@@ -140,6 +140,8 @@ class DFMP2(mp2.MP2):
     def init_amps(self, mo_energy=None, mo_coeff=None, eris=None, with_t2=WITH_T2):
         return kernel(self, mo_energy, mo_coeff, eris, with_t2)
 
+    to_gpu = lib.to_gpu
+
 MP2 = DFMP2
 
 from pyscf import scf

--- a/pyscf/mp/dfmp2_native.py
+++ b/pyscf/mp/dfmp2_native.py
@@ -236,6 +236,8 @@ class DFRMP2(lib.StreamObject):
     def nuc_grad_method(self):
         raise NotImplementedError
 
+    to_gpu = lib.to_gpu
+
 
 MP2 = RMP2 = DFMP2 = DFRMP2
 

--- a/pyscf/mp/dfump2_native.py
+++ b/pyscf/mp/dfump2_native.py
@@ -226,6 +226,8 @@ class DFUMP2(DFRMP2):
     def nuc_grad_method(self):
         raise NotImplementedError
 
+    to_gpu = lib.to_gpu
+
 
 MP2 = UMP2 = DFMP2 = DFUMP2
 

--- a/pyscf/mp/gmp2.py
+++ b/pyscf/mp/gmp2.py
@@ -214,6 +214,8 @@ class GMP2(mp2.MP2):
     def init_amps(self, mo_energy=None, mo_coeff=None, eris=None, with_t2=WITH_T2):
         return kernel(self, mo_energy, mo_coeff, eris, with_t2)
 
+    to_gpu = lib.to_gpu
+
 MP2 = GMP2
 
 scf.ghf.GHF.MP2 = lib.class_as_method(MP2)

--- a/pyscf/mp/mp2.py
+++ b/pyscf/mp/mp2.py
@@ -649,6 +649,8 @@ class MP2(lib.StreamObject):
     def init_amps(self, mo_energy=None, mo_coeff=None, eris=None, with_t2=WITH_T2):
         return kernel(self, mo_energy, mo_coeff, eris, with_t2)
 
+    to_gpu = lib.to_gpu
+
 RMP2 = MP2
 
 from pyscf import scf

--- a/pyscf/mp/ump2.py
+++ b/pyscf/mp/ump2.py
@@ -450,6 +450,8 @@ class UMP2(mp2.MP2):
     def init_amps(self, mo_energy=None, mo_coeff=None, eris=None, with_t2=WITH_T2):
         return kernel(self, mo_energy, mo_coeff, eris, with_t2)
 
+    to_gpu = lib.to_gpu
+
 MP2 = UMP2
 
 from pyscf import scf

--- a/pyscf/pbc/cc/kccsd.py
+++ b/pyscf/pbc/cc/kccsd.py
@@ -463,6 +463,8 @@ class GCCSD(gccsd.GCCSD):
     def to_uccsd(self, t1, t2, orbspin=None):
         return spin2spatial(t1, orbspin), spin2spatial(t2, orbspin)
 
+    to_gpu = lib.to_gpu
+
 CCSD = KCCSD = KGCCSD = GCCSD
 
 

--- a/pyscf/pbc/cc/kccsd_rhf.py
+++ b/pyscf/pbc/cc/kccsd_rhf.py
@@ -653,6 +653,8 @@ class RCCSD(pyscf.cc.ccsd.CCSD):
     def ao2mo(self, mo_coeff=None):
         return _ERIS(self, mo_coeff)
 
+    to_gpu = lib.to_gpu
+
 #####################################
 # Wrapper functions for IP/EA-EOM
 #####################################

--- a/pyscf/pbc/cc/kccsd_uhf.py
+++ b/pyscf/pbc/cc/kccsd_uhf.py
@@ -761,6 +761,8 @@ class KUCCSD(uccsd.UCCSD):
         if nkpts is None: nkpts = self.nkpts
         return vector_to_amplitudes(vec, nmo, nocc, nkpts)
 
+    to_gpu = lib.to_gpu
+
 UCCSD = KUCCSD
 
 

--- a/pyscf/pbc/df/df.py
+++ b/pyscf/pbc/df/df.py
@@ -524,6 +524,8 @@ class GDF(lib.StreamObject, aft.AFTDFMixin):
                     naux += dat.shape[0]
         return naux
 
+    to_gpu = lib.to_gpu
+
 DF = GDF
 
 class CDERIArray:

--- a/pyscf/pbc/df/fft.py
+++ b/pyscf/pbc/df/fft.py
@@ -355,3 +355,5 @@ class FFTDF(lib.StreamObject):
         return ngrids * 2
 
     range_coulomb = aft.AFTDF.range_coulomb
+
+    to_gpu = lib.to_gpu

--- a/pyscf/pbc/dft/gen_grid.py
+++ b/pyscf/pbc/dft/gen_grid.py
@@ -134,6 +134,8 @@ class UniformGrids(lib.StreamObject):
         if coords is None: coords = self.coords
         return make_mask(cell, coords, relativity, shls_slice, verbose)
 
+    to_gpu = lib.to_gpu
+
 
 # modified from pyscf.dft.gen_grid.gen_partition
 def get_becke_grids(cell, atom_grid={}, radi_method=dft.radi.gauss_chebyshev,
@@ -256,6 +258,8 @@ class BeckeGrids(dft.gen_grid.Grids):
         if cell is None: cell = self.cell
         if coords is None: coords = self.coords
         return make_mask(cell, coords, relativity, shls_slice, verbose)
+
+    to_gpu = lib.to_gpu
 
 AtomicGrids = BeckeGrids
 

--- a/pyscf/pbc/dft/gks.py
+++ b/pyscf/pbc/dft/gks.py
@@ -143,3 +143,5 @@ class GKS(rks.KohnShamDFT, pbcghf.GHF):
         '''Convert to GHF object.'''
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.GHF(self.cell, self.kpt))
+
+    to_gpu = lib.to_gpu

--- a/pyscf/pbc/dft/kgks.py
+++ b/pyscf/pbc/dft/kgks.py
@@ -148,3 +148,5 @@ class KGKS(rks.KohnShamDFT, kghf.KGHF):
         '''Convert to KGHF object.'''
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.KGHF(self.cell, self.kpts))
+
+    to_gpu = lib.to_gpu

--- a/pyscf/pbc/dft/krks.py
+++ b/pyscf/pbc/dft/krks.py
@@ -184,6 +184,8 @@ class KRKS(rks.KohnShamDFT, khf.KRHF):
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.KRHF(self.cell, self.kpts))
 
+    to_gpu = lib.to_gpu
+
 
 if __name__ == '__main__':
     from pyscf.pbc import gto

--- a/pyscf/pbc/dft/kroks.py
+++ b/pyscf/pbc/dft/kroks.py
@@ -64,6 +64,8 @@ class KROKS(rks.KohnShamDFT, krohf.KROHF):
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.KROHF(self.cell, self.kpts))
 
+    to_gpu = lib.to_gpu
+
 
 if __name__ == '__main__':
     from pyscf.pbc import gto

--- a/pyscf/pbc/dft/kuks.py
+++ b/pyscf/pbc/dft/kuks.py
@@ -160,6 +160,8 @@ class KUKS(rks.KohnShamDFT, kuhf.KUHF):
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.KUHF(self.cell, self.kpts))
 
+    to_gpu = lib.to_gpu
+
 
 if __name__ == '__main__':
     from pyscf.pbc import gto

--- a/pyscf/pbc/dft/numint.py
+++ b/pyscf/pbc/dft/numint.py
@@ -1082,6 +1082,8 @@ class NumInt(lib.StreamObject, numint.LibXCMixin):
         return self.eval_rho(cell, ao, dm, screen_index, xctype, hermi,
                              with_lapl, verbose)
 
+    to_gpu = lib.to_gpu
+
 _NumInt = NumInt
 
 
@@ -1286,5 +1288,7 @@ class KNumInt(lib.StreamObject, numint.LibXCMixin):
     cache_xc_kernel  = cache_xc_kernel
     cache_xc_kernel1 = cache_xc_kernel1
     get_rho = get_rho
+
+    to_gpu = lib.to_gpu
 
 _KNumInt = KNumInt

--- a/pyscf/pbc/dft/rks.py
+++ b/pyscf/pbc/dft/rks.py
@@ -346,6 +346,8 @@ class RKS(KohnShamDFT, pbchf.RHF):
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.RHF(self.cell, self.kpt))
 
+    to_gpu = lib.to_gpu
+
 
 if __name__ == '__main__':
     from pyscf.pbc import gto

--- a/pyscf/pbc/dft/roks.py
+++ b/pyscf/pbc/dft/roks.py
@@ -68,6 +68,8 @@ class ROKS(rks.KohnShamDFT, rohf.ROHF):
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.ROHF(self.cell, self.kpt))
 
+    to_gpu = lib.to_gpu
+
 
 if __name__ == '__main__':
     from pyscf.pbc import gto

--- a/pyscf/pbc/dft/uks.py
+++ b/pyscf/pbc/dft/uks.py
@@ -144,6 +144,8 @@ class UKS(rks.KohnShamDFT, pbcuhf.UHF):
         from pyscf.pbc import scf
         return self._transfer_attrs_(scf.UHF(self.cell, self.kpt))
 
+    to_gpu = lib.to_gpu
+
 
 if __name__ == '__main__':
     from pyscf.pbc import gto

--- a/pyscf/pbc/mp/kmp2.py
+++ b/pyscf/pbc/mp/kmp2.py
@@ -783,6 +783,8 @@ class KMP2(mp2.MP2):
 
         return self.e_corr, self.t2
 
+    to_gpu = lib.to_gpu
+
 KRMP2 = KMP2
 
 

--- a/pyscf/pbc/scf/ghf.py
+++ b/pyscf/pbc/scf/ghf.py
@@ -165,6 +165,8 @@ class GHF(pbchf.SCF):
         addons.convert_to_ghf(mf, self)
         return self
 
+    to_gpu = lib.to_gpu
+
 
 if __name__ == '__main__':
     from pyscf.pbc import gto

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -897,6 +897,7 @@ class RHF(SCF):
     analyze = mol_hf.RHF.analyze
     spin_square = mol_hf.RHF.spin_square
     stability = mol_hf.RHF.stability
+    to_gpu = lib.to_gpu
 
     def nuc_grad_method(self):
         raise NotImplementedError

--- a/pyscf/pbc/scf/kghf.py
+++ b/pyscf/pbc/scf/kghf.py
@@ -200,6 +200,8 @@ class KGHF(khf.KSCF):
     analyze = khf.analyze
     convert_from_ = pbcghf.GHF.convert_from_
 
+    to_gpu = lib.to_gpu
+
     def get_hcore(self, cell=None, kpts=None):
         hcore = khf.KSCF.get_hcore(self, cell, kpts)
         hcore = lib.asarray([scipy.linalg.block_diag(h, h) for h in hcore])

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -688,6 +688,7 @@ class KRHF(KSCF):
 
     analyze = analyze
     spin_square = mol_hf.RHF.spin_square
+    to_gpu = lib.to_gpu
 
     def check_sanity(self):
         cell = self.cell

--- a/pyscf/pbc/scf/krohf.py
+++ b/pyscf/pbc/scf/krohf.py
@@ -274,6 +274,7 @@ class KROHF(khf.KRHF):
     analyze = khf.analyze
     spin_square = pbcrohf.ROHF.spin_square
     canonicalize = canonicalize
+    to_gpu = lib.to_gpu
 
     def __init__(self, cell, kpts=np.zeros((1,3)),
                  exxdiv=getattr(__config__, 'pbc_scf_SCF_exxdiv', 'ewald')):

--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -384,6 +384,7 @@ class KUHF(khf.KSCF):
     get_rho = get_rho
     analyze = khf.analyze
     canonicalize = canonicalize
+    to_gpu = lib.to_gpu
 
     def __init__(self, cell, kpts=np.zeros((1,3)),
                  exxdiv=getattr(__config__, 'pbc_scf_SCF_exxdiv', 'ewald')):

--- a/pyscf/pbc/scf/rohf.py
+++ b/pyscf/pbc/scf/rohf.py
@@ -62,6 +62,7 @@ class ROHF(pbchf.RHF):
     spin_square = mol_rohf.ROHF.spin_square
     stability = mol_rohf.ROHF.stability
     dip_moment = pbchf.SCF.dip_moment
+    to_gpu = lib.to_gpu
 
     def __init__(self, cell, kpt=np.zeros(3),
                  exxdiv=getattr(__config__, 'pbc_scf_SCF_exxdiv', 'ewald')):

--- a/pyscf/pbc/scf/rsjk.py
+++ b/pyscf/pbc/scf/rsjk.py
@@ -1160,6 +1160,8 @@ class RangeSeparatedJKBuilder(lib.StreamObject):
         log.timer_debug1('get_lr_k_kpts', *cpu0)
         return vk_kpts
 
+    to_gpu = lib.to_gpu
+
 RangeSeparationJKBuilder = RangeSeparatedJKBuilder
 
 def _purify(mat_kpts, phase):

--- a/pyscf/pbc/scf/uhf.py
+++ b/pyscf/pbc/scf/uhf.py
@@ -128,6 +128,7 @@ class UHF(pbchf.SCF):
     canonicalize = mol_uhf.UHF.canonicalize
     spin_square = mol_uhf.UHF.spin_square
     stability = mol_uhf.UHF.stability
+    to_gpu = lib.to_gpu
 
     def __init__(self, cell, kpt=np.zeros(3),
                  exxdiv=getattr(__config__, 'pbc_scf_SCF_exxdiv', 'ewald')):

--- a/pyscf/qmmm/itrf.py
+++ b/pyscf/qmmm/itrf.py
@@ -188,6 +188,11 @@ class QMMMSCF(QMMM):
             nuc += q2*(charges/r).sum()
         return nuc
 
+    def to_gpu(self):
+        obj = self.undo_qmmm().to_gpu()
+        obj = qmmm_for_scf(obj, self.mm_mol)
+        return lib.to_gpu(self, obj)
+
     def nuc_grad_method(self):
         scf_grad = super().nuc_grad_method()
         return qmmm_grad_for_scf(scf_grad)
@@ -206,6 +211,8 @@ class QMMMPostSCF(QMMM):
         obj = lib.view(self, lib.drop_class(self.__class__, QMMM))
         obj._scf = self._scf.undo_qmmm()
         return obj
+
+    to_gpu = QMMMSCF.to_gpu
 
 
 def add_mm_charges_grad(scf_grad, atoms_or_coords, charges, radii=None, unit=None):
@@ -395,6 +402,11 @@ class QMMMGrad:
             r = lib.norm(r1-coords, axis=1)
             g_mm += q1 * numpy.einsum('i,ix,i->ix', charges, r1-coords, 1/r**3)
         return g_mm
+
+    def to_gpu(self):
+        obj = self.undo_qmmm().to_gpu()
+        obj = qmmm_grad_for_scf(obj)
+        return lib.to_gpu(self, obj)
 
 _QMMMGrad = QMMMGrad
 

--- a/pyscf/scf/dhf.py
+++ b/pyscf/scf/dhf.py
@@ -454,12 +454,11 @@ class DHF(hf.SCF):
     ssss_approx = getattr(__config__, 'scf_dhf_SCF_ssss_approx', 'Visscher')
 
     _keys = {'conv_tol', 'with_ssss', 'with_gaunt',
-                 'with_breit', 'ssss_approx', 'opt'}
+                 'with_breit', 'ssss_approx'}
 
     def __init__(self, mol):
         hf.SCF.__init__(self, mol)
         self._coulomb_level = 'SSSS' # 'SSSS' ~ LLLL+LLSS+SSSS
-        self.opt = None # (opt_llll, opt_ssll, opt_ssss, opt_gaunt)
 
     def dump_flags(self, verbose=None):
         hf.SCF.dump_flags(self, verbose)
@@ -518,8 +517,6 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
     def build(self, mol=None):
         if self.verbose >= logger.WARN:
             self.check_sanity()
-        if self.direct_scf:
-            self.opt = self.init_direct_scf(mol)
         return self
 
     def get_occ(self, mo_energy=None, mo_coeff=None):
@@ -686,7 +683,6 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
             self.mol = mol
         self._coulomb_level = 'SSSS' # 'SSSS' ~ LLLL+LLSS+SSSS
         self._opt = {None: None}
-        self.opt = None # (opt_llll, opt_ssll, opt_ssss, opt_gaunt)
         return self
 
     def stability(self, internal=None, external=None, verbose=None, return_status=False):
@@ -748,6 +744,8 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         return mf
 
     to_ks = to_dks
+
+    to_gpu = lib.to_gpu
 
 UHF = UDHF = DHF
 

--- a/pyscf/scf/diis.py
+++ b/pyscf/scf/diis.py
@@ -44,10 +44,6 @@ class CDIIS(lib.diis.DIIS):
         self.space = 8
         self.Corth = Corth
         self.damp = 0
-        #?self._scf = mf
-        #?if hasattr(self._scf, 'get_orbsym'): # Symmetry adapted SCF objects
-        #?    self.orbsym = mf.get_orbsym(Corth)
-        #?    sym_forbid = self.orbsym[:,None] != self.orbsym
 
     def update(self, s, d, f, *args, **kwargs):
         errvec = get_err_vec(s, d, f, self.Corth)

--- a/pyscf/scf/ghf.py
+++ b/pyscf/scf/ghf.py
@@ -382,15 +382,13 @@ class GHF(hf.SCF):
         mo_coeff[nao:nao*2] are the coefficients of AO with beta spin.
     '''
 
+    with_soc = None
+
     _keys = {'with_soc'}
 
     get_init_guess = hf.RHF.get_init_guess
     get_occ = get_occ
     _finalize = uhf.UHF._finalize
-
-    def __init__(self, mol):
-        hf.SCF.__init__(self, mol)
-        self.with_soc = None
 
     def get_hcore(self, mol=None):
         if mol is None: mol = self.mol
@@ -541,9 +539,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         from pyscf import dft
         return self._transfer_attrs_(dft.GKS(self.mol, xc=xc))
 
-    def to_gpu(self):
-        from gpu4pyscf.scf import GHF
-        return lib.to_gpu(hf.SCF.reset(self.view(GHF)))
+    to_gpu = lib.to_gpu
 
 def _from_rhf_init_dm(dm, breaksym=True):
     dma = dm * .5

--- a/pyscf/scf/ghf_symm.py
+++ b/pyscf/scf/ghf_symm.py
@@ -281,8 +281,7 @@ class SymAdaptedGHF(ghf.GHF):
         return numpy.asarray(get_orbsym(self.mol, mo_coeff, s))
     orbsym = property(get_orbsym)
 
-    def to_gpu(self):
-        raise NotImplementedError
+    to_gpu = lib.to_gpu
 
 GHF = SymAdaptedGHF
 

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -2062,7 +2062,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         '''This helper function transfers attributes from one SCF object to
         another SCF object. It is invoked by to_ks and to_hf methods.
         '''
-        # Search for all traced attributes, including those in base classes
+        # Search for all tracked attributes, including those in base classes
         cls_keys = [getattr(cls, '_keys', ()) for cls in dst.__class__.__mro__[:-1]]
         dst_keys = set(dst.__dict__).union(*cls_keys)
 

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -2062,8 +2062,12 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         '''This helper function transfers attributes from one SCF object to
         another SCF object. It is invoked by to_ks and to_hf methods.
         '''
+        # Search for all traced attributes, including those in base classes
+        cls_keys = [getattr(cls, '_keys', ()) for cls in dst.__class__.__mro__[:-1]]
+        dst_keys = set(dst.__dict__).union(*cls_keys)
+
         loc_dic = self.__dict__
-        keys = dst.__dict__.keys() & loc_dic.keys()
+        keys = set(loc_dic).intersection(dst_keys)
         dst.__dict__.update({k: loc_dic[k] for k in keys})
         dst.converged = False
         return dst

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -1504,6 +1504,7 @@ class SCF(lib.StreamObject):
     conv_tol_grad = getattr(__config__, 'scf_hf_SCF_conv_tol_grad', None)
     max_cycle = getattr(__config__, 'scf_hf_SCF_max_cycle', 50)
     init_guess = getattr(__config__, 'scf_hf_SCF_init_guess', 'minao')
+    disp = None  # for DFT-D3 and DFT-D4
 
     # To avoid diis pollution from previous run, self.diis should not be
     # initialized as DIIS instance here
@@ -1542,7 +1543,6 @@ class SCF(lib.StreamObject):
         self.verbose = mol.verbose
         self.max_memory = mol.max_memory
         self.stdout = mol.stdout
-        self.disp = None
 
         # If chkfile is muted, SCF intermediates will not be dumped anywhere.
         if MUTE_CHKFILE:
@@ -2197,11 +2197,8 @@ class RHF(SCF):
         from pyscf import dft
         return self._transfer_attrs_(dft.RKS(self.mol, xc=xc))
 
-    def to_gpu(self):
-        # FIXME: consider the density_fit, x2c and soscf decoration
-        from gpu4pyscf.scf import RHF
-        obj = SCF.reset(self.view(RHF))
-        return lib.to_gpu(obj)
+    # FIXME: consider the density_fit, x2c and soscf decoration
+    to_gpu = lib.to_gpu
 
 def _hf1e_scf(mf, *args):
     logger.info(mf, '\n')

--- a/pyscf/scf/hf_symm.py
+++ b/pyscf/scf/hf_symm.py
@@ -573,8 +573,7 @@ class SymAdaptedRHF(hf.RHF):
 
     canonicalize = canonicalize
 
-    def to_gpu(self):
-        raise NotImplementedError
+    to_gpu = lib.to_gpu
 
 RHF = SymAdaptedRHF
 
@@ -934,8 +933,7 @@ class SymAdaptedROHF(rohf.ROHF):
     get_wfnsym = get_wfnsym
     wfnsym = property(get_wfnsym)
 
-    def to_gpu(self):
-        raise NotImplementedError
+    to_gpu = lib.to_gpu
 
 ROHF = SymAdaptedROHF
 

--- a/pyscf/scf/rohf.py
+++ b/pyscf/scf/rohf.py
@@ -520,9 +520,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         from pyscf import dft
         return self._transfer_attrs_(dft.ROKS(self.mol, xc=xc))
 
-    def to_gpu(self):
-        from gpu4pyscf.scf import ROHF
-        return lib.to_gpu(hf.SCF.reset(self.view(ROHF)))
+    to_gpu = lib.to_gpu
 
 
 class HF1e(ROHF):

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -763,6 +763,8 @@ class UHF(hf.SCF):
     S^2 = 0.7570150, 2S+1 = 2.0070027
     '''
 
+    init_guess_breaksym = None
+
     _keys = {"init_guess_breaksym"}
 
     def __init__(self, mol):
@@ -771,7 +773,6 @@ class UHF(hf.SCF):
         # self.mo_occ => [mo_occ_a, mo_occ_b]
         # self.mo_energy => [mo_energy_a, mo_energy_b]
         self.nelec = None
-        self.init_guess_breaksym = None
 
     @property
     def nelec(self):
@@ -1066,9 +1067,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         from pyscf import dft
         return self._transfer_attrs_(dft.UKS(self.mol, xc=xc))
 
-    def to_gpu(self):
-        from gpu4pyscf.scf import UHF
-        return lib.to_gpu(hf.SCF.reset(self.view(UHF)))
+    to_gpu = lib.to_gpu
 
 def _hf1e_scf(mf, *args):
     logger.info(mf, '\n')

--- a/pyscf/scf/uhf_symm.py
+++ b/pyscf/scf/uhf_symm.py
@@ -565,8 +565,7 @@ class SymAdaptedUHF(uhf.UHF):
 
     canonicalize = canonicalize
 
-    def to_gpu(self):
-        raise NotImplementedError
+    to_gpu = lib.to_gpu
 
 UHF = SymAdaptedUHF
 

--- a/pyscf/sgx/sgx.py
+++ b/pyscf/sgx/sgx.py
@@ -214,6 +214,9 @@ class _SGXHF:
         self._last_vj = 0
         self._last_vk = 0
 
+    def to_gpu(self):
+        raise NotImplementedError
+
     def method_not_implemented(self, *args, **kwargs):
         raise NotImplementedError
     nuc_grad_method = Gradients = method_not_implemented

--- a/pyscf/sgx/sgx.py
+++ b/pyscf/sgx/sgx.py
@@ -374,3 +374,5 @@ class SGX(lib.StreamObject):
         else:
             vj, vk = sgx_jk.get_jk(self, dm, hermi, with_j, with_k, direct_scf_tol)
         return vj, vk
+
+    to_gpu = lib.to_gpu

--- a/pyscf/solvent/_attach_solvent.py
+++ b/pyscf/solvent/_attach_solvent.py
@@ -147,6 +147,11 @@ class SCFWithSolvent(_Solvation):
                                equilibrium_solvation=not self.with_solvent.frozen):
             return super().stability(*args, **kwargs)
 
+    def to_gpu(self):
+        obj = self.undo_solvent().to_gpu()
+        obj = _for_scf(obj, self.with_solvent)
+        return lib.to_gpu(self, obj)
+
 def _for_casscf(mc, solvent_obj, dm=None):
     '''Add solvent model to CASSCF method.
 
@@ -283,6 +288,11 @@ MCSCF_DM * V_solvent[d/dX MCSCF_DM] + V_solvent[MCSCF_DM] * d/dX MCSCF_DM
         return self.with_solvent.nuc_grad_method(grad_method)
 
     Gradients = nuc_grad_method
+
+    def to_gpu(self):
+        obj = self.undo_solvent().to_gpu()
+        obj = _for_casscf(obj, self.with_solvent)
+        return lib.to_gpu(self, obj)
 
 
 def _for_casci(mc, solvent_obj, dm=None):
@@ -421,6 +431,11 @@ MCSCF_DM * V_solvent[d/dX MCSCF_DM] + V_solvent[MCSCF_DM] * d/dX MCSCF_DM
 
     Gradients = nuc_grad_method
 
+    def to_gpu(self):
+        obj = self.undo_solvent().to_gpu()
+        obj = _for_casci(obj, self.with_solvent)
+        return lib.to_gpu(self, obj)
+
 
 def _for_post_scf(method, solvent_obj, dm=None):
     '''A wrapper of solvent model for post-SCF methods (CC, CI, MP etc.)
@@ -552,6 +567,11 @@ DM * V_solvent[d/dX DM] + V_solvent[DM] * d/dX DM
 
     Gradients = nuc_grad_method
 
+    def to_gpu(self):
+        obj = self.undo_solvent().to_gpu()
+        obj = _for_post_scf(obj, self.with_solvent)
+        return lib.to_gpu(self, obj)
+
 
 def _for_tdscf(method, solvent_obj, dm=None):
     '''Add solvent model in TDDFT calculations.
@@ -583,7 +603,7 @@ def _for_tdscf(method, solvent_obj, dm=None):
 class TDSCFWithSolvent(_Solvation):
     _keys = {'with_solvent'}
 
-    def __init__(self, method, scf_with_solvent):
+    def __init__(self, method, scf_with_solvent=None):
         self.__dict__.update(method.__dict__)
         self._scf = scf_with_solvent
         self.with_solvent = self._scf.with_solvent
@@ -630,3 +650,8 @@ class TDSCFWithSolvent(_Solvation):
     def nuc_grad_method(self):
         grad_method = super().nuc_grad_method()
         return self.with_solvent.nuc_grad_method(grad_method)
+
+    def to_gpu(self):
+        obj = self.undo_solvent().to_gpu()
+        obj = _for_tdscf(obj, self.with_solvent)
+        return lib.to_gpu(self, obj)

--- a/pyscf/solvent/ddcosmo.py
+++ b/pyscf/solvent/ddcosmo.py
@@ -869,6 +869,8 @@ class ddCOSMO(lib.StreamObject):
         else:
             return ddcosmo_grad.make_grad_object(grad_method)
 
+    to_gpu = lib.to_gpu
+
 DDCOSMO = ddCOSMO
 
 class Grids(gen_grid.Grids):

--- a/pyscf/soscf/newton_ah.py
+++ b/pyscf/soscf/newton_ah.py
@@ -800,6 +800,9 @@ class _CIAH_SOSCF:
                       _effective_svd(u[idx][:,idx], 1e-5))
         return mo
 
+    def to_gpu(self):
+        return self.undo_soscf().to_gpu()
+
 class _SecondOrderROHF(_CIAH_SOSCF):
     gen_g_hop = gen_g_hop_rohf
 

--- a/pyscf/tdscf/rhf.py
+++ b/pyscf/tdscf/rhf.py
@@ -764,6 +764,9 @@ class TDBase(lib.StreamObject):
         logger.note(self, 'Excited State energies (eV)\n%s', self.e * nist.HARTREE2EV)
         return self
 
+    def to_gpu(self):
+        raise NotImplementedError
+
 class TDA(TDBase):
     '''Tamm-Dancoff approximation
 
@@ -865,6 +868,8 @@ class TDA(TDBase):
         log.timer('TDA', *cpu0)
         self._finalize()
         return self.e, self.xy
+
+    to_gpu = lib.to_gpu
 
 CIS = TDA
 
@@ -1043,6 +1048,8 @@ class TDHF(TDA):
     def nuc_grad_method(self):
         from pyscf.grad import tdrhf
         return tdrhf.Gradients(self)
+
+    to_gpu = lib.to_gpu
 
 RPA = TDRHF = TDHF
 

--- a/pyscf/tdscf/uhf.py
+++ b/pyscf/tdscf/uhf.py
@@ -690,6 +690,8 @@ class TDA(TDBase):
         self._finalize()
         return self.e, self.xy
 
+    to_gpu = lib.to_gpu
+
 CIS = TDA
 
 
@@ -857,6 +859,8 @@ class TDHF(TDA):
         log.timer('TDDFT', *cpu0)
         self._finalize()
         return self.e, self.xy
+
+    to_gpu = lib.to_gpu
 
 RPA = TDUHF = TDHF
 

--- a/pyscf/x2c/sfx2c1e.py
+++ b/pyscf/x2c/sfx2c1e.py
@@ -154,6 +154,10 @@ class SFX2C1E_SCF(x2c._X2C_SCF):
             dst = dst.sfx2c()
         return hf.SCF._transfer_attrs_(self, dst)
 
+    def to_gpu(self):
+        obj = self.undo_x2c().to_gpu().sfx2c1e()
+        return lib.to_gpu(self, obj)
+
 
 class SpinFreeX2CHelper(x2c.X2CHelperBase):
     '''1-component X2c (spin-free part only)

--- a/pyscf/x2c/x2c.py
+++ b/pyscf/x2c/x2c.py
@@ -659,6 +659,8 @@ class UHF(SCF):
         from pyscf.x2c import dft
         return self._transfer_attrs_(dft.UKS(self.mol, xc=xc))
 
+    to_gpu = lib.to_gpu
+
 X2C_UHF = UHF
 
 class RHF(SCF):
@@ -679,6 +681,8 @@ class RHF(SCF):
         '''
         from pyscf.x2c import dft
         return self._transfer_attrs_(dft.RKS(self.mol, xc=xc))
+
+    to_gpu = lib.to_gpu
 
 X2C_RHF = RHF
 

--- a/pyscf/x2c/x2c.py
+++ b/pyscf/x2c/x2c.py
@@ -803,6 +803,10 @@ class X2C1E_GSCF(_X2C_SCF):
     def to_ks(self, xc='HF'):
         raise NotImplementedError
 
+    def to_gpu(self):
+        obj = self.undo_x2c().to_gpu().x2c1e()
+        return lib.to_gpu(self, obj)
+
 
 def _uncontract_mol(mol, xuncontract=None, exp_drop=0.2):
     '''mol._basis + uncontracted steep functions'''


### PR DESCRIPTION
The to_gpu method is changed to a more general implementation, and it is added to many modules. The new general function assumes the gpu4pyscf package has the same layout as the pyscf package.