### PR TITLE
limit effects of NumPy 2 type promotion

### DIFF
--- a/pyscf/ao2mo/nrr_outcore.py
+++ b/pyscf/ao2mo/nrr_outcore.py
@@ -380,9 +380,9 @@ def _count_naopair(mol, nao):
     ao_loc = mol.ao_loc_2c()
     nao_pair = 0
     for i in range(mol.nbas):
-        di = ao_loc[i+1] - ao_loc[i]
+        di = int(ao_loc[i+1] - ao_loc[i])
         for j in range(i+1):
-            dj = ao_loc[j+1] - ao_loc[j]
+            dj = int(ao_loc[j+1] - ao_loc[j])
             nao_pair += di * dj
     return nao_pair
 

--- a/pyscf/ao2mo/outcore.py
+++ b/pyscf/ao2mo/outcore.py
@@ -710,8 +710,8 @@ def guess_shell_ranges(mol, aosym, max_iobuf, max_aobuf=None, ao_loc=None,
                        compress_diag=True):
     if ao_loc is None: ao_loc = mol.ao_loc_nr()
     max_iobuf = max(1, max_iobuf)
-
-    dims = ao_loc[1:] - ao_loc[:-1]
+    ao_loc_long = ao_loc.astype(numpy.int64)
+    dims = ao_loc_long[1:] - ao_loc_long[:-1]
     dijs = (dims.reshape(-1,1) * dims)
     nbas = dijs.shape[0]
 
@@ -773,7 +773,7 @@ def balance_partition(ao_loc, blksize, start_id=0, stop_id=None):
     displs = [i+start_id for i in displs]
     tasks = []
     for i0, i1 in zip(displs[:-1],displs[1:]):
-        tasks.append((i0, i1, ao_loc[i1]-ao_loc[i0]))
+        tasks.append((i0, i1, int(ao_loc[i1]-ao_loc[i0])))
     return tasks
 
 del (MAX_MEMORY)

--- a/pyscf/ao2mo/r_outcore.py
+++ b/pyscf/ao2mo/r_outcore.py
@@ -302,9 +302,9 @@ def _count_naopair(mol, nao):
     ao_loc = mol.ao_loc_2c()
     nao_pair = 0
     for i in range(mol.nbas):
-        di = ao_loc[i+1] - ao_loc[i]
+        di = int(ao_loc[i+1] - ao_loc[i])
         for j in range(i+1):
-            dj = ao_loc[j+1] - ao_loc[j]
+            dj = int(ao_loc[j+1] - ao_loc[j])
             nao_pair += di * dj
     return nao_pair
 

