### PR TITLE
Fix SymAdaptedGHF.eig for complex orbitals

### DIFF
--- a/pyscf/scf/ghf_symm.py
+++ b/pyscf/scf/ghf_symm.py
@@ -153,8 +153,8 @@ class SymAdaptedGHF(ghf.GHF):
 
         nirrep = len(symm_orb)
         symm_orb = [scipy.linalg.block_diag(c, c) for c in symm_orb]
-        s = [reduce(numpy.dot, (c.T,s,c)) for c in symm_orb]
-        h = [reduce(numpy.dot, (c.T,h,c)) for c in symm_orb]
+        h = symm.symmetrize_matrix(h, symm_orb)
+        s = symm.symmetrize_matrix(s, symm_orb)
         cs = []
         es = []
         orbsym = []


### PR DESCRIPTION
Currently ``SymAdaptedGHF`` cannot be used with complex orbitals. Symmetry adapted GHF with complex orbital can happen when $L_z$ symmetry adaptation (https://github.com/pyscf/pyscf/blob/master/examples/symm/33-lz_adaption.py) is used for a linear molecule.

The change in this PR will also make the implementation of ``SymAdaptedGHF.eig`` more consistent with ``SymAdaptedRHF.eig`` and ``SymAdaptedUHF.eig``. See https://github.com/pyscf/pyscf/blob/v2.6.2/pyscf/scf/hf_symm.py#L309-L310 and https://github.com/pyscf/pyscf/blob/v2.6.2/pyscf/scf/uhf_symm.py#L336-L337 and https://github.com/pyscf/pyscf/blob/v2.6.2/pyscf/symm/basis.py#L192-L193.