### PR TITLE
CASSCF Density Fit Grad atmlist bug

### DIFF
--- a/pyscf/df/grad/casdm2_util.py
+++ b/pyscf/df/grad/casdm2_util.py
@@ -476,7 +476,7 @@ def grad_elec_dferi (mc_grad, mo_cas=None, ci=None, dfcasdm2=None, casdm2=None, 
 
     aoslices = mol.aoslice_by_atom ()
     dE = np.array ([dE[:,p0:p1].sum (axis=1) for p0, p1 in aoslices[:,2:]]).transpose (1,0,2)
-    return np.ascontiguousarray (dE)
+    return np.ascontiguousarray (dE)[:,atmlst,:]
 
 if __name__ == '__main__':
     from pyscf.tools import molden


### PR DESCRIPTION
The function [`grad_elec_dferi`](https://github.com/matthew-hennefarth/pyscf/blob/eafc3575234aca3832d270f4e1193bec2119d2b4/pyscf/df/grad/casdm2_util.py#L401-L429) should return an `ndarray` of shape `(len(dfcasdm2), len(atmlst), 3)`, but it is not. Looking closely, `atmlst` is never used.

This PR (as it is now), just slices out the correct portions of the final `dE` array. I am not sure where in the above code this could be optimized. @MatthewRHermes, I believe you authored this code so perhaps you have better insight.