### PR TITLE
Add missing init file in `solvent/grad`

### DIFF
--- a/pyscf/solvent/grad/__init__.py
+++ b/pyscf/solvent/grad/__init__.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# Copyright 2014-2024 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Qiming Sun <osirpt.sun@gmail.com>
+#


### PR DESCRIPTION
I noticed that this directory was missing in the `pip` release version, so adding the missing `__init__.py` file here 😁 