### PR TITLE
Density fitting performance optimization (re issue #1915)

### DIFF
--- a/pyscf/ao2mo/outcore.py
+++ b/pyscf/ao2mo/outcore.py
@@ -486,16 +486,16 @@ def _load_from_h5g(h5group, row0, row1, out=None):
         out = numpy.ndarray((row1-row0, ncol), dat.dtype, buffer=out)
         col1 = 0
         for key in range(nkeys):
-            dat = h5group[str(key)][row0:row1]
-            col0, col1 = col1, col1 + dat.shape[1]
-            out[:,col0:col1] = dat
+            col0, col1 = col1, col1 + h5group[str(key)].shape[1]
+            h5group[str(key)].read_direct(out, dest_sel=numpy.s_[:,col0:col1],
+                                          source_sel=numpy.s_[row0:row1])
     else:  # multiple components
         out = numpy.ndarray((dat.shape[0], row1-row0, ncol), dat.dtype, buffer=out)
         col1 = 0
         for key in range(nkeys):
-            dat = h5group[str(key)][:,row0:row1]
-            col0, col1 = col1, col1 + dat.shape[2]
-            out[:,:,col0:col1] = dat
+            col0, col1 = col1, col1 + h5group[str(key)].shape[2]
+            h5group[str(key)].read_direct(out, dest_sel=numpy.s_[:,:,col0:col1],
+                                          source_sel=numpy.s_[:,row0:row1])
     return out
 
 def _transpose_to_h5g(h5group, key, dat, blksize, chunks=None):

--- a/pyscf/df/df_jk.py
+++ b/pyscf/df/df_jk.py
@@ -289,7 +289,7 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
         for eri1 in dfobj.loop(blksize):
             naux, nao_pair = eri1.shape
             assert (nao_pair == nao*(nao+1)//2)
-            if with_j:               
+            if with_j:
                 vj += numpy.matmul(numpy.matmul(dmtril, eri1.T), eri1)
 
             for k in range(nset):

--- a/pyscf/df/df_jk.py
+++ b/pyscf/df/df_jk.py
@@ -260,7 +260,8 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
 
     if not with_k:
         for eri1 in dfobj.loop():
-            vj += numpy.matmul(numpy.matmul(dmtril, eri1.T), eri1)
+            # uses numpy.matmul
+            vj += (dmtril @ eri1.T) @ eri1
 
 
     elif getattr(dm, 'mo_coeff', None) is not None:
@@ -290,8 +291,8 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
             naux, nao_pair = eri1.shape
             assert (nao_pair == nao*(nao+1)//2)
             if with_j:
-                vj += numpy.matmul(numpy.matmul(dmtril, eri1.T), eri1)
-
+                # uses numpy.matmul
+                vj += (dmtril @ eri1.T) @ eri1
             for k in range(nset):
                 nocc = orbo[k].shape[1]
                 if nocc > 0:
@@ -317,7 +318,8 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
         for eri1 in dfobj.loop(blksize):
             naux, nao_pair = eri1.shape
             if with_j:
-                vj += numpy.matmul(numpy.matmul(dmtril, eri1.T), eri1)
+                # uses numpy.matmul
+                vj += (dmtril @ eri1.T) @ eri1
 
 
             for k in range(nset):

--- a/pyscf/df/df_jk.py
+++ b/pyscf/df/df_jk.py
@@ -304,7 +304,7 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
                          ctypes.c_int(naux), ctypes.c_int(nao),
                          (ctypes.c_int*4)(0, nocc, 0, nao),
                          null, ctypes.c_int(0))
-                    vk[k] += numpy.matmul(buf1.T, buf1)
+                    vk[k] += lib.dot(buf1.T, buf1)
             t1 = log.timer_debug1('jk', *t1)
     else:
         #:vk = numpy.einsum('pij,jk->pki', cderi, dm)
@@ -331,7 +331,7 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
                      ctypes.c_int(naux), *rargs)
 
                 buf2 = lib.unpack_tril(eri1, out=buf[1])
-                vk[k] += numpy.matmul(buf1.reshape(-1,nao).T, buf2.reshape(-1,nao))
+                vk[k] += lib.dot(buf1.reshape(-1,nao).T, buf2.reshape(-1,nao))
             t1 = log.timer_debug1('jk', *t1)
 
     if with_j: vj = lib.unpack_tril(vj, 1).reshape(dm_shape)

--- a/pyscf/df/incore.py
+++ b/pyscf/df/incore.py
@@ -179,10 +179,11 @@ def cholesky_eri(mol, auxbasis='weigend+etb', auxmol=None,
         p0, p1 = p1, p1 + nrow
         if decompose_j2c == 'cd':
             if ints.flags.c_contiguous:
-                ints = lib.transpose(ints, out=bufs2).T
-                bufs1, bufs2 = bufs2, bufs1
-            dat = scipy.linalg.solve_triangular(low, ints, lower=True,
-                                                overwrite_b=True, check_finite=False)
+                trsm, = scipy.linalg.get_blas_funcs(('trsm',), (low, ints))
+                dat = trsm(1.0, low, ints.T, lower=True, trans_a = 1, side = 1, overwrite_b=True).T
+            else:
+                dat = scipy.linalg.solve_triangular(low, ints, lower=True,
+                                                   overwrite_b=True, check_finite=False)
             if dat.flags.f_contiguous:
                 dat = lib.transpose(dat.T, out=bufs2)
             cderi[:,p0:p1] = dat


### PR DESCRIPTION
This pull request incorporates enhancements to density fitting proposed in #1915 by @ajz34 .

- Replace unoptimized `np.einsum` with `gemm` via `numpy.matmul`
- Replace `scipy.linalg.triangular_solve` with `?trsm` in order to avoid a single-threaded array transpose and related issues surrounding Fortran vs C order
- Since with trsm, setting `overwrite_b=True` actually _does_ cause `b` to get overwritten, we have to use `map` rather than `lib.map_with_prefetch` when writing the cderi chunks to disk
- Use of `read_direct` in `_load_from_h5g` avoids an unnecessary copy and reads the data right where they need to go

The test case is the same as in the issue: [here](https://github.com/pyscf/pyscf/files/13063667/benchmark_code.py.txt)

Benchmark, 48 cores cascade lake (CPU: 2x 24-core Intel Xeon Gold 6252N)
PySCF compiled with gcc. NumPy installed from conda-forge along with Intel MKL.

1087 cGTOs
| Task | Before | After |
| --- | --- | --- |
| density fitted RHF | 87.5568 s |  31.4202 s |
| CPU time for cholesky_eri | 25.96 s | 8.41 s |
| CPU time for df vj and vk  | 31.67 s |  11.24 s |
| `df.outcore.cholesky_eri_b` | 11.8159 s |  4.2692 s |
| `df.outcore.cholesky_eri` | 22.12 s |  10.08 s |
