### PR TITLE
Update 04-input_basis.py

### DIFF
--- a/examples/gto/04-input_basis.py
+++ b/examples/gto/04-input_basis.py
@@ -65,7 +65,7 @@ mol = gto.M(
 mol = gto.M(
     atom = '''O 0 0 0; H1 0 1 0; H2 0 0 1''',
     basis = {'O': gto.parse('''
-# Parse NWChem format basis string (see https://bse.pnl.gov/bse/portal).
+# Parse NWChem format basis string (see https://www.basissetexchange.org/).
 # Comment lines are ignored
 #BASIS SET: (6s,3p) -> [2s,1p]
 O    S


### PR DESCRIPTION
The Link for the basis set exchange is outdated (since more the one year) - the new URL is https://www.basissetexchange.org/