### PR TITLE
fix all ruff code C4 warnings

### DIFF
--- a/pyscf/agf2/aux_space.py
+++ b/pyscf/agf2/aux_space.py
@@ -446,7 +446,7 @@ def combine(*auxspcs):
     '''
 
     nphys = [auxspc.nphys for auxspc in auxspcs]
-    if not all([x == nphys[0] for x in nphys]):
+    if not all(x == nphys[0] for x in nphys):
         raise ValueError('Size of physical space must be the same to '
                          'combine AuxiliarySpace objects.')
     nphys = nphys[0]

--- a/pyscf/cc/ccsd.py
+++ b/pyscf/cc/ccsd.py
@@ -582,7 +582,7 @@ def _contract_s4vvvv_t2(mycc, mol, vvvv, t2, out=None, verbose=None):
         tril2sq = lib.square_mat_in_trilu_indices(nvira)
         loadbuf = numpy.empty((blksize,blksize,nvirb,nvirb))
 
-        slices = [(i0, i1) for i0, i1 in lib.prange(0, nvira, blksize)]
+        slices = list(lib.prange(0, nvira, blksize))
         for istep, wwbuf in enumerate(fmap(load, lib.prange(0, nvira, blksize))):
             i0, i1 = slices[istep]
             off0 = i0*(i0+1)//2

--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -1662,7 +1662,7 @@ def _eval_xc(xc_code, rho, spin=0, deriv=1, omega=None):
         warnings.warn('Libxc functionals %s may have discrepancy to xcfun '
                       'library.\n' % problem_xc)
 
-    if any([needs_laplacian(fid) for fid in fn_ids]):
+    if any(needs_laplacian(fid) for fid in fn_ids):
         raise NotImplementedError('laplacian in meta-GGA method')
 
     nvar, xlen = xc_deriv._XC_NVAR[xctype, spin]

--- a/pyscf/fci/addons.py
+++ b/pyscf/fci/addons.py
@@ -757,7 +757,7 @@ def civec_spinless_repr_generator(ci0_r, norb, nelec_r):
         strsb = cistring.addrs2str(norb, nelecb, list(range(ndetb)))
         strs = numpy.add.outer(strsa, numpy.left_shift(strsb, norb)).ravel()
         addrs[ne] = cistring.strs2addr(2*norb, nelec, strs)
-        ndet_sp[ne] = tuple((ndeta,ndetb))
+        ndet_sp[ne] = (ndeta,ndetb)
     strs = strsa = strsb = None
     ndet = cistring.num_strings(2*norb, nelec)
     def ss2spinless(ci0, ne, buf=None):

--- a/pyscf/grad/sacasscf.py
+++ b/pyscf/grad/sacasscf.py
@@ -876,7 +876,7 @@ class SACASLagPrec (lagrange.LagPrec):
                 except Exception as e:
                     print (i, j, desort_spin)
                     raise (e)
-        assert (all ([i is not None for i in Mxci]))
+        assert (all (i is not None for i in Mxci))
         return Mxci
 
 mcscf.addons.StateAverageMCSCFSolver.Gradients = lib.class_as_method(Gradients)

--- a/pyscf/gto/basis/parse_cp2k_pp.py
+++ b/pyscf/gto/basis/parse_cp2k_pp.py
@@ -84,7 +84,7 @@ def _parse(plines):
             for h in plines.pop(0).split():
                 hproj_p_ij.append(float(h))
         hproj_p = np.zeros((nproj[-1],nproj[-1]))
-        hproj_p[np.triu_indices(nproj[-1])] = [ h for h in hproj_p_ij ]
+        hproj_p[np.triu_indices(nproj[-1])] = list(hproj_p_ij)
         hproj_p_symm = hproj_p + hproj_p.T - np.diag(hproj_p.diagonal())
         hproj.append(hproj_p_symm.tolist())
 

--- a/pyscf/gto/basis/parse_nwchem.py
+++ b/pyscf/gto/basis/parse_nwchem.py
@@ -212,7 +212,7 @@ def optimize_contraction(basis):
             key = tuple(b[:1])
             ec = numpy.array(b[1:]).T
         es = ec[0]
-        cs = [c for c in ec[1:]]
+        cs = list(ec[1:])
 
         if key not in basdic:
             basdic[key] = []

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2760,7 +2760,7 @@ class MoleBase(lib.StreamObject):
                           '          X                Y                Z       unit  Magmom\n')
         for ia,atom in enumerate(self._atom):
             coorda = tuple([x * param.BOHR for x in atom[1]])
-            coordb = tuple([x for x in atom[1]])
+            coordb = tuple(atom[1])
             magmom = self.magmom[ia]
             self.stdout.write('[INPUT]%3d %-4s %16.12f %16.12f %16.12f AA  '
                               '%16.12f %16.12f %16.12f Bohr  %4.1f\n'
@@ -3080,7 +3080,7 @@ class MoleBase(lib.StreamObject):
             logger.info(mol, 'New geometry')
             for ia, atom in enumerate(mol._atom):
                 coorda = tuple([x * param.BOHR for x in atom[1]])
-                coordb = tuple([x for x in atom[1]])
+                coordb = tuple(atom[1])
                 coords = coorda + coordb
                 logger.info(mol, ' %3d %-4s %16.12f %16.12f %16.12f AA  '
                             '%16.12f %16.12f %16.12f Bohr\n',

--- a/pyscf/lib/linalg_helper.py
+++ b/pyscf/lib/linalg_helper.py
@@ -560,7 +560,7 @@ def davidson1(aop, x0, precond, tol=1e-12, max_cycle=50, max_space=12,
         if callable(callback):
             callback(locals())
 
-    x0 = [x for x in x0]  # nparray -> list
+    x0 = list(x0)  # nparray -> list
 
     # Check whether the solver finds enough eigenvectors.
     h_dim = x0[0].size
@@ -954,11 +954,11 @@ def davidson_nosym1(aop, x0, precond, tol=1e-12, max_cycle=50, max_space=20,
             raise RuntimeError(f'Not enough eigenvalues found by {pick}')
         xl = _gen_x0(vl[:,idx[:nroots]], xs)
         x0 = _gen_x0(v[:,:nroots], xs)
-        xl = [x for x in xl]  # nparray -> list
-        x0 = [x for x in x0]  # nparray -> list
+        xl = list(xl)  # nparray -> list
+        x0 = list(x0)  # nparray -> list
         return numpy.asarray(conv), e[:nroots], xl, x0
     else:
-        x0 = [x for x in x0]  # nparray -> list
+        x0 = list(x0)  # nparray -> list
         return numpy.asarray(conv), e, x0
 
 def dgeev(abop, x0, precond, type=1, tol=1e-12, max_cycle=50, max_space=12,
@@ -1244,7 +1244,7 @@ def dgeev1(abop, x0, precond, type=1, tol=1e-12, max_cycle=50, max_space=12,
         for k in range(nroots):
             x0[k] = abop(x0[k])[1]
 
-    x0 = [x for x in x0]  # nparray -> list
+    x0 = list(x0)  # nparray -> list
     return conv, e, x0
 
 

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -456,7 +456,7 @@ def tril_product(*iterables, **kwds):
             yield tup
             continue
 
-        if all([tup[tril_idx[i]] >= tup[tril_idx[i+1]] for i in range(ntril_idx-1)]):
+        if all(tup[tril_idx[i]] >= tup[tril_idx[i+1]] for i in range(ntril_idx-1)):
             yield tup
         else:
             pass

--- a/pyscf/lo/iao.py
+++ b/pyscf/lo/iao.py
@@ -123,7 +123,7 @@ def iao(mol, orbocc, minao=MINAO, kpts=None, lindep_threshold=1e-8):
 def reference_mol(mol, minao=MINAO):
     '''Create a molecule which uses reference minimal basis'''
     pmol = mol.copy()
-    atoms = [atom for atom in gto.format_atom(pmol.atom, unit=1)]
+    atoms = list(gto.format_atom(pmol.atom, unit=1))
     # remove ghost atoms
     pmol.atom = [atom for atom in atoms if not is_ghost_atom(atom[0])]
     if len(pmol.atom) != len(atoms):

--- a/pyscf/lo/pipek_jacobi.py
+++ b/pyscf/lo/pipek_jacobi.py
@@ -99,7 +99,7 @@ def PipekMezey_stability_jacobi(mlo, mo_coeff=None, conv_tol=None):
     rows = np.floor(((1+8*mo_pair_indices)**0.5-1)*0.5).astype(int)
     cols = mo_pair_indices - rows*(rows+1) // 2
     rows += 1
-    pairs = [(row,col) for row,col in zip(rows,cols)]
+    pairs = list(zip(rows,cols))
 
     if len(pairs) > 0:
         log.info('Jacobi sweep for %d mo pairs: %s', len(pairs), pairs)

--- a/pyscf/mcscf/addons.py
+++ b/pyscf/mcscf/addons.py
@@ -1364,7 +1364,7 @@ class StateAverageMixFCISolver(StateAverageFCISolver):
         ci0 = _state_args (ci0)
         link_index = _solver_args (link_index)
         nelec = _solver_args ([self._get_nelec (solver, nelec) for solver in self.fcisolvers])
-        return [dm for dm in self._collect ('make_rdm1', ci0, norb, nelec, link_index=link_index, **kwargs)]
+        return list(self._collect ('make_rdm1', ci0, norb, nelec, link_index=link_index, **kwargs))
 
     def make_rdm1(self, ci0, norb, nelec, link_index=None, **kwargs):
         dm1 = self.states_make_rdm1 (ci0, norb, nelec, link_index=link_index, **kwargs)

--- a/pyscf/pbc/cc/kccsd_rhf.py
+++ b/pyscf/pbc/cc/kccsd_rhf.py
@@ -255,7 +255,7 @@ def _get_epq(pindices,qindices,fac=[1.0,1.0],large_num=LARGE_DENOM):
     def get_idx(x0,x1,kx,n0_p):
         return np.logical_and(n0_p[kx] >= x0, n0_p[kx] < x1)
 
-    assert (all([len(x) == 5 for x in [pindices,qindices]]))
+    assert (all(len(x) == 5 for x in [pindices,qindices]))
     p0,p1,kp,mo_e_p,nonzero_p = pindices
     q0,q1,kq,mo_e_q,nonzero_q = qindices
     fac_p, fac_q = fac

--- a/pyscf/pbc/cc/kccsd_t_rhf.py
+++ b/pyscf/pbc/cc/kccsd_t_rhf.py
@@ -579,7 +579,7 @@ def _get_epqr(pindices,qindices,rindices,fac=[1.0,1.0,1.0],large_num=LARGE_DENOM
     def get_idx(x0,x1,kx,n0_p):
         return np.logical_and(n0_p[kx] >= x0, n0_p[kx] < x1)
 
-    assert (all([len(x) == 5 for x in [pindices,qindices]]))
+    assert (all(len(x) == 5 for x in [pindices,qindices]))
     p0,p1,kp,mo_e_p,nonzero_p = pindices
     q0,q1,kq,mo_e_q,nonzero_q = qindices
     r0,r1,kr,mo_e_r,nonzero_r = rindices

--- a/pyscf/pbc/df/rsdf_helper.py
+++ b/pyscf/pbc/df/rsdf_helper.py
@@ -395,7 +395,7 @@ def _get_schwartz_data(bas_lst, omega, dijs_lst=None, keep1ctr=True, safe=True):
                 imin = es.argmin()
                 jmax = abs(ecs[imin,1:]).argmax()
                 cs = ecs[:,jmax+1]
-                bas_new = [bas[0]] + [(e,c) for e,c in zip(es,cs)]
+                bas_new = [bas[0]] + list(zip(es,cs))
             bas_lst_new.append(bas_new)
         return bas_lst_new
     if keep1ctr:

--- a/pyscf/pbc/mpitools/mpi.py
+++ b/pyscf/pbc/mpitools/mpi.py
@@ -67,7 +67,7 @@ INQUIRY = 50050
 TASK = 50051
 def work_share_partition(tasks, interval=.02, loadmin=1):
     loadmin = max(loadmin, len(tasks)//50//pool.size)
-    rest_tasks = [x for x in tasks[loadmin*pool.size:]]
+    rest_tasks = list(tasks[loadmin*pool.size:])
     tasks = tasks[loadmin*rank:loadmin*rank+loadmin]
     def distribute_task():
         while True:

--- a/pyscf/pbc/symm/symmetry.py
+++ b/pyscf/pbc/symm/symmetry.py
@@ -193,7 +193,7 @@ class Symmetry():
                 self.ops = ops
 
         self.nop = len(self.ops)
-        self.has_inversion = any([op.rot_is_inversion for op in self.ops])
+        self.has_inversion = any(op.rot_is_inversion for op in self.ops)
 
         l_max = None
         if 'auxcell' in kwargs:

--- a/pyscf/pbc/tdscf/krhf.py
+++ b/pyscf/pbc/tdscf/krhf.py
@@ -79,7 +79,7 @@ class KTDBase(TDBase):
     def check_sanity(self):
         TDBase.check_sanity(self)
         mf = self._scf
-        if any([k != 0 for k in self.kshift_lst]):
+        if any(k != 0 for k in self.kshift_lst):
             if mf.rsjk is not None or not isinstance(mf.with_df, pbcdf.df.DF):
                 logger.error(self, 'Solutions with non-zero kshift for %s are '
                              'only supported by GDF/RSDF')

--- a/pyscf/pbc/tdscf/krks.py
+++ b/pyscf/pbc/tdscf/krks.py
@@ -43,7 +43,7 @@ RPA = KTDDFT = TDDFT
 def _rebuild_df(td):
     log = lib.logger.new_logger(td)
     mf = td._scf
-    if any([k != 0 for k in td.kshift_lst]):
+    if any(k != 0 for k in td.kshift_lst):
         if isinstance(mf.with_df, df.df.DF):
             if mf.with_df._j_only:
                 log.warn(f'Non-zero kshift is requested for {td.__class__.__name__}, '

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -1813,7 +1813,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
 This is the Gaussian fit version as described in doi:10.1063/5.0004046.''')
         if isinstance(sap_basis, str):
             atoms = [coord[0] for coord in mol._atom]
