### PR TITLE
compare version as int, not str (#2309)

### DIFF
--- a/pyscf/grad/lagrange.py
+++ b/pyscf/grad/lagrange.py
@@ -192,7 +192,7 @@ class LagPrec :
         x /= Adiagd
         return x
 
-if scipy.__version__.split('.')[1] >= '14': # scipy 1.14
+if int (scipy.__version__.split('.')[1]) >= 14: # scipy 1.14
     def _cg(A, b, x0=None, *, tol=1e-05, atol=0.0, maxiter=None, M=None, callback=None):
         return sparse_linalg.cg(A, b, x0, rtol=tol, atol=atol, maxiter=maxiter,
                                 M=M, callback=callback)


### PR DESCRIPTION
Comparing as str will evaluate to True if version is between 1.2 and 1.10.