--- a/pyscf/df/outcore.py
+++ b/pyscf/df/outcore.py
@@ -289,12 +289,12 @@ def general(mol, mo_coeffs, erifile, auxbasis='weigend+etb', dataname='eri_mo', 
 
 def _guess_shell_ranges(mol, buflen, aosym, start=0, stop=None):
     from pyscf.ao2mo.outcore import balance_partition
-    ao_loc = mol.ao_loc_nr()
+    ao_loc_long = mol.ao_loc_nr().astype(numpy.int64)
     if 's2' in aosym:
-        return balance_partition(ao_loc*(ao_loc+1)//2, buflen, start, stop)
+        return balance_partition(ao_loc_long*(ao_loc_long+1)//2, buflen, start, stop)
     else:
-        nao = ao_loc[-1]
-        return balance_partition(ao_loc*nao, buflen, start, stop)
+        nao = ao_loc_long[-1]
+        return balance_partition(ao_loc_long*nao, buflen, start, stop)
 
 def _create_h5file(erifile, dataname):
     if isinstance(getattr(erifile, 'name', None), str):

--- a/pyscf/gto/eval_gto.py
+++ b/pyscf/gto/eval_gto.py
@@ -121,7 +121,7 @@ def eval_gto(mol, eval_name, coords, comp=None, shls_slice=None, non0tab=None,
     if shls_slice is None:
         shls_slice = (0, nbas)
     sh0, sh1 = shls_slice
-    nao = ao_loc[sh1] - ao_loc[sh0]
+    nao = int(ao_loc[sh1] - ao_loc[sh0])
     if 'spinor' in eval_name:
         ao = numpy.ndarray((2,comp,nao,ngrids), dtype=numpy.complex128,
                            buffer=out).transpose(0,1,3,2)

--- a/pyscf/gto/ft_ao.py
+++ b/pyscf/gto/ft_ao.py
@@ -72,13 +72,13 @@ def ft_aopair(mol, Gv, shls_slice=None, aosym='s1', b=numpy.eye(3),
             fill = 'fill_s1hermi'
         else:
             fill = 'fill_s1'
-        ni = ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]]
-        nj = ao_loc[shls_slice[3]] - ao_loc[shls_slice[2]]
+        ni = int(ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]])
+        nj = int(ao_loc[shls_slice[3]] - ao_loc[shls_slice[2]])
         shape = (nj, ni, nGv)
     else:
         fill = 'fill_s2'
-        i0 = ao_loc[shls_slice[0]]
-        i1 = ao_loc[shls_slice[1]]
+        i0 = int(ao_loc[shls_slice[0]])
+        i1 = int(ao_loc[shls_slice[1]])
         nij = i1*(i1+1)//2 - i0*(i0+1)//2
         shape = (nij, nGv)
     if comp != 1:
@@ -179,9 +179,9 @@ def ft_ao(mol, Gv, shls_slice=None, b=numpy.eye(3),
     atm, bas, env = gto.conc_env(mol._atm, mol._bas, mol._env,
                                  ghost_atm, ghost_bas, ghost_env)
     ao_loc = mol.ao_loc_nr()
-    nao = ao_loc[mol.nbas]
+    nao = int(ao_loc[mol.nbas])
     ao_loc = numpy.asarray(numpy.hstack((ao_loc, [nao+1])), dtype=numpy.int32)
-    ni = ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]]
+    ni = int(ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]])
     shape = (ni, nGv)
     mat = numpy.zeros(shape, order='C', dtype=numpy.complex128)
     phase = 0

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -1377,9 +1377,9 @@ def npgto_nr(mol, cart=None):
         cart = mol.cart
     l = mol._bas[:,ANG_OF]
     if cart:
