### PR TITLE
fix check for ffsll and use builtin if available

### DIFF
--- a/.github/workflows/ci_conda.yml
+++ b/.github/workflows/ci_conda.yml
@@ -1,0 +1,25 @@
+name: CI_conda
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-conda-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup conda
+        uses: s-weigand/setup-conda@v1
+        with:
+          update-conda: true
+          conda-channels: conda-forge
+      - run: conda --version
+      - run: which python
+      - name: Build conda package
+        run: |
+          export CMAKE_BUILD_PARALLEL_LEVEL=4
+          conda install -y conda-build
+          conda config --set anaconda_upload False
+          conda build --output-folder . conda

--- a/pyscf/lib/CMakeLists.txt
+++ b/pyscf/lib/CMakeLists.txt
@@ -15,6 +15,8 @@
 cmake_minimum_required (VERSION 3.5)
 project (pyscf)
 
+include(CheckSymbolExists)
+
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RELWITHDEBINFO)
 endif()
@@ -69,7 +71,7 @@ endif()
 if (NOT BLAS_LIBRARIES)
 #enable_language(Fortran)
 find_package(BLAS)
-check_function_exists(ffsll HAVE_FFS)
+check_symbol_exists(ffsll "strings.h" HAVE_FFS)
 endif()
 
 if (NOT BLAS_LIBRARIES)

--- a/pyscf/lib/mcscf/fci_contract.c
+++ b/pyscf/lib/mcscf/fci_contract.c
@@ -21,6 +21,11 @@
 #include <string.h>
 #include <math.h>
 #include <assert.h>
+
+#ifdef HAVE_FFS
+#include <strings.h>
+#endif
+
 //#include <omp.h>
 #include "config.h"
 #include "vhf/fblas.h"
@@ -603,7 +608,9 @@ void FCImake_hdiag(double *hdiag, double *h1e, double *jdiag, double *kdiag,
 
 static int first1(uint64_t r)
 {
-#ifdef HAVE_FFS
+#if defined(__builtin_ffsll)
+        return __builtin_ffsll(r) - 1;
+#elif defined(HAVE_FFS)
         return ffsll(r) - 1;
 #else
         int n = 0;


### PR DESCRIPTION
This is a comment on PR #2449.

It seems that, in the conda build environment, `ffsll` is defined in glibc but not included in any headers. Replacing `check_function_exists` with `check_symbol_exists` allows this situation to be detected.

A Github Actions workflow for testing the conda-build process is also included. It's running on this PR here:
https://github.com/chillenb/pyscf/actions/runs/11243087685/job/31258188365

