### PR TITLE
improve the consistency in DF modules

### DIFF
--- a/pyscf/df/grad/rhf.py
+++ b/pyscf/df/grad/rhf.py
@@ -38,8 +38,9 @@ from functools import reduce
 from itertools import product
 from pyscf.ao2mo import _ao2mo
 from pyscf.df import df_jk
+from pyscf.df.incore import LINEAR_DEP_THR
 
-LINEAR_DEP_THRESHOLD = 1e-9
+LINEAR_DEP_THRESHOLD = LINEAR_DEP_THR
 
 def get_jk(mf_grad, mol=None, dm=None, hermi=0, with_j=True, with_k=True,
            decompose_j2c='CD', lindep=LINEAR_DEP_THRESHOLD):

--- a/pyscf/df/hessian/rhf.py
+++ b/pyscf/df/hessian/rhf.py
@@ -44,7 +44,7 @@ from pyscf.df.grad.rhf import (_int3c_wrapper, _gen_metric_solver,
                                LINEAR_DEP_THRESHOLD)
 
 def _pinv(a, lindep=LINEAR_DEP_THRESHOLD):
-    ''''''
+    '''Similar to pinv (v1.7.0) with atol=lindep and rtol=0'''
     w, v = scipy.linalg.eigh(a)
     mask = w > lindep
     v1 = v[:, mask]

--- a/pyscf/df/hessian/rhf.py
+++ b/pyscf/df/hessian/rhf.py
@@ -43,6 +43,13 @@ from pyscf.hessian import rhf as rhf_hess
 from pyscf.df.grad.rhf import (_int3c_wrapper, _gen_metric_solver,
                                LINEAR_DEP_THRESHOLD)
 