-            sapbas = dict()
+            sapbas = {}
             for atom in set(atoms):
                 single_element_bs = load(sap_basis, atom)
                 if isinstance(single_element_bs, dict):
@@ -1822,7 +1822,7 @@ This is the Gaussian fit version as described in doi:10.1063/5.0004046.''')
                     sapbas[atom] = numpy.asarray(single_element_bs[0][1:], dtype=float)
             logger.note(self, f'Found SAP basis {sap_basis.split("/")[-1]}')
         elif isinstance(sap_basis, dict):
-            sapbas = dict()
+            sapbas = {}
             for key in sap_basis:
                 sapbas[key] = numpy.asarray(sap_basis[key][0][1:], dtype=float)
         else:

--- a/pyscf/scf/rohf.py
+++ b/pyscf/scf/rohf.py
@@ -419,7 +419,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
 This is the Gaussian fit version as described in doi:10.1063/5.0004046.''')
         if isinstance(sap_basis, str):
             atoms = [coord[0] for coord in mol._atom]
-            sapbas = dict()
+            sapbas = {}
             for atom in set(atoms):
                 single_element_bs = load(sap_basis, atom)
                 if isinstance(single_element_bs, dict):
@@ -428,7 +428,7 @@ This is the Gaussian fit version as described in doi:10.1063/5.0004046.''')
                     sapbas[atom] = numpy.asarray(single_element_bs[0][1:], dtype=float)
             logger.note(self, f'Found SAP basis {sap_basis.split("/")[-1]}')
         elif isinstance(sap_basis, dict):
-            sapbas = dict()
+            sapbas = {}
             for key in sap_basis:
                 sapbas[key] = numpy.asarray(sap_basis[key][0][1:], dtype=float)
         else:

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -922,7 +922,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
 This is the Gaussian fit version as described in doi:10.1063/5.0004046.''')
         if isinstance(sap_basis, str):
             atoms = [coord[0] for coord in mol._atom]
