### PR TITLE
Parallel in-place matrix transposition and scaling

### DIFF
--- a/pyscf/lib/config.h.in
+++ b/pyscf/lib/config.h.in
@@ -3,6 +3,8 @@
 #else
 #define omp_get_thread_num() 0
 #define omp_get_num_threads() 1
+#define omp_get_max_active_levels() 1
+#define omp_set_max_active_levels(n) 0
 #endif
 
 #define XCFUN_MAX_DERIV_ORDER @XCFUN_MAX_ORDER@

--- a/pyscf/lib/config.h.in
+++ b/pyscf/lib/config.h.in
@@ -3,8 +3,6 @@
 #else
 #define omp_get_thread_num() 0
 #define omp_get_num_threads() 1
-#define omp_get_max_active_levels() 1
-#define omp_set_max_active_levels(n) 0
 #endif
 
 #define XCFUN_MAX_DERIV_ORDER @XCFUN_MAX_ORDER@

--- a/pyscf/lib/np_helper/CMakeLists.txt
+++ b/pyscf/lib/np_helper/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_library(np_helper SHARED 
-  transpose.c pack_tril.c npdot.c condense.c omp_reduce.c np_helper.c)
+  transpose.c pack_tril.c npdot.c condense.c omp_reduce.c np_helper.c imatcopy.c)
 
 set_target_properties(np_helper PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})

--- a/pyscf/lib/np_helper/imatcopy.c
+++ b/pyscf/lib/np_helper/imatcopy.c
@@ -29,7 +29,7 @@ const int TILESIZE = 32;
  * Calculate the largest integer i such that
  *  i * (i - 1) / 2 <= ijouter.
  */
-static int uncollapse_loop_index(ssize_t ijouter)
+static int uncollapse_loop_index(long long ijouter)
 {
   return (int) floor((sqrt(0.25 + 2.0 * ijouter) + 0.5));
 }
