### PR TITLE
Fix dump_input order in Cell.build

### DIFF
--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -1331,7 +1331,8 @@ class Cell(mole.MoleBase):
         if symmorphic is not None:
             self.symmorphic = symmorphic
 
-        mole.MoleBase.build(self, dump_input, parse_arg, *args, **kwargs)
+        _built = self._built
+        mole.MoleBase.build(self, False, parse_arg, *args, **kwargs)
 
         exp_min = np.array([self.bas_exp(ib).min() for ib in range(self.nbas)])
         if self.exp_to_discard is None:
@@ -1448,7 +1449,8 @@ class Cell(mole.MoleBase):
             _check_mesh_symm = not self._mesh_from_build
             self.build_lattice_symmetry(check_mesh_symmetry=_check_mesh_symm)
 
-        if dump_input:
+        if dump_input and not _built and self.verbose > logger.NOTE:
+            self.dump_input()
             logger.info(self, 'lattice vectors  a1 [%.9f, %.9f, %.9f]', *_a[0])
             logger.info(self, '                 a2 [%.9f, %.9f, %.9f]', *_a[1])
             logger.info(self, '                 a3 [%.9f, %.9f, %.9f]', *_a[2])

--- a/pyscf/pbc/gto/test/test_cell.py
+++ b/pyscf/pbc/gto/test/test_cell.py
@@ -177,7 +177,8 @@ class KnownValues(unittest.TestCase):
         cell.atom = 'He 0 0 0; He 0 1 1'
         cell.unit = 'B'
         cell.mesh = [9,9,60]
-        cell.verbose = 0
+        cell.verbose = 5
+        cell.output = '/dev/null'
         cell.dimension = 2
         cell.low_dim_ft_type = 'inf_vacuum'
         cell.rcut = 3.6
@@ -191,7 +192,8 @@ class KnownValues(unittest.TestCase):
         cell.atom = 'He 0 0 0; He 0 1 1'
         cell.unit = 'B'
         cell.mesh = [9,60,60]
-        cell.verbose = 0
+        cell.verbose = 5
+        cell.output = '/dev/null'
         cell.dimension = 1
         cell.low_dim_ft_type = 'inf_vacuum'
         cell.rcut = 3.6
@@ -204,8 +206,8 @@ class KnownValues(unittest.TestCase):
         cell.atom = 'He 0 0 0; He 0 1 1'
         cell.unit = 'B'
         cell.mesh = [60] * 3
-        cell.verbose = 0
-        cell.dimension = 0
+        cell.verbose = 5
+        cell.output = '/dev/null'
         cell.low_dim_ft_type = 'inf_vacuum'
         cell.build()
         eref = cell.to_mol().energy_nuc()
@@ -217,7 +219,8 @@ class KnownValues(unittest.TestCase):
         cell.atom = 'He 0 0 0; He 0 1 1'
         cell.unit = 'B'
         cell.mesh = [9,9,60]
-        cell.verbose = 0
+        cell.verbose = 5
+        cell.output = '/dev/null'
         cell.dimension = 2
         cell.rcut = 3.6
         cell.build()

--- a/pyscf/pbc/gto/test/test_cell.py
+++ b/pyscf/pbc/gto/test/test_cell.py
@@ -208,6 +208,7 @@ class KnownValues(unittest.TestCase):
         cell.mesh = [60] * 3
         cell.verbose = 5
         cell.output = '/dev/null'
+        cell.dimension = 0
         cell.low_dim_ft_type = 'inf_vacuum'
         cell.build()
         eref = cell.to_mol().energy_nuc()


### PR DESCRIPTION
Initializing a Cell object for a low-dimensional system may cause an uninitialized error, as shown below. This PR fixes the issue.
```
import pyscf
cell = pyscf.M(atom='H 0 0 0', a=np.eye(3)*10, dimension=2, low_dim_ft_type='inf_vacuum', verbose=5)

...
    ew_eta = np.sqrt(max(np.log(4*np.pi*ew_cut**2/precision)/ew_cut**2, .1))
                                        ~~~~~~^^~
TypeError: unsupported operand type(s) for ** or pow(): 'NoneType' and 'int'
```