### PR TITLE
debug and simplify to_gpu

### DIFF
--- a/pyscf/cc/ccsd.py
+++ b/pyscf/cc/ccsd.py
@@ -1240,6 +1240,15 @@ class CCSDBase(lib.StreamObject):
     def nuc_grad_method(self):
         raise NotImplementedError
 
+    # to_gpu can be reused only when __init__ still takes mf
+    def to_gpu(self):
+        mf = self.base.to_gpu()
+        from importlib import import_module
+        mod = import_module(self.__module__.replace('pyscf', 'gpu4pyscf'))
+        cls = getattr(mod, self.__class__.__name__)
+        obj = cls(mf)
+        return obj
+
 class CCSD(CCSDBase):
     __doc__ = CCSDBase.__doc__
 
@@ -1364,8 +1373,6 @@ class CCSD(CCSDBase):
     def get_d2_diagnostic(self, t2=None):
         if t2 is None: t2 = self.t2
         return get_d2_diagnostic(t2)
-
-    to_gpu = lib.to_gpu
 
 CC = RCCSD = CCSD
 

--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -523,6 +523,4 @@ class Gradients(rhf_grad.Gradients):
         else:
             return 0
 
-    to_gpu = lib.to_gpu
-
 Grad = Gradients

--- a/pyscf/df/grad/rks.py
+++ b/pyscf/df/grad/rks.py
@@ -123,6 +123,4 @@ class Gradients(rks_grad.Gradients):
             e1 += envs['vhf'].aux[atom_id]
         return e1
 
-    to_gpu = lib.to_gpu
-
 Grad = Gradients

--- a/pyscf/df/grad/uhf.py
+++ b/pyscf/df/grad/uhf.py
@@ -60,6 +60,4 @@ class Gradients(uhf_grad.Gradients):
         else:
             return 0
 
-    to_gpu = lib.to_gpu
-
 Grad = Gradients

--- a/pyscf/df/grad/uks.py
+++ b/pyscf/df/grad/uks.py
@@ -124,6 +124,4 @@ class Gradients(uks_grad.Gradients):
             e1 += envs['vhf'].aux[atom_id]
         return e1
 
-    to_gpu = lib.to_gpu
-
 Grad = Gradients

--- a/pyscf/df/hessian/rhf.py
+++ b/pyscf/df/hessian/rhf.py
@@ -480,7 +480,6 @@ class Hessian(rhf_hess.Hessian):
 
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
-    #to_gpu = lib.to_gpu
 
 #TODO: Insert into DF class
 

--- a/pyscf/df/hessian/rhf.py
+++ b/pyscf/df/hessian/rhf.py
@@ -480,7 +480,7 @@ class Hessian(rhf_hess.Hessian):
 
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
-    to_gpu = lib.to_gpu
+    #to_gpu = lib.to_gpu
 
 #TODO: Insert into DF class
 

--- a/pyscf/df/hessian/rks.py
+++ b/pyscf/df/hessian/rks.py
@@ -126,7 +126,6 @@ class Hessian(rks_hess.Hessian):
 
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
-    #to_gpu = lib.to_gpu
 
 
 if __name__ == '__main__':

--- a/pyscf/df/hessian/rks.py
+++ b/pyscf/df/hessian/rks.py
@@ -126,7 +126,7 @@ class Hessian(rks_hess.Hessian):
 
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
-    to_gpu = lib.to_gpu
+    #to_gpu = lib.to_gpu
 
 
 if __name__ == '__main__':

--- a/pyscf/df/hessian/uhf.py
+++ b/pyscf/df/hessian/uhf.py
@@ -531,7 +531,7 @@ class Hessian(uhf_hess.Hessian):
 
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
-    to_gpu = lib.to_gpu
+    #to_gpu = lib.to_gpu
 
 #TODO: Insert into DF class
 

--- a/pyscf/df/hessian/uhf.py
+++ b/pyscf/df/hessian/uhf.py
@@ -531,7 +531,6 @@ class Hessian(uhf_hess.Hessian):
 
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
-    #to_gpu = lib.to_gpu
 
 #TODO: Insert into DF class
 

