### PR TITLE
Fix frozen for FNO

### DIFF
--- a/pyscf/cc/__init__.py
+++ b/pyscf/cc/__init__.py
@@ -194,15 +194,9 @@ def FNOCCSD(mf, thresh=1e-6, pct_occ=None, nvir_act=None, frozen=None):
             Number of virtual NOs to keep. Default is None. If present, overrides `thresh` and `pct_occ`.
     """
     import numpy
-    if frozen is None:
-        frozenocc = 0
-    else:
-        assert(isinstance(frozen, (int,numpy.int64)))
-        frozenocc = frozen
     from pyscf import mp
-    pt = mp.MP2(mf).set(verbose=0).run()
+    pt = mp.MP2(mf, frozen=frozen).set(verbose=0).run()
     frozen, no_coeff = pt.make_fno(thresh=thresh, pct_occ=pct_occ, nvir_act=nvir_act)
-    frozen = numpy.hstack([numpy.arange(frozenocc),frozen])
     if len(frozen) == 0: frozen = None
     pt_no = mp.MP2(mf, frozen=frozen, mo_coeff=no_coeff).set(verbose=0).run()
     mycc = CCSD(mf, frozen=frozen, mo_coeff=no_coeff)

--- a/pyscf/cc/test/test_fno.py
+++ b/pyscf/cc/test/test_fno.py
@@ -51,16 +51,16 @@ class Water(unittest.TestCase):
         et = CCSD_T(mcc, eris=eris)
         return mcc.e_corr, et
 
-    @unittest.skip('fail due to updates of pp_int?')
     def test_fno_by_thresh(self):
         threshs = [1e-2,1e-3,1e-4]
         refs = [
-            [-0.1180210293, -0.0001530894],
-            [-0.1903456906, -0.0006322229],
-            [-0.2130000748, -0.0030061317],
+            [-0.1200179470,-0.0001506723],
+            [-0.1925851371,-0.0006428496],
+            [-0.2149635715,-0.0030270215],
         ]
         for thresh,ref in zip(threshs,refs):
             eccsd, et = self.kernel(cc.FNOCCSD, thresh=thresh)
+            # print('[%s],' % (','.join([f'{x:.10f}' for x in [eccsd,et]])))
             self.assertAlmostEqual(eccsd, ref[0], 6)
             self.assertAlmostEqual(et, ref[1], 6)
 
@@ -69,16 +69,16 @@ class Water(unittest.TestCase):
         self.assertAlmostEqual(eccsd, eccsd0, 6)
         self.assertAlmostEqual(et, et0, 6)
 
-    @unittest.skip('fail due to updates of pp_int?')
     def test_fno_by_thresh_frozen(self):
         threshs = [1e-2,1e-3,1e-4]
         refs = [
-            [-0.1173030018, -0.0001459448],
-            [-0.1889586685, -0.0006157799],
-            [-0.2109365568, -0.0029841323],
+            [-0.0777291294,-0.0000381574],
+            [-0.1409238993,-0.0004851219],
+            [-0.1500184791,-0.0021645217],
         ]
         for thresh,ref in zip(threshs,refs):
             eccsd, et = self.kernel(cc.FNOCCSD, thresh=thresh, frozen=1)
+            # print('[%s],' % (','.join([f'{x:.10f}' for x in [eccsd,et]])))
             self.assertAlmostEqual(eccsd, ref[0], 6)
             self.assertAlmostEqual(et, ref[1], 6)
 
@@ -118,16 +118,16 @@ class Water_density_fitting(unittest.TestCase):
         et = CCSD_T(mcc, eris=eris)
         return mcc.e_corr, et
 
-    @unittest.skip('fail due to updates of pp_int?')
     def test_fno_by_thresh(self):
         threshs = [1e-2,1e-3,1e-4]
         refs = [
-            [-0.1180086745, -0.0001528637],
-            [-0.1903723005, -0.0006323478],
-            [-0.2130687280, -0.0030086849],
+            [-0.1200039667,-0.0001504459],
+            [-0.1926097163,-0.0006429844],
+            [-0.2150297885,-0.0030295410],
         ]
         for thresh,ref in zip(threshs,refs):
             eccsd, et = self.kernel(cc.FNOCCSD, thresh=thresh)
+            # print('[%s],' % (','.join([f'{x:.10f}' for x in [eccsd,et]])))
             self.assertAlmostEqual(eccsd, ref[0], 6)
             self.assertAlmostEqual(et, ref[1], 6)
 
@@ -136,16 +136,16 @@ class Water_density_fitting(unittest.TestCase):
         self.assertAlmostEqual(eccsd, eccsd0, 6)
         self.assertAlmostEqual(et, et0, 6)
 
-    @unittest.skip('fail due to updates of pp_int?')
     def test_fno_by_thresh_frozen(self):
         threshs = [1e-2,1e-3,1e-4]
         refs = [
-            [-0.1172906846, -0.0001457165],
-            [-0.1889855085, -0.0006158811],
-            [-0.2110052374, -0.0029866440],
+            [-0.0777156383,-0.0000380971],
+            [-0.1409426400,-0.0004850786],
+            [-0.1500564421,-0.0021661544],
         ]
         for thresh,ref in zip(threshs,refs):
             eccsd, et = self.kernel(cc.FNOCCSD, thresh=thresh, frozen=1)
+            # print('[%s],' % (','.join([f'{x:.10f}' for x in [eccsd,et]])))
             self.assertAlmostEqual(eccsd, ref[0], 6)
             self.assertAlmostEqual(et, ref[1], 6)
 

--- a/pyscf/cc/test/test_fno_uhf.py
+++ b/pyscf/cc/test/test_fno_uhf.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# Copyright 2021 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+import numpy as np
+from pyscf import __config__
+from pyscf import gto, scf, cc
+from pyscf.cc.uccsd_t import kernel as CCSD_T
+
+
+class Water(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        mol = gto.Mole()
+        mol.verbose = 4
+        mol.output = '/dev/null'
+        mol.atom = '''
+        O          0.00000        0.00000        0.11779
+        H          0.00000        0.75545       -0.47116
+        H          0.00000       -0.75545       -0.47116
+        '''
+        mol.pseudo = 'gth-hf-rev'
+        mol.basis = 'cc-pvdz'
+        mol.precision = 1e-10
+        mol.build()
+        mf = scf.UHF(mol).run()
+        cls.mol = mol
+        cls.mf = mf
+    @classmethod
+    def tearDownClass(cls):
+        cls.mol.stdout.close()
+        del cls.mol, cls.mf
+
+    def kernel(self, CC, **kwargs):
+        mcc = CC(self.mf, **kwargs)
+        eris = mcc.ao2mo()
+        mcc.kernel(eris=eris)
+        et = CCSD_T(mcc, eris=eris)
+        return mcc.e_corr, et
+
+    def test_fno_by_thresh(self):
+        threshs = [1e-2,1e-3,1e-4]
+        refs = [
+            [-0.1200179470,-0.0001506723],
+            [-0.1925851371,-0.0006428496],
+            [-0.2149635715,-0.0030270215],
+        ]
+        for thresh,ref in zip(threshs,refs):
+            eccsd, et = self.kernel(cc.FNOCCSD, thresh=thresh)
+            # print('[%s],' % (','.join([f'{x:.10f}' for x in [eccsd,et]])))
+            self.assertAlmostEqual(eccsd, ref[0], 6)
+            self.assertAlmostEqual(et, ref[1], 6)
+
+        eccsd0, et0 = self.kernel(cc.CCSD)
+        eccsd, et = self.kernel(cc.FNOCCSD, thresh=1e-100)
+        self.assertAlmostEqual(eccsd, eccsd0, 6)
+        self.assertAlmostEqual(et, et0, 6)
+
+    def test_fno_by_thresh_frozen(self):
+        threshs = [1e-2,1e-3,1e-4]
+        refs = [
+            [-0.0777291294,-0.0000381574],
+            [-0.1409238993,-0.0004851219],
+            [-0.1500184791,-0.0021645217],
+        ]
+        for thresh,ref in zip(threshs,refs):
+            eccsd, et = self.kernel(cc.FNOCCSD, thresh=thresh, frozen=1)
+            # print('[%s],' % (','.join([f'{x:.10f}' for x in [eccsd,et]])))
+            self.assertAlmostEqual(eccsd, ref[0], 6)
+            self.assertAlmostEqual(et, ref[1], 6)
+
+        eccsd0, et0 = self.kernel(cc.UCCSD, frozen=1)
+        eccsd, et = self.kernel(cc.FNOCCSD, thresh=1e-100, frozen=1)
+        self.assertAlmostEqual(eccsd, eccsd0, 6)
+        self.assertAlmostEqual(et, et0, 6)
+
+
+if __name__ == "__main__":
+    print("Full Tests for FNO-CCSD and FNO-CCSD(T)")
+    unittest.main()

--- a/pyscf/mp/dfgmp2.py
+++ b/pyscf/mp/dfgmp2.py
@@ -150,11 +150,11 @@ class DFGMP2(dfmp2.DFMP2):
         eris._common_init_(self, mo_coeff)
         return eris
 
-    def make_rdm1(self, t2=None, ao_repr=False):
+    def make_rdm1(self, t2=None, ao_repr=False, with_frozen=True):
         if t2 is None:
             t2 = self.t2
         assert t2 is not None
-        return make_rdm1(self, t2, ao_repr=ao_repr)
+        return make_rdm1(self, t2, ao_repr=ao_repr, with_frozen=with_frozen)
 
     def make_rdm2(self, t2=None, ao_repr=False):
         if t2 is None:

--- a/pyscf/mp/dfmp2.py
+++ b/pyscf/mp/dfmp2.py
@@ -118,11 +118,11 @@ class DFMP2(mp2.MP2):
         eris._common_init_(self, mo_coeff)
         return eris
 
-    def make_rdm1(self, t2=None, ao_repr=False):
+    def make_rdm1(self, t2=None, ao_repr=False, with_frozen=True):
         if t2 is None:
             t2 = self.t2
         assert t2 is not None
-        return make_rdm1(self, t2, ao_repr=ao_repr)
+        return make_rdm1(self, t2, ao_repr=ao_repr, with_frozen=with_frozen)
 
     def make_rdm2(self, t2=None, ao_repr=False):
         if t2 is None:

--- a/pyscf/mp/gmp2.py
+++ b/pyscf/mp/gmp2.py
@@ -88,7 +88,7 @@ def update_amps(mp, t2, eris):
     return t2new
 
 
-def make_rdm1(mp, t2=None, ao_repr=False):
+def make_rdm1(mp, t2=None, ao_repr=False, with_frozen=True):
     r'''
     One-particle density matrix in the molecular spin-orbital representation
     (the occupied-virtual blocks from the orbital response contribution are
@@ -106,7 +106,7 @@ def make_rdm1(mp, t2=None, ao_repr=False):
     nocc, nvir = t2.shape[1:3]
     dov = numpy.zeros((nocc,nvir))
     d1 = doo, dov, dov.T, dvv
-    return gccsd_rdm._make_rdm1(mp, d1, with_frozen=True, ao_repr=ao_repr)
+    return gccsd_rdm._make_rdm1(mp, d1, with_frozen=with_frozen, ao_repr=ao_repr)
 
 def _gamma1_intermediates(mp, t2):
     doo = lib.einsum('imef,jmef->ij', t2.conj(), t2) *-.5

--- a/pyscf/mp/mp2.py
+++ b/pyscf/mp/mp2.py
@@ -207,8 +207,8 @@ def _mo_splitter(mp):
     maskact = mp.get_frozen_mask()
     maskocc = mp.mo_occ>1e-6
     masks = [
-         maskocc & ~maskact,    # frz occ
-         maskocc &  maskact,    # act occ
+        maskocc  & ~maskact,    # frz occ
+        maskocc  &  maskact,    # act occ
         ~maskocc &  maskact,    # act vir
         ~maskocc & ~maskact,    # frz vir
     ]
@@ -253,7 +253,7 @@ def make_fno(mp, thresh=1e-6, pct_occ=None, nvir_act=None, t2=None):
         nvir_keep = min(nvir, nvir_act)
 
     masks = _mo_splitter(mp)
-    moeoccfrz0, moeocc, moevir, moevirfrz0 = [mf.mo_energy[m]  for m in masks]
+    moeoccfrz0, moeocc, moevir, moevirfrz0 = [mf.mo_energy[m] for m in masks]
     orboccfrz0, orbocc, orbvir, orbvirfrz0 = [mf.mo_coeff[:,m] for m in masks]
 
     fvv = numpy.diag(moevir)

--- a/pyscf/mp/mp2.py
+++ b/pyscf/mp/mp2.py
@@ -148,7 +148,7 @@ def update_amps(mp, t2, eris):
     return t2new
 
 
-def make_rdm1(mp, t2=None, eris=None, ao_repr=False):
+def make_rdm1(mp, t2=None, eris=None, ao_repr=False, with_frozen=True):
     r'''Spin-traced one-particle density matrix.
     The occupied-virtual orbital response is not included.
 
@@ -169,7 +169,7 @@ def make_rdm1(mp, t2=None, eris=None, ao_repr=False):
     nvir = dvv.shape[0]
     dov = numpy.zeros((nocc,nvir), dtype=doo.dtype)
     dvo = dov.T
-    return ccsd_rdm._make_rdm1(mp, (doo, dov, dvo, dvv), with_frozen=True,
+    return ccsd_rdm._make_rdm1(mp, (doo, dov, dvo, dvv), with_frozen=with_frozen,
                                ao_repr=ao_repr)
 
 def _gamma1_intermediates(mp, t2=None, eris=None):
@@ -222,10 +222,11 @@ def make_fno(mp, thresh=1e-6, pct_occ=None, nvir_act=None, t2=None):
             Semicanonical NO coefficients in the AO basis
     '''
     mf = mp._scf
-    dm = mp.make_rdm1(t2=t2)
+    dm = mp.make_rdm1(t2=t2, with_frozen=False)
 
     nmo = mp.nmo
     nocc = mp.nocc
+    nvir = nmo - nocc
     n,v = numpy.linalg.eigh(dm[nocc:,nocc:])
     idx = numpy.argsort(n)[::-1]
     n,v = n[idx], v[:,idx]
@@ -234,18 +235,35 @@ def make_fno(mp, thresh=1e-6, pct_occ=None, nvir_act=None, t2=None):
         if pct_occ is None:
             nvir_act = numpy.count_nonzero(n>thresh)
         else:
-            print(numpy.cumsum(n/numpy.sum(n)))
-            nvir_act = numpy.count_nonzero(numpy.cumsum(n/numpy.sum(n))<pct_occ)
+            cumsum = numpy.cumsum(n/numpy.sum(n))
+            logger.debug('Sum(pct_occ): %s', cumsum)
+            nvir_act = numpy.count_nonzero(cumsum<pct_occ)
+    nvir_act = min(nvir, nvir_act)
 
-    fvv = numpy.diag(mf.mo_energy[nocc:])
+    maskact = mp.get_frozen_mask()
+    maskocc = mp.mo_occ>1e-6
+    masks = [
+         maskocc & ~maskact,    # frz occ
+         maskocc &  maskact,    # act occ
+        ~maskocc &  maskact,    # act vir
+        ~maskocc & ~maskact,    # frz vir
+    ]
+    moeoccfrz0, moeocc, moevir, moevirfrz0 = [mf.mo_energy[m]  for m in masks]
+    orboccfrz0, orbocc, orbvir, orbvirfrz0 = [mf.mo_coeff[:,m] for m in masks]
+
+    fvv = numpy.diag(moevir)
     fvv_no = numpy.dot(v.T, numpy.dot(fvv, v))
     _, v_canon = numpy.linalg.eigh(fvv_no[:nvir_act,:nvir_act])
 
-    no_coeff_1 = numpy.dot(mf.mo_coeff[:,nocc:], numpy.dot(v[:,:nvir_act], v_canon))
-    no_coeff_2 = numpy.dot(mf.mo_coeff[:,nocc:], v[:,nvir_act:])
-    no_coeff = numpy.concatenate((mf.mo_coeff[:,:nocc], no_coeff_1, no_coeff_2), axis=1)
+    orbviract = numpy.dot(orbvir, numpy.dot(v[:,:nvir_act], v_canon))
+    orbvirfrz = numpy.dot(orbvir, v[:,nvir_act:])
+    no_comp = (orboccfrz0, orbocc, orbviract, orbvirfrz, orbvirfrz0)
+    no_coeff = numpy.hstack(no_comp)
+    nocc_loc = numpy.cumsum([0]+[x.shape[1] for x in no_comp]).astype(int)
+    no_frozen = numpy.hstack((numpy.arange(nocc_loc[0], nocc_loc[1]),
+                              numpy.arange(nocc_loc[3], nocc_loc[5]))).astype(int)
 
-    return numpy.arange(nocc+nvir_act,nmo), no_coeff
+    return no_frozen, no_coeff
 
 
 def make_rdm2(mp, t2=None, eris=None, ao_repr=False):

--- a/pyscf/mp/mp2.py
+++ b/pyscf/mp/mp2.py
@@ -203,6 +203,17 @@ def _gamma1_intermediates(mp, t2=None, eris=None):
     return -dm1occ, dm1vir
 
 
+def _mo_splitter(mp):
+    maskact = mp.get_frozen_mask()
+    maskocc = mp.mo_occ>1e-6
+    masks = [
+         maskocc & ~maskact,    # frz occ
+         maskocc &  maskact,    # act occ
+        ~maskocc &  maskact,    # act vir
+        ~maskocc & ~maskact,    # frz vir
+    ]
+    return masks
+
 def make_fno(mp, thresh=1e-6, pct_occ=None, nvir_act=None, t2=None):
     r'''
     Frozen natural orbitals
@@ -233,30 +244,24 @@ def make_fno(mp, thresh=1e-6, pct_occ=None, nvir_act=None, t2=None):
 
     if nvir_act is None:
         if pct_occ is None:
-            nvir_act = numpy.count_nonzero(n>thresh)
+            nvir_keep = numpy.count_nonzero(n>thresh)
         else:
             cumsum = numpy.cumsum(n/numpy.sum(n))
-            logger.debug('Sum(pct_occ): %s', cumsum)
-            nvir_act = numpy.count_nonzero(cumsum<pct_occ)
-    nvir_act = min(nvir, nvir_act)
+            logger.debug(mp, 'Sum(pct_occ): %s', cumsum)
+            nvir_keep = numpy.count_nonzero(cumsum<pct_occ)
+    else:
+        nvir_keep = min(nvir, nvir_act)
 
-    maskact = mp.get_frozen_mask()
-    maskocc = mp.mo_occ>1e-6
-    masks = [
-         maskocc & ~maskact,    # frz occ
-         maskocc &  maskact,    # act occ
-        ~maskocc &  maskact,    # act vir
-        ~maskocc & ~maskact,    # frz vir
-    ]
+    masks = _mo_splitter(mp)
     moeoccfrz0, moeocc, moevir, moevirfrz0 = [mf.mo_energy[m]  for m in masks]
     orboccfrz0, orbocc, orbvir, orbvirfrz0 = [mf.mo_coeff[:,m] for m in masks]
 
     fvv = numpy.diag(moevir)
     fvv_no = numpy.dot(v.T, numpy.dot(fvv, v))
-    _, v_canon = numpy.linalg.eigh(fvv_no[:nvir_act,:nvir_act])
+    _, v_canon = numpy.linalg.eigh(fvv_no[:nvir_keep,:nvir_keep])
 
-    orbviract = numpy.dot(orbvir, numpy.dot(v[:,:nvir_act], v_canon))
-    orbvirfrz = numpy.dot(orbvir, v[:,nvir_act:])
+    orbviract = numpy.dot(orbvir, numpy.dot(v[:,:nvir_keep], v_canon))
+    orbvirfrz = numpy.dot(orbvir, v[:,nvir_keep:])
     no_comp = (orboccfrz0, orbocc, orbviract, orbvirfrz, orbvirfrz0)
     no_coeff = numpy.hstack(no_comp)
     nocc_loc = numpy.cumsum([0]+[x.shape[1] for x in no_comp]).astype(int)

--- a/pyscf/mp/ump2.py
+++ b/pyscf/mp/ump2.py
@@ -280,8 +280,8 @@ def _mo_splitter(mp):
     masks = []
     for s in [0,1]:
         masks.append([
-             maskocc[s] & ~maskact[s],  # frz occ
-             maskocc[s] &  maskact[s],  # act occ
+            maskocc[s]  & ~maskact[s],  # frz occ
+            maskocc[s]  &  maskact[s],  # act occ
             ~maskocc[s] &  maskact[s],  # act vir
             ~maskocc[s] & ~maskact[s],  # frz vir
         ])
@@ -327,7 +327,7 @@ def make_fno(mp, thresh=1e-6, pct_occ=None, nvir_act=None, t2=None, eris=None):
         else:
             nvir_keep = min(nvir, nvir_act[s])
 
-        moeoccfrz0, moeocc, moevir, moevirfrz0 = [mf.mo_energy[s][m]  for m in masks[s]]
+        moeoccfrz0, moeocc, moevir, moevirfrz0 = [mf.mo_energy[s][m] for m in masks[s]]
         orboccfrz0, orbocc, orbvir, orbvirfrz0 = [mf.mo_coeff[s][:,m] for m in masks[s]]
 
         fvv = numpy.diag(moevir)


### PR DESCRIPTION
In the previous implementation of `FNOCCSD`, the input `frozen` argument was not passed to the MP2 calculation used to generate FNOs. The FNOs generated this way are okay but the ∆MP2 composite correction is wrong. This PR fixes the bug. 

See the figure below for the convergence of the FNOCCSD correlation energy for benzene/cc-pVDZ with carbon 1s electrons being frozen. The uncorrected FNOCCSD energy from the old code is okay compared to the new one, but only the new PT2-corrected energy converges to the correct limit.

![fno_cmp](https://github.com/pyscf/pyscf/assets/12220457/2d8f9749-768c-4247-ae51-917d97478058)

The `make_fno` function was rewritten to handle general `frozen` (integer or list) for both RMP2 and UMP2. Tests are added for both.


NOTE: for UMP2, the natural orbital occupation number for each spin is multiplied by 2 (see [this line](https://github.com/pyscf/pyscf/pull/2217/files#diff-2413d646fb7c38c96523d14de45c6e41aae20d8f32021f21b52af8121fa8810bR318)) so that when the same `thresh` is used, RHF and UHF based FNO calculations generate the same results. I believe that this is a nice behavior but suggestions are appreciated.
