### PR TITLE
remove some traces of unicode (py2) and some unused imports

### DIFF
--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -25,7 +25,6 @@ import os
 import sys
 import types
 import re
-import gc
 
 import json
 import ctypes
@@ -990,10 +989,10 @@ def make_bas_env(basis_add, atom_id=0, ptr=0):
 
         if isinstance(b[1], int):
             kappa = b[1]
-            b_coeff = numpy.array(sorted(list(b[2:]), reverse=True))
+            b_coeff = numpy.array(sorted(b[2:], reverse=True))
         else:
             kappa = 0
-            b_coeff = numpy.array(sorted(list(b[1:]), reverse=True))
+            b_coeff = numpy.array(sorted(b[1:], reverse=True))
         es = b_coeff[:,0]
         cs = b_coeff[:,1:]
         nprim, nctr = cs.shape

--- a/pyscf/lib/numpy_helper.py
+++ b/pyscf/lib/numpy_helper.py
@@ -20,7 +20,6 @@
 Extension to numpy and scipy
 '''
 
-import string
 import ctypes
 import math
 import numpy
@@ -157,7 +156,7 @@ def _contract(subscripts, *tensors, **kwargs):
     idxBt = list(idxB)
     inner_shape = 1
     insert_B_loc = 0
-    shared_idxAB = sorted(list(shared_idxAB))
+    shared_idxAB = sorted(shared_idxAB)
     for n in shared_idxAB:
         if rangeA[n] != rangeB[n]:
             err = ('ERROR: In index string %s, the range of index %s is '

--- a/pyscf/symm/geom.py
+++ b/pyscf/symm/geom.py
@@ -49,10 +49,6 @@ from pyscf import __config__
 
 TOLERANCE = getattr(__config__, 'symm_geom_tol', 1e-5)
 
-# For code compatibility in python-2 and python-3
-if sys.version_info >= (3,):
-    unicode = str
-
 
 def parallel_vectors(v1, v2, tol=TOLERANCE):
     if numpy.allclose(v1, 0, atol=tol) or numpy.allclose(v2, 0, atol=tol):
@@ -402,7 +398,7 @@ def as_subgroup(topgroup, axes, subgroup=None):
 
     groupname, axes = get_subgroup(topgroup, axes)
 
-    if isinstance(subgroup, (str, unicode)):
+    if isinstance(subgroup, str):
         subgroup = std_symb(subgroup)
         if groupname == 'C2v' and subgroup == 'Cs':
             axes = numpy.einsum('ij,kj->ki', rotation_mat(axes[1], numpy.pi/2), axes)
@@ -467,7 +463,7 @@ def symm_identical_atoms(gpname, atoms):
         dup_atom_ids = numpy.sort((idx0,idx1), axis=0).T
         uniq_idx = numpy.unique(dup_atom_ids[:,0], return_index=True)[1]
         eql_atom_ids = dup_atom_ids[uniq_idx]
-        eql_atom_ids = [list(sorted(set(i))) for i in eql_atom_ids]
+        eql_atom_ids = [sorted(set(i)) for i in eql_atom_ids]
         return eql_atom_ids
     elif gpname == 'Coov':
         eql_atom_ids = [[i] for i,a in enumerate(atoms)]
@@ -496,7 +492,7 @@ def symm_identical_atoms(gpname, atoms):
     dup_atom_ids = numpy.sort(dup_atom_ids, axis=0).T
     uniq_idx = numpy.unique(dup_atom_ids[:,0], return_index=True)[1]
     eql_atom_ids = dup_atom_ids[uniq_idx]
-    eql_atom_ids = [list(sorted(set(i))) for i in eql_atom_ids]
+    eql_atom_ids = [sorted(set(i)) for i in eql_atom_ids]
     return eql_atom_ids
 
 def check_symm(gpname, atoms, basis=None):

--- a/pyscf/tdscf/common_slow.py
+++ b/pyscf/tdscf/common_slow.py
@@ -8,7 +8,6 @@ fashion without any issues related to the Davidson procedure.
 This is a helper module defining basic interfaces.
 """
 
-import sys
 from pyscf.lib import logger
 
 from pyscf.pbc.tools import get_kconserv
@@ -18,8 +17,6 @@ from scipy.linalg import solve
 
 from itertools import count, groupby
 
-if sys.version_info >= (3,):
-    unicode = str
 
 def msize(m):
     """
@@ -162,7 +159,7 @@ class TDMatrixBlocks:
             raise ValueError("The value returned by `tdhf_primary_form` is not a tuple")
         if len(m) < 1:
             raise ValueError("Empty tuple returned by `tdhf_primary_form`")
-        if not isinstance(m[0], (str, unicode)):
+        if not isinstance(m[0], str):
             raise ValueError("The first item returned by `tdhf_primary_form` must be a string")
         forms = {"ab": 3, "mk": 3, "full": 2}
         if m[0] in forms:

--- a/pyscf/tools/chgcar.py
+++ b/pyscf/tools/chgcar.py
@@ -24,7 +24,6 @@ See also
 https://cms.mpi.univie.ac.at/vasp/vasp/CHGCAR_file.html
 '''
 
-import sys
 import collections
 import time
 import numpy
@@ -33,9 +32,6 @@ from pyscf import lib
 from pyscf import gto
 from pyscf.pbc import gto as pbcgto
 from pyscf.tools import cubegen
-
-if sys.version_info >= (3,):
-    unicode = str
 
 RESOLUTION = cubegen.RESOLUTION
 BOX_MARGIN = cubegen.BOX_MARGIN
@@ -169,7 +165,7 @@ class CHGCAR(cubegen.Cube):
                             self.box, (nx,ny,nz))
             self.mol = cell
             cell = cell.view(pbcgto.Cell)
-            if (isinstance(cell.unit, (str, unicode)) and
+            if (isinstance(cell.unit, str) and
                 cell.unit.startswith(('B','b','au','AU'))):
                 cell.a = self.box
             else:


### PR DESCRIPTION
just a tiny PR

- remove some traces of python2 `unicode` type
- simplify some calls to `sorted`
- remove some unused imports