@@ -151,7 +151,7 @@ void NPomp_d_itranspose_scale(const int n, const double alpha, double *A, int ld
     int first_iteration = 1;
     int iouter, jouter;
 #pragma omp for nowait
-    for(ssize_t ijouter = 0; ijouter < (ntiles*(ntiles-1))/2; ijouter++) {
+    for(long long ijouter = 0; ijouter < (ntiles*(ntiles-1))/2; ijouter++) {
       if(first_iteration) {
         iouter = uncollapse_loop_index(ijouter);
         jouter = ijouter - iouter * (iouter - 1) / 2;
@@ -278,7 +278,7 @@ void NPomp_z_itranspose_scale(const int n, const double complex *alphaptr, doubl
     int first_iteration = 1;
     int iouter, jouter;
 #pragma omp for nowait
-    for(ssize_t ijouter = 0; ijouter < (ntiles*(ntiles-1))/2; ijouter++) {
+    for(long long ijouter = 0; ijouter < (ntiles*(ntiles-1))/2; ijouter++) {
       if(first_iteration) {
         iouter = uncollapse_loop_index(ijouter);
         jouter = ijouter - iouter * (iouter - 1) / 2;
@@ -337,7 +337,7 @@ void NPomp_z_itranspose_scale(const int n, const double complex *alphaptr, doubl
  * Batched versions for 3D tensors
  */
 
-void NPomp_dtensor_itranspose_scale021(const ssize_t matstride, int nmat, int n, const double alpha,
+void NPomp_dtensor_itranspose_scale021(const long long matstride, int nmat, int n, const double alpha,
                                       double *A, int lda)
 {
     if (omp_get_num_threads() >= nmat) {
@@ -358,7 +358,7 @@ void NPomp_dtensor_itranspose_scale021(const ssize_t matstride, int nmat, int n,
   }
 }
 
-void NPomp_ztensor_itranspose_scale021(const ssize_t matstride, int nmat, int n, const double complex *alpha,
+void NPomp_ztensor_itranspose_scale021(const long long matstride, int nmat, int n, const double complex *alpha,
                                       double complex *A, int lda)
 {
     if (omp_get_num_threads() >= nmat) {

--- a/pyscf/lib/np_helper/imatcopy.c
+++ b/pyscf/lib/np_helper/imatcopy.c
@@ -23,102 +23,104 @@
 
 const int TILESIZE = 32;
 
-#define ELEM_AT(A, i, j, lda) (A)[(i) * (lda) + (j)]
-
 /*
  * Calculate the largest integer i such that
  *  i * (i - 1) / 2 <= ijouter.
  */
-static int uncollapse_loop_index(long long ijouter)
+static inline int uncollapse_loop_index(const long long ijouter)
 {
   return (int) floor((sqrt(0.25 + 2.0 * ijouter) + 0.5));
 }
 
-
-static inline void dtranspose_scale_tile_offdiag(double *A, const int ii, const int jj,
-                                          int lda, const double alpha) {
+static inline void dtranspose_scale_tile_offdiag(double *A, const int ii,
+                                                 const int jj,
+                                                 const size_t lda_w,
+                                                 const double alpha) {
   for (int j = jj; j < jj + TILESIZE; j++) {
 #pragma omp simd
     for(int i = ii; i < ii + TILESIZE; i++) {
-      const double tmp = ELEM_AT(A, i, j, lda);
-      ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
-      ELEM_AT(A, j, i, lda) = alpha * tmp;
+      const double tmp = A[i * lda_w + j];
+      A[i * lda_w + j] = alpha * A[j * lda_w + i];
+      A[j * lda_w + i] = alpha * tmp;
     }
   }
 }
 
-static inline void dtranspose_scale_tile_diag(double *A, const int ii, const int jj,
-                                       int lda, const double alpha) {
+static inline void dtranspose_scale_tile_diag(double *A, const int ii,
+                                              const int jj, const size_t lda_w,
+                                              const double alpha) {
   for (int j = jj; j < jj + TILESIZE; j++) {
 #pragma omp simd
     for(int i = ii; i < j; i++) {
-      const double tmp = ELEM_AT(A, i, j, lda);
-      ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
-      ELEM_AT(A, j, i, lda) = alpha * tmp;
+      const double tmp = A[i * lda_w + j];
+      A[i * lda_w + j] = alpha * A[j * lda_w + i];
+      A[j * lda_w + i]= alpha * tmp;
     }
-    ELEM_AT(A, j, j, lda) *= alpha;
+    A[j * lda_w + j] *= alpha;
   }
 }
 
 static inline void dtranspose_tile_diag(double *A, const int ii, const int jj,
-                                       int lda) {
+                                        const size_t lda_w) {
   for (int j = jj; j < jj + TILESIZE; j++) {
 #pragma omp simd
     for(int i = ii; i < j; i++) {
-      const double tmp = ELEM_AT(A, i, j, lda);
-      ELEM_AT(A, i, j, lda) = ELEM_AT(A, j, i, lda);
-      ELEM_AT(A, j, i, lda) = tmp;
+      const double tmp = A[i * lda_w + j];
+      A[i * lda_w + j] = A[j * lda_w + i];
+      A[j * lda_w + i] = tmp;
     }
   }
 }
 
-static inline void ztranspose_scale_tile_offdiag(double complex *A, const int ii,
-                                          const int jj, int lda,
-                                          const double complex alpha) {
+static inline void ztranspose_scale_tile_offdiag(double complex *A,
+                                                 const int ii, const int jj,
+                                                 const size_t lda_w,
+                                                 const double complex alpha) {
   for (int j = jj; j < jj + TILESIZE; j++) {
 #pragma omp simd
     for(int i = ii; i < ii + TILESIZE; i++) {
-      const double complex tmp = ELEM_AT(A, i, j, lda);
-      ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
-      ELEM_AT(A, j, i, lda) = alpha * tmp;
+      const double complex tmp = A[i * lda_w + j];
+      A[i * lda_w + j] = alpha * A[j * lda_w + i];
+      A[j * lda_w + i] = alpha * tmp;
     }
   }
 }
 
 static inline void ztranspose_scale_tile_diag(double complex *A, const int ii,
-                                       const int jj, int lda,
-                                       const double complex alpha) {
+                                              const int jj, const size_t lda_w,
+                                              const double complex alpha) {
   for (int j = jj; j < jj + TILESIZE; j++) {
 #pragma omp simd
     for(int i = ii; i < j; i++) {
-      const double complex tmp = ELEM_AT(A, i, j, lda);
-      ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
-      ELEM_AT(A, j, i, lda) = alpha * tmp;
+      const double complex tmp = A[i * lda_w + j];
+      A[i * lda_w + j] = alpha * A[j * lda_w + i];
+      A[j * lda_w + i] = alpha * tmp;
     }
-    ELEM_AT(A, j, j, lda) *= alpha;
+    A[j * lda_w + j] *= alpha;
   }
 }
 
 static inline void ztranspose_tile_diag(double complex *A, const int ii,
-                                       const int jj, int lda) {
+                                       const int jj, const size_t lda_w) {
   for (int j = jj; j < jj + TILESIZE; j++) {
 #pragma omp simd
     for(int i = ii; i < j; i++) {
-      const double complex tmp = ELEM_AT(A, i, j, lda);
-      ELEM_AT(A, i, j, lda) = ELEM_AT(A, j, i, lda);
-      ELEM_AT(A, j, i, lda) = tmp;
+      const double complex tmp = A[i * lda_w + j];
+      A[i * lda_w + j] = A[j * lda_w + i];
+      A[j * lda_w + i] = tmp;
     }
   }
 }
 
 /*
- * In-place parallel matrix transpose
+ * In-place parallel matrix transpose, double version.
  * See https://colfaxresearch.com/multithreaded-transposition-of-square-matrices-with-common-code-for-intel-xeon-processors-and-intel-xeon-phi-coprocessors/
  */
 void NPomp_d_itranspose_scale(const int n, const double alpha, double *A, int lda)
 {
   const int nclean = n - n % TILESIZE;
   const int ntiles = nclean / TILESIZE;
+  const size_t lda_w = (size_t) lda;
 
 #pragma omp parallel
   {
@@ -150,7 +152,7 @@ void NPomp_d_itranspose_scale(const int n, const double alpha, double *A, int ld
  */
     int first_iteration = 1;
     int iouter, jouter;
-#pragma omp for nowait
+#pragma omp for schedule(static) nowait
     for(long long ijouter = 0; ijouter < (ntiles*(ntiles-1))/2; ijouter++) {
       if(first_iteration) {
         iouter = uncollapse_loop_index(ijouter);
@@ -163,7 +165,7 @@ void NPomp_d_itranspose_scale(const int n, const double alpha, double *A, int ld
           jouter = 0;
         }
       }
-      dtranspose_scale_tile_offdiag(A, iouter * TILESIZE, jouter * TILESIZE, lda, alpha);
+      dtranspose_scale_tile_offdiag(A, iouter * TILESIZE, jouter * TILESIZE, lda_w, alpha);
     }
 
 
@@ -188,12 +190,12 @@ void NPomp_d_itranspose_scale(const int n, const double alpha, double *A, int ld
     if(alpha != 1.0) {
 #pragma omp for schedule(static) nowait
       for(int ii = 0; ii < nclean; ii+=TILESIZE) {
-        dtranspose_scale_tile_diag(A, ii, ii, lda, alpha);
+        dtranspose_scale_tile_diag(A, ii, ii, lda_w, alpha);
       }
     } else {
 #pragma omp for schedule(static) nowait
       for(int ii = 0; ii < nclean; ii+=TILESIZE) {
-        dtranspose_tile_diag(A, ii, ii, lda);
+        dtranspose_tile_diag(A, ii, ii, lda_w);
       }
     }
 
@@ -218,9 +220,9 @@ void NPomp_d_itranspose_scale(const int n, const double alpha, double *A, int ld
 #pragma omp for schedule(static) nowait
     for(int j = 0; j < nclean; j++) {
       for(int i = nclean; i < n; i++) {
-        const double tmp = ELEM_AT(A, i, j, lda);
-        ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
-        ELEM_AT(A, j, i, lda) = alpha * tmp;
+        const double tmp = A[i * lda_w + j];
+        A[i * lda_w + j] = alpha * A[j * lda_w + i];
+        A[j * lda_w + i] = alpha * tmp;
       }
     }
   } // end parallel region
@@ -244,26 +246,30 @@ void NPomp_d_itranspose_scale(const int n, const double alpha, double *A, int ld
 
   for(int j = nclean; j < n; j++) {
     for(int i = nclean; i < j; i++) {
-      const double tmp = ELEM_AT(A, i, j, lda);
-      ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
-      ELEM_AT(A, j, i, lda) = alpha * tmp;
+      const double tmp = A[i * lda_w + j];
+      A[i * lda_w + j] = alpha * A[j * lda_w + i];
+      A[j * lda_w + i] = alpha * tmp;
     }
   }
 
   if(alpha != 1.0) {
     for(int i = nclean; i < n; i++) {
-      ELEM_AT(A, i, i, lda) *= alpha;
+      A[i * lda_w + i] *= alpha;
     }
   }
 
 }
 
-
+/*
+ * In-place parallel matrix transpose, double complex version.
+ * See https://colfaxresearch.com/multithreaded-transposition-of-square-matrices-with-common-code-for-intel-xeon-processors-and-intel-xeon-phi-coprocessors/
+ */
 void NPomp_z_itranspose_scale(const int n, const double complex *alphaptr, double complex *A, int lda)
 {
   const double complex alpha = *alphaptr;
   const int nclean = n - n % TILESIZE;
   const int ntiles = nclean / TILESIZE;
+  const size_t lda_w = (size_t) lda;
 
 #pragma omp parallel
   {
@@ -277,7 +283,7 @@ void NPomp_z_itranspose_scale(const int n, const double complex *alphaptr, doubl
  */
     int first_iteration = 1;
     int iouter, jouter;
-#pragma omp for nowait
+#pragma omp for schedule(static) nowait
     for(long long ijouter = 0; ijouter < (ntiles*(ntiles-1))/2; ijouter++) {
       if(first_iteration) {
         iouter = uncollapse_loop_index(ijouter);
@@ -290,27 +296,27 @@ void NPomp_z_itranspose_scale(const int n, const double complex *alphaptr, doubl
           jouter = 0;
         }
       }
-      ztranspose_scale_tile_offdiag(A, iouter * TILESIZE, jouter * TILESIZE, lda, alpha);
+      ztranspose_scale_tile_offdiag(A, iouter * TILESIZE, jouter * TILESIZE, lda_w, alpha);
     }
 
     if(alpha != 1.0) {
 #pragma omp for schedule(static) nowait
       for(int ii = 0; ii < nclean; ii+=TILESIZE) {
-        ztranspose_scale_tile_diag(A, ii, ii, lda, alpha);
+        ztranspose_scale_tile_diag(A, ii, ii, lda_w, alpha);
       }
     } else {
 #pragma omp for schedule(static) nowait
       for(int ii = 0; ii < nclean; ii+=TILESIZE) {
-        ztranspose_tile_diag(A, ii, ii, lda);
+        ztranspose_tile_diag(A, ii, ii, lda_w);
       }
     }
 
 #pragma omp for schedule(static) nowait
     for(int j = 0; j < nclean; j++) {
       for(int i = nclean; i < n; i++) {
-        const double complex tmp = ELEM_AT(A, i, j, lda);
-        ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
-        ELEM_AT(A, j, i, lda) = alpha * tmp;
+        const double complex tmp = A[i * lda_w + j];
+        A[i * lda_w + j] = alpha * A[j * lda_w + i];
+        A[j * lda_w + i] = alpha * tmp;
       }
     }
 
@@ -318,15 +324,15 @@ void NPomp_z_itranspose_scale(const int n, const double complex *alphaptr, doubl
 
   for(int j = nclean; j < n; j++) {
     for(int i = nclean; i < j; i++) {
-        const double complex tmp = ELEM_AT(A, i, j, lda);
-        ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
-        ELEM_AT(A, j, i, lda) = alpha * tmp;
+        const double complex tmp = A[i * lda_w + j];
+        A[i * lda_w + j] = alpha * A[j * lda_w + i];
+        A[j * lda_w + i] = alpha * tmp;
     }
   }
 
   if(alpha != 1.0) {
     for(int i = nclean; i < n; i++) {
-      ELEM_AT(A, i, i, lda) *= alpha;
+      A[i * lda_w + i] *= alpha;
     }
   }
 }
@@ -340,41 +346,15 @@ void NPomp_z_itranspose_scale(const int n, const double complex *alphaptr, doubl
 void NPomp_dtensor_itranspose_scale021(const long long matstride, int nmat, int n, const double alpha,
                                       double *A, int lda)
 {
-    if (omp_get_num_threads() >= nmat) {
-#pragma omp parallel
-{
-    int nlevels = omp_get_max_active_levels();
-    omp_set_max_active_levels(1);
-#pragma omp for schedule(static)
-    for (int imat = 0; imat < nmat; imat++) {
-      NPomp_d_itranspose_scale(n, alpha, A + imat * matstride, lda);
-    }
-    omp_set_max_active_levels(nlevels);
-}
-  } else {
-    for (int imat = 0; imat < nmat; imat++) {
-      NPomp_d_itranspose_scale(n, alpha, A + imat * matstride, lda);
-    }
+  for (int imat = 0; imat < nmat; imat++) {
+    NPomp_d_itranspose_scale(n, alpha, A + imat * matstride, lda);
   }
 }
 
 void NPomp_ztensor_itranspose_scale021(const long long matstride, int nmat, int n, const double complex *alpha,
                                       double complex *A, int lda)
 {
-    if (omp_get_num_threads() >= nmat) {
-#pragma omp parallel
-{
-    int nlevels = omp_get_max_active_levels();
-    omp_set_max_active_levels(1);
-#pragma omp for schedule(static)
     for (int imat = 0; imat < nmat; imat++) {
       NPomp_z_itranspose_scale(n, alpha, A + imat * matstride, lda);
     }
-    omp_set_max_active_levels(nlevels);
-}
-  } else {
-    for (int imat = 0; imat < nmat; imat++) {
-      NPomp_z_itranspose_scale(n, alpha, A + imat * matstride, lda);
-    }
-  }
 }

--- a/pyscf/lib/np_helper/imatcopy.c
+++ b/pyscf/lib/np_helper/imatcopy.c
@@ -18,7 +18,7 @@
 
 #include <complex.h>
 #include <math.h>
-#include <omp.h>
+#include "config.h"
 #include "np_helper.h"
 
 const int TILESIZE = 32;

--- a/pyscf/lib/np_helper/imatcopy.c
+++ b/pyscf/lib/np_helper/imatcopy.c
@@ -1,0 +1,333 @@
+/* Copyright 2014-2018 The PySCF Developers. All Rights Reserved.
+  
+   Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ *
+ * Author: Christopher Hillenbrand <chillenbrand15@gmail.com>
+ */
+
+#include <complex.h>
+#include <omp.h>
+#include "np_helper.h"
+
+const int TILESIZE = 32;
+
+#define ELEM_AT(A, i, j, lda) (A)[(i) * (lda) + (j)]
+
+static inline void dtranspose_scale_tile_offdiag(double *A, const int ii, const int jj,
+                                          int lda, const double alpha) {
+  for (int j = jj; j < jj + TILESIZE; j++) {
+#pragma omp simd
+    for(int i = ii; i < ii + TILESIZE; i++) {
+      const double tmp = ELEM_AT(A, i, j, lda);
+      ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
+      ELEM_AT(A, j, i, lda) = alpha * tmp;
+    }
+  }
+}
+
+static inline void dtranspose_scale_tile_diag(double *A, const int ii, const int jj,
+                                       int lda, const double alpha) {
+  for (int j = jj; j < jj + TILESIZE; j++) {
+#pragma omp simd
+    for(int i = ii; i < j; i++) {
+      const double tmp = ELEM_AT(A, i, j, lda);
+      ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
+      ELEM_AT(A, j, i, lda) = alpha * tmp;
+    }
+    ELEM_AT(A, j, j, lda) *= alpha;
+  }
+}
+
+static inline void dtranspose_tile_diag(double *A, const int ii, const int jj,
+                                       int lda) {
+  for (int j = jj; j < jj + TILESIZE; j++) {
+#pragma omp simd
+    for(int i = ii; i < j; i++) {
+      const double tmp = ELEM_AT(A, i, j, lda);
+      ELEM_AT(A, i, j, lda) = ELEM_AT(A, j, i, lda);
+      ELEM_AT(A, j, i, lda) = tmp;
+    }
+  }
+}
+
+static inline void ztranspose_scale_tile_offdiag(double complex *A, const int ii,
+                                          const int jj, int lda,
+                                          const double complex alpha) {
+  for (int j = jj; j < jj + TILESIZE; j++) {
+#pragma omp simd
+    for(int i = ii; i < ii + TILESIZE; i++) {
+      const double complex tmp = ELEM_AT(A, i, j, lda);
+      ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
+      ELEM_AT(A, j, i, lda) = alpha * tmp;
+    }
+  }
+}
+
+static inline void ztranspose_scale_tile_diag(double complex *A, const int ii,
+                                       const int jj, int lda,
+                                       const double complex alpha) {
+  for (int j = jj; j < jj + TILESIZE; j++) {
+#pragma omp simd
+    for(int i = ii; i < j; i++) {
+      const double complex tmp = ELEM_AT(A, i, j, lda);
+      ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
+      ELEM_AT(A, j, i, lda) = alpha * tmp;
+    }
+    ELEM_AT(A, j, j, lda) *= alpha;
+  }
+}
+
+static inline void ztranspose_tile_diag(double complex *A, const int ii,
+                                       const int jj, int lda) {
+  for (int j = jj; j < jj + TILESIZE; j++) {
+#pragma omp simd
+    for(int i = ii; i < j; i++) {
+      const double complex tmp = ELEM_AT(A, i, j, lda);
+      ELEM_AT(A, i, j, lda) = ELEM_AT(A, j, i, lda);
+      ELEM_AT(A, j, i, lda) = tmp;
+    }
+  }
+}
+
+/*
+ * In-place parallel matrix transpose
+ * See https://colfaxresearch.com/multithreaded-transposition-of-square-matrices-with-common-code-for-intel-xeon-processors-and-intel-xeon-phi-coprocessors/
+ */
+void NPomp_d_itranspose_scale(const int n, const double alpha, double *A, int lda)
+{
+  const int nclean = n - n % TILESIZE;
+  const int ntiles = nclean / TILESIZE;
+
+#pragma omp parallel
+  {
+
+/*
+ *   ---------------------------
+ *  |       ******************  |
+ *  |       ******************  |
+ *  |       ******************  |
+ *  | ******      ************  |
+ *  | ******      ************  |
+ *  | ******      ************  |
+ *  | ************      ******  |
+ *  | ************      ******  |
+ *  | ************      ******  |
+ *  | ******************        |
+ *  | ******************        |
+ *  | ******************        |
+ *  |                           |
+ *   ----------------------------
+ */
+
+#pragma omp for collapse(2) nowait
+    for(int iouter = 1; iouter < ntiles; iouter++) {
+      for(int jouter = 0; jouter < iouter; jouter++) {
+        dtranspose_scale_tile_offdiag(A, iouter * TILESIZE, jouter * TILESIZE, lda, alpha);
+      }
+    }
+
+
+/*
+ *   ---------------------------
+ *  | ******                    |
+ *  | ******                    |
+ *  | ******                    |
+ *  |       ******              |
+ *  |       ******              |
+ *  |       ******              |
+ *  |             ******        |
+ *  |             ******        |
+ *  |             ******        |
+ *  |                   ******  |
+ *  |                   ******  |
+ *  |                   ******  |
+ *  |                           |
+ *   ----------------------------
+ */
+
+    if(alpha != 1.0) {
+#pragma omp for schedule(static) nowait
+      for(int ii = 0; ii < nclean; ii+=TILESIZE) {
+        dtranspose_scale_tile_diag(A, ii, ii, lda, alpha);
+      }
+    } else {
+#pragma omp for schedule(static) nowait
+      for(int ii = 0; ii < nclean; ii+=TILESIZE) {
+        dtranspose_tile_diag(A, ii, ii, lda);
+      }
+    }
+
+
+/*
+ *   --------------------------
+ *  |                        ***|
+ *  |                        ***|
+ *  |                        ***|
+ *  |                        ***|
+ *  |                        ***|
+ *  |                        ***|
+ *  |                        ***|
+ *  |                        ***|
+ *  |                        ***|
+ *  |                        ***|
+ *  | ***********************   |
+ *  | ***********************   |
+ *   ---------------------------
+ */
+
+#pragma omp for schedule(static) nowait
+    for(int j = 0; j < nclean; j++) {
+      for(int i = nclean; i < n; i++) {
+        const double tmp = ELEM_AT(A, i, j, lda);
+        ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
+        ELEM_AT(A, j, i, lda) = alpha * tmp;
+      }
+    }
+  } // end parallel region
+
+/*
+ *   --------------------------
+ *  |                           |
+ *  |                           |
+ *  |                           |
+ *  |                           |
+ *  |                           |
+ *  |                           |
+ *  |                           |
+ *  |                           |
+ *  |                           |
+ *  |                           |
+ *  |                        ***|
+ *  |                        ***|
+ *   ---------------------------
+ */
+
+  for(int j = nclean; j < n; j++) {
+    for(int i = nclean; i < j; i++) {
+      const double tmp = ELEM_AT(A, i, j, lda);
+      ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
+      ELEM_AT(A, j, i, lda) = alpha * tmp;
+    }
+  }
+
+  if(alpha != 1.0) {
+    for(int i = nclean; i < n; i++) {
+      ELEM_AT(A, i, i, lda) *= alpha;
+    }
+  }
+
+}
+
+
+void NPomp_z_itranspose_scale(const int n, const double complex *alphaptr, double complex *A, int lda)
+{
+  const double complex alpha = *alphaptr;
+  const int nclean = n - n % TILESIZE;
+  const int ntiles = nclean / TILESIZE;
+
+#pragma omp parallel
+  {
+
+#pragma omp for collapse(2) nowait
+    for(int iouter = 1; iouter < ntiles; iouter++) {
+      for(int jouter = 0; jouter < iouter; jouter++) {
+        ztranspose_scale_tile_offdiag(A, iouter * TILESIZE, jouter * TILESIZE, lda, alpha);
+      }
+    }
+
+    if(alpha != 1.0) {
+#pragma omp for schedule(static) nowait
+      for(int ii = 0; ii < nclean; ii+=TILESIZE) {
+        ztranspose_scale_tile_diag(A, ii, ii, lda, alpha);
+      }
+    } else {
+#pragma omp for schedule(static) nowait
+      for(int ii = 0; ii < nclean; ii+=TILESIZE) {
+        ztranspose_tile_diag(A, ii, ii, lda);
+      }
+    }
+
+#pragma omp for schedule(static) nowait
+    for(int j = 0; j < nclean; j++) {
+      for(int i = nclean; i < n; i++) {
+        const double complex tmp = ELEM_AT(A, i, j, lda);
+        ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
+        ELEM_AT(A, j, i, lda) = alpha * tmp;
+      }
+    }
+
+  } // end parallel region
+
+  for(int j = nclean; j < n; j++) {
+    for(int i = nclean; i < j; i++) {
+        const double complex tmp = ELEM_AT(A, i, j, lda);
+        ELEM_AT(A, i, j, lda) = alpha * ELEM_AT(A, j, i, lda);
+        ELEM_AT(A, j, i, lda) = alpha * tmp;
+    }
+  }
+
+  if(alpha != 1.0) {
+    for(int i = nclean; i < n; i++) {
+      ELEM_AT(A, i, i, lda) *= alpha;
+    }
+  }
+}
+
+
+
+/*
+ * Batched versions for 3D tensors
+ */
+
+void NPomp_dtensor_itranspose_scale021(const ssize_t matstride, int nmat, int n, const double alpha,
+                                      double *A, int lda)
+{
+    if (omp_get_num_threads() >= nmat) {
+#pragma omp parallel
+{
+    int nlevels = omp_get_max_active_levels();
+    omp_set_max_active_levels(1);
+#pragma omp for schedule(static)
+    for (int imat = 0; imat < nmat; imat++) {
+      NPomp_d_itranspose_scale(n, alpha, A + imat * matstride, lda);
+    }
+    omp_set_max_active_levels(nlevels);
+}
+  } else {
+    for (int imat = 0; imat < nmat; imat++) {
+      NPomp_d_itranspose_scale(n, alpha, A + imat * matstride, lda);
+    }
+  }
+}
+
+void NPomp_ztensor_itranspose_scale021(const ssize_t matstride, int nmat, int n, const double complex *alpha,
+                                      double complex *A, int lda)
+{
+    if (omp_get_num_threads() >= nmat) {
+#pragma omp parallel
+{
+    int nlevels = omp_get_max_active_levels();
+    omp_set_max_active_levels(1);
+#pragma omp for schedule(static)
+    for (int imat = 0; imat < nmat; imat++) {
+      NPomp_z_itranspose_scale(n, alpha, A + imat * matstride, lda);
+    }
+    omp_set_max_active_levels(nlevels);
+}
+  } else {
+    for (int imat = 0; imat < nmat; imat++) {
+      NPomp_z_itranspose_scale(n, alpha, A + imat * matstride, lda);
+    }
+  }
+}

--- a/pyscf/lib/np_helper/np_helper.h
+++ b/pyscf/lib/np_helper/np_helper.h
@@ -49,9 +49,9 @@ void NPztranspose_021(int *shape, double complex *a, double complex *at);
 
 void NPomp_d_itranspose_scale(const int n, const double alpha, double *A, int lda);
 void NPomp_z_itranspose_scale(const int n, const double complex *alphaptr, double complex *A, int lda);
-void NPomp_dtensor_itranspose_scale021(const ssize_t matstride, int nmat, int n, const double alpha,
+void NPomp_dtensor_itranspose_scale021(const long long matstride, int nmat, int n, const double alpha,
                                       double *A, int lda);
-void NPomp_ztensor_itranspose_scale021(const ssize_t matstride, int nmat, int n, const double complex *alpha,
+void NPomp_ztensor_itranspose_scale021(const long long matstride, int nmat, int n, const double complex *alpha,
                                       double complex *A, int lda);
 
 void NPdunpack_tril_2d(int count, int n, double *tril, double *mat, int hermi);

--- a/pyscf/lib/np_helper/np_helper.h
+++ b/pyscf/lib/np_helper/np_helper.h
@@ -16,6 +16,7 @@
  * Author: Qiming Sun <osirpt.sun@gmail.com>
  */
 
+#include <stdlib.h>
 #include <complex.h>
 
 #define BLOCK_DIM    104
@@ -45,6 +46,13 @@ void NPdtranspose(int n, int m, double *a, double *at);
 void NPztranspose(int n, int m, double complex *a, double complex *at);
 void NPdtranspose_021(int *shape, double *a, double *at);
 void NPztranspose_021(int *shape, double complex *a, double complex *at);
+
+void NPomp_d_itranspose_scale(const int n, const double alpha, double *A, int lda);
+void NPomp_z_itranspose_scale(const int n, const double complex *alphaptr, double complex *A, int lda);
+void NPomp_dtensor_itranspose_scale021(const ssize_t matstride, int nmat, int n, const double alpha,
+                                      double *A, int lda);
+void NPomp_ztensor_itranspose_scale021(const ssize_t matstride, int nmat, int n, const double complex *alpha,
+                                      double complex *A, int lda);
 
 void NPdunpack_tril_2d(int count, int n, double *tril, double *mat, int hermi);
 void NPzunpack_tril_2d(int count, int n,

--- a/pyscf/lib/numpy_helper.py
+++ b/pyscf/lib/numpy_helper.py
@@ -540,6 +540,39 @@ def takebak_2d(out, a, idx, idy, thread_safe=True):
        ctypes.c_int(thread_safe))
     return out
 
+
+def inplace_transpose_scale(a, alpha=1.0):
+    """In-place parallel scaling and transposition of a square matrix
+
+    Parameters
+    ----------
+    a : ndarray
+        Square matrix of size (n,n) to be scaled and transposed.
+        Does not need to be contiguous; lda can exceed n.
+    alpha : float, optional
+        scaling factor, by default 1.0
+    """
+    assert a.ndim == 2
+    assert a.shape[0] == a.shape[1]
+    n = a.shape[0]
+    astrides = [s // a.itemsize for s in a.strides]
+    lda = max(astrides)
+    assert min(astrides) == 1
+    if a.dtype == numpy.double:
+        _np_helper.NPomp_d_itranspose_scale(
+            ctypes.c_int(n), ctypes.c_double(alpha),
+            a.ctypes.data_as(ctypes.c_void_p), ctypes.c_int(lda)
+        )
+    elif a.dtype == numpy.complex128:
+        alpha_arr = numpy.array([alpha], dtype=numpy.complex128)
+        _np_helper.NPomp_z_itranspose_scale(
+            ctypes.c_int(n), alpha_arr.ctypes.data_as(ctypes.c_void_p),
+            a.ctypes.data_as(ctypes.c_void_p), ctypes.c_int(lda)
+        )
+    else:
+        raise NotImplementedError
+    return a
+
 def transpose(a, axes=None, inplace=False, out=None):
     '''Transposing an array with better memory efficiency
 
@@ -550,16 +583,45 @@ def transpose(a, axes=None, inplace=False, out=None):
      [ 1.  1.  1.]]
     '''
     if inplace:
-        arow, acol = a.shape[:2]
-        assert arow == acol
-        tmp = numpy.empty((BLOCK_DIM,BLOCK_DIM))
-        for c0, c1 in misc.prange(0, acol, BLOCK_DIM):
-            for r0, r1 in misc.prange(0, c0, BLOCK_DIM):
-                tmp[:c1-c0,:r1-r0] = a[c0:c1,r0:r1]
-                a[c0:c1,r0:r1] = a[r0:r1,c0:c1].T
-                a[r0:r1,c0:c1] = tmp[:c1-c0,:r1-r0].T
-            # diagonal blocks
-            a[c0:c1,c0:c1] = a[c0:c1,c0:c1].T
+        if a.ndim == 2:
+            inplace_transpose_scale(a)
+        elif a.ndim == 3 and axes == (0,2,1):
+            assert a.shape[1] == a.shape[2]
+            astrides = [a.strides[i]//a.itemsize for i in (1, 2)]
+            lda = max(astrides)
+            assert min(astrides) == 1
+            if a.dtype == numpy.double:
+                _np_helper.NPomp_dtensor_itranspose_scale021(
+                    ctypes.c_ssize_t(a.strides[0]//a.itemsize),
+                    ctypes.c_int(a.shape[0]),
+                    ctypes.c_int(a.shape[1]),
+                    ctypes.c_double(1.0),
+                    a.ctypes.data_as(ctypes.c_void_p),
+                    ctypes.c_int(lda)
+                )
+            elif a.dtype == numpy.complex128:
+                one_cplx = numpy.array([1.0], dtype=numpy.complex128)
+                _np_helper.NPomp_ztensor_itranspose_scale021(
+                    ctypes.c_ssize_t(a.strides[0]//a.itemsize),
+                    ctypes.c_int(a.shape[0]),
+                    ctypes.c_int(a.shape[1]),
+                    one_cplx.ctypes.data_as(ctypes.c_void_p),
+                    a.ctypes.data_as(ctypes.c_void_p),
+                    ctypes.c_int(lda)
+                )
+            else:
+                raise NotImplementedError
+        else:
+            arow, acol = a.shape[:2]
+            assert arow == acol
+            tmp = numpy.empty((BLOCK_DIM,BLOCK_DIM))
+            for c0, c1 in misc.prange(0, acol, BLOCK_DIM):
+                for r0, r1 in misc.prange(0, c0, BLOCK_DIM):
+                    tmp[:c1-c0,:r1-r0] = a[c0:c1,r0:r1]
+                    a[c0:c1,r0:r1] = a[r0:r1,c0:c1].T
+                    a[r0:r1,c0:c1] = tmp[:c1-c0,:r1-r0].T
+                # diagonal blocks
+                a[c0:c1,c0:c1] = a[c0:c1,c0:c1].T
         return a
 
     if (not a.flags.c_contiguous

--- a/pyscf/lib/numpy_helper.py
+++ b/pyscf/lib/numpy_helper.py
@@ -592,7 +592,7 @@ def transpose(a, axes=None, inplace=False, out=None):
             assert min(astrides) == 1
             if a.dtype == numpy.double:
                 _np_helper.NPomp_dtensor_itranspose_scale021(
-                    ctypes.c_ssize_t(a.strides[0]//a.itemsize),
+                    ctypes.c_longlong(a.strides[0]//a.itemsize),
                     ctypes.c_int(a.shape[0]),
                     ctypes.c_int(a.shape[1]),
                     ctypes.c_double(1.0),
@@ -602,7 +602,7 @@ def transpose(a, axes=None, inplace=False, out=None):
             elif a.dtype == numpy.complex128:
                 one_cplx = numpy.array([1.0], dtype=numpy.complex128)
                 _np_helper.NPomp_ztensor_itranspose_scale021(
-                    ctypes.c_ssize_t(a.strides[0]//a.itemsize),
+                    ctypes.c_longlong(a.strides[0]//a.itemsize),
                     ctypes.c_int(a.shape[0]),
                     ctypes.c_int(a.shape[1]),
                     one_cplx.ctypes.data_as(ctypes.c_void_p),

--- a/pyscf/lib/test/test_numpy_helper.py
+++ b/pyscf/lib/test/test_numpy_helper.py
@@ -22,6 +22,23 @@ import itertools
 from pyscf import lib
 
 class KnownValues(unittest.TestCase):
+    def test_inplace_transpose_scale(self):
+        a = numpy.random.random((400,400))-1j
+        acopy = a.copy()
+        lib.transpose(a, inplace=True)
+        self.assertAlmostEqual(abs(a.T - acopy).max(), 0, 12)
+        a[:] = acopy
+        lib.inplace_transpose_scale(a, 1.5)
+        self.assertAlmostEqual(abs(a.T - acopy*1.5).max(), 0, 12)
+        a = numpy.random.random((2, 400, 400))
+        acopy = a.copy()
+        with lib.with_omp_threads(1):
+            lib.transpose(a, axes=(0,2,1), inplace=True)
+        self.assertAlmostEqual(abs(a - acopy.transpose(0,2,1)).max(), 0, 12)
+        a[:] = acopy
+        with lib.with_omp_threads(4):
+            lib.transpose(a, axes=(0,2,1), inplace=True)
+        self.assertAlmostEqual(abs(a - acopy.transpose(0,2,1)).max(), 0, 12)
     def test_transpose(self):
         a = numpy.random.random((400,900))
         self.assertAlmostEqual(abs(a.T - lib.transpose(a)).max(), 0, 12)

--- a/pyscf/lib/test/test_numpy_helper.py
+++ b/pyscf/lib/test/test_numpy_helper.py
@@ -23,14 +23,20 @@ from pyscf import lib
 
 class KnownValues(unittest.TestCase):
     def test_inplace_transpose_scale(self):
-        a = numpy.random.random((400,400))-1j
+        a = numpy.random.random((5,5))
+        acopy = a.copy()
+        with lib.with_omp_threads(4):
+            lib.transpose(a, inplace=True)
+        self.assertAlmostEqual(abs(a.T - acopy).max(), 0, 12)
+
+        a = numpy.random.random((405,405))-1j
         acopy = a.copy()
         lib.transpose(a, inplace=True)
         self.assertAlmostEqual(abs(a.T - acopy).max(), 0, 12)
         a[:] = acopy
         lib.inplace_transpose_scale(a, 1.5)
         self.assertAlmostEqual(abs(a.T - acopy*1.5).max(), 0, 12)
-        a = numpy.random.random((2, 400, 400))
+        a = numpy.random.random((2, 405, 405))
         acopy = a.copy()
         with lib.with_omp_threads(1):
             lib.transpose(a, axes=(0,2,1), inplace=True)
@@ -39,6 +45,7 @@ class KnownValues(unittest.TestCase):
         with lib.with_omp_threads(4):
             lib.transpose(a, axes=(0,2,1), inplace=True)
         self.assertAlmostEqual(abs(a - acopy.transpose(0,2,1)).max(), 0, 12)
+
     def test_transpose(self):
         a = numpy.random.random((400,900))
         self.assertAlmostEqual(abs(a.T - lib.transpose(a)).max(), 0, 12)


### PR DESCRIPTION
This PR adds a tiled parallel in-place matrix scaling / transposition routine to libnp_helper.
Read more about the algorithm at [this link](https://colfaxresearch.com/multithreaded-transposition-of-square-matrices-with-common-code-for-intel-xeon-processors-and-intel-xeon-phi-coprocessors/). I've added it to the 2D square inplace and (0,2,1) inplace cases of `lib.transpose`.

The new code implements only part of the functionality of[ `mkl_?imatcopy`](https://www.intel.com/content/www/us/en/docs/onemkl/developer-reference-c/2024-2/mkl-imatcopy.html). Conjugate transposes and non-square matrices are not supported.

~~Note: the source contains an `omp for collapse(2)` clause with a non-rectangular loop. Collapsing non-rectangular loops is [supported in OpenMP 5.0](https://developers.redhat.com/blog/2021/05/03/new-features-in-openmp-5-0-and-5-1#openmp_5_0_features) and works in GCC >= 11 and Clang >= 10. If this OpenMP feature is too new to use, let me know and I'll remove it.~~

I collapsed the loop nest manually to pass the CI tests.