### PR TITLE
Fix define_xc example

### DIFF
--- a/examples/dft/24-define_xc_functional.py
+++ b/examples/dft/24-define_xc_functional.py
@@ -50,11 +50,11 @@ def eval_xc(xc_code, rho, spin=0, relativity=0, deriv=1, omega=None, verbose=Non
     kxc = None  # 3rd order functional derivative
 
     # Mix with existing functionals
-    pbe_xc = dft.libxc.eval_xc('pbe,pbe', rho, spin, relativity, deriv,
-                               verbose)
+    pbe_xc = dft.libxc.eval_xc('pbe,pbe', rho, spin, relativity, deriv, verbose)
     exc += pbe_xc[0] * 0.5
     vrho += pbe_xc[1][0] * 0.5
     vgamma += pbe_xc[1][1] * 0.5
+    # The output follows the libxc.eval_xc API convention
     return exc, vxc, fxc, kxc
 
 mf = dft.RKS(mol)
@@ -70,4 +70,3 @@ mf = dft.RKS(mol)
 mf = mf.define_xc_(eval_xc, 'GGA', rsh=rsh_coeff)
 mf.verbose = 4
 mf.kernel()
-

--- a/examples/fci/03-cylindrical_symmetry.py
+++ b/examples/fci/03-cylindrical_symmetry.py
@@ -26,5 +26,5 @@ eri = ao2mo.kernel(mol, c)
 solver = direct_spin1_cyl_sym.FCI(mol)
 for sym in ['A1g', 'A1u', 'E1ux', 'E1uy', 'E1gx', 'E1gy', 'E2ux', 'E2uy', 'E2gx', 'E2gy', 'E3ux', 'E3uy', 'E3gx', 'E3gy']:
     e, v = solver.kernel(h1e, eri, c.shape[1], mol.nelec, orbsym=orbsym,
-                         wfnsym=sym, nroots=5, verbose=0)
+                         wfnsym=sym, nroots=5, ecore=mol.energy_nuc(), verbose=0)
     print(f'{sym}: {e}')

--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -1609,13 +1609,17 @@ def eval_xc1(xc_code, rho, spin=0, deriv=1, omega=None):
     '''
     out = _eval_xc(xc_code, rho, spin, deriv=deriv, omega=omega)
     xctype = xc_type(xc_code)
+    idx = _libxc_to_xcfun_indices(xctype, spin, deriv)
+    return out[idx]
+
+def _libxc_to_xcfun_indices(xctype, spin=0, deriv=1):
     if deriv <= 1:
-        return out
+        return slice(None)
     elif xctype == 'LDA' or xctype == 'HF':
-        return out
+        return slice(None)
     elif xctype == 'GGA':
         if spin == 0:
-            return out
+            return slice(None)
         else:
             idx = [numpy.arange(6)] # up to deriv=1
             for i in range(2, deriv+1):
@@ -1627,7 +1631,7 @@ def eval_xc1(xc_code, rho, spin=0, deriv=1, omega=None):
             idx = [numpy.arange(8)] # up to deriv=1
         for i in range(2, deriv+1):
             idx.append(_MGGA_SORT[(spin, i)])
-    return out[numpy.hstack(idx)]
+    return numpy.hstack(idx)
 
 def _eval_xc(xc_code, rho, spin=0, deriv=1, omega=None):
     assert deriv <= max_deriv_order(xc_code)
@@ -1762,19 +1766,43 @@ def define_xc_(ni, description, xctype='LDA', hyb=0, rsh=(0,0,0)):
     48.8525211046668
     '''
     if isinstance(description, str):
-        ni.eval_xc = lambda xc_code, rho, *args, **kwargs: \
-                eval_xc(description, rho, *args, **kwargs)
+        def _eval_xc(xc_code, rho, *args, **kwargs):
+            return eval_xc(description, rho, *args, **kwargs)
+        ni.eval_xc = _eval_xc
         ni.hybrid_coeff = lambda *args, **kwargs: hybrid_coeff(description)
         ni.rsh_coeff = lambda *args: rsh_coeff(description)
         ni._xc_type = lambda *args: xc_type(description)
 
     elif callable(description):
-        ni.eval_xc = description
+        ni.eval_xc = _eval_xc = description
         ni.hybrid_coeff = lambda *args, **kwargs: hyb
         ni.rsh_coeff = lambda *args, **kwargs: rsh
         ni._xc_type = lambda *args: xctype
+
     else:
         raise ValueError('Unknown description %s' % description)