+def _pinv(a, lindep=LINEAR_DEP_THRESHOLD):
+    ''''''
+    w, v = scipy.linalg.eigh(a)
+    mask = w > lindep
+    v1 = v[:, mask]
+    return lib.dot(v1/w[mask], v1.conj().T)
+
 def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
                       atmlst=None, max_memory=4000, verbose=None):
     e1, ej, ek = _partial_hess_ejk(hessobj, mo_energy, mo_coeff, mo_occ,
@@ -174,7 +181,7 @@ def _partial_hess_ejk(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
         get_int3c_ipip2 = _int3c_wrapper(mol, auxmol, 'int3c2e_ipip2', 's1')
         rhok0_P__ = lib.einsum('plj,li->pij', rhok0_Pl_, mocc_2)
         rho2c_0 = lib.einsum('pij,qji->pq', rhok0_P__, rhok0_P__)
-        int2c_inv = numpy.linalg.pinv(int2c, rcond=LINEAR_DEP_THRESHOLD)
+        int2c_inv = _pinv(int2c, lindep=LINEAR_DEP_THRESHOLD)
         int2c_ipip1 = auxmol.intor('int2c2e_ipip1', aosym='s1')
         int2c_ip_ip  = lib.einsum('xpq,qr,ysr->xyps', int2c_ip1, int2c_inv, int2c_ip1)
         int2c_ip_ip -= auxmol.intor('int2c2e_ip1ip2', aosym='s1').reshape(3,3,naux,naux)

--- a/pyscf/df/hessian/uhf.py
+++ b/pyscf/df/hessian/uhf.py
@@ -35,7 +35,7 @@ from pyscf.lib import logger
 from pyscf import ao2mo
 from pyscf.hessian import rhf as rhf_hess
 from pyscf.hessian import uhf as uhf_hess
-from pyscf.df.hessian.rhf import _load_dim0
+from pyscf.df.hessian.rhf import _load_dim0, _pinv
 from pyscf.df.grad.rhf import (_int3c_wrapper, _gen_metric_solver,
                                LINEAR_DEP_THRESHOLD)
 
@@ -197,7 +197,7 @@ def _partial_hess_ejk(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
         rhok0b_P__ = lib.einsum('plj,li->pij', rhok0b_Pl_, moccb)
         rho2c_0  = lib.einsum('pij,qij->pq', rhok0a_P__, rhok0a_P__)
         rho2c_0 += lib.einsum('pij,qij->pq', rhok0b_P__, rhok0b_P__)
-        int2c_inv = numpy.linalg.pinv(int2c, rcond=LINEAR_DEP_THRESHOLD)
+        int2c_inv = _pinv(int2c, lindep=LINEAR_DEP_THRESHOLD)
         int2c_ipip1 = auxmol.intor('int2c2e_ipip1', aosym='s1')
         int2c_ip_ip  = lib.einsum('xpq,qr,ysr->xyps', int2c_ip1, int2c_inv, int2c_ip1)
         int2c_ip_ip -= auxmol.intor('int2c2e_ip1ip2', aosym='s1').reshape(3,3,naux,naux)

--- a/pyscf/df/incore.py
+++ b/pyscf/df/incore.py
@@ -28,7 +28,7 @@ from pyscf import __config__
 
 
 MAX_MEMORY = getattr(__config__, 'df_outcore_max_memory', 2000)  # 2GB
-LINEAR_DEP_THR = getattr(__config__, 'df_df_DF_lindep', 1e-12)
+LINEAR_DEP_THR = getattr(__config__, 'df_df_DF_lindep', 1e-9)
 
 
 # This function is aliased for backward compatibility.

--- a/pyscf/df/test/test_df.py
+++ b/pyscf/df/test/test_df.py
@@ -121,8 +121,8 @@ class KnownValues(unittest.TestCase):
             dm[1] += scf.dhf.time_reversal_matrix(mol, dm[1])
             dfobj = df.DF4C(mol)
             vj, vk = dfobj.get_jk(dm, hermi=0, omega=0.9)
-            self.assertAlmostEqual(lib.fp(vj), 1364.9807926997748+215.73363929678885j, 4)
-            self.assertAlmostEqual(lib.fp(vk), 159.03611112342566+687.9032914356833j , 4)
+            self.assertAlmostEqual(lib.fp(vj), 1364.9808427400467+215.73363292535137j, 4)
+            self.assertAlmostEqual(lib.fp(vk), 159.036202745021+687.903428296142j , 4)
 
             vj1, vk1 = scf.dhf.get_jk(mol, dm, hermi=0, omega=0.9)
             self.assertAlmostEqual(abs(vj-vj1).max(), 0, 2)

--- a/pyscf/df/test/test_df_hessian.py
+++ b/pyscf/df/test/test_df_hessian.py
@@ -46,7 +46,6 @@ class KnownValues(unittest.TestCase):
     def test_rhf_hess(self):
         href = scf.RHF(mol).run().Hessian().kernel()
         h1 = scf.RHF(mol).density_fit().run().Hessian().kernel()
-        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 3)
 
     def test_rks_lda_hess(self):
@@ -54,7 +53,6 @@ class KnownValues(unittest.TestCase):
         df_h = mol.RKS.density_fit().run(xc='lda,vwn').Hessian()
         df_h.auxbasis_response = 2
         h1 = df_h.kernel()
-        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
     def test_rks_gga_hess(self):
@@ -62,7 +60,6 @@ class KnownValues(unittest.TestCase):
         df_h = mol.RKS.density_fit().run(xc='b3lyp').Hessian()
         df_h.auxbasis_response = 2
         h1 = df_h.kernel()
-        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
     def test_rks_mgga_hess(self):
@@ -70,7 +67,6 @@ class KnownValues(unittest.TestCase):
         df_h = mol.RKS.density_fit().run(xc='m06').Hessian()
         df_h.auxbasis_response = 2
         h1 = df_h.kernel()
-        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
     def test_rks_rsh_hess(self):
@@ -78,7 +74,6 @@ class KnownValues(unittest.TestCase):
         df_h = mol.RKS.density_fit().run(xc='camb3lyp').Hessian()
         df_h.auxbasis_response = 2
         h1 = df_h.kernel()
-        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
     def test_uhf_hess(self):
@@ -86,7 +81,6 @@ class KnownValues(unittest.TestCase):
         df_h = scf.UHF(mol).density_fit().run().Hessian()
         df_h.auxbasis_response = 2
         h1 = df_h.kernel()
-        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
     def test_uks_hess(self):
@@ -94,7 +88,6 @@ class KnownValues(unittest.TestCase):
         df_h = mol.UKS.density_fit().run(xc='camb3lyp').Hessian()
         df_h.auxbasis_response = 2
         h1 = df_h.kernel()
-        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
 if __name__ == "__main__":

--- a/pyscf/df/test/test_df_hessian.py
+++ b/pyscf/df/test/test_df_hessian.py
@@ -46,6 +46,7 @@ class KnownValues(unittest.TestCase):
     def test_rhf_hess(self):
         href = scf.RHF(mol).run().Hessian().kernel()
         h1 = scf.RHF(mol).density_fit().run().Hessian().kernel()
+        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 3)
 
     def test_rks_lda_hess(self):
@@ -53,6 +54,7 @@ class KnownValues(unittest.TestCase):
         df_h = mol.RKS.density_fit().run(xc='lda,vwn').Hessian()
         df_h.auxbasis_response = 2
         h1 = df_h.kernel()
+        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
     def test_rks_gga_hess(self):
@@ -60,6 +62,7 @@ class KnownValues(unittest.TestCase):
         df_h = mol.RKS.density_fit().run(xc='b3lyp').Hessian()
         df_h.auxbasis_response = 2
         h1 = df_h.kernel()
+        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
     def test_rks_mgga_hess(self):
@@ -67,6 +70,7 @@ class KnownValues(unittest.TestCase):
         df_h = mol.RKS.density_fit().run(xc='m06').Hessian()
         df_h.auxbasis_response = 2
         h1 = df_h.kernel()
+        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
     def test_rks_rsh_hess(self):
@@ -74,6 +78,7 @@ class KnownValues(unittest.TestCase):
         df_h = mol.RKS.density_fit().run(xc='camb3lyp').Hessian()
         df_h.auxbasis_response = 2
         h1 = df_h.kernel()
+        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
     def test_uhf_hess(self):
@@ -81,6 +86,7 @@ class KnownValues(unittest.TestCase):
         df_h = scf.UHF(mol).density_fit().run().Hessian()
         df_h.auxbasis_response = 2
         h1 = df_h.kernel()
+        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
     def test_uks_hess(self):
@@ -88,6 +94,7 @@ class KnownValues(unittest.TestCase):
         df_h = mol.UKS.density_fit().run(xc='camb3lyp').Hessian()
         df_h.auxbasis_response = 2
         h1 = df_h.kernel()
+        print(abs(href - h1).max())
         self.assertAlmostEqual(abs(href - h1).max(), 0, 4)
 
 if __name__ == "__main__":

--- a/pyscf/grad/rks.py
+++ b/pyscf/grad/rks.py
@@ -591,9 +591,6 @@ class Gradients(rhf_grad.Gradients):
         rhf_grad.Gradients.__init__(self, mf)
         self.grids = None
         self.nlcgrids = None
-        # This parameter has no effects for HF gradients. Add this attribute so that
-        # the kernel function can be reused in the DFT gradients code.
-        self.grid_response = False
 
     def dump_flags(self, verbose=None):
         rhf_grad.Gradients.dump_flags(self, verbose)

--- a/pyscf/grad/uks.py
+++ b/pyscf/grad/uks.py
@@ -250,7 +250,6 @@ class Gradients(uhf_grad.Gradients):
         uhf_grad.Gradients.__init__(self, mf)
         self.grids = None
         self.nlcgrids = None
-        self.grid_response = False
 
     def dump_flags(self, verbose=None):
         uhf_grad.Gradients.dump_flags(self, verbose)

--- a/pyscf/hessian/rhf.py
+++ b/pyscf/hessian/rhf.py
@@ -344,8 +344,9 @@ def solve_mo1(mf, mo_energy, mo_coeff, mo_occ, h1ao_or_chkfile,
 
         h1vo = numpy.vstack(h1vo)
         s1vo = numpy.vstack(s1vo)
+        tol = mf.conv_tol_cpscf * (ia1 - ia0)
         mo1, e1 = cphf.solve(fx, mo_energy, mo_occ, h1vo, s1vo,
-                             max_cycle=max_cycle, level_shift=level_shift)
+                             max_cycle=max_cycle, level_shift=level_shift, tol=tol)
         mo1 = numpy.einsum('pq,xqi->xpi', mo_coeff, mo1).reshape(-1,3,nao,nocc)
         e1 = e1.reshape(-1,3,nocc,nocc)
 

--- a/pyscf/hessian/uhf.py
+++ b/pyscf/hessian/uhf.py
@@ -307,8 +307,9 @@ def solve_mo1(mf, mo_energy, mo_coeff, mo_occ, h1ao_or_chkfile,
 
         h1vo = (numpy.vstack(h1voa), numpy.vstack(h1vob))
         s1vo = (numpy.vstack(s1voa), numpy.vstack(s1vob))
+        tol = mf.conv_tol_cpscf * (ia1 - ia0)
         mo1, e1 = ucphf.solve(fx, mo_energy, mo_occ, h1vo, s1vo,
-                              max_cycle=max_cycle, level_shift=level_shift)
+                              max_cycle=max_cycle, level_shift=level_shift, tol=tol)
         mo1a = numpy.einsum('pq,xqi->xpi', mo_coeff[0], mo1[0]).reshape(-1,3,nao,nocca)
         mo1b = numpy.einsum('pq,xqi->xpi', mo_coeff[1], mo1[1]).reshape(-1,3,nao,noccb)
         e1a = e1[0].reshape(-1,3,nocca,nocca)

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -1505,7 +1505,7 @@ class SCF(lib.StreamObject):
     '''
     conv_tol = getattr(__config__, 'scf_hf_SCF_conv_tol', 1e-9)
     conv_tol_grad = getattr(__config__, 'scf_hf_SCF_conv_tol_grad', None)
-    conv_tol_cpscf = getattr(__config__, 'scf_hf_SCF_conv_tol_cpscf', 1e-3)
+    conv_tol_cpscf = getattr(__config__, 'scf_hf_SCF_conv_tol_cpscf', 1e-8)
     max_cycle = getattr(__config__, 'scf_hf_SCF_max_cycle', 50)
     init_guess = getattr(__config__, 'scf_hf_SCF_init_guess', 'minao')
     disp = None  # for DFT-D3 and DFT-D4

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -1505,6 +1505,7 @@ class SCF(lib.StreamObject):
     '''
     conv_tol = getattr(__config__, 'scf_hf_SCF_conv_tol', 1e-9)
     conv_tol_grad = getattr(__config__, 'scf_hf_SCF_conv_tol_grad', None)
+    conv_tol_cpscf = getattr(__config__, 'scf_hf_SCF_conv_tol_cpscf', 1e-3)
     max_cycle = getattr(__config__, 'scf_hf_SCF_max_cycle', 50)
     init_guess = getattr(__config__, 'scf_hf_SCF_init_guess', 'minao')
     disp = None  # for DFT-D3 and DFT-D4
@@ -1529,7 +1530,7 @@ class SCF(lib.StreamObject):
     callback = None
 
     _keys = {
-        'conv_tol', 'conv_tol_grad', 'max_cycle', 'init_guess',
+        'conv_tol', 'conv_tol_grad', 'conv_tol_cpscf', 'max_cycle', 'init_guess',
         'DIIS', 'diis', 'diis_space', 'diis_damp', 'diis_start_cycle',
         'diis_file', 'diis_space_rollback', 'damp', 'level_shift',
         'direct_scf', 'direct_scf_tol', 'conv_check', 'callback',


### PR DESCRIPTION
- Use the same linear dependence threshold in DF modules, SCF, Gradient, and Hessian.
- Add conv_tol_cpscf in mf to control the convergence of CPSCF.
- Remove the repeated definitions of grid_response in RKS and UKS.