### PR TITLE
fix conda package CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -168,7 +168,7 @@ jobs:
         uses: s-weigand/setup-conda@v1
         with:
           update-conda: true
-          conda-channels: anaconda, conda-forge
+          conda-channels: conda-forge
       - run: conda --version
       - run: which python
       - name: Publish to conda


### PR DESCRIPTION
Most of the packages used in the build process are installed from conda-forge, especially gcc and mkl. I think removing the anaconda channel might fix the 2.6.1 build error, but I'm not 100% sure.

The conda-forge channel supplies `anaconda-client`, so it should work; if not, then `conda install -y -c anaconda anaconda-client`, then `conda install -y conda-build` should install Anaconda's version without bringing in Anaconda g++ and gfortran.