-        return ((l+1)*(l+2)//2 * mol._bas[:,NPRIM_OF]).sum()
+        return int(((l+1)*(l+2)//2 * mol._bas[:,NPRIM_OF]).sum())
     else:
-        return ((l*2+1) * mol._bas[:,NPRIM_OF]).sum()
+        return int(((l*2+1) * mol._bas[:,NPRIM_OF]).sum())
 def nao_nr(mol, cart=None):
     '''Total number of contracted GTOs for the given :class:`Mole` object'''
     if cart is None:
@@ -1387,11 +1387,11 @@ def nao_nr(mol, cart=None):
     if cart:
         return nao_cart(mol)
     else:
-        return ((mol._bas[:,ANG_OF]*2+1) * mol._bas[:,NCTR_OF]).sum()
+        return int(((mol._bas[:,ANG_OF]*2+1) * mol._bas[:,NCTR_OF]).sum())
 def nao_cart(mol):
     '''Total number of contracted cartesian GTOs for the given :class:`Mole` object'''
     l = mol._bas[:,ANG_OF]
-    return ((l+1)*(l+2)//2 * mol._bas[:,NCTR_OF]).sum()
+    return int(((l+1)*(l+2)//2 * mol._bas[:,NCTR_OF]).sum())
 
 # nao_id0:nao_id1 corresponding to bas_id0:bas_id1
 def nao_nr_range(mol, bas_id0, bas_id1):
@@ -1416,8 +1416,8 @@ def nao_nr_range(mol, bas_id0, bas_id1):
     (2, 6)
     '''
     ao_loc = moleintor.make_loc(mol._bas[:bas_id1], 'sph')
-    nao_id0 = ao_loc[bas_id0]
-    nao_id1 = ao_loc[-1]
+    nao_id0 = int(ao_loc[bas_id0])
+    nao_id1 = int(ao_loc[-1])
     return nao_id0, nao_id1
 
 def nao_2c(mol):
@@ -1427,7 +1427,7 @@ def nao_2c(mol):
     dims = (l*4+2) * mol._bas[:,NCTR_OF]
     dims[kappa<0] = (l[kappa<0] * 2 + 2) * mol._bas[kappa<0,NCTR_OF]
     dims[kappa>0] = (l[kappa>0] * 2) * mol._bas[kappa>0,NCTR_OF]
-    return dims.sum()
+    return int(dims.sum())
 
 # nao_id0:nao_id1 corresponding to bas_id0:bas_id1
 def nao_2c_range(mol, bas_id0, bas_id1):
@@ -1452,8 +1452,8 @@ def nao_2c_range(mol, bas_id0, bas_id1):
     (4, 12)
     '''
     ao_loc = moleintor.make_loc(mol._bas[:bas_id1], '')
-    nao_id0 = ao_loc[bas_id0]
-    nao_id1 = ao_loc[-1]
+    nao_id0 = int(ao_loc[bas_id0])
+    nao_id1 = int(ao_loc[-1])
     return nao_id0, nao_id1
 
 def ao_loc_nr(mol, cart=None):
@@ -3157,7 +3157,7 @@ class MoleBase(lib.StreamObject):
         '''
         if self._atm[atm_id,NUC_MOD_OF] != NUC_FRAC_CHARGE:
             # regular QM atoms
-            return self._atm[atm_id,CHARGE_OF]
+            return int(self._atm[atm_id,CHARGE_OF])
         else:
             # MM atoms with fractional charges
             return self._env[self._atm[atm_id,PTR_FRAC_CHARGE]]
@@ -3221,7 +3221,7 @@ class MoleBase(lib.StreamObject):
         >>> mol.atom_nshells(1)
         5
         '''
-        return (self._bas[:,ATOM_OF] == atm_id).sum()
+        return int((self._bas[:,ATOM_OF] == atm_id).sum())
 
     def atom_shell_ids(self, atm_id):
         r'''A list of the shell-ids of the given atom
@@ -3268,7 +3268,7 @@ class MoleBase(lib.StreamObject):
         >>> mol.bas_atom(7)
         1
         '''
-        return self._bas[bas_id,ATOM_OF].copy()
+        return int(self._bas[bas_id,ATOM_OF])
 
     def bas_angular(self, bas_id):
         r'''The angular momentum associated with the given basis
@@ -3283,7 +3283,7 @@ class MoleBase(lib.StreamObject):
         >>> mol.bas_atom(7)
         2
         '''
-        return self._bas[bas_id,ANG_OF].copy()
+        return int(self._bas[bas_id,ANG_OF])
 
     def bas_nctr(self, bas_id):
         r'''The number of contracted GTOs for the given shell
@@ -3298,7 +3298,7 @@ class MoleBase(lib.StreamObject):
         >>> mol.bas_atom(3)
         3
         '''
-        return self._bas[bas_id,NCTR_OF].copy()
+        return int(self._bas[bas_id,NCTR_OF])
 
     def bas_nprim(self, bas_id):
         r'''The number of primitive GTOs for the given shell
@@ -3313,7 +3313,7 @@ class MoleBase(lib.StreamObject):
         >>> mol.bas_atom(3)
         11
         '''
-        return self._bas[bas_id,NPRIM_OF].copy()
+        return int(self._bas[bas_id,NPRIM_OF])
 
     def bas_kappa(self, bas_id):
         r'''Kappa (if l < j, -l-1, else l) of the given shell
@@ -3328,7 +3328,7 @@ class MoleBase(lib.StreamObject):
         >>> mol.bas_kappa(3)
         0
         '''
-        return self._bas[bas_id,KAPPA_OF].copy()
+        return int(self._bas[bas_id,KAPPA_OF])
 
     def bas_exp(self, bas_id):
         r'''exponents (ndarray) of the given shell

--- a/pyscf/mp/dfmp2_native.py
+++ b/pyscf/mp/dfmp2_native.py
@@ -630,7 +630,7 @@ def shellBatchGenerator(mol, nao_max):
         if shell_stop == shell_start:
             raise BatchSizeError('empty batch')
         shell_range = (shell_start, shell_stop)
-        ao_range = (ao_loc[shell_start], ao_loc[shell_stop])
+        ao_range = (int(ao_loc[shell_start]), int(ao_loc[shell_stop]))
         yield shell_range, ao_range
         shell_start = shell_stop
 

--- a/pyscf/mp/mp2.py
+++ b/pyscf/mp/mp2.py
@@ -837,8 +837,8 @@ def _ao2mo_ovov(mp, orbo, orbv, feri, max_memory=2000, verbose=None):
     with lib.call_in_background(ftmp.__setitem__) as save:
         for ip, (ish0, ish1, ni) in enumerate(sh_ranges):
             for jsh0, jsh1, nj in sh_ranges[:ip+1]:
-                i0, i1 = ao_loc[ish0], ao_loc[ish1]
-                j0, j1 = ao_loc[jsh0], ao_loc[jsh1]
+                i0, i1 = int(ao_loc[ish0]), int(ao_loc[ish1])
+                j0, j1 = int(ao_loc[jsh0]), int(ao_loc[jsh1])
                 jk_blk_slices.append((i0,i1,j0,j1))
 
                 eri = fint(int2e, mol._atm, mol._bas, mol._env,

--- a/pyscf/mp/ump2.py
+++ b/pyscf/mp/ump2.py
@@ -632,8 +632,8 @@ def _ao2mo_ovov(mp, orbs, feri, max_memory=2000, verbose=None):
     with lib.call_in_background(ftmp.__setitem__) as save:
         for ish0, ish1, ni in sh_ranges:
             for jsh0, jsh1, nj in sh_ranges:
-                i0, i1 = ao_loc[ish0], ao_loc[ish1]
-                j0, j1 = ao_loc[jsh0], ao_loc[jsh1]
+                i0, i1 = int(ao_loc[ish0]), int(ao_loc[ish1])
+                j0, j1 = int(ao_loc[jsh0]), int(ao_loc[jsh1])
 
                 eri = fint(int2e, mol._atm, mol._bas, mol._env,
                            shls_slice=(0,nbas,ish0,ish1, jsh0,jsh1,0,nbas),

--- a/pyscf/pbc/df/incore.py
+++ b/pyscf/pbc/df/incore.py
@@ -275,7 +275,7 @@ class Int3cBuilder(lib.StreamObject):
         cache_size = max(_get_cache_size(cell, intor),
                          _get_cache_size(rs_auxcell, intor))
         cell0_dims = cell0_ao_loc[1:] - cell0_ao_loc[:-1]
-        dijk = cell0_dims[:nbasp].max()**2 * cell0_dims[nbasp:].max() * comp
+        dijk = int(cell0_dims[:nbasp].max())**2 * int(cell0_dims[nbasp:].max()) * comp
 
         aosym = aosym[:2]
         gamma_point_only = is_zero(kpts)

--- a/pyscf/pbc/df/outcore.py
+++ b/pyscf/pbc/df/outcore.py
@@ -65,12 +65,12 @@ def aux_e1(cell, auxcell_or_auxbasis, erifile, intor='int3c2e', aosym='s2ij', co
 
     ao_loc = cell.ao_loc_nr()
     aux_loc = auxcell.ao_loc_nr(auxcell.cart or 'ssc' in intor)[:shls_slice[5]+1]
-    ni = ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]]
-    nj = ao_loc[shls_slice[3]] - ao_loc[shls_slice[2]]
-    naux = aux_loc[shls_slice[5]] - aux_loc[shls_slice[4]]
+    ni = int(ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]])
+    nj = int(ao_loc[shls_slice[3]] - ao_loc[shls_slice[2]])
+    naux = int(aux_loc[shls_slice[5]] - aux_loc[shls_slice[4]])
     nkptij = len(kptij_lst)
 
-    nii = (ao_loc[shls_slice[1]]*(ao_loc[shls_slice[1]]+1)//2 -
+    nii = int(ao_loc[shls_slice[1]]*(ao_loc[shls_slice[1]]+1)//2 -
            ao_loc[shls_slice[0]]*(ao_loc[shls_slice[0]]+1)//2)
     nij = ni * nj
 
@@ -186,11 +186,11 @@ def _aux_e2(cell, auxcell_or_auxbasis, erifile, intor='int3c2e', aosym='s2ij', c
 
     ao_loc = cell.ao_loc_nr()
     aux_loc = auxcell.ao_loc_nr(auxcell.cart or 'ssc' in intor)[:shls_slice[5]+1]
-    ni = ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]]
-    nj = ao_loc[shls_slice[3]] - ao_loc[shls_slice[2]]
+    ni = int(ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]])
+    nj = int(ao_loc[shls_slice[3]] - ao_loc[shls_slice[2]])
     nkptij = len(kptij_lst)
 
-    nii = (ao_loc[shls_slice[1]]*(ao_loc[shls_slice[1]]+1)//2 -
+    nii = int(ao_loc[shls_slice[1]]*(ao_loc[shls_slice[1]]+1)//2 -
            ao_loc[shls_slice[0]]*(ao_loc[shls_slice[0]]+1)//2)
     nij = ni * nj
 
@@ -208,7 +208,7 @@ def _aux_e2(cell, auxcell_or_auxbasis, erifile, intor='int3c2e', aosym='s2ij', c
         nao_pair = nij
 
     buflen = max(8, int(max_memory*.47e6/16/(nkptij*ni*nj*comp)))
-    auxdims = aux_loc[shls_slice[4]+1:shls_slice[5]+1] - aux_loc[shls_slice[4]:shls_slice[5]]
+    auxdims = int(aux_loc[shls_slice[4]+1:shls_slice[5]+1] - aux_loc[shls_slice[4]:shls_slice[5]])
     auxranges = balance_segs(auxdims, buflen)
     buflen = max([x[2] for x in auxranges])
     int3c = wrap_int3c(cell, auxcell, intor, 's1', comp, kptij_lst)

--- a/pyscf/pbc/df/rsdf_builder.py
+++ b/pyscf/pbc/df/rsdf_builder.py
@@ -416,8 +416,8 @@ class _RSGDFBuilder(Int3cBuilder):
         ao_loc = cell.ao_loc
         aux_loc = auxcell.ao_loc_nr(auxcell.cart or 'ssc' in intor)
         ish0, ish1, jsh0, jsh1, ksh0, ksh1 = shls_slice
-        i0, i1, j0, j1 = ao_loc[list(shls_slice[:4])]
-        k0, k1 = aux_loc[[ksh0, ksh1]]
+        i0, i1, j0, j1 = ao_loc[list(shls_slice[:4])].astype(np.int64)
+        k0, k1 = aux_loc[[ksh0, ksh1]].astype(np.int64)
         if aosym == 's1':
             nao_pair = (i1 - i0) * (j1 - j0)
         else:

--- a/pyscf/pbc/df/rsdf_helper.py
+++ b/pyscf/pbc/df/rsdf_helper.py
@@ -1073,11 +1073,11 @@ def _aux_e2_nospltbas(cell, auxcell_or_auxbasis, omega, erifile,
 
     ao_loc = cell.ao_loc_nr()
     aux_loc = auxcell.ao_loc_nr(auxcell.cart or 'ssc' in intor)[:shls_slice[5]+1]
-    ni = ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]]
-    nj = ao_loc[shls_slice[3]] - ao_loc[shls_slice[2]]
+    ni = int(ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]])
+    nj = int(ao_loc[shls_slice[3]] - ao_loc[shls_slice[2]])
     nkptij = len(kptij_lst)
 
-    nii = (ao_loc[shls_slice[1]]*(ao_loc[shls_slice[1]]+1)//2 -
+    nii = int(ao_loc[shls_slice[1]]*(ao_loc[shls_slice[1]]+1)//2 -
            ao_loc[shls_slice[0]]*(ao_loc[shls_slice[0]]+1)//2)
     nij = ni * nj
 

--- a/pyscf/pbc/scf/rsjk.py
+++ b/pyscf/pbc/scf/rsjk.py
@@ -365,7 +365,7 @@ class RangeSeparatedJKBuilder(lib.StreamObject):
 
         cache_size = _get_cache_size(cell, 'int2e_sph')
         cell0_dims = cell0_ao_loc[1:] - cell0_ao_loc[:-1]
-        cache_size += cell0_dims.max()**4 * comp * 2
+        cache_size += int(cell0_dims.max())**4 * comp * 2
 
         if hermi:
             fdot_suffix = 's2kl'


### PR DESCRIPTION
In NumPy 2, int32 is not promoted to a larger type during arithmetic. This has caused problems due to overflow (see PR #2495 and issue #2481).
Even worse, `int * np.int32 -> np.int32`, so one bad apple spoils the barrel.

I think it would be a little easier to write correct user code if functions used in many places, such as guess_shell_ranges and nao_nr(), avoid returning `np.int32` scalars.

So, this PR consists of a lot of casts to `int` and `np.int64`. Some of these casts are probably not necessary, but at least they are cheap to do. The underlying types of important data structures have not been changed.