--- a/pyscf/df/hessian/uks.py
+++ b/pyscf/df/hessian/uks.py
@@ -139,7 +139,7 @@ class Hessian(uks_hess.Hessian):
 
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
-    to_gpu = lib.to_gpu
+    #to_gpu = lib.to_gpu
 
 
 if __name__ == '__main__':

--- a/pyscf/df/hessian/uks.py
+++ b/pyscf/df/hessian/uks.py
@@ -139,7 +139,6 @@ class Hessian(uks_hess.Hessian):
 
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
-    #to_gpu = lib.to_gpu
 
 
 if __name__ == '__main__':

--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -2865,12 +2865,11 @@ class NumInt(lib.StreamObject, LibXCMixin):
                                      with_lapl)
         return make_rho, ndms, nao
 
-    to_gpu = lib.to_gpu
     def to_gpu(self):
         try:
             from gpu4pyscf.dft import numint
             return numint.NumInt()
-        except:
+        except ImportError:
             raise ImportError('Cannot find GPU4PySCF')
 _NumInt = NumInt
 

--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -2866,7 +2866,12 @@ class NumInt(lib.StreamObject, LibXCMixin):
         return make_rho, ndms, nao
 
     to_gpu = lib.to_gpu
-
+    def to_gpu(self):
+        try:
+            from gpu4pyscf.dft import numint
+            return numint.NumInt()
+        except:
+            raise ImportError('Cannot find GPU4PySCF')
 _NumInt = NumInt
 
 

