### PR TITLE
Adds COSMO-RS functionality

### DIFF
--- a/examples/solvent/05-pcm.py
+++ b/examples/solvent/05-pcm.py
@@ -64,3 +64,12 @@ td.kernel()
 
 mf = mol.RHF().PCM().run()
 td = mf.TDA().run()
+
+# infinite epsilon with any PCM computations
+cm = pcm.PCM(mol)
+cm.eps = float('inf') # ideal conductor
+mf = dft.RKS(mol, xc='b3lyp')
+mf = mf.PCM(cm)
+mf.kernel()
+
+

--- a/examples/solvent/07-cosmors.py
+++ b/examples/solvent/07-cosmors.py
@@ -43,8 +43,7 @@ mf = mf.PCM(cm)
 mf.kernel()
 
 # generate COSMO-file
-with io.StringIO() as outp: 
-#with open('formaldehyde.cosmo', 'w') as outf: # to create the actual file
+with io.StringIO() as outp: # with open('formaldehyde.cosmo', 'w') as outf:
     write_cosmo_file(outp, mf)
     print(outp.getvalue())
 
@@ -60,15 +59,15 @@ mf = mf.PCM(cm)
 mf.kernel()
 
 # try to get COSMO-file
-with io.StringIO() as outp: 
+with io.StringIO() as outp:
     try:
         write_cosmo_file(outp, mf)
         print(outp.getvalue())
     except ValueError as e:
         print(e)
 
-# overruling 
-with io.StringIO() as outp: 
+# overruling
+with io.StringIO() as outp:
     write_cosmo_file(outp, mf, ignore_low_feps=True)
     print(outp.getvalue())
 

--- a/examples/solvent/07-cosmors.py
+++ b/examples/solvent/07-cosmors.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+'''
+An example of using COSMO-RS functionality.
+'''
+
+#%% Imports
+
+import io
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from pyscf import gto, dft
+from pyscf.solvent import pcm
+from pyscf.solvent.cosmors import get_sas_volume
+from pyscf.solvent.cosmors import write_cosmo_file
+from pyscf.solvent.cosmors import get_cosmors_parameters
+
+
+#%% Set parameters
+
+# get molecule
+coords = '''
+C        0.000000    0.000000             -0.542500
+O        0.000000    0.000000              0.677500
+H        0.000000    0.9353074360871938   -1.082500
+H        0.000000   -0.9353074360871938   -1.082500
+'''
+mol = gto.M(atom=coords, basis='6-31G*', verbose=1)
+
+# configure PCM
+cm = pcm.PCM(mol)
+cm.eps = float('inf') # f_epsilon = 1 is required for COSMO-RS
+cm.method = 'C-PCM' # or COSMO, IEF-PCM, SS(V)PE, see https://manual.q-chem.com/5.4/topic_pcm-em.html
+cm.lebedev_order = 29 # lebedev grids on the cavity surface, lebedev_order=29  <--> # of grids = 302
+
+
+#%% COSMO-files
+
+# run DFT SCF (any level of theory is OK, though DFT is optimal)
+mf = dft.RKS(mol, xc='b3lyp')
+mf = mf.PCM(cm)
+mf.kernel()
+
+# generate COSMO-file
+with io.StringIO() as outp: 
+#with open('formaldehyde.cosmo', 'w') as outf: # to create the actual file
+    write_cosmo_file(outp, mf)
+    print(outp.getvalue())
+
+
+# if PCM DFT were computed with fepsilon < 1 <=> eps != inf the ValueError will be raised
+# use ignore_low_feps=True to overrule it, but please be sure you know what you're doing
+
+# run DFT SCF
+cm = pcm.PCM(mol)
+cm.eps = 32.613 # methanol
+mf = dft.RKS(mol, xc='b3lyp')
+mf = mf.PCM(cm)
+mf.kernel()
+
+# try to get COSMO-file
+with io.StringIO() as outp: 
+    try:
+        write_cosmo_file(outp, mf)
+        print(outp.getvalue())
+    except ValueError as e:
+        print(e)
+
+# overruling 
+with io.StringIO() as outp: 
+    write_cosmo_file(outp, mf, ignore_low_feps=True)
+    print(outp.getvalue())
+
+
+# The molecular volume is computed for the solvent-accessible surface generated
+# within pcm.PCM object. Please note that r_sol is assumed to be equal to zero,
+# so that SAS is a union of vdW spheres.
+# Increasing integration step increases accuracy of integration, but for most COSMO-RS
+# modelling and ML step=0.2 should be enough:
+
+# compute volumes with different step values
+steps = [1.0, 0.5, 0.2, 0.1, 0.05, 0.02, 0.01]
+Vs = [get_sas_volume(mf.with_solvent.surface, step) for step in steps]
+# plot
+ax = plt.gca()
+ax.plot(Vs)
+ax.set_xticks(range(len(steps)))
+_ = ax.set_xticklabels(steps)
+plt.show()
+
+
+#%% Sigma-profiles
+
+# compute SCF PCM
+cm = pcm.PCM(mol)
+cm.eps = float('inf')
+mf = dft.RKS(mol, xc='b3lyp')
+mf = mf.PCM(cm)
+mf.kernel()
+
+# compute sigma-profile and related parameters
+params = get_cosmors_parameters(mf)
+print(params)
+plt.plot(params['Screening charge, e/A**2'],
+         params['Screening charge density, A**2'])
+plt.show()
+
+# custom sigma grid
+sigmas_grid = np.linspace(-0.025, 0.025, 101)
+params = get_cosmors_parameters(mf, sigmas_grid)
+plt.plot(params['Screening charge, e/A**2'],
+         params['Screening charge density, A**2'])
+plt.show()
+
+

