### PR TITLE
Restore functionality for CDFT example

### DIFF
--- a/examples/1-advanced/033-constrained_dft.py
+++ b/examples/1-advanced/033-constrained_dft.py
@@ -186,7 +186,7 @@ def W_cdft(mf, constraints, V_c, orb_pop):
     sites_a, sites_b = constraints.unique_sites()
     N_cur = pop_a[sites_a], pop_b[sites_b]
     N_cur_sum = constraints.separated2sum(N_cur)[1]
-    return np.einsum('i,i', V_c, N_cur_sum - N_c)
+    return np.inner(V_c, N_cur_sum - N_c)
 
 # get gradient of W, as well as return the current population of selected orbitals
 def jac_cdft(mf, constraints, V_c, orb_pop):
@@ -197,7 +197,7 @@ def jac_cdft(mf, constraints, V_c, orb_pop):
 
     N_c = constraints.nelec_required
     sites_a, sites_b = constraints.unique_sites()
-    N_cur = np.array([pop_a[sites_a],pop_b[sites_b]]).real
+    N_cur = pop_a[sites_a].real, pop_b[sites_b].real
     N_cur_sum = constraints.separated2sum(N_cur)[1]
     return N_cur_sum - N_c, N_cur_sum
 
@@ -507,7 +507,7 @@ if __name__ == '__main__':
     h  -2.172991468538160 -1.254577209307266  0.000000000000000
     c   0.000000000000000 -1.406124906933854  0.000000000000000
     h   0.000000000000000 -2.509154418614532  0.000000000000000
-    '''
+    ''' # benzene
     mol.basis = '631g'
     mol.spin=0
     mol.build()
@@ -521,7 +521,7 @@ if __name__ == '__main__':
     mf.run()
 
     idx = mol.search_ao_label('C 2pz') # find all idx for carbon
-    # there are 4 constraints:
+    # there are 3 constraints:
     # 1. N_alpha_C0 + N_beta_C0 + N_beta_C1 = 1.5
     # 2. N_alpha_C2 = 0.5
     # 3. N_beta_C2 = 0.5

