### PR TITLE
bug fix for RCCSD(T) with complex orbitals

### DIFF
--- a/pyscf/cc/ccsd_t.py
+++ b/pyscf/cc/ccsd_t.py
@@ -176,7 +176,7 @@ def _sort_eri(mycc, eris, nocc, nvir, vvop, log):
 
 def _sort_t2_vooo_(mycc, orbsym, t1, t2, eris):
     assert (t2.flags.c_contiguous)
-    vooo = numpy.asarray(eris.ovoo).transpose(1,0,3,2).conj().copy()
+    vooo = numpy.asarray(eris.ovoo).transpose(1,0,2,3).conj().copy()
     nocc, nvir = t1.shape
     if mycc.mol.symmetry:
         orbsym = numpy.asarray(orbsym, dtype=numpy.int32)

--- a/pyscf/cc/ccsd_t_slow.py
+++ b/pyscf/cc/ccsd_t_slow.py
@@ -45,7 +45,7 @@ def kernel(mycc, eris, t1=None, t2=None, verbose=logger.NOTE):
     eijk = lib.direct_sum('i,j,k->ijk', e_occ, e_occ, e_occ)
 
     eris_vvov = eris.get_ovvv().conj().transpose(1,3,0,2)
-    eris_vooo = numpy.asarray(eris.ovoo).conj().transpose(1,0,3,2)
+    eris_vooo = numpy.asarray(eris.ovoo).conj().transpose(1,0,2,3)
     eris_vvoo = numpy.asarray(eris.ovov).conj().transpose(1,3,0,2)
     fvo = eris.fock[nocc:,:nocc]
     def get_w(a, b, c):

--- a/pyscf/cc/qcisd_t_slow.py
+++ b/pyscf/cc/qcisd_t_slow.py
@@ -47,7 +47,7 @@ def kernel(mycc, eris, t1=None, t2=None, verbose=logger.NOTE):
     eijk = lib.direct_sum('i,j,k->ijk', e_occ, e_occ, e_occ)
 
     eris_vvov = eris.get_ovvv().conj().transpose(1,3,0,2)
-    eris_vooo = numpy.asarray(eris.ovoo).conj().transpose(1,0,3,2)
+    eris_vooo = numpy.asarray(eris.ovoo).conj().transpose(1,0,2,3)
     eris_vvoo = numpy.asarray(eris.ovov).conj().transpose(1,3,0,2)
     fvo = eris.fock[nocc:,:nocc]
     def get_w(a, b, c):

--- a/pyscf/pbc/cc/test/test_rccsd_t_shift.py
+++ b/pyscf/pbc/cc/test/test_rccsd_t_shift.py
@@ -51,14 +51,14 @@ class KnownValues(unittest.TestCase):
         pseudo = 'gth-hf-rev'
         a = np.eye(3) * 30
         cell = gto.M(atom=atom, basis=basis, a=a, pseudo=pseudo)
-        
+
         eccsd_gamma, et_gamma = run_cell(cell, [0,0,0])
         self.assertAlmostEqual(eccsd_gamma, -0.2082317212, 8)
         self.assertAlmostEqual(et_gamma   , -0.0033716894, 8)
 
         eccsd_shifted, et_shifted = run_cell(cell, [0.1,0.1,0.1])
         self.assertAlmostEqual(eccsd_gamma, eccsd_shifted, 8)
-        self.assertAlmostEqual(et_gamma, et_shifted, 8)
+        self.assertAlmostEqual(et_gamma   , et_shifted   , 8)
 
 if __name__ == '__main__':
     print("RCCSD(T) with shift k-point test")

--- a/pyscf/pbc/cc/test/test_rccsd_t_shift.py
+++ b/pyscf/pbc/cc/test/test_rccsd_t_shift.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# Copyright 2014-2018 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors: Hong-Zhou Ye <hzyechem@gmail.com>
+#
+
+import unittest
+import numpy as np
+
+from pyscf.pbc import gto, scf, cc
+from pyscf.cc.ccsd_t import kernel as CCSD_T
+
+
+def run_cell(cell, scaled_center):
+    kpt = cell.make_kpts([1,1,1], scaled_center=scaled_center)[0]
+
+    mf = scf.RHF(cell, kpt=kpt).rs_density_fit()
+    mf.with_df.omega = 0.1
+    mf.kernel()
+
+    mcc = cc.RCCSD(mf)
+    eris = mcc.ao2mo()
+    mcc.kernel(eris=eris)
+    eccsd = mcc.e_corr
+
+    et = CCSD_T(mcc, eris)
+
+    return eccsd, et
+
+
+class KnownValues(unittest.TestCase):
+    def test_water(self):
+        atom = '''
+        O          0.00000        0.00000        0.11779
+        H          0.00000        0.75545       -0.47116
+        H          0.00000       -0.75545       -0.47116
+        '''
+        basis = 'gth-dzvp'
+        pseudo = 'gth-hf-rev'
+        a = np.eye(3) * 30
+        cell = gto.M(atom=atom, basis=basis, a=a, pseudo=pseudo)
+        
+        eccsd_gamma, et_gamma = run_cell(cell, [0,0,0])
+        self.assertAlmostEqual(eccsd_gamma, -0.2082317212, 8)
+        self.assertAlmostEqual(et_gamma   , -0.0033716894, 8)
+
+        eccsd_shifted, et_shifted = run_cell(cell, [0.1,0.1,0.1])
+        self.assertAlmostEqual(eccsd_gamma, eccsd_shifted, 8)
+        self.assertAlmostEqual(et_gamma, et_shifted, 8)
+
+if __name__ == '__main__':
+    print("RCCSD(T) with shift k-point test")
+    unittest.main()


### PR DESCRIPTION
It is found that complex-orbital RCCSD(T) energy does not reduce correctly to real-orbital RCCSD(T) energy (e.g., in case of a single molecule in a large box with a single shifted k-point). This is traced back to the incorrect order of the `vooo` integrals. The correct contraction is (see eqn 2 of [10.1063/1.460359](https://doi.org/10.1063/1.460359))
```
\sum_{m} (ia|jm) T^{bc}_{mk} = \sum_{m} conj((ai|mj)) T^{bc}_{mk}
```
while PySCF currently does
```
\sum_{m} conj((ai|jm)) T^{bc}_{mk}
```
This PR fixes the said bug and adds a test.

A similar bug in the QCISD(T) code is also fixed. The UCCSD(T) and GCCSD(T) codes don't have this bug.

------
Thanks to @tberkel and @verena-neufeld for helpful discussions.