### PR TITLE
Fix dipole moment in sfx2c1e

### DIFF
--- a/pyscf/x2c/sfx2c1e.py
+++ b/pyscf/x2c/sfx2c1e.py
@@ -128,8 +128,9 @@ class SFX2C1E_SCF(x2c._X2C_SCF):
             if picture_change:
                 xmol = self.with_x2c.get_xmol()[0]
                 nao = xmol.nao
-                prp = xmol.intor_symmetric('int1e_sprsp').reshape(3,4,nao,nao)[:,0]
-                ao_dip = self.with_x2c.picture_change(('int1e_r', prp))
+                prp = xmol.intor_symmetric('int1e_sprsp').reshape(3,4,nao,nao)[:,3]
+                c1 = 0.5/lib.param.LIGHT_SPEED
+                ao_dip = self.with_x2c.picture_change(('int1e_r', prp*c1**2))
             else:
                 ao_dip = mol.intor_symmetric('int1e_r')
 


### PR DESCRIPTION
The previous dipole moment was wrong due to two reasons.
1. When picking the scalar contribution of 'int1e_sprsp', the wrong component was chosen. It was confirmed by transforming 'int1e_sprsp_spinor' integral and unpack the scalar, sigma_x, sigma_y and sigma_z contribution.
2. The 1/4c^2 factor was not multiplied when doing picture change transformation, the _picture_change function multiplies 1/4c^2 only for those integrals with only symbols passed to it.
Note that the current implementation still is just an expectation value of correct dipole operator with the x2c density. The response of the X and R matrix is not included. I will add that in the future.