### PR TITLE
Fix MP2 FNO bug when pct_occ=1

### DIFF
--- a/pyscf/mp/mp2.py
+++ b/pyscf/mp/mp2.py
@@ -248,7 +248,8 @@ def make_fno(mp, thresh=1e-6, pct_occ=None, nvir_act=None, t2=None):
         else:
             cumsum = numpy.cumsum(n/numpy.sum(n))
             logger.debug(mp, 'Sum(pct_occ): %s', cumsum)
-            nvir_keep = numpy.count_nonzero(cumsum<pct_occ)
+            nvir_keep = numpy.count_nonzero(
+                [c <= pct_occ or numpy.isclose(c, pct_occ) for c in cumsum])
     else:
         nvir_keep = min(nvir, nvir_act)
 

--- a/pyscf/mp/ump2.py
+++ b/pyscf/mp/ump2.py
@@ -323,7 +323,8 @@ def make_fno(mp, thresh=1e-6, pct_occ=None, nvir_act=None, t2=None, eris=None):
             else:
                 cumsum = numpy.cumsum(n/numpy.sum(n))
                 logger.debug(mp, 'Sum(pct_occ): %s', cumsum)
-                nvir_keep = numpy.count_nonzero(cumsum<pct_occ)
+                nvir_keep = numpy.count_nonzero(
+                    [c <= pct_occ or numpy.isclose(c, pct_occ) for c in cumsum])
         else:
             nvir_keep = min(nvir, nvir_act[s])
 


### PR DESCRIPTION
When MP2 FNOs are made using kwarg `pct_occ=1`, not all virtuals are included due to a floating point comparison of `1<1`. This bugfix ensures that all virtuals are included in this limiting case.