### PR TITLE
NumPy 2 compatibility

### DIFF
--- a/pyscf/cc/ccsd_lambda.py
+++ b/pyscf/cc/ccsd_lambda.py
@@ -364,7 +364,9 @@ def update_lambda(mycc, t1, t2, l1, l2, eris=None, imds=None):
     return l1new, l2new
 
 def _cp(a):
-    return numpy.array(a, copy=False, order='C')
+    # NumPy 2.0 changes:
+    # https://numpy.org/doc/stable/release/2.0.0-notes.html#copy-keyword-changes-2-0
+    return numpy.asarray(a, order='C')
 
 
 if __name__ == '__main__':

--- a/pyscf/cc/dfccsd.py
+++ b/pyscf/cc/dfccsd.py
@@ -191,7 +191,9 @@ def _make_df_eris(cc, mo_coeff=None):
     return eris
 
 def _cp(a):
-    return numpy.array(a, copy=False, order='C')
+    # NumPy 2.0 changes:
+    # https://numpy.org/doc/stable/release/2.0.0-notes.html#copy-keyword-changes-2-0
+    return numpy.asarray(a, order='C')
 
 if __name__ == '__main__':
     from pyscf import gto

--- a/pyscf/ci/cisd.py
+++ b/pyscf/ci/cisd.py
@@ -1141,7 +1141,9 @@ scf.hf.RHF.CISD = lib.class_as_method(RCISD)
 scf.rohf.ROHF.CISD = None
 
 def _cp(a):
-    return numpy.array(a, copy=False, order='C')
+    # NumPy 2.0 changes:
+    # https://numpy.org/doc/stable/release/2.0.0-notes.html#copy-keyword-changes-2-0
+    return numpy.asarray(a, order='C')
 
 
 if __name__ == '__main__':

--- a/pyscf/ci/ucisd.py
+++ b/pyscf/ci/ucisd.py
@@ -976,4 +976,6 @@ from pyscf import scf
 scf.uhf.UHF.CISD = lib.class_as_method(CISD)
 
 def _cp(a):
-    return numpy.array(a, copy=False, order='C')
+    # NumPy 2.0 changes:
+    # https://numpy.org/doc/stable/release/2.0.0-notes.html#copy-keyword-changes-2-0
+    return numpy.asarray(a, order='C')

--- a/pyscf/dft/gen_grid.py
+++ b/pyscf/dft/gen_grid.py
@@ -364,8 +364,11 @@ def arg_group_grids(mol, coords, box_size=GROUP_BOX_SIZE):
     box_ids[box_ids[:,0] > boxes[0], 0] = boxes[0]
     box_ids[box_ids[:,1] > boxes[1], 1] = boxes[1]
     box_ids[box_ids[:,2] > boxes[2], 2] = boxes[2]
-    rev_idx, counts = numpy.unique(box_ids, axis=0, return_inverse=True,
-                                   return_counts=True)[1:3]
+    # Change in NumPy 2.0.0
+    # https://github.com/numpy/numpy/issues/26738
+    _, rev_idx, counts = numpy.unique(box_ids, axis=0, return_inverse=True,
+                                   return_counts=True)
+    rev_idx = rev_idx.reshape(-1)
     return rev_idx.argsort(kind='stable')
 
 def _load_conf(mod, name, default):

--- a/pyscf/scf/dhf.py
+++ b/pyscf/scf/dhf.py
@@ -624,9 +624,9 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         if mol is None: mol = self.mol
         if dm is None: dm = self.make_rdm1()
         if self.direct_scf:
-            ddm = numpy.array(dm, copy=False) - numpy.array(dm_last, copy=False)
+            ddm = numpy.asarray(dm)- numpy.asarray(dm_last)
             vj, vk = self.get_jk(mol, ddm, hermi=hermi)
-            return numpy.array(vhf_last, copy=False) + vj - vk
+            return numpy.asarray(vhf_last) + vj - vk
         else:
             vj, vk = self.get_jk(mol, dm, hermi=hermi)
             return vj - vk

--- a/pyscf/x2c/x2c.py
+++ b/pyscf/x2c/x2c.py
@@ -546,9 +546,9 @@ class SCF(hf.SCF):
         if mol is None: mol = self.mol
         if dm is None: dm = self.make_rdm1()
         if self.direct_scf:
-            ddm = numpy.array(dm, copy=False) - numpy.array(dm_last, copy=False)
+            ddm = numpy.asarray(dm) - numpy.asarray(dm_last)
             vj, vk = self.get_jk(mol, ddm, hermi=hermi)
-            return numpy.array(vhf_last, copy=False) + vj - vk
+            return numpy.asarray(vhf_last) + vj - vk
         else:
             vj, vk = self.get_jk(mol, dm, hermi=hermi)
             return vj - vk


### PR DESCRIPTION
These small tweaks fix many of the tests with NumPy 2.0.

- np.array and np.asarray: the meaning of the `copy` kwarg is different; see https://numpy.org/doc/stable/release/2.0.0-notes.html#copy-keyword-changes-2-0

- np.unique behaves differently: https://github.com/numpy/numpy/issues/26738