### PR TITLE
Bug fix for single k-point JK-build in PBC DF

### DIFF
--- a/pyscf/pbc/df/aft_jk.py
+++ b/pyscf/pbc/df/aft_jk.py
@@ -732,7 +732,7 @@ def get_jk(mydf, dm, hermi=1, kpt=numpy.zeros(3),
                     iLkI *= vkcoulG[p0:p1].reshape(1,nG,1)
                     zdotNC(iLkR.reshape(nao,-1), iLkI.reshape(nao,-1),
                            pLqR.reshape(nao,-1).T, pLqI.reshape(nao,-1).T,
-                           1, vkR[i], vkI[i])
+                           1, vkR[i], vkI[i], 1)
             #t2 = log.timer_debug1('        with_k', *t2)
         pqkR = pqkI = pLqR = pLqI = iLkR = iLkI = None
         #t2 = log.timer_debug1('%d:%d'%(p0,p1), *t2)

--- a/pyscf/pbc/df/df_jk.py
+++ b/pyscf/pbc/df/df_jk.py
@@ -1261,12 +1261,12 @@ def get_jk(mydf, dm, hermi=1, kpt=numpy.zeros(3),
         if with_j:
             #:rho_coeff = numpy.einsum('Lpq,xqp->xL', Lpq, dms)
             #:vj += numpy.dot(rho_coeff, Lpq.reshape(-1,nao**2))
-            rhoR  = numpy.einsum('Lpq,xpq->xL', LpqR, dmsR)
+            rhoR  = numpy.einsum('Lpq,xqp->xL', LpqR, dmsR)
             if not j_real:
                 LpqI = LpqI.reshape(-1,nao,nao)
-                rhoR -= numpy.einsum('Lpq,xpq->xL', LpqI, dmsI)
-                rhoI  = numpy.einsum('Lpq,xpq->xL', LpqR, dmsI)
-                rhoI += numpy.einsum('Lpq,xpq->xL', LpqI, dmsR)
+                rhoR -= numpy.einsum('Lpq,xqp->xL', LpqI, dmsI)
+                rhoI  = numpy.einsum('Lpq,xqp->xL', LpqR, dmsI)
+                rhoI += numpy.einsum('Lpq,xqp->xL', LpqI, dmsR)
             vjR += sign * numpy.einsum('xL,Lpq->xpq', rhoR, LpqR)
             if not j_real:
                 vjR -= sign * numpy.einsum('xL,Lpq->xpq', rhoI, LpqI)

--- a/pyscf/pbc/df/test/test_aft_jk.py
+++ b/pyscf/pbc/df/test/test_aft_jk.py
@@ -119,6 +119,26 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(ej1, 12.233546641482697, 8)
         self.assertAlmostEqual(ek1, 43.946958026023722, 7)
 
+    def test_jk_complex_dm(self):
+        scaled_center = [0.3728,0.5524,0.7672]
+        kpt = cell.make_kpts([1,1,1], scaled_center=scaled_center)[0]
+        mf = scf.RHF(cell, kpt=kpt)
+        dm = mf.init_guess_by_1e()
+
+        mydf = aft.AFTDF(cell, kpts=[kpt])
+        vj1, vk1 = mydf.get_jk(dm, kpts=kpt, exxdiv='ewald')
+        vjs, vks = mydf.get_jk([dm], kpts=[kpt], exxdiv='ewald')
+        vj , vk  = vjs[0], vks[0]
+
+        ej1 = numpy.einsum('ij,ji->', vj1, dm)
+        ek1 = numpy.einsum('ij,ji->', vk1, dm)
+        ej  = numpy.einsum('ij,ji->', vj , dm)
+        ek  = numpy.einsum('ij,ji->', vk , dm)
+
+        # kpts and single kpt AFTDF must match exactly
+        self.assertAlmostEqual(ej1, ej, 10)
+        self.assertAlmostEqual(ek1, ek, 10)
+
     def test_aft_j(self):
         numpy.random.seed(1)
         nao = cell.nao_nr()

--- a/pyscf/pbc/df/test/test_df_jk.py
+++ b/pyscf/pbc/df/test/test_df_jk.py
@@ -81,6 +81,21 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(ej1, 25.8129854469354, 6)
         self.assertAlmostEqual(ek1, 72.6088517709998, 6)
 
+    def test_jk_single_kpt_complex_dm(self):
+        scaled_center = [0.3728,0.5524,0.7672]
+        kpt = cell0.make_kpts([1,1,1], scaled_center=scaled_center)[0]
+        mf = pscf.RHF(cell0, kpt=kpt).density_fit('weigend')
+        dm = mf.init_guess_by_1e()
+        with lib.temporary_env(mf.cell, incore_anyway=True):
+            vj1, vk1 = mf.get_jk(dm=dm) # from mol_hf.dot_eri_dm
+        ej1 = numpy.einsum('ij,ji->', vj1, dm)
+        ek1 = numpy.einsum('ij,ji->', vk1, dm)
+        vj, vk = mf.with_df.get_jk(dm=dm, kpts=kpt, exxdiv=mf.exxdiv)
+        ej = numpy.einsum('ij,ji->', vj, dm)
+        ek = numpy.einsum('ij,ji->', vk, dm)
+        self.assertAlmostEqual(ej1, ej, 10)
+        self.assertAlmostEqual(ek1, ek, 10)
+
     def test_jk_single_kpt_high_cost(self):
         mf0 = pscf.RHF(cell)
         mf0.exxdiv = None


### PR DESCRIPTION
The current implementation of the single-k-point J-build in `pbc/df/df_jk/get_jk`
```
einsum('Lpq,xpq->xL', Lpq, dms)
```
is incorrect: the indices for dms should be `xqp`. This leads to incorrect Coulomb energy for SCF calculations using a single twisted angle. This PR fixed the bug and added a test requiring `df.get_jk` results to match those from `mol_hf.dot_eri_dm`.

Doing similar checks on other PBC DF modules (single k-point JK builds must match k-points JK builds), I also found a bug in the single k-point K-build in AFTDF, which was also fixed by this PR (and a test was added).