### PR TITLE
reset enuc in _build_supcell_

### DIFF
--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -676,6 +676,7 @@ def _build_supcell_(supcell, cell, Ls):
     x, y, z = coords.T
     supcell.atom = supcell._atom = list(zip(symbs, zip(x, y, z)))
     supcell.unit = 'B'
+    supcell.enuc = None # reset nuclear energy
 
     # Do not call supcell.build() to initialize supcell since it may normalize
     # the basis contraction coefficients

--- a/pyscf/pbc/tools/test/test_pbc.py
+++ b/pyscf/pbc/tools/test/test_pbc.py
@@ -144,9 +144,13 @@ C  15.16687337 15.16687337 15.16687337
                        mesh = [3]*3,
                        atom ='''He .1 .0 .0''',
                        basis = 'ccpvdz')
-        cl2 = tools.super_cell(cl1, [2,3,4])
+        _ = cl1.enuc
+        ncopy = [2,3,4]
+        ncell = ncopy[0]*ncopy[1]*ncopy[2]
+        cl2 = tools.super_cell(cl1, ncopy)
         self.assertAlmostEqual(lib.fp(cl2.atom_coords()), -18.946080642714836, 9)
         self.assertAlmostEqual(lib.fp(cl2._bas[:,gto.ATOM_OF]), 16.515144238434807, 9)
+        self.assertAlmostEqual(cl1.enuc, cl2.enuc / ncell, 9)
 
     def test_super_cell_with_symm(self):
         cl1 = pbcgto.M(a = 1.4 * numpy.eye(3),


### PR DESCRIPTION
In PR #2078, the nuclear energy in periodic HF was changed from `cell.energy_nuc()` to `cell.enuc`. The latter allows reusing previously calculated nuclear energy saved in `cell._enuc`. This causes a bug when making a supercell from a unit cell where `_enuc` is already set because the supercell inherits `_enuc` from the unit cell. This PR fixes the bug.