+
+    def _eval_xc1(xc_code, rho, spin=0, deriv=1, omega=None):
+        libxc_out = _eval_xc(xc_code, rho, spin, deriv=deriv, omega=omega)
+        nvar, xlen = xc_deriv._XC_NVAR[xctype, spin]
+        outlen = lib.comb(xlen+deriv, deriv)
+        exc, vxc, fxc, kxc = libxc_out[:4]
+        out = [exc]
+        if vxc is not None:
+            out.extend([x for x in vxc if x is not None])
+        if fxc is not None:
+            out.extend([fxc[i] for i in [0, 1, 2, 6, 4, 9]])
+        if kxc is not None:
+            out.extend([x for x in kxc if x is not None])
+        if spin == 1:
+            # Returns of eval_xc are structured as [grid_id,deriv_component]
+            # for each term in libxc_out. Change the shape to [deriv_comp, grid_id]
+            out = [x.T for x in out]
+        out = numpy.vstack(out)[:outlen]
+        assert len(out) == outlen
+        idx = _libxc_to_xcfun_indices(xctype, spin, deriv)
+        return out[idx]
+    ni.eval_xc1 = _eval_xc1
     return ni
 
 def define_xc(ni, description, xctype='LDA', hyb=0, rsh=(0,0,0)):

--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -2654,6 +2654,10 @@ class LibXCMixin:
         return self.libxc.eval_xc(xc_code, rho, spin, relativity, deriv,
                                   omega, verbose)
 
+    def eval_xc1(xc_code, rho, spin=0, deriv=1, omega=None):
+        if omega is None: omega = self.omega
+        return self.libxc.eval_xc1(xc_code, rho, spin, deriv, omega)
+
     def eval_xc_eff(self, xc_code, rho, deriv=1, omega=None, xctype=None,
                     verbose=None):
         r'''Returns the derivative tensor against the density parameters
@@ -2693,12 +2697,12 @@ class LibXCMixin:
         else:
             spin = 0
 
-        out = self.libxc.eval_xc1(xc_code, rho, spin, deriv, omega)
+        out = self.eval_xc1(xc_code, rho, spin, deriv, omega)
         evfk = [out[0]]
         for order in range(1, deriv+1):
             evfk.append(xc_deriv.transform_xc(rho, out, xctype, spin, order))
         if deriv < 3:
-            # The return has at least [e, v, f, k] terms
+            # Returns at least [e, v, f, k] terms
             evfk.extend([None] * (3 - deriv))
         return evfk
 

--- a/pyscf/dft/test/test_libxc.py
+++ b/pyscf/dft/test/test_libxc.py
@@ -22,7 +22,7 @@ from pyscf import dft
 from pyscf import lib
 
 def setUpModule():
-    global mol, mf, ao, rho
+    global mol, mf, ao, rho, dm
     mol = gto.Mole()
     mol.verbose = 0
     mol.output = None
@@ -206,7 +206,7 @@ class KnownValues(unittest.TestCase):
     #    e, v = dft.libxc.eval_xc('tpss,', (rho_a, rho_b), spin=1, deriv=1)[:2]
 
     def test_define_xc(self):
-        def eval_xc(xc_code, rho, spin=0, relativity=0, deriv=1, verbose=None):
+        def eval_xc(xc_code, rho, spin=0, relativity=0, deriv=1, omega=None, verbose=None):
             # A fictitious XC functional to demonstrate the usage
             rho0, dx, dy, dz = rho[:4]
             gamma = (dx**2 + dy**2 + dz**2)
@@ -228,6 +228,11 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(lib.fp(exc), 0.0012441814416833327, 9)
         self.assertAlmostEqual(lib.fp(vxc[0]), 0.0065565189784811129, 9)
         self.assertAlmostEqual(lib.fp(vxc[1]), 0.0049270110162854116, 9)
+
+        n, exc, vxc = ni.nr_rks(mol, mf.grids, 'm06x', dm)
+        self.assertAlmostEqual(n, 4, 6)
+        self.assertAlmostEqual(lib.fp(exc), 0.01197588220700074, 6)
+        self.assertAlmostEqual(lib.fp(vxc), -0.043974912389152986, 6)
 
         mf = mf.define_xc_('0.5*B3LYP+0.5*B3LYP')
         exc0, vxc0 = mf._numint.eval_xc(None, rho, 0, deriv=1)[:2]


### PR DESCRIPTION
Update examples: 24-define_xc_functional.py and 31-xc_value_on_grid.py . (Fix issue #2092 , #2011)