### PR TITLE
Add support for fractional coordinates in Cell

### DIFF
--- a/examples/pbc/00-input_cell.py
+++ b/examples/pbc/00-input_cell.py
@@ -43,3 +43,22 @@ cell = gto.M(
     pseudo = 'gth-pade',
     a = numpy.eye(3)*3.5668)
 
+#
+# By default, the atom positions are interpreted as Cartesian coordinates.
+# Atoms within the cell can be defined using fractional coordinates.
+# The "fractional" attribute of the Cell object specifies the type of
+# coordinates in the input (the .atom attribute).
+#
+cell = gto.M(
+    atom = '''C     0.    0.    0.    
+              C     1/4   1/4   1/4
+              C     1/2   1/2   0  
+              C     3/4   3/4   1/4
+              C     1/2   0     1/2
+              C     .75   .25   .75
+              C     0     .5    .5 
+              C     .25   .75   .75''',
+    fractional = True,
+    basis = 'gth-szv',
+    pseudo = 'gth-pade',
+    a = numpy.eye(3)*3.5668)

--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -1757,13 +1757,14 @@ class Cell(mole.MoleBase):
         '''Return a Mole object using the same atoms and basis functions as
         the Cell object.
         '''
-        #FIXME: should cell be converted to mole object?  If cell is converted
-        # and a mole object is returned, many attributes (e.g. the GTH basis,
-        # gth-PP) will not be recognized by mole.build function.
         mol = self.view(mole.Mole)
-        del (mol.a, mol.fractional, mol.precision, mol.ke_cutoff,
-             mol.exp_to_discard, mol._mesh, mol._rcut, mol.dimension,
-             mol.low_dim_ft_type)
+        del mol.a
+        mol.__dict__.pop('fractional', None)
+        mol.__dict__.pop('ke_cutoff', None)
+        mol.__dict__.pop('_mesh', None)
+        mol.__dict__.pop('_rcut', None)
+        mol.__dict__.pop('dimension', None)
+        mol.__dict__.pop('low_dim_ft_type', None)
         mol.enuc = None #reset nuclear energy
         if mol.symmetry:
             mol._build_symmetry()

--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -66,6 +66,7 @@ def pack(cell):
     '''
     cldic = mole.pack(cell)
     cldic['a'] = cell.a
+    cldic['fractional'] = cell.fractional
     cldic['precision'] = cell.precision
     cldic['ke_cutoff'] = cell.ke_cutoff
     cldic['exp_to_discard'] = cell.exp_to_discard
@@ -87,8 +88,8 @@ def unpack(celldic):
 def dumps(cell):
     '''Serialize Cell object to a JSON formatted str.
     '''
-    exclude_keys = {'output', 'stdout', '_keys', 'symm_orb', 'irrep_id',
-                        'irrep_name', 'lattice_symmetry'}
+    exclude_keys = {'output', 'stdout', '_keys', '_ctx_lock',
+                    'symm_orb', 'irrep_id', 'irrep_name', 'lattice_symmetry'}
 
     celldic = dict(cell.__dict__)
     for k in exclude_keys:
@@ -1075,7 +1076,7 @@ class Cell(mole.MoleBase):
 
     _keys = {
         'precision', 'exp_to_discard',
-        'a', 'ke_cutoff', 'pseudo', 'dimension', 'low_dim_ft_type',
+        'a', 'ke_cutoff', 'pseudo', 'fractional', 'dimension', 'low_dim_ft_type',
         'space_group_symmetry', 'symmorphic', 'lattice_symmetry', 'mesh', 'rcut',
         'use_loose_rcut', 'use_particle_mesh_ewald',
     }
@@ -1087,6 +1088,7 @@ class Cell(mole.MoleBase):
         # of fourier components, with .5 * G**2 < ke_cutoff
         self.ke_cutoff = None
 
+        self.fractional = False
         self.dimension = 3
         # TODO: Simple hack for now; the implementation of ewald depends on the
         #       density-fitting class.  This determines how the ewald produces
@@ -1265,13 +1267,23 @@ class Cell(mole.MoleBase):
             self._mesh_from_build = _mesh_from_build
         return self
 
+    @lib.with_doc(mole.format_atom.__doc__)
+    def format_atom(self, atoms, origin=0, axes=None,
+                    unit=getattr(__config__, 'UNIT', 'Ang')):
+        if not self.fractional:
+            return mole.format_atom(atoms, origin, axes, unit)
+        _atoms = mole.format_atom(atoms, origin, axes, unit=1.)
+        _a = self.lattice_vectors()
+        c = np.array([a[1] for a in _atoms]).dot(_a)
+        return [(a[0], r) for a, r in zip(_atoms, c.tolist())]
+
 #Note: Exculde dump_input, parse_arg, basis from kwargs to avoid parsing twice
     def build(self, dump_input=True, parse_arg=mole.ARGPARSE,
               a=None, mesh=None, ke_cutoff=None, precision=None, nimgs=None,
               h=None, dimension=None, rcut= None, low_dim_ft_type=None,
               space_group_symmetry=None, symmorphic=None,
               use_loose_rcut=None, use_particle_mesh_ewald=None,
-              *args, **kwargs):
+              fractional=None, *args, **kwargs):
         '''Setup Mole molecule and Cell and initialize some control parameters.
         Whenever you change the value of the attributes of :class:`Cell`,
         you need call this function to refresh the internal data of Cell.
