### PR TITLE
move static configurations from setup.py to pyproject.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
             echo 'pbc_tools_pbc_fft_engine = "NUMPY"' > .pyscf_conf.py && \
             echo "dftd3_DFTD3PATH = './pyscf/lib/deps/lib'" >> .pyscf_conf.py && \
             echo "scf_hf_SCF_mute_chkfile = True" >> .pyscf_conf.py && \
-            ulimit -s 20000 && /opt/python/${{ matrix.pyver }}/bin/pytest pyscf/ --ignore=pyscf/adc --ignore=pyscf/pbc/df --ignore=pyscf/pbc/cc -s -c setup.cfg pyscf'
+            ulimit -s 20000 && /opt/python/${{ matrix.pyver }}/bin/pytest pyscf/ --ignore=pyscf/adc --ignore=pyscf/pbc/df --ignore=pyscf/pbc/cc -s -c pytest.ini pyscf'
 
   macos-build:
     runs-on: macos-latest

--- a/.github/workflows/ci_linux/python_deps.sh
+++ b/.github/workflows/ci_linux/python_deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 python -m pip install --upgrade pip
-pip install "numpy!=1.16,!=1.17" "scipy!=1.5" h5py pytest pytest-cov pytest-timer
+pip install "numpy!=1.16,!=1.17" "scipy!=1.5" h5py pytest pytest-cov pytest-timer build
 pip install pyberny
 
 version=$(python -c 'import sys; version=sys.version_info[:2]; print("{0}.{1}".format(*version))')

--- a/.github/workflows/ci_linux/python_deps.sh
+++ b/.github/workflows/ci_linux/python_deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 python -m pip install --upgrade pip
-pip install "numpy!=1.16,!=1.17" "scipy!=1.5" h5py pytest pytest-cov pytest-timer build
+pip install "numpy!=1.16,!=1.17" "scipy!=1.5" h5py pytest pytest-cov pytest-timer
 pip install pyberny
 
 version=$(python -c 'import sys; version=sys.version_info[:2]; print("{0}.{1}".format(*version))')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build wheels
         run: |
-            docker run --rm -v ${{ github.workspace }}:/src/pyscf pyscf/pyscf-pypa-env:latest \
+            docker run --rm -v ${{ github.workspace }}:/src/pyscf \
+            -e CMAKE_BUILD_PARALLEL_LEVEL=4 \
+            pyscf/pyscf-pypa-env:latest \
             bash /src/pyscf/docker/pypa-env/build-wheels.sh
       - name: List available wheels
         run: |
@@ -57,6 +59,7 @@ jobs:
             export src=${GITHUB_WORKSPACE:-/src/pyscf} && \
             export dst=${GITHUB_WORKSPACE:-/src/pyscf}/linux-wheels && \
             export CMAKE_CONFIGURE_ARGS="-DWITH_F12=OFF" && \
+            export CMAKE_BUILD_PARALLEL_LEVEL=4 && \
             mkdir -p /root/wheelhouse $src/linux-wheels && \
             sed -i "/            if basename(fn) not in needed_libs:/s/basename.*libs/1/" /opt/_internal/pipx/venvs/auditwheel/lib/python*/site-packages/auditwheel/wheel_abi.py && \
             /opt/python/${{ matrix.pyver }}/bin/pip wheel -v --no-deps --no-clean -w /root/wheelhouse $src && \
@@ -82,6 +85,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build sdist
         run: |
+          pip install build
           python3 -m build -s
       - name: List available sdist
         run: |
@@ -108,6 +112,7 @@ jobs:
           CIBW_BUILD: cp311-macosx_x86_64
           CIBW_BUILD_VERBOSITY: "1"
           CMAKE_CONFIGURE_ARGS: "-DWITH_F12=OFF"
+          CMAKE_BUILD_PARALLEL_LEVEL: "4"
         with:
           output-dir: mac-wheels
       - name: List available wheels
@@ -133,6 +138,7 @@ jobs:
           # Cross-platform build for arm64 wheels on x86 platform
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
           CMAKE_CONFIGURE_ARGS: "-DWITH_F12=OFF"
+          CMAKE_BUILD_PARALLEL_LEVEL: "4"
           CMAKE_OSX_ARCHITECTURES: arm64
         with:
           output-dir: mac-wheels
@@ -161,6 +167,7 @@ jobs:
       - run: which python
       - name: Publish to conda
         run: |
+          export CMAKE_BUILD_PARALLEL_LEVEL=4
           export ANACONDA_API_TOKEN=${{ secrets.ANACONDA_TOKEN }}
           conda install -y anaconda-client conda-build
           conda config --set anaconda_upload yes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build sdist
         run: |
-          python3 setup.py sdist
+          python3 -m build -s
       - name: List available sdist
         run: |
           ls ${{ github.workspace }}/dist

--- a/.github/workflows/run_tests.sh
+++ b/.github/workflows/run_tests.sh
@@ -10,8 +10,8 @@ echo "scf_hf_SCF_mute_chkfile = True" >> .pyscf_conf.py
 version=$(python -c 'import sys; print("{0}.{1}".format(*sys.version_info[:2]))')
 # pytest-cov on Python 3.12 consumes huge memory
 if [ "$RUNNER_OS" == "Linux" ] && [ $version != "3.12" ]; then
