### PR TITLE
bug fix for pcm uhf

### DIFF
--- a/pyscf/solvent/pcm.py
+++ b/pyscf/solvent/pcm.py
@@ -331,6 +331,10 @@ class PCM(ddcosmo.DDCOSMO):
         if not self._intermediates or self.grids.coords is None:
             self.build()
 
+        if not (isinstance(dms, numpy.ndarray) and dms.ndim == 2):
+            # spin-traced DM for UHF or ROHF
+            dms = dms[0] + dms[1]
+
         nao = dms.shape[-1]
         dms = dms.reshape(-1,nao,nao)
 
@@ -402,4 +406,3 @@ class PCM(ddcosmo.DDCOSMO):
             v_nj = df.incore.aux_e2(mol, fakemol, intor=int3c2e, aosym='s1', cintopt=cintopt)
             vmat += -numpy.einsum('ijL,L->ij', v_nj, q[p0:p1])
         return vmat
-

--- a/pyscf/solvent/test/test_pcm.py
+++ b/pyscf/solvent/test/test_pcm.py
@@ -46,7 +46,12 @@ class KnownValues(unittest.TestCase):
         cm.method = 'C-PCM'
         mf = scf.RHF(mol).PCM(cm)
         e_tot = mf.kernel()
-        print(f"Energy error in C-PCM: {numpy.abs(e_tot - -74.9690902442)}")
+        print(f"Energy error in RHF C-PCM: {numpy.abs(e_tot - -74.9690902442)}")
+        assert numpy.abs(e_tot - -74.9690902442) < 1e-9
+
+        mf = scf.UHF(mol).PCM(cm)
+        e_tot = mf.kernel()
+        print(f"Energy error in UHF C-PCM: {numpy.abs(e_tot - -74.9690902442)}")
         assert numpy.abs(e_tot - -74.9690902442) < 1e-9
 
     def test_COSMO(self):


### PR DESCRIPTION
The rdm1 is not spin traced in PCM for UHF/UKS, leading to incorrect solvation energy. This PR fixed the bug. A test is added.