### PR TITLE
fix uccsd failing for empty active space

### DIFF
--- a/pyscf/cc/ccsd.py
+++ b/pyscf/cc/ccsd.py
@@ -611,6 +611,8 @@ def _contract_s1vvvv_t2(mycc, mol, vvvv, t2, out=None, verbose=None):
     # vvvv == None means AO-direct CCSD. It should redirect to
     # _contract_s4vvvv_t2(mycc, mol, vvvv, t2, out, verbose)
     assert (vvvv is not None)
+    if t2.size == 0:
+        return numpy.zeros_like(t2)
 
     time0 = logger.process_clock(), logger.perf_counter()
     log = logger.new_logger(mycc, verbose)

--- a/pyscf/cc/uccsd.py
+++ b/pyscf/cc/uccsd.py
@@ -396,12 +396,12 @@ def vector_to_amplitudes(vector, nmo, nocc):
     nvir = nvira + nvirb
     nov = nocc * nvir
     size = nov + nocc*(nocc-1)//2*nvir*(nvir-1)//2
-    if vector.size == size:
+    sizea = nocca * nvira + nocca*(nocca-1)//2*nvira*(nvira-1)//2
+    sizeb = noccb * nvirb + noccb*(noccb-1)//2*nvirb*(nvirb-1)//2
+    if vector.size == size and sizea > 0 and sizeb > 0:
         #return ccsd.vector_to_amplitudes_s4(vector, nmo, nocc)
         raise RuntimeError('Input vector is GCCSD vector')
     else:
-        sizea = nocca * nvira + nocca*(nocca-1)//2*nvira*(nvira-1)//2
-        sizeb = noccb * nvirb + noccb*(noccb-1)//2*nvirb*(nvirb-1)//2
         sections = np.cumsum([sizea, sizeb])
         veca, vecb, t2ab = np.split(vector, sections)
         t1a, t2aa = ccsd.vector_to_amplitudes_s4(veca, nmoa, nocca)


### PR DESCRIPTION
Currently, PySCF UCCSD fails for situations like
```
nocca = 1, nvira = 1
noccb = 0, nvirb = 0
```
This PR fix it.