-            sapbas = dict()
+            sapbas = {}
             for atom in set(atoms):
                 single_element_bs = load(sap_basis, atom)
                 if isinstance(single_element_bs, dict):
@@ -931,7 +931,7 @@ This is the Gaussian fit version as described in doi:10.1063/5.0004046.''')
                     sapbas[atom] = numpy.asarray(single_element_bs[0][1:], dtype=float)
             logger.note(self, f'Found SAP basis {sap_basis.split("/")[-1]}')
         elif isinstance(sap_basis, dict):
-            sapbas = dict()
+            sapbas = {}
             for key in sap_basis:
                 sapbas[key] = numpy.asarray(sap_basis[key][0][1:], dtype=float)
         else:

--- a/pyscf/solvent/pol_embed.py
+++ b/pyscf/solvent/pol_embed.py
@@ -205,7 +205,7 @@ class PolEmbed(lib.StreamObject):
                 element_row = _get_element_row(p.element)
                 ecp_label, _ = _pe_ecps[element_row]
                 ecpatoms.append([ecp_label, p.x, p.y, p.z])
-            self.ecpmol = gto.M(atom=ecpatoms, ecp={l: k for (l, k) in _pe_ecps},
+            self.ecpmol = gto.M(atom=ecpatoms, ecp=dict(_pe_ecps),
                                 basis={}, unit="Bohr")
             # add the normal mol to compute integrals
             self.ecpmol += self.mol

--- a/pyscf/tdscf/common_slow.py
+++ b/pyscf/tdscf/common_slow.py
@@ -621,7 +621,7 @@ class VindTracker:
 
     @property
     def elements_calc(self):
-        return sum(map(lambda i: i[0] * i[1] if i is not None else 0, self.results))
+        return sum((i[0] * i[1] if i is not None else 0 for i in self.results))
 
     @property
     def ratio(self):


### PR DESCRIPTION
according to https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4

purely scripted using

`ruff check --fix --select=C4 pyscf/`

(not added to the linter, as this is apparently not welcome)