--- a/pyscf/grad/rhf.py
+++ b/pyscf/grad/rhf.py
@@ -440,8 +440,14 @@ class GradientsBase(lib.StreamObject):
         to be split into alpha,beta in DF-ROHF subclass'''
         return lib.tag_array (dm, mo_coeff=mo_coeff, mo_occ=mo_occ)
 
+    # to_gpu can be reused only when __init__ still takes mf
     def to_gpu(self):
-        raise NotImplementedError
+        mf = self.base.to_gpu()
+        from importlib import import_module
+        mod = import_module(self.__module__.replace('pyscf', 'gpu4pyscf'))
+        cls = getattr(mod, self.__class__.__name__)
+        obj = cls(mf)
+        return obj
 
 # export the symbol GradientsMixin for backward compatibility.
 # GradientsMixin should be dropped in the future.
@@ -462,8 +468,6 @@ class Gradients(GradientsBase):
         return make_rdm1e(mo_energy, mo_coeff, mo_occ)
 
     grad_elec = grad_elec
-
-    to_gpu = lib.to_gpu
 
 Grad = Gradients
 

--- a/pyscf/grad/rks.py
+++ b/pyscf/grad/rks.py
@@ -622,8 +622,6 @@ class Gradients(rhf_grad.Gradients):
         else:
             return 0
 
-    to_gpu = lib.to_gpu
-
 Grad = Gradients
 
 from pyscf import dft

--- a/pyscf/grad/uhf.py
+++ b/pyscf/grad/uhf.py
@@ -106,8 +106,6 @@ class Gradients(rhf_grad.GradientsBase):
 
     grad_elec = grad_elec
 
-    to_gpu = lib.to_gpu
-
 Grad = Gradients
 
 from pyscf import scf

--- a/pyscf/grad/uks.py
+++ b/pyscf/grad/uks.py
@@ -275,8 +275,6 @@ class Gradients(uhf_grad.Gradients):
         else:
             return 0
 
-    to_gpu = lib.to_gpu
-
 Grad = Gradients
 
 from pyscf import dft

--- a/pyscf/hessian/rhf.py
+++ b/pyscf/hessian/rhf.py
@@ -599,16 +599,20 @@ class HessianBase(lib.StreamObject):
 
     gen_hop = gen_hop
 
+    # to_gpu can be reused only when __init__ still takes mf
     def to_gpu(self):
-        raise NotImplementedError
-
+        mf = self.base.to_gpu()
+        from importlib import import_module
+        mod = import_module(self.__module__.replace('pyscf', 'gpu4pyscf'))
+        cls = getattr(mod, self.__class__.__name__)
+        obj = cls(mf)
+        return obj
 
 class Hessian(HessianBase):
 
     partial_hess_elec = partial_hess_elec
     hess_elec = hess_elec
     make_h1 = make_h1
-    to_gpu = lib.to_gpu
 
 # Inject to RHF class
 from pyscf import scf

--- a/pyscf/hessian/rks.py
+++ b/pyscf/hessian/rks.py
@@ -590,7 +590,6 @@ class Hessian(rhf_hess.HessianBase):
     partial_hess_elec = partial_hess_elec
     hess_elec = rhf_hess.hess_elec
     make_h1 = make_h1
-    to_gpu = lib.to_gpu
 
 from pyscf import dft
 dft.rks.RKS.Hessian = dft.rks_symm.RKS.Hessian = lib.class_as_method(Hessian)

--- a/pyscf/hessian/uhf.py
+++ b/pyscf/hessian/uhf.py
@@ -454,8 +454,6 @@ class Hessian(rhf_hess.HessianBase):
                          fx, atmlst, max_memory, verbose,
                          max_cycle=self.max_cycle, level_shift=self.level_shift)
 
-    to_gpu = lib.to_gpu
-
 from pyscf import scf
 scf.uhf.UHF.Hessian = lib.class_as_method(Hessian)
 

--- a/pyscf/hessian/uks.py
+++ b/pyscf/hessian/uks.py
@@ -667,7 +667,6 @@ class Hessian(rhf_hess.HessianBase):
     solve_mo1 = uhf_hess.Hessian.solve_mo1
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
-    to_gpu = lib.to_gpu
 
 from pyscf import dft
 dft.uks.UKS.Hessian = dft.uks_symm.UKS.Hessian = lib.class_as_method(Hessian)

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -1379,6 +1379,7 @@ class _OmniObject:
 # Then class can be instantiated easily like cls(omniobj) in the following
 # to_gpu function.
 omniobj = _OmniObject()
+omniobj._built = True
 omniobj.mol = omniobj
 omniobj._scf = omniobj
 omniobj.base = omniobj
@@ -1408,7 +1409,7 @@ def to_gpu(method, out=None):
         if isinstance(method, (SinglePointScanner, GradScanner)):
             method = method.undo_scanner()
 
-        import import_module
+        from importlib import import_module
         mod = import_module(method.__module__.replace('pyscf', 'gpu4pyscf'))
         cls = getattr(mod, method.__class__.__name__)
         # A temporary GPU instance. This ensures to initialize private
@@ -1430,3 +1431,4 @@ def to_gpu(method, out=None):
         setattr(out, key, val)
     out.reset()
     return out
+

--- a/pyscf/mp/dfmp2.py
+++ b/pyscf/mp/dfmp2.py
@@ -140,8 +140,6 @@ class DFMP2(mp2.MP2):
     def init_amps(self, mo_energy=None, mo_coeff=None, eris=None, with_t2=WITH_T2):
         return kernel(self, mo_energy, mo_coeff, eris, with_t2)
 
-    to_gpu = lib.to_gpu
-
 MP2 = DFMP2
 
 from pyscf import scf

--- a/pyscf/mp/mp2.py
+++ b/pyscf/mp/mp2.py
@@ -649,7 +649,14 @@ class MP2(lib.StreamObject):
     def init_amps(self, mo_energy=None, mo_coeff=None, eris=None, with_t2=WITH_T2):
         return kernel(self, mo_energy, mo_coeff, eris, with_t2)
 
-    to_gpu = lib.to_gpu
+    # to_gpu can be reused only when __init__ still takes mf
+    def to_gpu(self):
+        mf = self._scf.to_gpu()
+        from importlib import import_module
+        mod = import_module(self.__module__.replace('pyscf', 'gpu4pyscf'))
+        cls = getattr(mod, self.__class__.__name__)
+        obj = cls(mf)
+        return obj
 
 RMP2 = MP2
 


### PR DESCRIPTION
- add `built` attribute in `_OmniObject`, avoid building `mol` objects
- add `to_gpu` the base class and avoid to redefine `to_gpu` in each class