### PR TITLE
Use the logger instead of stderr for warnings in the pbc modules

### DIFF
--- a/pyscf/pbc/dft/numint.py
+++ b/pyscf/pbc/dft/numint.py
@@ -17,7 +17,6 @@
 #         Qiming Sun <osirpt.sun@gmail.com>
 #
 
-import sys
 import numpy
 from pyscf import lib
 from pyscf.dft import numint
@@ -28,6 +27,7 @@ from pyscf.dft.gen_grid import NBINS, CUTOFF, ALIGNMENT_UNIT
 from pyscf.pbc.dft.gen_grid import make_mask, BLKSIZE
 from pyscf.pbc.lib.kpts_helper import is_zero, KPT_DIFF_TOL
 from pyscf.pbc.lib.kpts import KPoints
+from pyscf.lib import logger
 
 
 def eval_ao(cell, coords, kpt=numpy.zeros(3), deriv=0, relativity=0, shls_slice=None,
@@ -75,10 +75,12 @@ def eval_ao_kpts(cell, coords, kpts=None, deriv=0, relativity=0,
         ao_kpts: (nkpts, [comp], ngrids, nao) ndarray
             AO values at each k-point
     '''
+    from types import SimpleNamespace
     if kpts is None:
         if 'kpt' in kwargs:
-            sys.stderr.write('WARN: KNumInt.eval_ao function finds keyword '
-                             'argument "kpt" and converts it to "kpts"\n')
+            logger.warn(SimpleNamespace(verbose=verbose),
+                        'KNumInt.eval_ao function finds keyword '
+                        'argument "kpt" and converts it to "kpts"')
             kpts = kwargs['kpt']
         else:
             kpts = numpy.zeros((1,3))
@@ -1159,8 +1161,9 @@ class KNumInt(lib.StreamObject, numint.LibXCMixin):
                kpts=None, kpts_band=None, max_memory=2000, verbose=None, **kwargs):
         if kpts is None:
             if 'kpt' in kwargs:
-                sys.stderr.write('WARN: KNumInt.nr_rks function finds keyword '
-                                 'argument "kpt" and converts it to "kpts"\n')
+                logger.warn(self, 'KNumInt.nr_rks function finds '
+                                  'keyword argument "kpt" and converts it '
+                                  'to "kpts"')
                 kpts = kwargs['kpt']
             else:
                 kpts = self.kpts
@@ -1174,8 +1177,9 @@ class KNumInt(lib.StreamObject, numint.LibXCMixin):
                kpts=None, kpts_band=None, max_memory=2000, verbose=None, **kwargs):
         if kpts is None:
             if 'kpt' in kwargs:
-                sys.stderr.write('WARN: KNumInt.nr_uks function finds keyword '
-                                 'argument "kpt" and converts it to "kpts"\n')
+                logger.warn(self, 'KNumInt.nr_uks function finds '
+                                  'keyword argument "kpt" and converts it '
+                                  'to "kpts"')
                 kpts = kwargs['kpt']
             else:
                 kpts = self.kpts

--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -17,7 +17,6 @@
 #         Timothy Berkelbach <tim.berkelbach@gmail.com>
 #
 
-import sys
 import json
 import ctypes
 import warnings
@@ -1337,10 +1336,13 @@ class Cell(mole.MoleBase):
         exp_min = np.array([self.bas_exp(ib).min() for ib in range(self.nbas)])
         if self.exp_to_discard is None:
             if np.any(exp_min < 0.1):
-                sys.stderr.write('''WARNING!
-  Very diffused basis functions are found in the basis set. They may lead to severe
-  linear dependence and numerical instability.  You can set  cell.exp_to_discard=0.1
-  to remove the diffused Gaussians whose exponents are less than 0.1.\n\n''')
+                logger.warn(self, 'Very diffused basis functions are found '
+                                  'in the basis set. They may lead to severe '
+                                  'linear dependence and numerical '
+                                  'instability.  You can set '
+                                  'cell.exp_to_discard=0.1 to remove the '
+                                  'diffused Gaussians whose exponents are '
+                                  'less than 0.1.')
         elif np.any(exp_min < self.exp_to_discard):
             # Discard functions of small exponents in basis
             _basis = {}
@@ -1420,18 +1422,20 @@ class Cell(mole.MoleBase):
 
         _a = self.lattice_vectors()
         if np.linalg.det(_a) < 0:
-            sys.stderr.write('''WARNING!
-  Lattice are not in right-handed coordinate system. This can cause wrong value for some integrals.
-  It's recommended to resort the lattice vectors to\na = %s\n\n''' % _a[[0,2,1]])
+            logger.warn(self, "Lattice are not in right-handed coordinate "
+                              "system. This can cause wrong value for some "
+                              "integrals.  It's recommended to resort the "
+                              "lattice vectors to a = %s" % _a[[0,2,1]])
 
         if self.dimension == 2 and self.low_dim_ft_type != 'inf_vacuum':
             # check vacuum size. See Fig 1 of PRB, 73, 2015119
             #Lz_guess = self.rcut*(1+np.sqrt(2))
             Lz_guess = self.rcut * 2
             if np.linalg.norm(_a[2]) < 0.7 * Lz_guess:
-                sys.stderr.write('''WARNING!
-  Size of vacuum may not be enough. The recommended vacuum size is %s AA (%s Bohr)\n\n'''
-                                 % (Lz_guess*param.BOHR, Lz_guess))
+                logger.warn(self, 'Size of vacuum may not be enough. The '
+                                  'recommended vacuum size is '
+                                  '%s AA (%s Bohr)'
+                                  % (Lz_guess*param.BOHR, Lz_guess))
 
         if self.mesh is None or self._mesh_from_build:
             if self.ke_cutoff is None:

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -25,8 +25,6 @@ See Also:
     pyscf.pbc.scf.khf.py : Hartree-Fock for periodic systems with k-point sampling
 '''
 
-import sys
-
 import numpy as np
 import h5py
 from pyscf.scf import hf as mol_hf
@@ -514,7 +512,7 @@ class SCF(mol_hf.SCF):
     def __init__(self, cell, kpt=np.zeros(3),
                  exxdiv=getattr(__config__, 'pbc_scf_SCF_exxdiv', 'ewald')):
         if not cell._built:
-            sys.stderr.write('Warning: cell.build() is not called in input\n')
+            logger.warn(self, 'cell.build() is not called in input')
             cell.build()
         mol_hf.SCF.__init__(self, cell)
 

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -25,8 +25,6 @@ See Also:
     hf.py : Hartree-Fock for periodic systems at a single k-point
 '''
 
-import sys
-
 from functools import reduce
 import numpy as np
 import scipy.linalg
@@ -443,7 +441,7 @@ class KSCF(pbchf.SCF):
     def __init__(self, cell, kpts=np.zeros((1,3)),
                  exxdiv=getattr(__config__, 'pbc_scf_SCF_exxdiv', 'ewald')):
         if not cell._built:
-            sys.stderr.write('Warning: cell.build() is not called in input\n')
+            logger.warn(self, 'cell.build() is not called in input')
             cell.build()
         mol_hf.SCF.__init__(self, cell)
 

--- a/pyscf/pbc/symm/symmetry.py
+++ b/pyscf/pbc/symm/symmetry.py
@@ -16,7 +16,6 @@
 # Authors: Xing Zhang <zhangxing.nju@gmail.com>
 #
 
-import sys
 import copy
 from functools import reduce
 import numpy as np
@@ -172,15 +171,17 @@ class Symmetry():
             self.ops = [space_group.SPGElement(),]
         else:
             if not cell._built:
-                sys.stderr.write('Warning: %s must be initialized before calling Symmetry.\n'
-                                 'Initialize %s in %s\n' % (cell, cell, self))
+                logger.warn(self, '%s must be initialized before calling '
+                                  'Symmetry. Initialize %s in %s'
+                                  % (cell, cell, self))
                 cell.build()
 
             self.spacegroup = space_group.SpaceGroup(cell).build(dump_info=False)
             self.symmorphic = symmorphic
             if cell.dimension < 3:
                 if not self.symmorphic:
-                    sys.stderr.write('Warning: setting symmorphic=True for low-dimensional system.\n')
+                    logger.warn(self, 'setting symmorphic=True for '
+                                      'low-dimensional system.')
                     self.symmorphic = True
 
             ops = self.spacegroup.ops


### PR DESCRIPTION
Inside the pbc modules, many times `sys.stderr.write` is used to write warnings, instead of the `warn` member function of `pyscf.lib.logger`. This makes it difficult to suppress warnings. I modified each of those spots to instead call the logger. 

In all but one place, I could pass `self` to `warn` to ensure the verbosity parameter was communicated. However, in `pyscf/pbc/dft/numint.py`, the function `eval_ao` takes instead an integer directly for the verbosity. This is why I use the `SimpleNamespace` trick there, but if you prefer another approach let me know.