### PR TITLE
Use weakref for automatic deletion of tmpfiles (to fix #2318)

### DIFF
--- a/.github/workflows/run_tests.sh
+++ b/.github/workflows/run_tests.sh
@@ -3,7 +3,7 @@ export OMP_NUM_THREADS=1
 export PYTHONPATH=$(pwd):$PYTHONPATH 
 ulimit -s 20000
 
-mkdir pyscftmpdir
+mkdir -p pyscftmpdir
 echo 'pbc_tools_pbc_fft_engine = "NUMPY"' > .pyscf_conf.py
 echo "dftd3_DFTD3PATH = './pyscf/lib/deps/lib'" >> .pyscf_conf.py
 echo "scf_hf_SCF_mute_chkfile = True" >> .pyscf_conf.py
@@ -18,5 +18,13 @@ else
   pytest pyscf/ -s -c pytest.ini pyscf
 fi
 
-echo "There are $(ls pyscftmpdir | wc -l) leftover temporary files"
+pytest_status=$?
+
+num_tmpfiles="$(ls -1 pyscftmpdir | wc -l)"
+echo "There are "$num_tmpfiles" leftover temporary files"
 rm -rf pyscftmpdir
+
+# Test fails if pytest failed or if temporary files were left over.
+if test "$num_tmpfiles" -gt 0 || test "$pytest_status" -ne 0; then
+  exit 1
+fi

--- a/.github/workflows/run_tests.sh
+++ b/.github/workflows/run_tests.sh
@@ -3,9 +3,11 @@ export OMP_NUM_THREADS=1
 export PYTHONPATH=$(pwd):$PYTHONPATH 
 ulimit -s 20000
 
+mkdir pyscftmpdir
 echo 'pbc_tools_pbc_fft_engine = "NUMPY"' > .pyscf_conf.py
 echo "dftd3_DFTD3PATH = './pyscf/lib/deps/lib'" >> .pyscf_conf.py
 echo "scf_hf_SCF_mute_chkfile = True" >> .pyscf_conf.py
+echo 'TMPDIR = "./pyscftmpdir"' >> .pyscf_conf.py
 
 version=$(python -c 'import sys; print("{0}.{1}".format(*sys.version_info[:2]))')
 # pytest-cov on Python 3.12 consumes huge memory
@@ -15,3 +17,6 @@ if [ "$RUNNER_OS" == "Linux" ] && [ $version != "3.12" ]; then
 else
   pytest pyscf/ -s -c pytest.ini pyscf
 fi
+
+echo "There are $(ls pyscftmpdir | wc -l) leftover temporary files"
+rm -rf pyscftmpdir

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -1145,7 +1145,7 @@ class H5FileWrap(h5py.File):
         causes outcore DF to hang on an NFS filesystem.
         '''
         try:
-            if super().id:
+            if super().id and super().id.valid:
                 super().flush()
             super().close()
         except AttributeError:  # close not defined in old h5py

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -31,6 +31,7 @@ import functools
 import itertools
 import inspect
 import collections
+import weakref
 import ctypes
 import numpy
 import scipy
@@ -1181,6 +1182,14 @@ class H5TmpFile(H5FileWrap):
         if filename is None:
             filename = H5TmpFile._gen_unique_name(dir, pre=prefix, suf=suffix)
             self.delete_on_close = True
+
+        def _delete_with_check(fname, should_delete):
+            if should_delete and os.path.exists(fname):
+                os.remove(fname)
+
+        self._finalizer = weakref.finalize(self, _delete_with_check,
+                                           filename, self.delete_on_close)
+
         super().__init__(filename, mode, *args, **kwargs)
 
     # Python 3 stdlib does not have a way to just generate
@@ -1201,11 +1210,9 @@ class H5TmpFile(H5FileWrap):
         raise FileExistsError("No usable temporary file name found")
 
     def close(self):
-        filename = self.filename
         self._finished()
-        if self.delete_on_close:
-            if os.path.exists(filename):
-                os.remove(filename)
+        self._finalizer()
+
     def __exit__(self, type, value, traceback):
         self.close()
 


### PR DESCRIPTION
This is intended to fix #2318 using weakref-based finalizers (see the example in https://docs.python.org/3/library/weakref.html)