### PR TITLE
Fix DHF dipole moment

### DIFF
--- a/pyscf/scf/dhf.py
+++ b/pyscf/scf/dhf.py
@@ -416,7 +416,7 @@ def dip_moment(mol, dm, unit='Debye', verbose=logger.NOTE, **kwargs):
 
     charges = mol.atom_charges()
     coords  = mol.atom_coords()
-    charge_center = numpy.einsum('i,ix->x', charges, coords)
+    charge_center = numpy.einsum('i,ix->x', charges, coords) / sum(charges)
     with mol.with_common_orig(charge_center):
         ll_dip = mol.intor_symmetric('int1e_r_spinor', comp=3)
         ss_dip = mol.intor_symmetric('int1e_sprsp_spinor', comp=3)
@@ -424,7 +424,7 @@ def dip_moment(mol, dm, unit='Debye', verbose=logger.NOTE, **kwargs):
     n2c = mol.nao_2c()
     c = lib.param.LIGHT_SPEED
     dip = numpy.einsum('xij,ji->x', ll_dip, dm[:n2c,:n2c]).real
-    dip+= numpy.einsum('xij,ji->x', ss_dip, dm[n2c:,n2c:]).real * (.5/c**2)
+    dip+= numpy.einsum('xij,ji->x', ss_dip, dm[n2c:,n2c:]).real * (.5/c)**2
 
     if unit.upper() == 'DEBYE':
         dip *= nist.AU2DEBYE

--- a/pyscf/scf/dhf.py
+++ b/pyscf/scf/dhf.py
@@ -426,6 +426,8 @@ def dip_moment(mol, dm, unit='Debye', verbose=logger.NOTE, **kwargs):
     dip = numpy.einsum('xij,ji->x', ll_dip, dm[:n2c,:n2c]).real
     dip+= numpy.einsum('xij,ji->x', ss_dip, dm[n2c:,n2c:]).real * (.5/c)**2
 
+    dip *= -1.
+
     if unit.upper() == 'DEBYE':
         dip *= nist.AU2DEBYE
         log.note('Dipole moment(X, Y, Z, Debye): %8.5f, %8.5f, %8.5f', *dip)


### PR DESCRIPTION
The current DHF dipole implementation has a few problems. This PR fixes them.

1. The charge center was not calculated properly.
2. The ss block integral was divided by (0.5*c^2) while it should be (0.5*c)^2
3. The electronic part of dipole missed a negative sign.