--- a/pyscf/solvent/cosmors.py
+++ b/pyscf/solvent/cosmors.py
@@ -1,0 +1,367 @@
+# Copyright 2014-2018 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Provides functionality to generate COSMO files and sigma-profiles
+for the further use in COSMO-RS/COSMO-SAC computations and/or ML
+'''
+
+#%% Imports
+
+import re as _re
+from itertools import product as _product
+
+import numpy as _np
+
+from pyscf import __version__
+from pyscf.data.nist import BOHR as _BOHR
+
+
+
+#%% SAS volume
+
+def _get_line_atom_intersection(x, y, atom, r):
+    '''Returns z-coordinates of boundaries of intersection of
+    the (x,y,0) + t(0,0,1) line and vdW sphere
+    
+    Arguments:
+        x (float): x parameter of the line
+        y (float): y parameter of the line
+        atom (np.ndarray): xyz-coordinates of the atom
+        r (float): van der Waals radii of the atom
+    
+    Returns:
+        _tp.Optional[_tp.List[float, float]]: z-coordinates
+            of the line/sphere intersection, and None
+            if they do not intersect
+    
+    '''
+    # check distance between line and atom
+    d = _np.linalg.norm(_np.array([x,y]) - atom[:2])
+    if d >= r:
+        return None
+    # find interval
+    dz = (r**2 - d**2)**0.5
+    interval = [atom[2] - dz, atom[2] + dz]
+    
+    return interval
+
+
+def _unite_intervals(intervals):
+    '''Unites float intervals
+    
+    Arguments:
+        intervals (_tp.List[_tp.List[float, float]]): list of intervals
+    
+    Returns:
+        _tp.List[_tp.List[float, float]]: list of united intervals
+    
+    '''
+    united = []
+    for begin, end in sorted(intervals):
+        if united and united[-1][1] >= begin:
+            united[-1][1] = end
+        else:
+            united.append([begin, end])
+    
+    return united
+
+
+def _get_line_sas_intersection_length(x, y, coords, radii):
+    '''Finds total length of all (x,y,0) + t(0,0,1) line's intervals
+    enclosed by intersections with solvent-accessible surface
+    
+    Arguments:
+        x (float): x parameter of the line
+        y (float): y parameter of the line
+        atoms (_np.ndarray): (n*3) array of atomic coordinates
+        radii (_np.ndarray): array of vdW radii
+    
+    Returns:
+        float: total length of all line's intervals enclosed by SAS
+    
+    '''
+    intervals = [_get_line_atom_intersection(x, y, atom, r) for atom, r in zip(coords, radii)]
+    intervals = _unite_intervals([_ for _ in intervals if _])
+    length = sum([end - begin for begin, end in intervals])
+    
+    return length
+
+
+def get_sas_volume(surface, step=0.2):
+    '''Computes volume [A**3] of space enclosed by solvent-accessible surface
+    
+    Arguments:
+        surface (dict): dictionary containing SAS parameters (mc.with_solvent.surface)
+        step (float): grid spacing parameter, [Bohr]
+    
+    Returns:
+        float: SAS-defined volume of the molecule [A**3]
+    
+    '''
+    # get parameters
+    coords = surface['atom_coords']
+    radii = _np.array([surface['R_vdw'][i] for i, j in surface['gslice_by_atom']])
+    # compute minimaxes of SAS coordinates
+    bounds = _np.array([(coords - radii[:, _np.newaxis]).min(axis = 0),
+                        (coords + radii[:, _np.newaxis]).max(axis = 0)])
+    # swap axes to minimize integration mesh
+    axes = [(val, idx) for idx, val in enumerate(bounds[1] - bounds[0])]
+    axes = [idx for val, idx in sorted(axes)]
+    coords = coords[:,axes]
+    bounds = bounds[:,axes]
+    # mesh parameters
+    xs = _np.linspace(bounds[0,0], bounds[1,0],
+                      int(_np.ceil((bounds[1,0] - bounds[0,0])/step)) + 1)
+    ys = _np.linspace(bounds[0,1], bounds[1,1],
+                      int(_np.ceil((bounds[1,1] - bounds[0,1])/step)) + 1)
+    dxdy = (xs[1] - xs[0])*(ys[1] - ys[0])
+    # integration
+    V = sum([dxdy * _get_line_sas_intersection_length(x, y, coords, radii) \
+             for x, y in _product(xs, ys)])
+    
+    return V * _BOHR**3
+
+
+
+#%% COSMO-files
+
+def _check_feps(mf, ignore_low_feps):
+    '''Checks f_epsilon value and raises ValueError for f_eps < 1
+    
+    Arguments:
+        mf: processed SCF with PCM solvation
+        ignore_low_feps (bool): if True, does not raise ValueError if feps < 1
+    
+    Raises:
+        ValueError: if f_epsilon < 1 and ignore_low_feps flag is set to False
+    
+    '''
+    if ignore_low_feps:
+        return
+    
+    f_eps = mf.with_solvent._intermediates['f_epsilon']
+    if f_eps < 1.0:
+        message  = f'Low f_eps value: {f_eps}. '
+        message += 'COSMO-RS requires f_epsilon=1.0 or eps=float("inf"). '
+        message += 'Rerun computation with correct epsilon or use the ignore_low_feps argument.'
+        raise ValueError(message)
+    
+    return
+
+
+def _lot(mf):
+    '''Returns level of theory in method-disp/basis/solvation format (raw solution)
+    
+    Arguments:
+        mf: processed SCF
+    
+    Returns:
+        str: method-dispersion/basis/solvation
+    
+    '''
+    # method
+    method = mf.xc if hasattr(mf, 'xc') else None
+    if method is None:
+        match = _re.search('HF|MP2|CCSD', str(type(mf)))
+        method = match.group(0) if match else '???'
+    # dispersion
+    match = _re.search('D3|D4', str(type(mf)))
+    disp = '-' + match.group(0) if match else ''
+    # other
+    basis = mf.mol.basis
+    solv = '/' + mf.with_solvent.method if hasattr(mf, 'with_solvent') else ''
+    # approx
+    lot = f'{method}{disp}/{basis}{solv}'.lower()
+
+    return lot
+
+
+def write_cosmo_file(fout, mf, step=0.2, ignore_low_feps=False):
+    '''Saves COSMO file
+    
+    Arguments:
+        fout: writable file object
+        mf: processed SCF with PCM solvation
+        step (float): grid spacing parameter to compute volume, [Bohr]
+        ignore_low_feps (bool): if True, does not raise ValueError if feps < 1
+    
+    Raises:
+        ValueError: if f_epsilon < 1 and ignore_low_feps flag is set to False
+    
+    '''
+    _check_feps(mf, ignore_low_feps)
+
+    # qm params
+    fout.write('$info\n')
+    fout.write(f'PySCF v. {__version__}, {_lot(mf)}\n')
+    
+    # cosmo data
+    f_epsilon = mf.with_solvent._intermediates['f_epsilon']
+    n_segments = len(mf.with_solvent._intermediates['q'])
+    area = sum(mf.with_solvent.surface['area'])
+    volume = get_sas_volume(mf.with_solvent.surface, step) /  _BOHR**3
+    # print
+    fout.write('$cosmo_data\n')
+    fout.write(f'  fepsi  = {f_epsilon:>.8f}\n')
+    fout.write(f'  nps    = {n_segments:>10d}\n')
+    fout.write(f'  area   = {area:>10.2f}       # [Bohr**2]\n')
+    fout.write(f'  volume = {volume:>10.2f}       # [Bohr**3]\n')
+
+    # atomic coordinates
+    atoms = range(1, 1 + len(mf.mol.elements))
+    xs, ys, zs = zip(*mf.mol.atom_coords().tolist())
+    elems = [elem.lower() for elem in mf.mol.elements]
+    radii = [mf.with_solvent.surface['R_vdw'][i] \
+             for i, j in mf.with_solvent.surface['gslice_by_atom']]
+    # print
+    fout.write('$coord_rad\n')
+    fout.write('#atom   x [Bohr]           y [Bohr]           z [Bohr]      element  radius [Bohr]\n')
+    for atom, x, y, z, elem, r in zip(atoms, xs, ys, zs, elems, radii):
+        fout.write(f'{atom:>4d}{x:>19.14f}{y:>19.14f}{z:>19.14f}  {elem:<2}{r:>12.5f}\n')
+
+    # cosmo parameters
+    screening_charge = sum(mf.with_solvent._intermediates['q'])
+    E_tot = sum(mf.scf_summary.values())
+    E_diel = mf.scf_summary['e_solvent']
+    # print
+    fout.write('$screening_charge\n')
+    fout.write(f'  cosmo                          = {screening_charge:>15.6f}\n')
+    fout.write('$cosmo_energy\n')
+    fout.write(f'  Total energy [a.u.]            = {E_tot:>19.10f}\n')
+    fout.write(f'  Dielectric energy [a.u.]       = {E_diel:>19.10f}\n')
+    
+    # segments
+    xs, ys, zs = zip(*mf.with_solvent.surface['grid_coords'].tolist())
+    ns = range(1, len(xs) + 1)
+    atoms = []
+    for idx, (start, end) in enumerate(mf.with_solvent.surface['gslice_by_atom']):
+        atoms += [idx + 1] * (end - start)
+    qs = mf.with_solvent._intermediates['q']
+    areas = mf.with_solvent.surface['area'] * _BOHR**2
+    sigmas = qs / areas
+    pots = mf.with_solvent._intermediates['v_grids']
+    # print legend
+    fout.write('$segment_information\n')
+    fout.write('# n             - segment number\n')
+    fout.write('# atom          - atom associated with segment n\n')
+    fout.write('# x, y, z       - segment coordinates, [Bohr]\n')
+    fout.write('# charge        - segment charge\n')
+    fout.write('# area          - segment area [A**2]\n')
+    fout.write('# charge/area   - segment charge density [e/A**2]\n')
+    fout.write('# potential     - solute potential on segment\n')
+    fout.write('#\n')
+    fout.write('#  n   atom              position (X, Y, Z)                   charge         area        charge/area     potential\n')
+    fout.write('#\n')
+    fout.write('#\n')
+    # print params
+    for n, x, y, z, atom, q, area, sigma, pot in zip(ns, xs, ys, zs, atoms, qs, areas, sigmas, pots):
+        line  = f'{n:>5d}{atom:>5d}{x:>15.9f}{y:>15.9f}{z:>15.9f}'
+        line += f'{q:>15.9f}{area:>15.9f}{sigma:>15.9f}{pot:>15.9f}\n'
+        fout.write(line)
+    
+    return
+
+
+
+#%% Sigma-profile
+
+def get_sigma_profile(mf, sigmas_grid, ignore_low_feps=False):
+    '''Computes sigma-profile in [-0.025..0.025] e/A**2 range as in
+    https://github.com/usnistgov/COSMOSAC/blob/master/profiles/to_sigma.py#L181
+    https://doi.org/10.1021/acs.jctc.9b01016
+    
+    Arguments:
+        mf: processed SCF with PCM solvation
+        sigmas_grid (_np.ndarray): grid of screening charge values,
+            e.g. np.linspace(-0.025, 0.025, 51)
+        ignore_low_feps (bool): if True, does not raise ValueError if feps < 1
+    
+    Returns:
+        _np.ndarray: array of 51 elements corresponding to the p(sigma) values for
+            the screening charge values in [-0.025..0.025] e/A**2 range
+    
+    Raises:
+        ValueError: if f_epsilon < 1 and ignore_low_feps flag is set to False
+    
+    '''
+    _check_feps(mf, ignore_low_feps)
+    
+    # prepare params
+    qs = mf.with_solvent._intermediates['q']
+    areas = mf.with_solvent.surface['area'] * _BOHR**2
+    sigmas = qs / areas
+    step = sigmas_grid[1] - sigmas_grid[0]
+    max_sigma = sigmas_grid[-1] + step
+    n_bins = len(sigmas_grid)
+    
+    # compute profile
+    psigma = _np.zeros(n_bins)
+    for sigma, area in zip(sigmas, areas):
+        # get index of left sigma grid value
+        left = int(_np.floor((sigma - sigmas_grid[0]) / step))
+        if left < -1 or left > n_bins - 1:
+            continue
+        # get impact of the segment to the left bin
+        val_right = sigmas_grid[left+1] if left < n_bins - 1 else max_sigma
+        w_left = (val_right - sigma) / step
+        # add areas to p(sigma)
+        if left > -1:
+            psigma[left] += area * w_left
+        if left < n_bins - 1:
+            psigma[left+1] += area * (1 - w_left)
+
+    return psigma
+
+
+def get_cosmors_parameters(mf, sigmas_grid=_np.linspace(-0.025, 0.025, 51),
+                           step=0.2, ignore_low_feps=False):
+    '''Computes main COSMO-RS parameters
+    
+    Arguments:
+        mf: processed SCF with PCM solvation
+        step (float): grid spacing parameter to compute volume, [Bohr]
+        ignore_low_feps (bool): if True, does not raise ValueError if feps < 1
+    
+    Returns:
+        dict: main COSMO-RS parameters, including sigma-profile, volume, surface area,
+            SCF and dielectric energies
+    
+    Raises:
+        ValueError: if f_epsilon < 1 and ignore_low_feps flag is set to False
+    
+    '''
+    _check_feps(mf, ignore_low_feps)
+
+    # get params
+    lot = _lot(mf)
+    area = sum(mf.with_solvent.surface['area']) * _BOHR**2
+    volume = get_sas_volume(mf.with_solvent.surface, step)
+    psigma = get_sigma_profile(mf, sigmas_grid, ignore_low_feps=True)
+    E_tot = sum(mf.scf_summary.values())
+    E_diel = mf.scf_summary['e_solvent']
+
+    # output
+    params = {'PySCF version': __version__,
+              'Level of theory': lot,
+              'Surface area, A**2': float(area), # since np.float is not json-seriazable
+              'Volume, A**3': float(volume),
+              'Total energy, a.u.': float(E_tot),
+              'Dielectric energy, a.u.': float(E_diel),
+              'Screening charge density, A**2': psigma.tolist(),
+              'Screening charge, e/A**2': sigmas_grid.tolist()}
+    
+    return params
+
+

--- a/pyscf/solvent/pcm.py
+++ b/pyscf/solvent/pcm.py
@@ -328,21 +328,21 @@ class PCM(lib.StreamObject):
 
         epsilon = self.eps
         if self.method.upper() in ['C-PCM', 'CPCM']:
-            f_epsilon = (epsilon-1.)/epsilon
+            f_epsilon = (epsilon-1.)/epsilon if epsilon != float('inf') else 1.0
             K = S
             R = -f_epsilon * numpy.eye(K.shape[0])
         elif self.method.upper() == 'COSMO':
-            f_epsilon = (epsilon - 1.0)/(epsilon + 1.0/2.0)
+            f_epsilon = (epsilon - 1.0)/(epsilon + 1.0/2.0) if epsilon != float('inf') else 1.0
             K = S
             R = -f_epsilon * numpy.eye(K.shape[0])
         elif self.method.upper() in ['IEF-PCM', 'IEFPCM']:
-            f_epsilon = (epsilon - 1.0)/(epsilon + 1.0)
+            f_epsilon = (epsilon - 1.0)/(epsilon + 1.0) if epsilon != float('inf') else 1.0
             DA = D*A
             DAS = numpy.dot(DA, S)
             K = S - f_epsilon/(2.0*PI) * DAS
             R = -f_epsilon * (numpy.eye(K.shape[0]) - 1.0/(2.0*PI)*DA)
         elif self.method.upper() == 'SS(V)PE':
-            f_epsilon = (epsilon - 1.0)/(epsilon + 1.0)
+            f_epsilon = (epsilon - 1.0)/(epsilon + 1.0) if epsilon != float('inf') else 1.0
             DA = D*A
             DAS = numpy.dot(DA, S)
             K = S - f_epsilon/(4.0*PI) * (DAS + DAS.T)

--- a/pyscf/solvent/test/test_cosmors.py
+++ b/pyscf/solvent/test/test_cosmors.py
@@ -1,0 +1,89 @@
+# Copyright 2023 The GPU4PySCF Authors. All Rights Reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import io, re
+from pyscf import gto, dft
+from pyscf.solvent import pcm, cosmors
+
+def setUpModule():
+    global mol, cm0, cm1, mf0
+    mol = gto.M(atom='''
+           6        0.000000    0.000000   -0.542500
+           8        0.000000    0.000000    0.677500
+           1        0.000000    0.935307   -1.082500
+           1        0.000000   -0.935307   -1.082500
+                ''', basis='sto3g', verbose=0,
+                output='/dev/null')
+    # ideal conductor
+    cm0 = pcm.PCM(mol)
+    cm0.eps = float('inf')
+    cm0.method = 'C-PCM'
+    cm0.lebedev_order = 29
+    cm0.verbose = 0
+    # computation
+    mf0 = dft.RKS(mol, xc='b3lyp').PCM(cm0)
+    mf0.kernel()
+    # water
+    cm1 = pcm.PCM(mol)
+    cm1.eps = 78.4
+    cm1.method = 'C-PCM'
+    cm1.lebedev_order = 29
+    cm1.verbose = 0
+
+def tearDownModule():
+    global mol, cm0, cm1, mf0
+    mol.stdout.close()
+    del mol, cm0, cm1, mf0
+
+class TestCosmoRS(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.original_grids = dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS
+        dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = False
+
+    @classmethod
+    def tearDownClass(cls):
+        dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = cls.original_grids
+
+    def test_finite_epsilon(self):
+        mf1 = dft.RKS(mol, xc='b3lyp').PCM(cm1)
+        mf1.kernel()
+        self.assertRaises(ValueError, cosmors.get_cosmors_parameters, mf1)
+
+    def test_cosmo_file(self):
+        with io.StringIO() as outp: 
+            cosmors.write_cosmo_file(outp, mf0)
+            text = outp.getvalue()
+        E_diel = float(re.search('Dielectric energy \[a.u.\] += +(-*\d+\.\d+)', text).group(1))
+        self.assertAlmostEqual(E_diel, -0.0023256022, 8)
+
+    def test_cosmo_parameters(self):
+        ps = cosmors.get_cosmors_parameters(mf0)
+        self.assertAlmostEqual(ps['Total energy, a.u.'], -112.9530441986, 7)
+        self.assertAlmostEqual(ps['Dielectric energy, a.u.'], -0.0023256022, 7)
+        self.assertAlmostEqual(ps['Surface area, A**2'], 64.848604, 2)
+        self.assertAlmostEqual(ps['Screening charge density, A**2'][26], 2.974345636, 4)
+
+    def test_sas_volume(self):
+        V1 = cosmors.get_sas_volume(mf0.with_solvent.surface, step = 0.2)
+        self.assertAlmostEqual(V1, 46.391962, 3)
+        V2 = cosmors.get_sas_volume(mf0.with_solvent.surface, step = 0.05)
+        self.assertAlmostEqual(V2, 46.497054, 3)
+
+
+if __name__ == "__main__":
+    print("Full Tests for COSMO-RS")
+    unittest.main()

--- a/pyscf/solvent/test/test_cosmors.py
+++ b/pyscf/solvent/test/test_cosmors.py
@@ -72,8 +72,8 @@ class TestCosmoRS(unittest.TestCase):
 
     def test_cosmo_parameters(self):
         ps = cosmors.get_cosmors_parameters(mf0)
-        self.assertAlmostEqual(ps['Total energy, a.u.'], -112.9530441986, 7)
-        self.assertAlmostEqual(ps['Dielectric energy, a.u.'], -0.0023256022, 7)
+        self.assertAlmostEqual(ps['Total energy, a.u.'], -112.953044138, 6)
+        self.assertAlmostEqual(ps['Dielectric energy, a.u.'], -0.0023256022, 6)
         self.assertAlmostEqual(ps['Surface area, A**2'], 64.848604, 2)
         self.assertAlmostEqual(ps['Screening charge density, A**2'][26], 2.974345636, 4)
 

--- a/pyscf/solvent/test/test_cosmors.py
+++ b/pyscf/solvent/test/test_cosmors.py
@@ -72,8 +72,8 @@ class TestCosmoRS(unittest.TestCase):
 
     def test_cosmo_parameters(self):
         ps = cosmors.get_cosmors_parameters(mf0)
-        self.assertAlmostEqual(ps['Total energy, a.u.'], -112.953044138, 6)
-        self.assertAlmostEqual(ps['Dielectric energy, a.u.'], -0.0023256022, 6)
+        self.assertAlmostEqual(ps['Total energy, a.u.'], -112.953044138, 5)
+        self.assertAlmostEqual(ps['Dielectric energy, a.u.'], -0.0023256022, 5)
         self.assertAlmostEqual(ps['Surface area, A**2'], 64.848604, 2)
         self.assertAlmostEqual(ps['Screening charge density, A**2'][26], 2.974345636, 4)
 


### PR DESCRIPTION
Adds functionality to generate Turbomole-formatted COSMO-files from DFT PCM computations.

List of changes:
1. PCM model:
    * `pyscf/solvent/pcm.py`: adds possibility to use `epsilon = float('inf')` in PCM computations;
    * `examples/solvent/05-pcm.py`: adds test with `epsilon = float('inf')`.
2. COSMO-RS model:
    * `pyscf/solvent/cosmors.py`: functions transforming results of PCM computation to COSMO-file or COSMO-RS-related parameters;
    * `pyscf/solvent/test/test_cosmors.py`: tests;
    * `examples/solvent/07-cosmors.py`: examples showing all available COSMO-RS functionality.