### PR TITLE
Fix to kscf for dft

### DIFF
--- a/pyscf/pbc/scf/addons.py
+++ b/pyscf/pbc/scf/addons.py
@@ -497,6 +497,10 @@ def convert_to_kscf(mf, out=None):
                 mf.mo_coeff = mf.mo_coeff[numpy.newaxis]
                 mf.mo_energy = mf.mo_energy[numpy.newaxis]
 
+        if hasattr(mf, '_numint'):
+            kpts = mf.kpts.kpts if isinstance(mf.kpts, KPoints) else mf.kpts
+            mf._numint = dft.numint.KNumInt(kpts)
+
     if out is None:
         return mf
 

--- a/pyscf/pbc/scf/addons.py
+++ b/pyscf/pbc/scf/addons.py
@@ -488,10 +488,10 @@ def convert_to_kscf(mf, out=None):
         }
         mf = mol_addons._object_without_soscf(mf, known_cls, False)
         if mf.mo_energy is not None:
-            if mf.istype('UHF'):
-                mf.mo_occ = mf.mo_occ[:,numpy.newaxis]
-                mf.mo_coeff = mf.mo_coeff[:,numpy.newaxis]
-                mf.mo_energy = mf.mo_energy[:,numpy.newaxis]
+            if isinstance(mf, scf.kuhf.KUHF):
+                mf.mo_occ = mf.mo_occ[numpy.newaxis]
+                mf.mo_coeff = mf.mo_coeff[numpy.newaxis]
+                mf.mo_energy = mf.mo_energy[numpy.newaxis]
             else:
                 mf.mo_occ = mf.mo_occ[numpy.newaxis]
                 mf.mo_coeff = mf.mo_coeff[numpy.newaxis]

--- a/pyscf/pbc/scf/addons.py
+++ b/pyscf/pbc/scf/addons.py
@@ -498,7 +498,7 @@ def convert_to_kscf(mf, out=None):
                 mf.mo_energy = mf.mo_energy[numpy.newaxis]
 
         if hasattr(mf, '_numint'):
-            kpts = mf.kpts.kpts if isinstance(mf.kpts, KPoints) else mf.kpts
+            kpts = getattr(mf.kpts, 'kpts', mf.kpts)
             mf._numint = dft.numint.KNumInt(kpts)
 
     if out is None:

--- a/pyscf/pbc/scf/test/test_addons.py
+++ b/pyscf/pbc/scf/test/test_addons.py
@@ -312,6 +312,11 @@ class KnownValues(unittest.TestCase):
         mf1 = pscf.ROHF(cell)
         self.assertTrue(isinstance(pscf.addons.convert_to_khf(mf1), pscf.krohf.KROHF))
 
+        from pyscf.pbc import dft
+        mf1 = dft.RKS(cell)
+        self.assertTrue(isinstance(mf1._numint, dft.numint.NumInt))
+        self.assertTrue(isinstance(pscf.addons.convert_to_kscf(mf1)._numint, dft.numint.KNumInt))
+
     def test_canonical_occ(self):
         kpts = numpy.random.rand(2,3)
         mf1 = pscf.kuhf.KUHF(cell, kpts)


### PR DESCRIPTION
`pyscf.pbc.scf.addons.convert_to_kscf` is not updating `_numint` to k-points version.