### PR TITLE
Update 09-band_ase.py

### DIFF
--- a/examples/pbc/09-band_ase.py
+++ b/examples/pbc/09-band_ase.py
@@ -4,7 +4,7 @@ import pyscf.pbc.dft as pbcdft
 
 import matplotlib.pyplot as plt
 
-from ase.lattice import bulk
+from ase.build import bulk
 from ase.dft.kpoints import sc_special_points as special_points, get_bandpath
 
 c = bulk('C', 'diamond', a=3.5668)


### PR DESCRIPTION
In version 3.11.0 of ASE, the ase.lattice.bulk() function has been moved to ase.build.bulk.