### PR TITLE
Allow ``SecondOrderSymAdaptedUHF`` for scf created from FCIDUMP

### DIFF
--- a/examples/tools/01-fcidump.py
+++ b/examples/tools/01-fcidump.py
@@ -104,3 +104,4 @@ mf = fcidump.to_scf('fcidump.example5', molpro_orbsym=True)
 mf.mol.verbose = 4
 mf.run()
 mf.MP2().run()
+mf.to_uhf().newton().run()

--- a/pyscf/tools/fcidump.py
+++ b/pyscf/tools/fcidump.py
@@ -372,6 +372,9 @@ def to_scf(filename, molpro_orbsym=MOLPRO_ORBSYM, mf=None, **kwargs):
     mf.get_hcore = lambda *args: h1
     mf.get_ovlp = lambda *args: numpy.eye(norb)
     mf._eri = ctx['H2']
+    intor_symmetric = mf.mol.intor_symmetric
+    mf.mol.intor_symmetric = lambda intor, **kwargs: numpy.eye(norb) \
+        if intor == 'int1e_ovlp' else intor_symmetric(intor, **kwargs)
 
     return mf
 


### PR DESCRIPTION
Currently, appending a line ``mf.to_uhf().newton().run()`` to the script ``examples/tools/01-fcidump.py`` will cause the following error:

```python3
/usr/local/lib/python3.10/dist-packages/pyscf/symm/addons.py in label_orb_symm(mol, irrep_name, symm_orb, mo, s, check, tol)
     68     if s is None:
     69         s = mol.intor_symmetric('int1e_ovlp')
---> 70     s_mo = numpy.dot(s, mo)
     71     norm = numpy.zeros((len(irrep_name), nmo))
     72     for i, csym in enumerate(symm_orb):

ValueError: shapes (0,0) and (12,12) not aligned: 0 (dim 1) != 12 (dim 0)
```

The problem can be solved by adding a definition for ``mol.intor_symmetric('int1e_ovlp')`` for the ``scf`` object created by loading the ``FCIDUMP`` file.