### PR TITLE
Remove the ase module bulk from pyscf_ase (fix #2271)

### DIFF
--- a/pyscf/pbc/tools/pyscf_ase.py
+++ b/pyscf/pbc/tools/pyscf_ase.py
@@ -24,7 +24,6 @@ ASE package interface
 import numpy as np
 from ase.calculators.calculator import Calculator
 import ase.dft.kpoints
-from ase.lattice import bulk
 
 def pyscf_to_ase_atoms(cell):
     '''

--- a/pyscf/tdscf/dhf.py
+++ b/pyscf/tdscf/dhf.py
@@ -127,6 +127,7 @@ def get_ab(mf, mo_energy=None, mo_coeff=None, mo_occ=None):
             raise NotImplementedError('DKS-TDDFT for NLC functionals')
 
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
+        assert omega == 0.
 
         a, b = add_hf_(a, b, hyb)
 

--- a/pyscf/tdscf/ghf.py
+++ b/pyscf/tdscf/ghf.py
@@ -162,6 +162,7 @@ def get_ab(mf, mo_energy=None, mo_coeff=None, mo_occ=None):
             raise NotImplementedError
 
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
+        assert omega == 0.
 
         a, b = add_hf_(a, b, hyb)
 

--- a/pyscf/tdscf/rhf.py
+++ b/pyscf/tdscf/rhf.py
@@ -157,8 +157,8 @@ def get_ab(mf, mo_energy=None, mo_coeff=None, mo_occ=None):
                 eri_mo = ao2mo.general(mol, [orbo,mo,mo,mo], compact=False)
                 eri_mo = eri_mo.reshape(nocc,nmo,nmo,nmo)
                 k_fac = alpha - hyb
-                a -= np.einsum('ijba->iajb', eri_mo[:nocc,:nocc,nocc:,nocc:]) * k_fac
-                b -= np.einsum('jaib->iajb', eri_mo[:nocc,nocc:,:nocc,nocc:]) * k_fac
+                a -= numpy.einsum('ijba->iajb', eri_mo[:nocc,:nocc,nocc:,nocc:]) * k_fac
+                b -= numpy.einsum('jaib->iajb', eri_mo[:nocc,nocc:,:nocc,nocc:]) * k_fac
 
         xctype = ni._xc_type(mf.xc)
         dm0 = mf.make_rdm1(mo_coeff, mo_occ)

--- a/pyscf/tdscf/rhf.py
+++ b/pyscf/tdscf/rhf.py
@@ -152,6 +152,13 @@ def get_ab(mf, mo_energy=None, mo_coeff=None, mo_occ=None):
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
 
         add_hf_(a, b, hyb)
+        if omega != 0:  # For RSH
+            with mol.with_range_coulomb(omega):
+                eri_mo = ao2mo.general(mol, [orbo,mo,mo,mo], compact=False)
+                eri_mo = eri_mo.reshape(nocc,nmo,nmo,nmo)
+                k_fac = alpha - hyb
+                a -= np.einsum('ijba->iajb', eri_mo[:nocc,:nocc,nocc:,nocc:]) * k_fac
+                b -= np.einsum('jaib->iajb', eri_mo[:nocc,nocc:,:nocc,nocc:]) * k_fac
 
         xctype = ni._xc_type(mf.xc)
         dm0 = mf.make_rdm1(mo_coeff, mo_occ)

--- a/pyscf/tdscf/test/test_tdrks.py
+++ b/pyscf/tdscf/test/test_tdrks.py
@@ -107,6 +107,15 @@ class KnownValues(unittest.TestCase):
         ref = diagonalize(a, b, nroots=5) * 27.2114
         self.assertAlmostEqual(abs(es - ref).max(), 0, 7)
 
+    def test_tddft_camb3lyp(self):
+        mf = mol.RKS(xc='camb3lyp').run()
+        td = mf.TDDFT()
+        es = td.kernel(nstates=4)[0]
+        a,b = td.get_ab()
+        e_ref = diagonalize(a, b, 5)
+        self.assertAlmostEqual(abs(es[:3]-e_ref[:3]).max(), 0, 8)
+        self.assertAlmostEqual(lib.fp(es[:3]*27.2114), 9.0054057603534, 4)
+
     def test_tda_b3lypg(self):
         mf = dft.RKS(mol)
         mf.xc = 'b3lypg'

--- a/pyscf/tdscf/test/test_tduks.py
+++ b/pyscf/tdscf/test/test_tduks.py
@@ -130,6 +130,15 @@ class KnownValues(unittest.TestCase):
         es = td.kernel(nstates=4)[0] * 27.2114
         self.assertAlmostEqual(lib.fp(es[:3]), 1.2984822994759448, 4)
 
+    def test_tddft_camb3lyp(self):
+        mf = mol1.UKS(xc='camb3lyp').run()
+        td = mf.TDDFT()
+        es = td.kernel(nstates=4)[0]
+        a,b = td.get_ab()
+        e_ref = diagonalize(a, b, 5)
+        self.assertAlmostEqual(abs(es[:3]-e_ref[:3]).max(), 0, 8)
+        self.assertAlmostEqual(lib.fp(es[:3]*27.2114), 7.69383202636, 4)
+
     def test_tda_b3lyp(self):
         td = tdscf.TDA(mf_b3lyp).set(conv_tol=1e-12)
         es = td.kernel(nstates=4)[0] * 27.2114
@@ -470,4 +479,6 @@ class KnownValues(unittest.TestCase):
 
 if __name__ == "__main__":
     print("Full Tests for TD-UKS")
-    unittest.main()
+    #unittest.main()
+
+    if 1:

--- a/pyscf/tdscf/test/test_tduks.py
+++ b/pyscf/tdscf/test/test_tduks.py
@@ -479,6 +479,4 @@ class KnownValues(unittest.TestCase):
 
 if __name__ == "__main__":
     print("Full Tests for TD-UKS")
-    #unittest.main()
-
-    if 1:
+    unittest.main()


### PR DESCRIPTION
Fix pyscf_ase (fix #2271)
Fix the TDDFT get_ab method for RSH functions (fix #2261)