### PR TITLE
More efficient PBC-CDERI loading

### DIFF
--- a/pyscf/ao2mo/outcore.py
+++ b/pyscf/ao2mo/outcore.py
@@ -487,15 +487,17 @@ def _load_from_h5g(h5group, row0, row1, out=None):
         col1 = 0
         for key in range(nkeys):
             col0, col1 = col1, col1 + h5group[str(key)].shape[1]
-            h5group[str(key)].read_direct(out, dest_sel=numpy.s_[:,col0:col1],
-                                          source_sel=numpy.s_[row0:row1])
+            if col1 > col0:
+                h5group[str(key)].read_direct(out, dest_sel=numpy.s_[:,col0:col1],
+                                            source_sel=numpy.s_[row0:row1])
     else:  # multiple components
         out = numpy.ndarray((dat.shape[0], row1-row0, ncol), dat.dtype, buffer=out)
         col1 = 0
         for key in range(nkeys):
             col0, col1 = col1, col1 + h5group[str(key)].shape[2]
-            h5group[str(key)].read_direct(out, dest_sel=numpy.s_[:,:,col0:col1],
-                                          source_sel=numpy.s_[:,row0:row1])
+            if col1 > col0:
+                h5group[str(key)].read_direct(out, dest_sel=numpy.s_[:,:,col0:col1],
+                                            source_sel=numpy.s_[:,row0:row1])
     return out
 
 def _transpose_to_h5g(h5group, key, dat, blksize, chunks=None):

--- a/pyscf/pbc/df/df.py
+++ b/pyscf/pbc/df/df.py
@@ -895,7 +895,7 @@ def _hstack_datasets(data_to_stack, slices=numpy.s_[:]):
                 )
         else:
             # For array-like objects
-            out[dest_sel] = dset
+            out[dest_sel] = dset[slices]
         ax1ind += ax1width
     return out
 

--- a/pyscf/pbc/df/df.py
+++ b/pyscf/pbc/df/df.py
@@ -832,13 +832,15 @@ class _load_and_unpack:
             return dat.shape
 
 def _hstack_datasets(data_to_stack, slices=numpy.s_[:]):
-    """Faster version of numpy.hstack for h5py datasets
+    """Faster version of the operation
+    np.hstack([x[slices] for x in data_to_stack]) for h5py datasets.
 
     Parameters
     ----------
     data_to_stack : list of h5py.Dataset or np.ndarray
-        Datasets/arrays to be stacked along first axis
+        Datasets/arrays to be stacked along first axis.
     slices: tuple or list of slices, a slice, or ().
+        The slices (or indices) to select data from each H5 dataset.
 
     Returns
     -------


### PR DESCRIPTION
More efficient method for loading k-point CDERI. The idea is really simple: skipping numpy.hstack by letting h5py load the CDERI directly into the output buffer.