### PR TITLE
Use `self.ci` if set for mcscf

### DIFF
--- a/pyscf/fci/direct_spin0_symm.py
+++ b/pyscf/fci/direct_spin0_symm.py
@@ -97,7 +97,8 @@ def get_init_guess(norb, nelec, nroots, hdiag, orbsym, wfnsym=0):
         ci0.append(x.ravel().view(direct_spin1.FCIvector))
 
     if len(ci0) == 0:
-        raise RuntimeError(f'Initial guess for symmetry {wfnsym} not found')
+        raise lib.exceptions.WfnSymmetryError(
+            f'Initial guess for symmetry {wfnsym} not found')
     return ci0
 
 def get_init_guess_cyl_sym(norb, nelec, nroots, hdiag, orbsym, wfnsym=0):
@@ -146,7 +147,8 @@ def get_init_guess_cyl_sym(norb, nelec, nroots, hdiag, orbsym, wfnsym=0):
             break
 
     if len(ci0) == 0:
-        raise RuntimeError(f'Initial guess for symmetry {wfnsym} not found')
+        raise lib.exceptions.WfnSymmetryError(
+            f'Initial guess for symmetry {wfnsym} not found')
     return ci0
 
 

--- a/pyscf/fci/direct_spin1_symm.py
+++ b/pyscf/fci/direct_spin1_symm.py
@@ -237,7 +237,8 @@ def _get_init_guess(airreps, birreps, nroots, hdiag, nelec, orbsym, wfnsym=0):
         ci0.append(x.ravel().view(direct_spin1.FCIvector))
 
     if len(ci0) == 0:
-        raise RuntimeError(f'Initial guess for symmetry {wfnsym} not found')
+        raise lib.exceptions.WfnSymmetryError(
+            f'Initial guess for symmetry {wfnsym} not found')
     return ci0
 
 def get_init_guess(norb, nelec, nroots, hdiag, orbsym, wfnsym=0):
@@ -263,7 +264,8 @@ def get_init_guess(norb, nelec, nroots, hdiag, orbsym, wfnsym=0):
         ci0.append(x.ravel().view(direct_spin1.FCIvector))
 
     if len(ci0) == 0:
-        raise RuntimeError(f'Initial guess for symmetry {wfnsym} not found')
+        raise lib.exceptions.WfnSymmetryError(
+            f'Initial guess for symmetry {wfnsym} not found')
     return ci0
 
 def _validate_degen_mapping(mapping, norb):
@@ -355,7 +357,8 @@ def get_init_guess_cyl_sym(norb, nelec, nroots, hdiag, orbsym, wfnsym=0):
             break
 
     if len(ci0) == 0:
-        raise RuntimeError(f'Initial guess for symmetry {wfnsym} not found')
+        raise lib.exceptions.WfnSymmetryError(
+            f'Initial guess for symmetry {wfnsym} not found')
     return ci0
 
 def _cyl_sym_csf2civec(strs, addr, orbsym, degen_mapping):