-  pytest pyscf/ -s -c setup.cfg \
+  pytest pyscf/ -s -c pytest.ini \
     --cov-report xml --cov-report term --cov-config .coveragerc --cov pyscf
 else
-  pytest pyscf/ -s -c setup.cfg pyscf
+  pytest pyscf/ -s -c pytest.ini pyscf
 fi

--- a/NOTICE
+++ b/NOTICE
@@ -106,6 +106,7 @@ Jiachen Li
 Felipe S. S. Schneider
 Aniruddha Seal
 Peter Reinholdt
+Christopher Hillenbrand
 
 
 ---

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -17,4 +17,4 @@ export CMAKE_CONFIGURE_ARGS="-DWITH_F12=OFF -DBLA_VENDOR=Intel10_64lp_seq"
 
 # env PYTHON not defined in certain conda-build version
 # $PYTHON -m pip install . -vv
-pip install -v --prefix=$PREFIX .
+MAKEFLAGS="-j4" pip install -v --prefix=$PREFIX .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,68 @@
+[build-system]
+requires = ["setuptools >= 61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+
+[project]
+name = "pyscf"
+dynamic = ["version"]
+description = "PySCF: Python-based Simulations of Chemistry Framework"
+readme = "README.md"
+classifiers = [
+  'Development Status :: 5 - Production/Stable',
+  'Intended Audience :: Science/Research',
+  'Intended Audience :: Developers',
+  'License :: OSI Approved :: Apache Software License',
+  'Programming Language :: C',
+  'Programming Language :: Python',
+  'Programming Language :: Python :: 3.7',
+  'Programming Language :: Python :: 3.8',
+  'Programming Language :: Python :: 3.9',
+  'Programming Language :: Python :: 3.10',
+  'Programming Language :: Python :: 3.11',
+  'Programming Language :: Python :: 3.12',
+  'Topic :: Software Development',
+  'Topic :: Scientific/Engineering',
+  'Operating System :: POSIX',
+  'Operating System :: Unix',
+  'Operating System :: MacOS',
+]
+
+maintainers = [{ name = "Qiming Sun", email = "osirpt.sun@gmail.com" }]
+
+authors = [{ name = "Qiming Sun", email = "osirpt.sun@gmail.com" }]
+
+license = { text = "Apache-2.0" }
+
+dependencies = [
+  'numpy>=1.13,!=1.16,!=1.17',
+  'scipy!=1.5.0,!=1.5.1',
+  'h5py>=2.7',
+  'setuptools',
+]
+
+[project.urls]
+Homepage = "http://www.pyscf.org"
+Repository = "https://github.com/pyscf/pyscf"
+Documentation = "http://www.pyscf.org"
+
+[project.optional-dependencies]
+
+geomopt = ["pyberny>=0.6.2", "geometric>=0.9.7.2", "pyscf-qsdopt"]
+doci = ["pyscf-doci"]
+properties = ["pyscf-properties"]
+semiempirical = ['pyscf-semiempirical']
+cppe = ["cppe"]
+pyqmc = ["pyqmc"]
+mcfun = ["mcfun>=0.2.1"]
+bse = ["basis-set-exchange"]
+
+all = ["pyscf[geomopt,doci,properties,semiempirical,cppe,pyqmc,mcfun,bse]"]
+
+# extras which should not be installed by "all" components
+cornell_shci = ["pyscf-cornell-shci"]
+nao = ["pyscf-nao"]
+fciqmcscf = ["pyscf-fciqmc"]
+tblis = ["pyscf-tblis"]
+icmpspt = ["pyscf-icmpspt"] # broken
+shciscf = ["pyscf-shciscf"] # broken

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,4 @@
-[egg_info]
-tag_build = 
-tag_date = 0
-tag_svn_revision = 0
-
-[tool:pytest]
+[pytest]
 addopts = --import-mode=importlib
   -k "not _high_cost and not _skip"
   --ignore=examples
@@ -13,3 +8,4 @@ addopts = --import-mode=importlib
   --ignore-glob="*test_bz*"
   --ignore-glob="*pbc/cc/test/*test_h_*.py"
   --ignore-glob="*test_ks_noimport*.py"
+

--- a/setup.py
+++ b/setup.py
@@ -18,37 +18,6 @@ import sys
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_py import build_py
 
-CLASSIFIERS = [
-'Development Status :: 5 - Production/Stable',
-'Intended Audience :: Science/Research',
-'Intended Audience :: Developers',
-'License :: OSI Approved :: Apache Software License',
-'Programming Language :: C',
-'Programming Language :: Python',
-'Programming Language :: Python :: 3.7',
-'Programming Language :: Python :: 3.8',
-'Programming Language :: Python :: 3.9',
-'Programming Language :: Python :: 3.10',
-'Programming Language :: Python :: 3.11',
-'Programming Language :: Python :: 3.12',
-'Topic :: Software Development',
-'Topic :: Scientific/Engineering',
-'Operating System :: POSIX',
-'Operating System :: Unix',
-'Operating System :: MacOS',
-]
-
-NAME             = 'pyscf'
-MAINTAINER       = 'Qiming Sun'
-MAINTAINER_EMAIL = 'osirpt.sun@gmail.com'
-DESCRIPTION      = 'PySCF: Python-based Simulations of Chemistry Framework'
-#LONG_DESCRIPTION = ''
-URL              = 'http://www.pyscf.org'
-DOWNLOAD_URL     = 'http://github.com/pyscf/pyscf'
-LICENSE          = 'Apache License 2.0'
-AUTHOR           = 'Qiming Sun'
-AUTHOR_EMAIL     = 'osirpt.sun@gmail.com'
-PLATFORMS        = ['Linux', 'Mac OS-X', 'Unix']
 def get_version():
     topdir = os.path.abspath(os.path.join(__file__, '..'))
     with open(os.path.join(topdir, 'pyscf', '__init__.py'), 'r') as f:
@@ -59,25 +28,6 @@ def get_version():
     raise ValueError("Version string not found")
 VERSION = get_version()
 
-EXTRAS = {
-    'geomopt': ['pyberny>=0.6.2', 'geometric>=0.9.7.2', 'pyscf-qsdopt'],
-    #'dmrgscf': ['pyscf-dmrgscf'],
-    'doci': ['pyscf-doci'],
-    'icmpspt': ['pyscf-icmpspt'],
-    'properties': ['pyscf-properties'],
-    'semiempirical': ['pyscf-semiempirical'],
-    'shciscf': ['pyscf-shciscf'],
-    'cppe': ['cppe'],
-    'pyqmc': ['pyqmc'],
-    'mcfun': ['mcfun>=0.2.1'],
-    'bse': ['basis-set-exchange'],
-}
-EXTRAS['all'] = [p for extras in EXTRAS.values() for p in extras]
-# extras which should not be installed by "all" components
-EXTRAS['cornell_shci'] = ['pyscf-cornell-shci']
-EXTRAS['nao'] = ['pyscf-nao']
-EXTRAS['fciqmcscf'] = ['pyscf-fciqmc']
-EXTRAS['tblis'] = ['pyscf-tblis']
 
 def get_platform():
     from distutils.util import get_platform
@@ -117,9 +67,11 @@ class CMakeBuildPy(build_py):
         self.spawn(cmd)
 
         self.announce('Building binaries', level=3)
-        # Do not use high level parallel compilation. OOM may be triggered
-        # when compiling certain functionals in libxc.
-        cmd = ['cmake', '--build', self.build_temp, '-j', '2']
+        # By default do not use high level parallel compilation.
+        # OOM may be triggered when compiling certain functionals in libxc.
+        # Set the shell variable CMAKE_BUILD_PARALLEL_LEVEL=n to enable
+        # parallel compilation.
+        cmd = ['cmake', '--build', self.build_temp]
         build_args = os.getenv('CMAKE_BUILD_ARGS')
         if build_args:
             cmd.extend(build_args.split(' '))
@@ -150,27 +102,11 @@ if sys.platform == 'darwin':
               'https://github.com/scipy/scipy/issues/16151)')
 
 setup(
-    name=NAME,
     version=VERSION,
-    description=DESCRIPTION,
-    long_description_content_type="text/markdown",
-    long_description=DESCRIPTION,
-    url=URL,
-    download_url=DOWNLOAD_URL,
-    license=LICENSE,
-    classifiers=CLASSIFIERS,
-    author=AUTHOR,
-    author_email=AUTHOR_EMAIL,
-    platforms=PLATFORMS,
     #package_dir={'pyscf': 'pyscf'},  # packages are under directory pyscf
     #include *.so *.dat files. They are now placed in MANIFEST.in
     #package_data={'': ['*.so', '*.dylib', '*.dll', '*.dat']},
     include_package_data=True,  # include everything in source control
     packages=find_packages(exclude=['*test*', '*examples*']),
     cmdclass={'build_py': CMakeBuildPy},
-    install_requires=['numpy>=1.13,!=1.16,!=1.17',
-                      _scipy_version,
-                      'h5py>=2.7',
-                      'setuptools'],
-    extras_require=EXTRAS,
 )


### PR DESCRIPTION
Changes in this pull request:

- Simple package metadata is moved from setup.py to pyproject.toml where possible
- The number of parallel jobs for `cmake --build` is not hardcoded anymore in setup.py and can be set with the environment variable CMAKE_BUILD_PARALLEL_LEVEL, or MAKEFLAGS when using the makefiles generator, if a parallel build is desired. Before, changing this required editing setup.py. The conda build script is also set to -j4 so that it does not take longer.
    - Github Action runners have 16 GB RAM, and no libxc functional currently uses more than 1.6 GB RAM to compile, so there is little risk of OOM errors.
- Because `python setup.py sdist` is [not supported anymore](https://setuptools.pypa.io/en/latest/deprecated/commands.html), and in fact sometimes gives inconsistent results, it is replaced with `python -m build` as recommended by the setuptools maintainers.

Incorporates suggestions from #2132