### PR TITLE
Allow scientific notations in libxc.parse_xc

### DIFF
--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -1136,7 +1136,7 @@ def parse_xc(description):
                 fac, key = token.split('*')
                 if fac[0].isalpha():
                     fac, key = key, fac
-                fac = sign * float(fac)
+                fac = sign * float(fac.replace('E_', 'E-'))
             else:
                 fac, key = sign, token
 
@@ -1277,7 +1277,8 @@ _NAME_WITH_DASH = {'SR-HF'    : 'SR_HF',
                    'LRC-WPBE' : 'LRC_WPBE',
                    'LRC-WPBEH': 'LRC_WPBEH',
                    'LC-VV10'  : 'LC_VV10',
-                   'CAM-B3LYP': 'CAM_B3LYP'}
+                   'CAM-B3LYP': 'CAM_B3LYP',
+                   'E-'       : 'E_'} # For scientific notation
 
 
 def eval_xc(xc_code, rho, spin=0, relativity=0, deriv=1, omega=None, verbose=None):

--- a/pyscf/dft/test/test_libxc.py
+++ b/pyscf/dft/test/test_libxc.py
@@ -108,6 +108,9 @@ class KnownValues(unittest.TestCase):
         #hyb, fn_facs = dft.libxc.parse_xc('TF,')
         #self.assertEqual(fn_facs, [(50, 1)])
 
+        hyb, fn_facs = dft.libxc.parse_xc("9.999e-5*HF,")
+        self.assertEqual(hyb, (9.999e-5, 0, 0))
+
         ref = ((1, 1), (7, 1))
         self.assertEqual(dft.libxc.parse_xc_name('LDA,VWN'), (1,7))
         self.assertEqual(dft.libxc.parse_xc(('LDA','VWN'))[1], ref)

--- a/pyscf/dft/xcfun.py
+++ b/pyscf/dft/xcfun.py
@@ -449,7 +449,7 @@ def parse_xc(description):
                 fac, key = token.split('*')
                 if fac[0].isalpha():
                     fac, key = key, fac
-                fac = sign * float(fac.replace('_', '-'))
+                fac = sign * float(fac.replace('E_', 'E-'))
             else:
                 fac, key = sign, token
 


### PR DESCRIPTION
fix #1787