@@ -598,8 +601,9 @@ def guess_wfnsym(solver, norb, nelec, fcivec=None, orbsym=None, wfnsym=None, **k
                 fcivec = fcivec[0]
             wfnsym1 = _guess_wfnsym_cyl_sym(fcivec, strsa, strsb, orbsym)
             if wfnsym1 != _id_wfnsym(solver, norb, nelec, orbsym, wfnsym):
-                raise RuntimeError(f'Input wfnsym {wfnsym} is not consistent with '
-                                   f'fcivec symmetry {wfnsym1}')
+                raise lib.exceptions.WfnSymmetryError(
+                    f'Input wfnsym {wfnsym} is not consistent with '
+                    f'fcivec symmetry {wfnsym1}')
             wfnsym = wfnsym1
         else:
             na, nb = strsa.size, strsb.size
@@ -617,8 +621,8 @@ def guess_wfnsym(solver, norb, nelec, fcivec=None, orbsym=None, wfnsym=None, **k
             if isinstance(fcivec, np.ndarray) and fcivec.ndim <= 2:
                 fcivec = [fcivec]
             if all(abs(c.reshape(na, nb)[mask]).max() < 1e-5 for c in fcivec):
-                raise RuntimeError('Input wfnsym {wfnsym} is not consistent with '
-                                   'fcivec coefficients')
+                raise lib.exceptions.WfnSymmetryError(
+                    'Input wfnsym {wfnsym} is not consistent with fcivec coefficients')
     return wfnsym
 
 def sym_allowed_indices(nelec, orbsym, wfnsym):
@@ -787,7 +791,7 @@ class FCISolver(direct_spin1.FCISolver):
         logger.debug(self, 'Num symmetry allowed elements %d',
                      sum([x.size for x in self.sym_allowed_idx]))
         if s_idx.size == 0:
-            raise RuntimeError(
+            raise lib.exceptions.WfnSymmetryError(
                 f'Symmetry allowed determinants not found for wfnsym {wfnsym}')
 
         if wfnsym_ir > 7:

--- a/pyscf/lib/exceptions.py
+++ b/pyscf/lib/exceptions.py
@@ -20,3 +20,6 @@ class BasisNotFoundError(RuntimeError):
 
 class PointGroupSymmetryError(RuntimeError):
     pass
+
+class WfnSymmetryError(RuntimeError):
+    pass

--- a/pyscf/mcscf/casci.py
+++ b/pyscf/mcscf/casci.py
@@ -583,6 +583,8 @@ def kernel(casci, mo_coeff=None, ci0=None, verbose=logger.NOTE, envs=None):
             and "envs" pop in kernel function
     '''
     if mo_coeff is None: mo_coeff = casci.mo_coeff
+    if ci0 is None: ci0 = casci.ci
+
     log = logger.new_logger(casci, verbose)
     t0 = (logger.process_clock(), logger.perf_counter())
     log.debug('Start CASCI')

--- a/pyscf/mcscf/mc1step.py
+++ b/pyscf/mcscf/mc1step.py
@@ -853,6 +853,9 @@ To enable the solvent model for CASSCF, the following code needs to be called
             self.mo_coeff = mo_coeff
         if callback is None: callback = self.callback
 
+        if ci0 is None:
+            ci0 = self.ci
+
         self.check_sanity()
         self.dump_flags()
 

--- a/pyscf/mcscf/mc1step.py
+++ b/pyscf/mcscf/mc1step.py
@@ -341,6 +341,9 @@ def kernel(casscf, mo_coeff, tol=1e-7, conv_tol_grad=None,
     if callback is None:
         callback = casscf.callback
 
+    if ci0 is None:
+        ci0 = casscf.ci
+
     mo = mo_coeff
     nmo = mo_coeff.shape[1]
     ncore = casscf.ncore

--- a/pyscf/mcscf/test/test_mc1step.py
+++ b/pyscf/mcscf/test/test_mc1step.py
@@ -25,10 +25,11 @@ from pyscf import fci
 from pyscf import mcscf
 
 def setUpModule():
+    global mols
     global mol, molsym, m, msym, mc0
     b = 1.4
     mol = gto.M(
-    verbose = 5,
+    verbose = 0,
     output = '/dev/null',
     atom = [
         ['N',(  0.000000,  0.000000, -b/2)],
@@ -42,7 +43,7 @@ def setUpModule():
     mc0 = mcscf.CASSCF(m, 4, 4).run()
 
     molsym = gto.M(
-    verbose = 5,
+    verbose = 0,
     output = '/dev/null',
     atom = [
         ['N',(  0.000000,  0.000000, -b/2)],
@@ -86,7 +87,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(mc1.e_tot, -109.02535605303684, 7)
 
     def test_0core_0virtual(self):
-        mol = gto.M(atom='He', basis='321g')
+        mol = gto.M(atom='He', basis='321g', verbose=0)
         mf = scf.RHF(mol).run()
         mc1 = mcscf.CASSCF(mf, 2, 2).run()
         self.assertAlmostEqual(mc1.e_tot, -2.850576699649737, 9)
@@ -316,14 +317,14 @@ class KnownValues(unittest.TestCase):
         mc.analyze()
         mo_coeff, civec, mo_occ = mc.cas_natorb(sort=True)
 
-        mc.kernel(mo_coeff=mo_coeff)
+        mc.kernel(mo_coeff=mo_coeff, ci0=civec)
         self.assertAlmostEqual(mc.e_states[0], -108.7506795311190, 5)
         self.assertAlmostEqual(mc.e_states[1], -108.8582272809495, 5)
         self.assertAlmostEqual(abs((civec[0]*mc.ci[0]).sum()), 1, 7)
         self.assertAlmostEqual(abs((civec[1]*mc.ci[1]).sum()), 1, 7)
 
     def test_small_system(self):
-        mol = gto.M(atom='H 0 0 0; H 0 0 .74', symmetry=True, basis='6-31g')
+        mol = gto.M(atom='H 0 0 0; H 0 0 .74', symmetry=True, basis='6-31g', verbose=0)
         mf = scf.RHF(mol).run()
         mc = mcscf.CASSCF(mf, 2, 2)
         mc.max_cycle = 5

--- a/pyscf/mcscf/test/test_mc1step.py
+++ b/pyscf/mcscf/test/test_mc1step.py
@@ -25,7 +25,6 @@ from pyscf import fci
 from pyscf import mcscf
 
 def setUpModule():
-    global mols
     global mol, molsym, m, msym, mc0
     b = 1.4
     mol = gto.M(

--- a/pyscf/mcscf/test/test_n2.py
+++ b/pyscf/mcscf/test/test_n2.py
@@ -165,6 +165,7 @@ class KnownValues(unittest.TestCase):
         emc = mc.mc1step()[0]
         self.assertAlmostEqual(emc, -108.74508322877787, 7)
 
+        mc = mcscf.CASSCF(msym, 4, (3,1))
         mc.wfnsym = 'A2u'
         emc = mc.mc1step()[0]
         self.assertAlmostEqual(emc, -108.69019443475308, 7)

--- a/pyscf/mcscf/test/test_n2.py
+++ b/pyscf/mcscf/test/test_n2.py
@@ -17,6 +17,7 @@ import unittest
 import numpy
 from pyscf import gto
 from pyscf import scf
+from pyscf import lib
 from pyscf import mcscf
 
 def setUpModule():
@@ -165,8 +166,10 @@ class KnownValues(unittest.TestCase):
         emc = mc.mc1step()[0]
         self.assertAlmostEqual(emc, -108.74508322877787, 7)
 
-        mc = mcscf.CASSCF(msym, 4, (3,1))
         mc.wfnsym = 'A2u'
+        with self.assertRaises(lib.exceptions.WfnSymmetryError):
+            mc.mc1step()
+        mc.ci = None
         emc = mc.mc1step()[0]
         self.assertAlmostEqual(emc, -108.69019443475308, 7)
 


### PR DESCRIPTION
Suppose there is an mcscf solver as such 

```python
mol = gto.M(atom="h 0 0 0; h 1 0 0", basis="sto-3g")
mf = mol.RHF().run()
mc = mcscf.CASSCF(2,2)

mc.kernel()
```

If we call `mc.kernel` again, one would expect that the calculation would reuse both the converged MO coefficients and CI. Unfortunately this is not the case, it will only reuse the MO coefficients. This PR fixes this by reusing the `mc.ci` if `ci0` is not passed into the kernel function. 

Note, that this is also important if one uses a checkpoint file and saves the ci vector to it using the `chk_ci` flag. If one uses the provided `.update()` function as 

```python
mc.update("old_chk")
mc.kernel()
```
again, the old CI coefficients stored in `"old_chk"` would not be used.