--- a/examples/1-advanced/033-constrained_dft.py
+++ b/examples/1-advanced/033-constrained_dft.py
@@ -258,7 +258,7 @@ def cdft(mf, constraints, V_0=None, lo_method='lowdin', alpha=0.2, tol=1e-5,
     cdft_diis = lib.diis.DIIS()
     cdft_diis.space = 8
 
-    def get_fock(h1e, s1e, vhf, dm, cycle=0, mf_diis=None):
+    def get_fock(h1e, s1e, vhf, dm, cycle=0, mf_diis=None, fock_last=None):
         fock_0 = old_get_fock(h1e, s1e, vhf, dm, cycle, None)
         V_0 = constraints._final_V
         if mf_diis is None:
@@ -300,7 +300,6 @@ def cdft(mf, constraints, V_0=None, lo_method='lowdin', alpha=0.2, tol=1e-5,
                 W_new = W_cdft(mf, constraints, V_0, orb_pop)
                 jacob, N_cur = jac_cdft(mf, constraints, V_0, orb_pop)
                 hess = hess_cdft(mf, constraints, V_0, mo_on_loc_ao)
-
                 deltaV = get_newton_step_aug_hess(jacob,hess)
                 #deltaV = np.linalg.solve (hess, -jacob)
 

--- a/examples/1-advanced/033-constrained_dft.py
+++ b/examples/1-advanced/033-constrained_dft.py
@@ -142,9 +142,10 @@ def pop_analysis(mf, mo_on_loc_ao, disp=True, full_dm=False):
         return np.einsum('...ii->...i', dm_lo)
 
 
-# get the matrix which should be added to the fock matrix, due to the lagrange multiplier V_lagr (in separate format)
 def get_fock_add_cdft(constraints, V, C_ao2lo_inv):
     '''
+    Get the matrix which should be added to the fock matrix, due to the lagrange multiplier V_lagr (in separate format)
+    
     mf is a pre-converged mf object, with NO constraints.
 
     F_ao_new=F_ao_old + C^{-1}.T * V_diag_lo * C^{-1}
@@ -188,8 +189,8 @@ def W_cdft(mf, constraints, V_c, orb_pop):
     N_cur_sum = constraints.separated2sum(N_cur)[1]
     return np.inner(V_c, N_cur_sum - N_c)
 
-# get gradient of W, as well as return the current population of selected orbitals
 def jac_cdft(mf, constraints, V_c, orb_pop):
+    '''Get gradient of W, as well as return the current population of selected orbitals'''
     if isinstance(mf, scf.hf.RHF):
         pop_a = pop_b = orb_pop * .5
     else:
@@ -232,17 +233,19 @@ def hess_cdft(mf, constraints, V_c, mo_on_loc_ao):
     return hess_arr
 
 
-# main function for cdft
-# mf : pre-converged mf object
-# V_0 : initial guess of lagrange multipliers
-# orb_idx: orbital index for orbital to be constrained
-# alpha : newton step
-# lo_method: localization method, one of 'lowdin', 'meta-lowdin', 'iao', 'nao'
-# diis_pos: 3 choices: post, pre, both
-# diis_type: 3 choices: use gradient of error vectors, use subsequent diff as error vector, no DIIS
 def cdft(mf, constraints, V_0=None, lo_method='lowdin', alpha=0.2, tol=1e-5,
          constraints_tol=1e-3, maxiter=200, C_inv=None, verbose=4,
          diis_pos='post', diis_type=1):
+    '''
+    main function for cdft
+    mf : pre-converged mf object
+    V_0 : initial guess of lagrange multipliers
+    orb_idx: orbital index for orbital to be constrained
+    alpha : newton step
+    lo_method: localization method, one of 'lowdin', 'meta-lowdin', 'iao', 'nao'
+    diis_pos: 3 choices: post, pre, both
+    diis_type: 3 choices: use gradient of error vectors, use subsequent diff as error vector, no DIIS
+    '''
 
     mf.verbose = verbose
     mf.max_cycle = maxiter

--- a/examples/1-advanced/033-constrained_dft.py
+++ b/examples/1-advanced/033-constrained_dft.py
@@ -311,10 +311,11 @@ def cdft(mf, constraints, V_0=None, lo_method='lowdin', alpha=0.2, tol=1e-5,
 
                 V = V_0 + deltaV * stp
                 g_norm = np.linalg.norm(jacob)
+                V_step_size = np.linalg.norm(V-V_0)
                 if verbose > 3:
-                    print("  loop %4s : W: %.5e    V_c: %s     Nele: %s      g_norm: %.3e    "
-                          % (it,W_new, V_0, N_cur, g_norm))
-                if g_norm < tol and np.linalg.norm(V-V_0) < constraints_tol:
+                    print("  loop %4s : W: %.5e    V_c: %s     Nele: %s      g_norm: %.3e    V_step_size: %.3e"
+                          % (it,W_new, V_0, N_cur, g_norm, V_step_size))
+                if g_norm < tol and V_step_size < constraints_tol:
                     cdft_conv_flag = True
                     break
                 V_0 = V

--- a/examples/1-advanced/033-constrained_dft.py
+++ b/examples/1-advanced/033-constrained_dft.py
@@ -480,7 +480,7 @@ def get_newton_step_aug_hess(jac,hess):
 
     eigval, eigvec = la.eigh(ah)
     idx = None
-    for i in xrange(len(eigvec)):
+    for i in range(len(eigvec)):
         if abs(eigvec[0,i]) > 0.1 and eigval[i] > 0.0:
             idx = i
             break

--- a/examples/1-advanced/033-constrained_dft.py
+++ b/examples/1-advanced/033-constrained_dft.py
@@ -385,6 +385,8 @@ def cdft(mf, constraints, V_0=None, lo_method='lowdin', alpha=0.2, tol=1e-5,
 
     mo_on_loc_ao = get_localized_orbitals(mf, lo_method, mf.mo_coeff)[1]
     orb_pop = pop_analysis(mf, mo_on_loc_ao, disp=True)
+    
+    #print(f'Vc: {constraints._final_V}')
     return mf, orb_pop
 
 
@@ -531,3 +533,4 @@ if __name__ == '__main__':
     nelec_required = [1.5, .5, .5]
     constraints = Constraints(orbital_indices, spin_labels, nelec_required)
     mf, dm_pop = cdft(mf, constraints, lo_method='lowdin', verbose=4)
+    #expected Vc: [-0.00142391 -0.00021137 -0.00270322]

--- a/examples/1-advanced/033-constrained_dft.py
+++ b/examples/1-advanced/033-constrained_dft.py
@@ -237,7 +237,7 @@ def cdft(mf, constraints, V_0=None, lo_method='lowdin', alpha=0.2, tol=1e-5,
     V_0 : initial guess of lagrange multipliers
     orb_idx: orbital index for orbital to be constrained
     alpha : newton step
-    lo_method: localization method, one of 'lowdin', 'meta-lowdin', 'iao', 'nao'
+    lo_method: localization method, one of 'lowdin', 'meta_lowdin', 'iao', 'nao'
     diis_pos: 3 choices: post, pre, both
     diis_type: 3 choices: use gradient of error vectors, use subsequent diff as error vector, no DIIS
     '''
@@ -377,8 +377,8 @@ class Constraints(object):
         constraints.nelec_required = [1.5 , 0.5]
 
         correspond to two constraints:
-        1. N_{alpha-MO_2} + N_{beta-MO_2} = 1.5
-        2. N_{beta-MO_3} = 0.5
+        1. N_{alpha-AO_2} + N_{beta-AO_2} = 1.5
+        2. N_{beta-AO_3} = 0.5
     '''
     def __init__(self, orbital_indices, spin_labels, nelec_required):
         self.orbital_indices = orbital_indices


### PR DESCRIPTION
I'm sure this example worked when it was authored, but that is no longer the case. This patch restores functionality.

Line 200 would raise if the number of alpha and beta restrictions was different. The separated2sum() method rightly allows for this, so I just take the real part of each channel separately.