@@ -1280,6 +1292,10 @@ class Cell(mole.MoleBase):
             a : (3,3) ndarray
                 The real-space cell lattice vectors. Each row represents
                 a lattice vector.
+            fractional : bool
+                Whether the atom postions are specified in fractional coordinates.
+                The default value is False, which means the coordinates are
+                interpreted as Cartesian coordinate.
             mesh : (3,) ndarray of ints
                 The number of *positive* G-vectors along each direction.
             ke_cutoff : float
@@ -1318,6 +1334,7 @@ class Cell(mole.MoleBase):
         if mesh is not None: self.mesh = mesh
         if nimgs is not None: self.nimgs = nimgs
         if dimension is not None: self.dimension = dimension
+        if fractional is not None: self.fractional = fractional
         if precision is not None: self.precision = precision
         if rcut is not None: self.rcut = rcut
         if ke_cutoff is not None: self.ke_cutoff = ke_cutoff
@@ -1330,6 +1347,9 @@ class Cell(mole.MoleBase):
             self.space_group_symmetry = space_group_symmetry
         if symmorphic is not None:
             self.symmorphic = symmorphic
+
+        if self.a is None:
+            raise RuntimeError('Lattice parameters not specified')
 
         dump_input = dump_input and not self._built and self.verbose > logger.NOTE
         mole.MoleBase.build(self, dump_input, parse_arg, *args, **kwargs)
@@ -1408,11 +1428,6 @@ class Cell(mole.MoleBase):
             logger.info(self, 'Discarded %d diffused primitive functions, '
                         '%d contracted functions', nprim_drop, nctr_drop)
             #logger.debug1(self, 'Old shells %s', steep_shls)
-
-        # The rest initialization requires lattice parameters.  If .a is not
-        # set, pass the rest initialization.
-        if self.a is None:
-            return self
 
         if self.rcut is None or self._rcut_from_build:
             self._rcut = estimate_rcut(self, self.precision)
@@ -1746,8 +1761,9 @@ class Cell(mole.MoleBase):
         # and a mole object is returned, many attributes (e.g. the GTH basis,
         # gth-PP) will not be recognized by mole.build function.
         mol = self.view(mole.Mole)
-        delattr(mol, 'a')
-        delattr(mol, '_mesh')
+        del (mol.a, mol.fractional, mol.precision, mol.ke_cutoff,
+             mol.exp_to_discard, mol._mesh, mol._rcut, mol.dimension,
+             mol.low_dim_ft_type)
         mol.enuc = None #reset nuclear energy
         if mol.symmetry:
             mol._build_symmetry()

--- a/pyscf/pbc/gto/test/test_cell.py
+++ b/pyscf/pbc/gto/test/test_cell.py
@@ -114,6 +114,20 @@ class KnownValues(unittest.TestCase):
         #rcut = max([cell.bas_rcut(ib, 1e-9) for ib in range(cell.nbas)])
         #self.assertEqual(cell.get_lattice_Ls(rcut=rcut).shape, (1499, 3))
 
+    def test_fractional_coordinates(self):
+        cell = pgto.M(atom = '''
+        C 0 0 0
+        C .25 .25 .25''',
+        unit='B', basis = 'gth-dzvp', pseudo = 'gth-pade',
+        fractional=True,
+        a = '''
+        0.000000000  3.370137329  3.370137329
+        3.370137329  0.000000000  3.370137329
+        3.370137329  3.370137329  0.000000000''')
+        #[[0.         0.         0.        ]
+        #  [1.68506866 1.68506866 1.68506866]]
+        self.assertAlmostEqual(lib.fp(cell.atom_coords()), -2.2916494573514545, 14)
+
     def test_ewald(self):
         cell = pgto.Cell()
         cell.unit = 'B'


### PR DESCRIPTION
When "fractional=True" is specified when defining the Cell object, the coordinates specified in "atom" definition are interpreted as fractional coordinates. Is the new attribute "fractional" a good name for this feature? Comments and suggestions are welcome.