### PR TITLE
allow modifying tol and nroots in stability

### DIFF
--- a/examples/scf/17-stability.py
+++ b/examples/scf/17-stability.py
@@ -85,3 +85,15 @@ mol = gto.M(atom='C 0 0 0; C 0 0 2.0', basis='631g*')
 mf2 = scf.UHF(mol).run()
 mf2 = stable_opt_internal(mf2)
 
+#
+# Some cases need tight tol to give the stability correctly
+#
+from pyscf.scf.stability import uhf_internal
+mol = gto.M(atom='''
+O         -0.23497692        0.90193619       -0.06868800
+H          1.10502308        0.90193619       -0.06868800
+H         -0.68227811        2.16507579       -0.06868800''', 
+basis = 'def2svp', spin=0)
+mf = mol.UHF().run()
+uhf_internal(mf, verbose=4) # wrong
+uhf_internal(mf, verbose=4, tol=1e-6) # correct

--- a/examples/scf/17-stability.py
+++ b/examples/scf/17-stability.py
@@ -86,7 +86,7 @@ mf2 = scf.UHF(mol).run()
 mf2 = stable_opt_internal(mf2)
 
 #
-# Some cases need tight tol to give the stability correctly
+# Some cases need tight tolerance to give the stability correctly
 #
 from pyscf.scf.stability import uhf_internal
 mol = gto.M(atom='''
@@ -97,3 +97,6 @@ basis = 'def2svp', spin=0)
 mf = mol.UHF().run()
 uhf_internal(mf, verbose=4) # wrong
 uhf_internal(mf, verbose=4, tol=1e-6) # correct
+
+# the tolerance and nroots are both adjustable in the stability analysis
+mf.stability(verbose=4, tol=1e-6, nroots=5)

--- a/pyscf/scf/dhf.py
+++ b/pyscf/scf/dhf.py
@@ -685,7 +685,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         self._opt = {None: None}
         return self
 
-    def stability(self, internal=None, external=None, verbose=None, return_status=False):
+    def stability(self, internal=None, external=None, verbose=None, return_status=False, **kwargs):
         '''
         DHF/DKS stability analysis.
 
@@ -707,7 +707,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
             and the second corresponds to the external stability.
         '''
         from pyscf.scf.stability import dhf_stability
-        return dhf_stability(self, verbose, return_status)
+        return dhf_stability(self, verbose, return_status, **kwargs)
 
     def to_rhf(self):
         raise RuntimeError

--- a/pyscf/scf/ghf.py
+++ b/pyscf/scf/ghf.py
@@ -515,9 +515,9 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         self.__dict__.update(tgt.__dict__)
         return self
 
-    def stability(self, internal=None, external=None, verbose=None, return_status=False):
+    def stability(self, internal=None, external=None, verbose=None, return_status=False, **kwargs):
         from pyscf.scf.stability import ghf_stability
-        return ghf_stability(self, verbose, return_status)
+        return ghf_stability(self, verbose, return_status, **kwargs)
 
     def nuc_grad_method(self):
         raise NotImplementedError

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -2172,7 +2172,8 @@ class RHF(SCF):
                   internal=getattr(__config__, 'scf_stability_internal', True),
                   external=getattr(__config__, 'scf_stability_external', False),
                   verbose=None,
-                  return_status=False):
+                  return_status=False,
+                  **kwargs):
         '''
         RHF/RKS stability analysis.
 
@@ -2199,7 +2200,7 @@ class RHF(SCF):
             and the second corresponds to the external stability.
         '''
         from pyscf.scf.stability import rhf_stability
-        return rhf_stability(self, internal, external, verbose, return_status)
+        return rhf_stability(self, internal, external, verbose, return_status, **kwargs)
 
     def nuc_grad_method(self):
         from pyscf.grad import rhf

--- a/pyscf/scf/rohf.py
+++ b/pyscf/scf/rohf.py
@@ -480,7 +480,8 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
                   internal=getattr(__config__, 'scf_stability_internal', True),
                   external=getattr(__config__, 'scf_stability_external', False),
                   verbose=None,
-                  return_status=False):
+                  return_status=False,
+                  **kwargs):
         '''
         ROHF/ROKS stability analysis.
 
@@ -506,7 +507,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
             and the second corresponds to the external stability.
         '''
         from pyscf.scf.stability import rohf_stability
-        return rohf_stability(self, internal, external, verbose, return_status)
+        return rohf_stability(self, internal, external, verbose, return_status, **kwargs)
 
     def nuc_grad_method(self):
         from pyscf.grad import rohf

--- a/pyscf/scf/stability.py
+++ b/pyscf/scf/stability.py
@@ -265,7 +265,7 @@ def dhf_stability(mf, verbose=None, return_status=False,
     x0[g!=0] = 1. / hdiag[g!=0]
     x0[numpy.argmin(hdiag)] = 1
     e, v = lib.davidson(hessian_x, x0, precond, tol=tol, verbose=log, nroots=nroots)
-    log.info('ghf_stability: lowest eigs of H = %s', e)
+    log.info('dhf_stability: lowest eigs of H = %s', e)
     if nroots != 1:
         e, v = e[0], v[0]
     stable = not (e < -1e-5)

--- a/pyscf/scf/stability.py
+++ b/pyscf/scf/stability.py
@@ -33,8 +33,13 @@ from pyscf.lib import logger
 from pyscf.scf import hf, hf_symm, uhf_symm
 from pyscf.scf import _response_functions  # noqa
 from pyscf.soscf import newton_ah
+from pyscf import __config__
 
-def rhf_stability(mf, internal=True, external=False, verbose=None, return_status=False):
+STAB_NROOTS = getattr(__config__, 'stab_nroots', 3)
+STAB_TOL = getattr(__config__, 'stab_tol', 1e-4)
+
+def rhf_stability(mf, internal=True, external=False, verbose=None, return_status=False,
+                  nroots=STAB_NROOTS, tol=STAB_TOL):
     '''
     Stability analysis for RHF/RKS method.
 
@@ -49,6 +54,10 @@ def rhf_stability(mf, internal=True, external=False, verbose=None, return_status
             stability analysis.
         return_status: bool
             Whether to return `stable_i` and `stable_e`
+        nroots : int
+            Number of roots solved by Davidson solver
+        tol : float
+            Convergence threshold for Davidson solver
 
     Returns:
         If return_status is False (default), the return value includes
@@ -62,21 +71,18 @@ def rhf_stability(mf, internal=True, external=False, verbose=None, return_status
         and the second corresponds to the external stability.
     '''
     mo_i = mo_e = None
+    stable_i = stable_e = None
+    if internal:
+        mo_i, stable_i = rhf_internal(mf, verbose=verbose, return_status=True, nroots=nroots, tol=tol)
+    if external:
+        mo_e, stable_e = rhf_external(mf, verbose=verbose, return_status=True, nroots=nroots, tol=tol)
     if return_status:
-        stable_i = stable_e = None
-        if internal:
-            mo_i, stable_i = rhf_internal(mf, verbose=verbose, return_status=True)
-        if external:
-            mo_e, stable_e = rhf_external(mf, verbose=verbose, return_status=True)
         return mo_i, mo_e, stable_i, stable_e
     else:
-        if internal:
-            mo_i = rhf_internal(mf, verbose=verbose)
-        if external:
-            mo_e = rhf_external(mf, verbose=verbose)
         return mo_i, mo_e
 
-def uhf_stability(mf, internal=True, external=False, verbose=None, return_status=False):
+def uhf_stability(mf, internal=True, external=False, verbose=None, return_status=False,
+                  nroots=STAB_NROOTS, tol=STAB_TOL):
     '''
     Stability analysis for UHF/UKS method.
 
@@ -91,6 +97,10 @@ def uhf_stability(mf, internal=True, external=False, verbose=None, return_status
             stability analysis.
         return_status: bool
             Whether to return `stable_i` and `stable_e`
+        nroots : int
+            Number of roots solved by Davidson solver
+        tol : float
+            Convergence threshold for Davidson solver
 
     Returns:
         If return_status is False (default), the return value includes
@@ -104,21 +114,18 @@ def uhf_stability(mf, internal=True, external=False, verbose=None, return_status
         and the second corresponds to the external stability.
     '''
     mo_i = mo_e = None
+    stable_i = stable_e = None
+    if internal:
+        mo_i, stable_i = uhf_internal(mf, verbose=verbose, return_status=True, nroots=nroots, tol=tol)
+    if external:
+        mo_e, stable_e = uhf_external(mf, verbose=verbose, return_status=True, nroots=nroots, tol=tol)
     if return_status:
-        stable_i = stable_e = None
-        if internal:
-            mo_i, stable_i = uhf_internal(mf, verbose=verbose, return_status=True)
-        if external:
-            mo_e, stable_e = uhf_external(mf, verbose=verbose, return_status=True)
         return mo_i, mo_e, stable_i, stable_e
     else:
-        if internal:
-            mo_i = uhf_internal(mf, verbose=verbose)
-        if external:
-            mo_e = uhf_external(mf, verbose=verbose)
         return mo_i, mo_e
 
-def rohf_stability(mf, internal=True, external=False, verbose=None, return_status=False):
+def rohf_stability(mf, internal=True, external=False, verbose=None, return_status=False,
+                   nroots=STAB_NROOTS, tol=STAB_TOL):
     '''
     Stability analysis for ROHF/ROKS method.
 
@@ -132,6 +139,10 @@ def rohf_stability(mf, internal=True, external=False, verbose=None, return_statu
             External stability. It is not available in current version.
         return_status: bool
             Whether to return `stable_i` and `stable_e`
+        nroots : int
+            Number of roots solved by Davidson solver
+        tol : float
+            Convergence threshold for Davidson solver
 
     Returns:
         If return_status is False (default), the return value includes
@@ -145,21 +156,25 @@ def rohf_stability(mf, internal=True, external=False, verbose=None, return_statu
         and the second corresponds to the external stability.
     '''
     mo_i = mo_e = None
+    stable_i = stable_e = None
+    if internal:
+        mo_i, stable_i = rohf_internal(mf, verbose=verbose, return_status=True, nroots=nroots, tol=tol)
+    if external:
+        mo_e, stable_e = rohf_external(mf, verbose=verbose, return_status=True, nroots=nroots, tol=tol)
     if return_status:
-        stable_i = stable_e = None
-        if internal:
-            mo_i, stable_i = rohf_internal(mf, verbose=verbose, return_status=True)
-        if external:
-            mo_e, stable_e = rohf_external(mf, verbose=verbose, return_status=True)
         return mo_i, mo_e, stable_i, stable_e
     else:
-        if internal:
-            mo_i = rohf_internal(mf, verbose=verbose)
-        if external:
-            mo_e = rohf_external(mf, verbose=verbose)
         return mo_i, mo_e
 
-def ghf_stability(mf, verbose=None, return_status=False):
+def dump_status(log, stable, method_class, stab_type):
+    if not stable:
+        log.note(method_class + f' wavefunction has an {stab_type} instability')
+    else:
+        log.note(method_class + f' wavefunction is stable in the {stab_type} '
+                 'stability analysis')
+
+def ghf_stability(mf, verbose=None, return_status=False,
+                  nroots=STAB_NROOTS, tol=STAB_TOL):
     '''
     Stability analysis for GHF/GKS method.
 
@@ -169,6 +184,10 @@ def ghf_stability(mf, verbose=None, return_status=False):
     Kwargs:
         return_status: bool
             Whether to return `stable_i` and `stable_e`
+        nroots : int
+            Number of roots solved by Davidson solver
+        tol : float
+            Convergence threshold for Davidson solver
 
     Returns:
         If return_status is False (default), the return value includes
@@ -193,21 +212,23 @@ def ghf_stability(mf, verbose=None, return_status=False):
     x0[g!=0] = 1. / hdiag[g!=0]
     if not with_symmetry:  # allow to break point group symmetry
         x0[numpy.argmin(hdiag)] = 1
-    e, v = lib.davidson(hessian_x, x0, precond, tol=1e-4, verbose=log)
-    if e < -1e-5:
-        log.note(f'{mf.__class__} wavefunction has an internal instability')
-        mo = _rotate_mo(mf.mo_coeff, mf.mo_occ, v)
-        stable = False
-    else:
-        log.note(f'{mf.__class__} wavefunction is stable in the internal '
-                 'stability analysis')
+    e, v = lib.davidson(hessian_x, x0, precond, tol=tol, verbose=log, nroots=nroots)
+    log.info('ghf_stability: lowest eigs of H = %s', e)
+    if nroots != 1:
+        e, v = e[0], v[0]
+    stable = not (e < -1e-5)
+    dump_status(log, stable, f'{mf.__class__}', 'internal')
+    if stable:
         mo = mf.mo_coeff
+    else:
+        mo = _rotate_mo(mf.mo_coeff, mf.mo_occ, v)
     if return_status:
         return mo, stable
     else:
         return mo
 
-def dhf_stability(mf, verbose=None, return_status=False):
+def dhf_stability(mf, verbose=None, return_status=False,
+                  nroots=STAB_NROOTS, tol=STAB_TOL):
     '''
     Stability analysis for DHF/DKS method.
 
@@ -217,6 +238,10 @@ def dhf_stability(mf, verbose=None, return_status=False):
     Kwargs:
         return_status: bool
             Whether to return `stable_i` and `stable_e`
+        nroots : int
+            Number of roots solved by Davidson solver
+        tol : float
+            Convergence threshold for Davidson solver
 
     Returns:
         If return_status is False (default), the return value includes
@@ -239,26 +264,27 @@ def dhf_stability(mf, verbose=None, return_status=False):
     x0 = numpy.zeros_like(g)
     x0[g!=0] = 1. / hdiag[g!=0]
     x0[numpy.argmin(hdiag)] = 1
-    e, v = lib.davidson(hessian_x, x0, precond, tol=1e-4, verbose=log)
-    if e < -1e-5:
-        log.note(f'{mf.__class__} wavefunction has an internal instability')
-        mo = _rotate_mo(mf.mo_coeff, mf.mo_occ, v)
-        stable = False
-    else:
-        log.note(f'{mf.__class__} wavefunction is stable in the internal '
-                 'stability analysis')
+    e, v = lib.davidson(hessian_x, x0, precond, tol=tol, verbose=log, nroots=nroots)
+    log.info('ghf_stability: lowest eigs of H = %s', e)
+    if nroots != 1:
+        e, v = e[0], v[0]
+    stable = not (e < -1e-5)
+    dump_status(log, stable, f'{mf.__class__}', 'internal')
+    if stable:
         mo = mf.mo_coeff
+    else:
+        mo = _rotate_mo(mf.mo_coeff, mf.mo_occ, v)
     if return_status:
         return mo, stable
     else:
         return mo
 
-def rhf_internal(mf, with_symmetry=True, verbose=None, return_status=False):
+def rhf_internal(mf, with_symmetry=True, verbose=None, return_status=False,
+                 nroots=STAB_NROOTS, tol=STAB_TOL):
     log = logger.new_logger(mf, verbose)
     g, hop, hdiag = newton_ah.gen_g_hop_rhf(mf, mf.mo_coeff, mf.mo_occ,
                                             with_symmetry=with_symmetry)
     hdiag *= 2
-    stable = True
     def precond(dx, e, x0):
         hdiagd = hdiag - e
         hdiagd[abs(hdiagd)<1e-8] = 1e-8
@@ -275,15 +301,16 @@ def rhf_internal(mf, with_symmetry=True, verbose=None, return_status=False):
     x0[g!=0] = 1. / hdiag[g!=0]
     if not with_symmetry:  # allow to break point group symmetry
         x0[numpy.argmin(hdiag)] = 1
-    e, v = lib.davidson(hessian_x, x0, precond, tol=1e-4, verbose=log)
-    if e < -1e-5:
-        log.note(f'{mf.__class__} wavefunction has an internal instability')
-        mo = _rotate_mo(mf.mo_coeff, mf.mo_occ, v)
-        stable = False
-    else:
-        log.note(f'{mf.__class__} wavefunction is stable in the internal '
-                 'stability analysis')
+    e, v = lib.davidson(hessian_x, x0, precond, tol=tol, verbose=log, nroots=nroots)
+    log.info('rhf_internal: lowest eigs of H = %s', e)
+    if nroots != 1:
+        e, v = e[0], v[0]
+    stable = not (e < -1e-5)
+    dump_status(log, stable, f'{mf.__class__}', 'internal')
+    if stable:
         mo = mf.mo_coeff
+    else:
+        mo = _rotate_mo(mf.mo_coeff, mf.mo_occ, v)
     if return_status:
         return mo, stable
     else:
@@ -360,10 +387,10 @@ def _gen_hop_rhf_external(mf, with_symmetry=True, verbose=None):
     return hop_real2complex, hdiag, hop_rhf2uhf, hdiag
 
 
-def rhf_external(mf, with_symmetry=True, verbose=None, return_status=False):
+def rhf_external(mf, with_symmetry=True, verbose=None, return_status=False,
+                 nroots=STAB_NROOTS, tol=STAB_TOL):
     log = logger.new_logger(mf, verbose)
     hop1, hdiag1, hop2, hdiag2 = _gen_hop_rhf_external(mf, with_symmetry)
-    stable = True
 
     def precond(dx, e, x0):
         hdiagd = hdiag1 - e
@@ -373,12 +400,12 @@ def rhf_external(mf, with_symmetry=True, verbose=None, return_status=False):
     x0[hdiag1>1e-5] = 1. / hdiag1[hdiag1>1e-5]
     if not with_symmetry:  # allow to break point group symmetry
         x0[numpy.argmin(hdiag1)] = 1
-    e1, v1 = lib.davidson(hop1, x0, precond, tol=1e-4, verbose=log)
-    if e1 < -1e-5:
-        log.note(f'{mf.__class__} wavefunction has a real -> complex instability')
-    else:
-        log.note(f'{mf.__class__} wavefunction is stable in the real -> complex '
-                 'stability analysis')
+    e1, v1 = lib.davidson(hop1, x0, precond, tol=tol, verbose=log, nroots=nroots)
+    log.info('rhf_real2complex: lowest eigs of H = %s', e1)
+    if nroots != 1:
+        e1, v1 = e1[0], v1[0]
+    stable1 = not (e1 < -1e-5)
+    dump_status(log, stable1, f'{mf.__class__}', 'real -> complex')
 
     def precond(dx, e, x0):
         hdiagd = hdiag2 - e
@@ -386,26 +413,27 @@ def rhf_external(mf, with_symmetry=True, verbose=None, return_status=False):
         return dx/hdiagd
     x0 = numpy.zeros_like(hdiag2)
     x0[hdiag2>1e-5] = 1. / hdiag2[hdiag2>1e-5]
-    e3, v3 = lib.davidson(hop2, x0, precond, tol=1e-4, verbose=log)
-    if e3 < -1e-5:
-        log.note(f'{mf.__class__} wavefunction has a RHF/RKS -> UHF/UKS instability.')
-        mo = (_rotate_mo(mf.mo_coeff, mf.mo_occ, v3), mf.mo_coeff)
-        stable = False
-    else:
-        log.note(f'{mf.__class__} wavefunction is stable in the RHF/RKS -> '
-                 'UHF/UKS stability analysis')
+    e3, v3 = lib.davidson(hop2, x0, precond, tol=tol, verbose=log, nroots=nroots)
+    log.info('rhf_external: lowest eigs of H = %s', e3)
+    if nroots != 1:
+        e3, v3 = e3[0], v3[0]
+    stable = not (e3 < -1e-5)
+    dump_status(log, stable, f'{mf.__class__}', 'RHF/RKS -> UHF/UKS')
+    if stable:
         mo = (mf.mo_coeff, mf.mo_coeff)
+    else:
+        mo = (_rotate_mo(mf.mo_coeff, mf.mo_occ, v3), mf.mo_coeff)
     if return_status:
         return mo, stable
     else:
         return mo
 
-def rohf_internal(mf, with_symmetry=True, verbose=None, return_status=False):
+def rohf_internal(mf, with_symmetry=True, verbose=None, return_status=False,
+                  nroots=STAB_NROOTS, tol=STAB_TOL):
     log = logger.new_logger(mf, verbose)
     g, hop, hdiag = newton_ah.gen_g_hop_rohf(mf, mf.mo_coeff, mf.mo_occ,
                                              with_symmetry=with_symmetry)
     hdiag *= 2
-    stable = True
     def precond(dx, e, x0):
         hdiagd = hdiag - e
         hdiagd[abs(hdiagd)<1e-8] = 1e-8
@@ -417,29 +445,31 @@ def rohf_internal(mf, with_symmetry=True, verbose=None, return_status=False):
     x0[g!=0] = 1. / hdiag[g!=0]
     if not with_symmetry:  # allow to break point group symmetry
         x0[numpy.argmin(hdiag)] = 1
-    e, v = lib.davidson(hessian_x, x0, precond, tol=1e-4, verbose=log)
-    if e < -1e-5:
-        log.note(f'{mf.__class__} wavefunction has an internal instability.')
-        mo = _rotate_mo(mf.mo_coeff, mf.mo_occ, v)
-        stable = False
-    else:
-        log.note(f'{mf.__class__} wavefunction is stable in the internal '
-                 'stability analysis')
+    e, v = lib.davidson(hessian_x, x0, precond, tol=tol, verbose=log, nroots=nroots)
+    log.info('rohf_internal: lowest eigs of H = %s', e)
+    if nroots != 1:
+        e, v = e[0], v[0]
+    stable = not (e < -1e-5)
+    dump_status(log, stable, f'{mf.__class__}', 'internal')
+    if stable:
         mo = mf.mo_coeff
+    else:
+        mo = _rotate_mo(mf.mo_coeff, mf.mo_occ, v)
     if return_status:
         return mo, stable
     else:
         return mo
 
-def rohf_external(mf, with_symmetry=True, verbose=None, return_status=False):
+def rohf_external(mf, with_symmetry=True, verbose=None, return_status=False,
+                  nroots=STAB_NROOTS, tol=STAB_TOL):
     raise NotImplementedError
 
-def uhf_internal(mf, with_symmetry=True, verbose=None, return_status=False):
+def uhf_internal(mf, with_symmetry=True, verbose=None, return_status=False,
+                 nroots=STAB_NROOTS, tol=STAB_TOL):
     log = logger.new_logger(mf, verbose)
     g, hop, hdiag = newton_ah.gen_g_hop_uhf(mf, mf.mo_coeff, mf.mo_occ,
                                             with_symmetry=with_symmetry)
     hdiag *= 2
-    stable = True
     def precond(dx, e, x0):
         hdiagd = hdiag - e
         hdiagd[abs(hdiagd)<1e-8] = 1e-8
@@ -451,18 +481,19 @@ def uhf_internal(mf, with_symmetry=True, verbose=None, return_status=False):
     x0[g!=0] = 1. / hdiag[g!=0]
     if not with_symmetry:  # allow to break point group symmetry
         x0[numpy.argmin(hdiag)] = 1
-    e, v = lib.davidson(hessian_x, x0, precond, tol=1e-4, verbose=log)
-    if e < -1e-5:
-        log.note(f'{mf.__class__} wavefunction has an internal instability.')
+    e, v = lib.davidson(hessian_x, x0, precond, tol=tol, verbose=log, nroots=nroots)
+    log.info('uhf_internal: lowest eigs of H = %s', e)
+    if nroots != 1:
+        e, v = e[0], v[0]
+    stable = not (e < -1e-5)
+    dump_status(log, stable, f'{mf.__class__}', 'internal')
+    if stable:
+        mo = mf.mo_coeff
+    else:
         nocca = numpy.count_nonzero(mf.mo_occ[0]> 0)
         nvira = numpy.count_nonzero(mf.mo_occ[0]==0)
         mo = (_rotate_mo(mf.mo_coeff[0], mf.mo_occ[0], v[:nocca*nvira]),
               _rotate_mo(mf.mo_coeff[1], mf.mo_occ[1], v[nocca*nvira:]))
-        stable = False
-    else:
-        log.note(f'{mf.__class__} wavefunction is stable in the internal '
-                 'stability analysis')
-        mo = mf.mo_coeff
     if return_status:
         return mo, stable
     else:
@@ -569,10 +600,10 @@ def _gen_hop_uhf_external(mf, with_symmetry=True, verbose=None):
     return hop_real2complex, hdiag1, hop_uhf2ghf, hdiag2
 
 
-def uhf_external(mf, with_symmetry=True, verbose=None, return_status=False):
+def uhf_external(mf, with_symmetry=True, verbose=None, return_status=False,
+                 nroots=STAB_NROOTS, tol=STAB_TOL):
     log = logger.new_logger(mf, verbose)
     hop1, hdiag1, hop2, hdiag2 = _gen_hop_uhf_external(mf, with_symmetry)
-    stable = True
 
     def precond(dx, e, x0):
         hdiagd = hdiag1 - e
@@ -582,12 +613,12 @@ def uhf_external(mf, with_symmetry=True, verbose=None, return_status=False):
     x0[hdiag1>1e-5] = 1. / hdiag1[hdiag1>1e-5]
     if not with_symmetry:  # allow to break point group symmetry
         x0[numpy.argmin(hdiag1)] = 1
-    e1, v = lib.davidson(hop1, x0, precond, tol=1e-4, verbose=log)
-    if e1 < -1e-5:
-        log.note(f'{mf.__class__} wavefunction has a real -> complex instability')
-    else:
-        log.note(f'{mf.__class__} wavefunction is stable in the real -> complex '
-                 'stability analysis')
+    e1, v = lib.davidson(hop1, x0, precond, tol=tol, verbose=log, nroots=nroots)
+    log.info('uhf_real2complex: lowest eigs of H = %s', e1)
+    if nroots != 1:
+        e1, v = e1[0], v[0]
+    stable1 = not (e1 < -1e-5)
+    dump_status(log, stable1, f'{mf.__class__}', 'real -> complex')
 
     def precond(dx, e, x0):
         hdiagd = hdiag2 - e
@@ -597,11 +628,14 @@ def uhf_external(mf, with_symmetry=True, verbose=None, return_status=False):
     x0[hdiag2>1e-5] = 1. / hdiag2[hdiag2>1e-5]
     if not with_symmetry:  # allow to break point group symmetry
         x0[numpy.argmin(hdiag2)] = 1
-    e3, v = lib.davidson(hop2, x0, precond, tol=1e-4, verbose=log)
-    log.debug('uhf_external: lowest eigs of H = %s', e3)
+    e3, v = lib.davidson(hop2, x0, precond, tol=tol, verbose=log, nroots=nroots)
+    log.info('uhf_external: lowest eigs of H = %s', e3)
+    if nroots != 1:
+        e3, v = e3[0], v[0]
+    stable = not (e3 < -1e-5)
+    dump_status(log, stable, f'{mf.__class__}', 'UHF/UKS -> GHF/GKS')
     mo = scipy.linalg.block_diag(*mf.mo_coeff)
-    if e3 < -1e-5:
-        log.note(f'{mf.__class__} wavefunction has an UHF/UKS -> GHF/GKS instability.')
+    if not stable:
         occidxa = numpy.where(mf.mo_occ[0]> 0)[0]
         viridxa = numpy.where(mf.mo_occ[0]==0)[0]
         occidxb = numpy.where(mf.mo_occ[1]> 0)[0]
@@ -618,10 +652,6 @@ def uhf_external(mf, with_symmetry=True, verbose=None, return_status=False):
         mo = numpy.dot(mo, u)
         mo = numpy.hstack([mo[:,:nocca], mo[:,nmo:nmo+noccb],
                            mo[:,nocca:nmo], mo[:,nmo+noccb:]])
-        stable = False
-    else:
-        log.note(f'{mf.__class__} wavefunction is stable in the UHF/UKS -> '
-                 'GHF/GKS stability analysis')
     if return_status:
         return mo, stable
     else:

--- a/pyscf/scf/test/test_stability.py
+++ b/pyscf/scf/test/test_stability.py
@@ -217,7 +217,7 @@ class KnownValues(unittest.TestCase):
         mf1 = scf.convert_to_ghf(mf).newton()
         s = mf1.det_ovlp(mo_e, mf1.mo_coeff, mf1.mo_occ, mf1.mo_occ,
                          mf1.get_ovlp())[0]
-        self.assertAlmostEqual(s, 0.57993272190912937, 6)
+        self.assertAlmostEqual(s, 0.5799335722196731, 5)
         mf1.kernel(mo_coeff=mo_e, mo_occ=mf1.mo_occ)
         self.assertAlmostEqual(mf1.e_tot, -149.6097443357186, 8)
 
@@ -237,7 +237,7 @@ class KnownValues(unittest.TestCase):
         mf1 = scf.convert_to_ghf(mf).newton()
         s = mf1.det_ovlp(mo_e, mf1.mo_coeff, mf1.mo_occ, mf1.mo_occ,
                          mf1.get_ovlp())[0]
-        self.assertAlmostEqual(s, 0.57993272190912937, 6)
+        self.assertAlmostEqual(s, 0.5799335722196731, 5)
         mf1.kernel(mo_coeff=mo_e, mo_occ=mf1.mo_occ)
         self.assertAlmostEqual(mf1.e_tot, -149.6097443357186, 8)
 

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -1025,7 +1025,8 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
                   internal=getattr(__config__, 'scf_stability_internal', True),
                   external=getattr(__config__, 'scf_stability_external', False),
                   verbose=None,
-                  return_status=False):
+                  return_status=False,
+                  **kwargs):
         '''
         Stability analysis for UHF/UKS method.
 
@@ -1055,7 +1056,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
             and the second corresponds to the external stability.
         '''
         from pyscf.scf.stability import uhf_stability
-        return uhf_stability(self, internal, external, verbose, return_status)
+        return uhf_stability(self, internal, external, verbose, return_status, **kwargs)
 
     def nuc_grad_method(self):
         from pyscf.grad import uhf


### PR DESCRIPTION
* allow user modifying Davidson solver tolerance in stability. It is important to use tight tol for some hard cases, as shown in the example. And this is part of #1416.
* allow user modifying nroots of Davidson solver of stability and set the default value to 3 instead of 1, as suggested and tested by #1587.
* print the eigenvalues by default (at verbose 4). So the user can see if the current eigenvalues is close to zero.