### PR TITLE
Multiple small fixes: bugs, comments, and tests

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -366,6 +366,7 @@ PySCF 1.7.6 (2021-03-28)
   - Auxiliary second-order Green's function perturbation theory (AGF2)
   - Smearing for molecules
   - Visscher small component correction approximation for DHF
+  - DFT+U
 * Improved
   - Threading safety in Mole temporary context
   - Basis parser to support arithmetic expressions in basis data

--- a/examples/dft/16-dft_d3.py
+++ b/examples/dft/16-dft_d3.py
@@ -6,18 +6,21 @@ from pyscf.dft import KS
 '''
 D3 and D4 Dispersion.
 
-This is a simplified dispersion interface to
-d3 (https://github.com/dftd3/simple-dftd3) and
-d4 (https://github.com/dftd4/dftd4) libraries.
-This interface can automatically configure the necessary settings including
-dispersion, xc, and nlc attributes of PySCF mean-field objects. However,
-advanced features of d3 and d4 program are not available.
+This example shows the functionality of the pyscf-dispersion extension, which
+implements a simplified interface to d3 (https://github.com/dftd3/simple-dftd3)
+and d4 (https://github.com/dftd4/dftd4) libraries. This interface can
+automatically configure the necessary settings including dispersion, xc, and nlc
+attributes of PySCF mean-field objects. However, advanced features of d3 and d4
+program are not available. To execute the code in this example, you would need
+to install the pyscf-dispersion extension:
+
+pip install pyscf-dispersion
 
 If you need to access more features d3 and d4 libraries, such as overwriting the
 dispersion parameters, you can use the wrapper provided by the simple-dftd3 and
-dftd4 libraries. When using these libraries, please disable the .disp attribute
-of the underlying mean-field object, and properly set the .xc and .nlc attributes
-following this example.
+dftd4 libraries. When accessing dispersion through the APIs of these libraries,
+please disable the .disp attribute of the mean-field object, and properly set
+the .xc and .nlc attributes as shown in this example.
 '''
 
 mol = pyscf.M(
@@ -134,7 +137,7 @@ mf.xc = 'wb97m-d3bj'
 mf.disp = 'd4'
 mf.kernel() # Crash
 
-# Please note, not every xc functional can be used for D3/D4 corrections.
+# Please note, NOT every xc functional can be used for D3/D4 corrections.
 # For the valid xc and D3/D4 combinations, please refer to
 # https://github.com/dftd3/simple-dftd3/blob/main/assets/parameters.toml
 # https://github.com/dftd4/dftd4/blob/main/assets/parameters.toml

--- a/examples/geomopt/16-apply_soscf.py
+++ b/examples/geomopt/16-apply_soscf.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+'''
+Automatically apply SOSCF for unconverged SCF calculations in geometry optimization.
+'''
+
+import pyscf
+from pyscf.geomopt import geometric_solver, as_pyscf_method
+
+# Force SCF to stop early at an unconverged state
+pyscf.scf.hf.RHF.max_cycle = 5
+
+mol = pyscf.M(
+    atom='''
+    O 0 0 0
+    H 0 .7 .8
+    H 0 -.7 .8
+    ''')
+mf = mol.RHF()
+try:
+    mol_eq = geometric_solver.optimize(mf)
+except RuntimeError:
+    print('geometry optimization should stop for unconverged calculation')
+
+# Apply SOSCF when SCF is not converged
+mf_scanner = mf.as_scanner()
+def apply_soscf_as_needed(mol):
+    mf_scanner(mol)
+    if not mf_scanner.converged:
+        mf_soscf = mf_scanner.newton().run()
+        for key in ['converged', 'mo_energy', 'mo_coeff', 'mo_occ', 'e_tot', 'scf_summary']:
+            setattr(mf_scanner, key, getattr(mf_soscf, key))
+    grad = mf_scanner.Gradients().kernel()
+    return mf_scanner.e_tot, grad
+
+mol_eq = geometric_solver.optimize(as_pyscf_method(mol, apply_soscf_as_needed))

--- a/examples/pbc/22-dft+u.py
+++ b/examples/pbc/22-dft+u.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+'''
+DFT+U with kpoint sampling
+'''
+
+from pyscf.pbc import gto, dft
+cell = gto.Cell()
+cell.unit = 'A'
+cell.atom = 'C 0.,  0.,  0.; C 0.8917,  0.8917,  0.8917'
+cell.a = '''0.      1.7834  1.7834
+            1.7834  0.      1.7834
+            1.7834  1.7834  0.    '''
+
+cell.basis = 'gth-dzvp'
+cell.pseudo = 'gth-pade'
+cell.verbose = 4
+cell.build()
+
+kmesh = [2, 2, 2]
+kpts = cell.make_kpts(kmesh)
+# Add U term to the 2p orbital of the second Carbon atom
+U_idx = ['1 C 2p']
+U_val = [5.0]
+mf = dft.KRKSpU(cell, kpts, U_idx=U_idx, U_val=U_val, minao_ref='gth-szv')
+print(mf.U_idx)
+print(mf.U_val)
+mf.run()
+
+# When space group symmetry in k-point samples is enabled, the symmetry adapted
+# DFT+U method will be invoked automatically.
+kpts = cell.make_kpts(
+    kmesh, wrap_around=True, space_group_symmetry=True, time_reversal_symmetry=True)
+# Add U term to 2s and 2p orbitals
+U_idx = ['2p', '2s']
+U_val = [5.0, 2.0]
+mf = dft.KUKSpU(cell, kpts, U_idx=U_idx, U_val=U_val, minao_ref='gth-szv')
+print(mf.U_idx)
+print(mf.U_val)
+mf.run()

--- a/pyscf/df/addons.py
+++ b/pyscf/df/addons.py
@@ -151,8 +151,8 @@ def aug_etb_for_dfbasis(mol, dfbasis=DFBASIS, beta=ETB_BETA,
             if etb:
                 newbasis[symb] = gto.expand_etbs(etb)
                 for l, n, emin, beta in etb:
-                    logger.info(mol, 'l = %d, exps = %s * %g^n for n = 0..%d',
-                                l, emin, beta, n-1)
+                    logger.info(mol, 'ETB for %s: l = %d, exps = %s * %g^n , n = 0..%d',
+                                symb, l, emin, beta, n-1)
             else:
                 raise RuntimeError(f'Failed to generate even-tempered auxbasis for {symb}')
 

--- a/pyscf/df/autoaux.py
+++ b/pyscf/df/autoaux.py
@@ -24,6 +24,7 @@ Ref:
 from math import factorial
 import numpy as np
 from pyscf import gto
+from pyscf.lib import logger
 
 F_LAUX   = np.array([20 , 7.0, 4.0, 4.0, 3.5, 2.5, 2.0, 2.0])
 BETA_BIG = np.array([1.8, 2.0, 2.2, 2.2, 2.2, 2.3, 3.0, 3.0])
@@ -136,6 +137,9 @@ def autoaux(mol):
         Z = gto.charge(symb)
         etb = _auto_aux_element(Z, mol._basis[symb])
         if etb:
+            for l, n, emin, beta in etb:
+                logger.info(mol, 'ETB for %s: l = %d, exps = %s * %g^n , n = 0..%d',
+                            symb, l, emin, beta, n-1)
             return gto.expand_etbs(etb)
         raise RuntimeError(f'Failed to generate even-tempered auxbasis for {symb}')
 

--- a/pyscf/df/df_jk.py
+++ b/pyscf/df/df_jk.py
@@ -233,7 +233,7 @@ class _DFHF:
         return lib.to_gpu(self, obj)
 
 
-def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
+def get_jk(dfobj, dm, hermi=0, with_j=True, with_k=True, direct_scf_tol=1e-13):
     assert (with_j or with_k)
     if (not with_k and not dfobj.mol.incore_anyway and
         # 3-center integral tensor is not initialized
@@ -263,8 +263,7 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
     if not with_k:
         for eri1 in dfobj.loop():
             # uses numpy.matmul
-            vj += (dmtril @ eri1.T) @ eri1
-
+            vj += dmtril.dot(eri1.T).dot(eri1)
 
     elif getattr(dm, 'mo_coeff', None) is not None:
         #TODO: test whether dm.mo_coeff matching dm
@@ -294,7 +293,8 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
             assert (nao_pair == nao*(nao+1)//2)
             if with_j:
                 # uses numpy.matmul
-                vj += (dmtril @ eri1.T) @ eri1
+                vj += dmtril.dot(eri1.T).dot(eri1)
+
             for k in range(nset):
                 nocc = orbo[k].shape[1]
                 if nocc > 0:
@@ -321,8 +321,7 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
             naux, nao_pair = eri1.shape
             if with_j:
                 # uses numpy.matmul
-                vj += (dmtril @ eri1.T) @ eri1
-
+                vj += dmtril.dot(eri1.T).dot(eri1)
 
             for k in range(nset):
                 buf1 = buf[0,:naux]
@@ -341,7 +340,7 @@ def get_jk(dfobj, dm, hermi=1, with_j=True, with_k=True, direct_scf_tol=1e-13):
     logger.timer(dfobj, 'df vj and vk', *t0)
     return vj, vk
 
-def get_j(dfobj, dm, hermi=1, direct_scf_tol=1e-13):
+def get_j(dfobj, dm, hermi=0, direct_scf_tol=1e-13):
     from pyscf.scf import _vhf
     from pyscf.scf import jk
     from pyscf.df import addons
@@ -434,7 +433,7 @@ def get_j(dfobj, dm, hermi=1, direct_scf_tol=1e-13):
     return numpy.asarray(vj).reshape(dm_shape)
 
 
-def r_get_jk(dfobj, dms, hermi=1, with_j=True, with_k=True):
+def r_get_jk(dfobj, dms, hermi=0, with_j=True, with_k=True):
     '''Relativistic density fitting JK'''
     t0 = (logger.process_clock(), logger.perf_counter())
     mol = dfobj.mol

--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -176,9 +176,9 @@ def eval_rho(mol, ao, dm, non0tab=None, xctype='LDA', hermi=0,
         if hermi:
             rho[1:4] *= 2  # *2 for + einsum('pi,ij,pj->p', ao[i], dm, ao[0])
         else:
+            c1 = _dot_ao_dm(mol, ao[0], dm.conj().T, non0tab, shls_slice, ao_loc)
             for i in range(1, 4):
-                c1 = _dot_ao_dm(mol, ao[i], dm, non0tab, shls_slice, ao_loc)
-                rho[i] += _contract_rho(c1, ao[0])
+                rho[i] += _contract_rho(c1, ao[i])
     else: # meta-GGA
         if with_lapl:
             # rho[4] = \nabla^2 rho, rho[5] = 1/2 |nabla f|^2

--- a/pyscf/dft/rks.py
+++ b/pyscf/dft/rks.py
@@ -322,6 +322,9 @@ class KohnShamDFT:
 
     _keys = {'xc', 'nlc', 'grids', 'disp', 'nlcgrids', 'small_rho_cutoff'}
 
+    # Use rho to filter grids
+    small_rho_cutoff = getattr(__config__, 'dft_rks_RKS_small_rho_cutoff', 1e-7)
+
     def __init__(self, xc='LDA,VWN'):
         # By default, self.nlc = '' and self.disp = None
         self.xc = xc
@@ -333,9 +336,6 @@ class KohnShamDFT:
         self.nlcgrids = gen_grid.Grids(self.mol)
         self.nlcgrids.level = getattr(
             __config__, 'dft_rks_RKS_nlcgrids_level', self.nlcgrids.level)
-        # Use rho to filter grids
-        self.small_rho_cutoff = getattr(
-            __config__, 'dft_rks_RKS_small_rho_cutoff', 1e-7)
 ##################################################
 # don't modify the following attributes, they are not input options
         self._numint = numint.NumInt()

--- a/pyscf/gto/basis/parse_cp2k.py
+++ b/pyscf/gto/basis/parse_cp2k.py
@@ -53,12 +53,14 @@ def parse(string, symb=None, optimize=False):
     '''
     if symb is not None:
         raw_data = list(filter(None, re.split(BASIS_SET_DELIMITER, string)))
-        string = _search_basis_block(raw_data, symb)
-        if not string:
+        line_data = _search_basis_block(raw_data, symb)
+        if not line_data:
             raise BasisNotFoundError(f'Basis not found for {symb}')
+    else:
+        line_data = string.splitlines()
 
     bastxt = []
-    for dat in string.splitlines():
+    for dat in line_data:
         x = dat.split('#')[0].strip()
         if (x and not x.startswith('END') and not x.startswith('BASIS')):
             bastxt.append(x)
@@ -122,8 +124,7 @@ BASIS_SET_DELIMITER = re.compile('# *BASIS SET.*\n')
 def search_seg(basisfile, symb):
     with open(basisfile, 'r') as fin:
         fdata = re.split(BASIS_SET_DELIMITER, fin.read())
-    raw_basis = _search_basis_block(fdata[1:], symb)
-    if not raw_basis:
+    line_data = _search_basis_block(fdata[1:], symb)
+    if not line_data:
         raise BasisNotFoundError(f'Basis for {symb} not found in {basisfile}')
-    return [x.strip() for x in raw_basis.splitlines()
-            if x.strip() and 'END' not in x]
+    return [x for x in line_data if x and 'END' not in x]

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -1257,16 +1257,12 @@ def dumps(mol):
     exclude_keys = {'output', 'stdout', '_keys', '_ctx_lock',
                     # Constructing in function loads
                     'symm_orb', 'irrep_id', 'irrep_name'}
-    # FIXME: nparray and kpts for cell objects may need to be excluded
-    nparray_keys = {'_atm', '_bas', '_env', '_ecpbas',
-                    '_symm_orig', '_symm_axes'}
-
     moldic = dict(mol.__dict__)
     for k in exclude_keys:
         if k in moldic:
             del (moldic[k])
-    for k in nparray_keys:
-        if isinstance(moldic[k], numpy.ndarray):
+    for k in moldic:
+        if isinstance(moldic[k], (numpy.ndarray, numpy.generic)):
             moldic[k] = moldic[k].tolist()
     moldic['atom'] = repr(mol.atom)
     moldic['basis']= repr(mol.basis)
@@ -1288,6 +1284,8 @@ def dumps(mol):
                     dic1[k] = list(v)
                 elif isinstance(v, dict):
                     dic1[k] = skip_value(v)
+                elif isinstance(v, np.generic):
+                    dic1[k] = v.tolist()
                 else:
                     msg =('Function mol.dumps drops attribute %s because '
                           'it is not JSON-serializable' % k)

--- a/pyscf/gto/test/test_basis_parser.py
+++ b/pyscf/gto/test/test_basis_parser.py
@@ -37,7 +37,6 @@ class KnownValues(unittest.TestCase):
         self.assertRaises(KeyError, gto.basis._parse_pople_basis, '631g++', 'C')
 
     def test_basis_load(self):
-        self.assertRaises(BasisNotFoundError, gto.basis.load, __file__, 'H')
         self.assertRaises(BasisNotFoundError, gto.basis.load, 'abas', 'H')
 
         self.assertEqual(len(gto.basis.load('631++g**', 'C')), 8)
@@ -93,6 +92,30 @@ C    SP
         self.assertRaises(BasisNotFoundError, gto.basis.parse_nwchem.parse, basis_str, 'O')
         basis_dat = gto.basis.parse_nwchem.parse(basis_str)
         self.assertEqual(len(basis_dat), 3)
+
+        basis_str = '''
+#BASIS SET: (3s) -> [1s]
+H    S
+     18.7311370     0.03349460
+      2.8253937     0.23472695
+      0.6401217     0.81375733
+#BASIS SET:
+#C    S
+#     1.5   1.
+C    SP
+      0.25  1.  1.'''
+        basis_dat = gto.basis.parse_nwchem.parse(basis_str, 'C')
+        self.assertEqual(len(basis_dat), 2)
+
+        bas = gto.parse(r'''
+#        C    S
+#              0.2222899             1.
+        C    S
+              2.9412494             0.15591627
+              0.6834831             0.60768372
+              0.2222899             0.39195739''',
+                        'C')
+        self.assertEqual(len(bas), 1)
 
     def test_parse_ecp(self):
         ecp_str = '''

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -1533,11 +1533,14 @@ def to_gpu(method, out=None):
     out_keys = set(out.__dict__).union(*cls_keys)
     # Only overwrite the attributes of the same name.
     keys = set(method.__dict__).intersection(out_keys)
+    # Keys that are not required to convert to cupy array
+    keep_in_nparray = {'kpt', 'kpts', 'frozen'}
 
     for key in keys:
         val = getattr(method, key)
         if isinstance(val, numpy.ndarray):
-            val = cupy.asarray(val)
+            if key not in keep_in_nparray:
+                val = cupy.asarray(val)
         elif hasattr(val, 'to_gpu'):
             val = val.to_gpu()
         setattr(out, key, val)

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -1541,5 +1541,6 @@ def to_gpu(method, out=None):
         elif hasattr(val, 'to_gpu'):
             val = val.to_gpu()
         setattr(out, key, val)
-    out.reset()
+    if hasattr(out, 'reset'):
+        out.reset()
     return out

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -1534,7 +1534,7 @@ def to_gpu(method, out=None):
     # Only overwrite the attributes of the same name.
     keys = set(method.__dict__).intersection(out_keys)
     # Keys that are not required to convert to cupy array
-    keep_in_nparray = {'kpt', 'kpts', 'frozen'}
+    keep_in_nparray = {'kpt', 'kpts', 'mesh', 'frozen'}
 
     for key in keys:
         val = getattr(method, key)

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -1495,6 +1495,10 @@ omniobj._built = True
 omniobj.mol = omniobj
 omniobj._scf = omniobj
 omniobj.base = omniobj
+omniobj.precision = 1e-8 # utilized by several pbc modules
+
+# Attributes that are kept in np.ndarray during the to_gpu conversion
+_ATTRIBUTES_IN_NPARRAY = {'kpt', 'kpts', 'kpts_band', 'mesh', 'frozen'}
 
 def to_gpu(method, out=None):
     '''Convert a method to its corresponding GPU variant, and recursively
@@ -1533,13 +1537,11 @@ def to_gpu(method, out=None):
     out_keys = set(out.__dict__).union(*cls_keys)
     # Only overwrite the attributes of the same name.
     keys = set(method.__dict__).intersection(out_keys)
-    # Keys that are not required to convert to cupy array
-    keep_in_nparray = {'kpt', 'kpts', 'mesh', 'frozen'}
 
     for key in keys:
         val = getattr(method, key)
         if isinstance(val, numpy.ndarray):
-            if key not in keep_in_nparray:
+            if key not in _ATTRIBUTES_IN_NPARRAY:
                 val = cupy.asarray(val)
         elif hasattr(val, 'to_gpu'):
             val = val.to_gpu()

--- a/pyscf/pbc/df/aft.py
+++ b/pyscf/pbc/df/aft.py
@@ -571,6 +571,9 @@ class AFTDF(lib.StreamObject, AFTDFMixin):
         'cell', 'mesh', 'kpts', 'time_reversal_symmetry', 'blockdim',
     }
 
+    # to mimic molecular DF object
+    blockdim = getattr(__config__, 'pbc_df_df_DF_blockdim', 240)
+
     def __init__(self, cell, kpts=np.zeros((1,3))):
         self.cell = cell
         self.stdout = cell.stdout
@@ -579,9 +582,6 @@ class AFTDF(lib.StreamObject, AFTDFMixin):
         self.mesh = cell.mesh
         self.kpts = kpts
         self.time_reversal_symmetry = True
-
-        # to mimic molecular DF object
-        self.blockdim = getattr(__config__, 'pbc_df_df_DF_blockdim', 240)
 
         # The following attributes are not input options.
         self._rsh_df = {}  # Range separated Coulomb DF objects

--- a/pyscf/pbc/df/fft.py
+++ b/pyscf/pbc/df/fft.py
@@ -161,6 +161,9 @@ class FFTDF(lib.StreamObject):
     '''Density expansion on plane waves
     '''
 
+    # to mimic molecular DF object
+    blockdim = getattr(__config__, 'pbc_df_df_DF_blockdim', 240)
+
     _keys = {
         'cell', 'kpts', 'grids', 'mesh', 'blockdim', 'exxdiv',
     }
@@ -184,9 +187,6 @@ class FFTDF(lib.StreamObject):
         # This is a first order error, same to the error estimation for nuclear
         # attraction.
         self.mesh = cell.mesh
-
-        # to mimic molecular DF object
-        self.blockdim = getattr(__config__, 'pbc_df_df_DF_blockdim', 240)
 
         # The following attributes are not input options.
         # self.exxdiv has no effects. It was set in the get_k_kpts function to

--- a/pyscf/pbc/dft/krks_ksymm.py
+++ b/pyscf/pbc/dft/krks_ksymm.py
@@ -110,7 +110,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=0, vhf_last=0, hermi=1,
             exc -= np.einsum('K,Kij,Kji', weight, dm, vk).real * .5 * .5
 
     if ground_state:
-        ecoul = np.einsum('K,Kij,Kji', weight, dm, vj).real * .5
+        ecoul = np.einsum('K,Kij,Kji', weight, dm, vj) * .5
     else:
         ecoul = None
 
@@ -170,16 +170,17 @@ class KsymAdaptedKRKS(krks.KRKS, khf_ksymm.KRHF):
         weight = self.kpts.weights_ibz
         e1 = np.einsum('k,kij,kji', weight, h1e_kpts, dm_kpts)
         ecoul = vhf.ecoul
-        tot_e = e1 + ecoul + vhf.exc
+        exc = vhf.exc
+        tot_e = e1 + ecoul + exc
         self.scf_summary['e1'] = e1.real
         self.scf_summary['coul'] = ecoul.real
-        self.scf_summary['exc'] = vhf.exc.real
-        logger.debug(self, 'E1 = %s  Ecoul = %s  Exc = %s', e1, ecoul, vhf.exc)
-        if khf.CHECK_COULOMB_IMAG and abs(ecoul.imag > self.cell.precision*10):
+        self.scf_summary['exc'] = exc.real
+        logger.debug(self, 'E1 = %s  Ecoul = %s  Exc = %s', e1, ecoul, exc)
+        if khf.CHECK_COULOMB_IMAG and abs(ecoul.imag) > self.cell.precision*10:
             logger.warn(self, "Coulomb energy has imaginary part %s. "
                         "Coulomb integrals (e-e, e-N) may not converge !",
                         ecoul.imag)
-        return tot_e.real, vhf.ecoul + vhf.exc
+        return tot_e.real, ecoul.real + exc.real
 
     def to_hf(self):
         '''Convert to KRHF object.'''

--- a/pyscf/pbc/dft/krkspu.py
+++ b/pyscf/pbc/dft/krkspu.py
@@ -280,32 +280,3 @@ class KRKSpU(krks.KRKS):
 
     def nuc_grad_method(self):
         raise NotImplementedError
-
-if __name__ == '__main__':
-    from pyscf.pbc import gto
-    np.set_printoptions(3, linewidth=1000, suppress=True)
-    cell = gto.Cell()
-    cell.unit = 'A'
-    cell.atom = 'C 0.,  0.,  0.; C 0.8917,  0.8917,  0.8917'
-    cell.a = '''0.      1.7834  1.7834
-                1.7834  0.      1.7834
-                1.7834  1.7834  0.    '''
-
-    cell.basis = 'gth-dzvp'
-    cell.pseudo = 'gth-pade'
-    cell.verbose = 7
-    cell.build()
-    kmesh = [2, 2, 2]
-    kpts = cell.make_kpts(kmesh, wrap_around=True)
-    #U_idx = ["2p", "2s"]
-    #U_val = [5.0, 2.0]
-    U_idx = ["1 C 2p"]
-    U_val = [5.0]
-
-    mf = KRKSpU(cell, kpts, U_idx=U_idx, U_val=U_val, C_ao_lo='minao',
-                minao_ref='gth-szv')
-    mf.conv_tol = 1e-10
-    print (mf.U_idx)
-    print (mf.U_val)
-    print (mf.C_ao_lo.shape)
-    print (mf.kernel())

--- a/pyscf/pbc/dft/krkspu_ksymm.py
+++ b/pyscf/pbc/dft/krkspu_ksymm.py
@@ -38,33 +38,3 @@ class KsymAdaptedKRKSpU(krks_ksymm.KRKS):
                                minao_ref=minao_ref, **kwargs)
 
 KRKSpU = KsymAdaptedKRKSpU
-
-if __name__ == '__main__':
-    from pyscf.pbc import gto
-    np.set_printoptions(3, linewidth=1000, suppress=True)
-    cell = gto.Cell()
-    cell.unit = 'A'
-    cell.atom = 'C 0.,  0.,  0.; C 0.8917,  0.8917,  0.8917'
-    cell.a = '''0.      1.7834  1.7834
-                1.7834  0.      1.7834
-                1.7834  1.7834  0.    '''
-
-    cell.basis = 'gth-dzvp'
-    cell.pseudo = 'gth-pade'
-    cell.verbose = 7
-    cell.build()
-    kmesh = [2, 2, 2]
-    kpts = cell.make_kpts(kmesh, wrap_around=True,
-                          space_group_symmetry=True, time_reversal_symmetry=True)
-    #U_idx = ["2p", "2s"]
-    #U_val = [5.0, 2.0]
-    U_idx = ["1 C 2p"]
-    U_val = [5.0]
-
-    mf = KRKSpU(cell, kpts, U_idx=U_idx, U_val=U_val, C_ao_lo='minao',
-                minao_ref='gth-szv')
-    mf.conv_tol = 1e-10
-    print (mf.U_idx)
-    print (mf.U_val)
-    print (mf.C_ao_lo.shape)
-    print (mf.kernel())

--- a/pyscf/pbc/dft/kuks_ksymm.py
+++ b/pyscf/pbc/dft/kuks_ksymm.py
@@ -112,7 +112,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=0, vhf_last=0, hermi=1,
                     np.einsum('K,Kij,Kji', weight, dm[1], vk[1])).real * .5
 
     if ground_state:
-        ecoul = np.einsum('K,Kij,Kji', weight, dm[0]+dm[1], vj).real * .5
+        ecoul = np.einsum('K,Kij,Kji', weight, dm[0]+dm[1], vj) * .5
     else:
         ecoul = None
 
@@ -166,16 +166,17 @@ class KsymAdaptedKUKS(kuks.KUKS, kuhf_ksymm.KUHF):
         weight = self.kpts.weights_ibz
         e1 = np.einsum('k,kij,kji', weight, h1e_kpts, dm_kpts[0]+dm_kpts[1])
         ecoul = vhf.ecoul
-        tot_e = e1 + ecoul + vhf.exc
+        exc = vhf.exc
+        tot_e = e1 + ecoul + exc
         self.scf_summary['e1'] = e1.real
         self.scf_summary['coul'] = ecoul.real
-        self.scf_summary['exc'] = vhf.exc.real
-        logger.debug(self, 'E1 = %s  Ecoul = %s  Exc = %s', e1, ecoul, vhf.exc)
-        if khf.CHECK_COULOMB_IMAG and abs(ecoul.imag > self.cell.precision*10):
+        self.scf_summary['exc'] = exc.real
+        logger.debug(self, 'E1 = %s  Ecoul = %s  Exc = %s', e1, ecoul, exc)
+        if khf.CHECK_COULOMB_IMAG and abs(ecoul.imag) > self.cell.precision*10:
             logger.warn(self, "Coulomb energy has imaginary part %s. "
                         "Coulomb integrals (e-e, e-N) may not converge !",
                         ecoul.imag)
-        return tot_e.real, vhf.ecoul + vhf.exc
+        return tot_e.real, ecoul.real + exc.real
 
     def to_hf(self):
         '''Convert to KRHF object.'''

--- a/pyscf/pbc/dft/kukspu.py
+++ b/pyscf/pbc/dft/kukspu.py
@@ -172,30 +172,3 @@ class KUKSpU(kuks.KUKS):
 
     def nuc_grad_method(self):
         raise NotImplementedError
-
-if __name__ == '__main__':
-    from pyscf.pbc import gto
-    cell = gto.Cell()
-    cell.unit = 'A'
-    cell.atom = 'C 0.,  0.,  0.; C 0.8917,  0.8917,  0.8917'
-    cell.a = '''0.      1.7834  1.7834
-                1.7834  0.      1.7834
-                1.7834  1.7834  0.    '''
-
-    cell.basis = 'gth-dzvp'
-    cell.pseudo = 'gth-pade'
-    cell.verbose = 7
-    cell.build()
-    kmesh = [2, 2, 2]
-    kpts = cell.make_kpts(kmesh, wrap_around=True)
-    #U_idx = ["2p", "2s"]
-    #U_val = [5.0, 2.0]
-    U_idx = ["1 C 2p"]
-    U_val = [5.0]
-
-    mf = KUKSpU(cell, kpts, U_idx=U_idx, U_val=U_val, minao_ref='gth-szv')
-    mf.conv_tol = 1e-10
-    print (mf.U_idx)
-    print (mf.U_val)
-    print (mf.C_ao_lo.shape)
-    print (mf.kernel())

--- a/pyscf/pbc/dft/kukspu_ksymm.py
+++ b/pyscf/pbc/dft/kukspu_ksymm.py
@@ -38,33 +38,3 @@ class KsymAdaptedKUKSpU(kuks_ksymm.KUKS):
                                minao_ref=minao_ref, **kwargs)
 
 KUKSpU = KsymAdaptedKUKSpU
-
-if __name__ == '__main__':
-    from pyscf.pbc import gto
-    np.set_printoptions(3, linewidth=1000, suppress=True)
-    cell = gto.Cell()
-    cell.unit = 'A'
-    cell.atom = 'C 0.,  0.,  0.; C 0.8917,  0.8917,  0.8917'
-    cell.a = '''0.      1.7834  1.7834
-                1.7834  0.      1.7834
-                1.7834  1.7834  0.    '''
-
-    cell.basis = 'gth-dzvp'
-    cell.pseudo = 'gth-pade'
-    cell.verbose = 7
-    cell.build()
-    kmesh = [2, 2, 2]
-    kpts = cell.make_kpts(kmesh, wrap_around=True,
-                          space_group_symmetry=True, time_reversal_symmetry=True)
-    #U_idx = ["2p", "2s"]
-    #U_val = [5.0, 2.0]
-    U_idx = ["1 C 2p"]
-    U_val = [5.0]
-
-    mf = KUKSpU(cell, kpts, U_idx=U_idx, U_val=U_val, C_ao_lo='minao',
-                minao_ref='gth-szv')
-    mf.conv_tol = 1e-10
-    print (mf.U_idx)
-    print (mf.U_val)
-    print (mf.C_ao_lo.shape)
-    print (mf.kernel())

--- a/pyscf/pbc/dft/numint.py
+++ b/pyscf/pbc/dft/numint.py
@@ -340,7 +340,7 @@ def nr_rks(ni, cell, grids, xc_code, dms, spin=0, relativity=0, hermi=1,
     elif xctype == 'HF':
         ao_deriv = 0
     else:
-        raise NotImplementedError(f'r_vxc for functional {xc_code}')
+        raise NotImplementedError(f'nr_rks for functional {xc_code}')
 
     make_rho, nset, nao = ni._gen_rho_evaluator(cell, dms, hermi, False)
 
@@ -440,7 +440,7 @@ def nr_uks(ni, cell, grids, xc_code, dms, spin=1, relativity=0, hermi=1,
     elif xctype == 'HF':
         ao_deriv = 0
     else:
-        raise NotImplementedError(f'r_vxc for functional {xc_code}')
+        raise NotImplementedError(f'nr_uks for functional {xc_code}')
 
     dma, dmb = _format_uks_dm(dms)
     nao = dma.shape[-1]
@@ -626,7 +626,7 @@ def nr_rks_fxc(ni, cell, grids, xc_code, dm0, dms, relativity=0, hermi=0,
     elif xctype == 'HF':
         ao_deriv = 0
     else:
-        raise NotImplementedError(f'r_vxc for functional {xc_code}')
+        raise NotImplementedError(f'nr_rks_fxc for functional {xc_code}')
 
     if fxc is None and xctype in ('LDA', 'GGA', 'MGGA'):
         spin = 0
@@ -749,7 +749,7 @@ def nr_uks_fxc(ni, cell, grids, xc_code, dm0, dms, relativity=0, hermi=0,
     elif xctype == 'HF':
         ao_deriv = 0
     else:
-        raise NotImplementedError(f'r_vxc for functional {xc_code}')
+        raise NotImplementedError(f'nr_uks_fxc for functional {xc_code}')
 
     if fxc is None and xctype in ('LDA', 'GGA', 'MGGA'):
         spin = 1
@@ -1210,6 +1210,18 @@ class KNumInt(lib.StreamObject, numint.LibXCMixin):
             mat[k] = _vxc_mat(cell, ao_kpts[k], wv, mask, xctype, shls_slice,
                               ao_loc, hermi)
         return mat
+
+    @lib.with_doc(nr_rks_fxc.__doc__)
+    def nr_fxc(self, cell, grids, xc_code, dm0, dms, spin=0, relativity=0, hermi=0,
+               rho0=None, vxc=None, fxc=None, kpts=None, max_memory=2000,
+               verbose=None):
+        if spin == 0:
+            return self.nr_rks_fxc(cell, grids, xc_code, dm0, dms, relativity,
+                                   hermi, rho0, vxc, fxc, kpts, max_memory, verbose)
+        else:
+            return self.nr_uks_fxc(cell, grids, xc_code, dm0, dms, relativity,
+                                   hermi, rho0, vxc, fxc, kpts, max_memory, verbose)
+    get_fxc = nr_fxc
 
     def block_loop(self, cell, grids, nao=None, deriv=0, kpts=None,
                    kpts_band=None, max_memory=2000, non0tab=None, blksize=None):

--- a/pyscf/pbc/dft/numint.py
+++ b/pyscf/pbc/dft/numint.py
@@ -1089,7 +1089,9 @@ class NumInt(lib.StreamObject, numint.LibXCMixin):
         return self.eval_rho(cell, ao, dm, screen_index, xctype, hermi,
                              with_lapl, verbose)
 
-    to_gpu = lib.to_gpu
+    def to_gpu(self):
+        from gpu4pyscf.pbc.dft.numint import NumInt # type: ignore
+        return NumInt()
 
 _NumInt = NumInt
 
@@ -1310,6 +1312,8 @@ class KNumInt(lib.StreamObject, numint.LibXCMixin):
     cache_xc_kernel1 = cache_xc_kernel1
     get_rho = get_rho
 
-    to_gpu = lib.to_gpu
+    def to_gpu(self):
+        from gpu4pyscf.pbc.dft.numint import KNumInt # type: ignore
+        return KNumInt()
 
 _KNumInt = KNumInt

--- a/pyscf/pbc/dft/numint.py
+++ b/pyscf/pbc/dft/numint.py
@@ -144,9 +144,9 @@ def eval_rho(cell, ao, dm, non0tab=None, xctype='LDA', hermi=0, with_lapl=True,
             if hermi == 1:
                 rho[1:4] *= 2
             else:
+                c1 = _dot_ao_dm(cell, ao[0], dm.conj().T, non0tab, shls_slice, ao_loc)
                 for i in range(1, 4):
-                    c1 = _dot_ao_dm(cell, ao[i], dm, non0tab, shls_slice, ao_loc)
-                    rho[i] += dot_bra(ao[0], c1)
+                    rho[i] += dot_bra(c1, ao[i])
 
         else:
             if with_lapl:

--- a/pyscf/pbc/dft/rks.py
+++ b/pyscf/pbc/dft/rks.py
@@ -170,6 +170,8 @@ class KohnShamDFT(mol_ks.KohnShamDFT):
     '''PBC-KS'''
 
     _keys = {'xc', 'nlc', 'grids', 'nlcgrids', 'small_rho_cutoff'}
+    # Use rho to filter grids
+    small_rho_cutoff = getattr(__config__, 'dft_rks_RKS_small_rho_cutoff', 1e-7)
 
     get_rho = get_rho
 
@@ -182,9 +184,6 @@ class KohnShamDFT(mol_ks.KohnShamDFT):
         self.grids = gen_grid.UniformGrids(self.cell)
         self.nlc = ''
         self.nlcgrids = gen_grid.UniformGrids(self.cell)
-        # Use rho to filter grids
-        self.small_rho_cutoff = getattr(
-            __config__, 'dft_rks_RKS_small_rho_cutoff', 1e-7)
 ##################################################
 # don't modify the following attributes, they are not input options
         # Note Do not refer to .with_df._numint because mesh/coords may be different

--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -96,15 +96,12 @@ def dumps(cell):
         if k in celldic:
             del (celldic[k])
     for k in celldic:
-        if isinstance(celldic[k], np.ndarray):
+        if isinstance(celldic[k], (np.ndarray, np.generic)):
             celldic[k] = celldic[k].tolist()
     celldic['atom'] = repr(cell.atom)
     celldic['basis']= repr(cell.basis)
     celldic['pseudo'] = repr(cell.pseudo)
     celldic['ecp'] = repr(cell.ecp)
-    # Explicitly convert mesh because it is often created as numpy array
-    if isinstance(cell.mesh, np.ndarray):
-        celldic['mesh'] = cell.mesh.tolist()
 
     try:
         return json.dumps(celldic)
@@ -121,6 +118,8 @@ def dumps(cell):
                     dic1[k] = list(v)
                 elif isinstance(v, dict):
                     dic1[k] = skip_value(v)
+                elif isinstance(v, np.generic):
+                    dic1[k] = v.tolist()
                 else:
                     msg =('Function cell.dumps drops attribute %s because '
                           'it is not JSON-serializable' % k)

--- a/pyscf/pbc/scf/khf.py
+++ b/pyscf/pbc/scf/khf.py
@@ -249,7 +249,7 @@ def energy_elec(mf, dm_kpts=None, h1e_kpts=None, vhf_kpts=None):
     mf.scf_summary['e1'] = e1.real
     mf.scf_summary['e2'] = e_coul.real
     logger.debug(mf, 'E1 = %s  E_coul = %s', e1, e_coul)
-    if CHECK_COULOMB_IMAG and abs(e_coul.imag > mf.cell.precision*10):
+    if CHECK_COULOMB_IMAG and abs(e_coul.imag) > mf.cell.precision*10:
         logger.warn(mf, "Coulomb energy has imaginary part %s. "
                     "Coulomb integrals (e-e, e-N) may not converge !",
                     e_coul.imag)

--- a/pyscf/pbc/scf/khf_ksymm.py
+++ b/pyscf/pbc/scf/khf_ksymm.py
@@ -76,7 +76,7 @@ def energy_elec(mf, dm_kpts=None, h1e_kpts=None, vhf_kpts=None):
     mf.scf_summary['e1'] = e1.real
     mf.scf_summary['e2'] = e_coul.real
     logger.debug(mf, 'E1 = %s  E_coul = %s', e1, e_coul)
-    if khf.CHECK_COULOMB_IMAG and abs(e_coul.imag > mf.cell.precision*10):
+    if khf.CHECK_COULOMB_IMAG and abs(e_coul.imag) > mf.cell.precision*10:
         logger.warn(mf, "Coulomb energy has imaginary part %s. "
                     "Coulomb integrals (e-e, e-N) may not converge !",
                     e_coul.imag)

--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -209,7 +209,7 @@ def energy_elec(mf, dm_kpts=None, h1e_kpts=None, vhf_kpts=None):
     mf.scf_summary['e1'] = e1.real
     mf.scf_summary['e2'] = e_coul.real
     logger.debug(mf, 'E1 = %s  E_coul = %s', e1, e_coul)
-    if CHECK_COULOMB_IMAG and abs(e_coul.imag > mf.cell.precision*10):
+    if CHECK_COULOMB_IMAG and abs(e_coul.imag) > mf.cell.precision*10:
         logger.warn(mf, "Coulomb energy has imaginary part %s. "
                     "Coulomb integrals (e-e, e-N) may not converge !",
                     e_coul.imag)

--- a/pyscf/pbc/scf/kuhf_ksymm.py
+++ b/pyscf/pbc/scf/kuhf_ksymm.py
@@ -102,7 +102,7 @@ def energy_elec(mf, dm_kpts=None, h1e_kpts=None, vhf_kpts=None):
     mf.scf_summary['e1'] = e1.real
     mf.scf_summary['e2'] = e_coul.real
     logger.debug(mf, 'E1 = %s  E_coul = %s', e1, e_coul)
-    if kuhf.CHECK_COULOMB_IMAG and abs(e_coul.imag > mf.cell.precision*10):
+    if kuhf.CHECK_COULOMB_IMAG and abs(e_coul.imag) > mf.cell.precision*10:
         logger.warn(mf, "Coulomb energy has imaginary part %s. "
                     "Coulomb integrals (e-e, e-N) may not converge !",
                     e_coul.imag)

--- a/pyscf/pbc/tools/lattice.py
+++ b/pyscf/pbc/tools/lattice.py
@@ -57,7 +57,7 @@ def get_ase_wurtzite(A='Zn', B='O'):
     # citation at this point? en.wikipedia.org/wiki/Lattice_constant)
     assert A in ['Zn']
     assert B in ['O']
-    from ase.lattice import bulk
+    from ase.build import bulk
     if A=='Zn' and B=='O':
         ase_atom = bulk('ZnO', 'wurtzite', a=3.25*A2B, c=5.2*A2B)
     else:
@@ -84,7 +84,7 @@ def get_ase_zincblende(A='Ga', B='As'):
     # Lattice constants from Shishkin and Kresse, PRB 75, 235102 (2007)
     assert A in ['Si', 'Ga', 'Cd', 'Zn', 'B', 'Al']
     assert B in ['C', 'As', 'S', 'O', 'N', 'P']
-    from ase.lattice import bulk
+    from ase.build import bulk
     if A=='Si' and B=='C':
         ase_atom = bulk('SiC', 'zincblende', a=4.350*A2B)
     elif A=='Ga' and B=='As':
@@ -112,7 +112,7 @@ def get_ase_rocksalt(A='Li', B='Cl'):
     # Add Na, K
     assert B in ['H', 'F', 'Cl', 'O']
     # Add Br, I
-    from ase.lattice import bulk
+    from ase.build import bulk
     if A=='Li':
         if B=='H':
             ase_atom = bulk('LiH', 'rocksalt', a=4.0834*A2B)

--- a/pyscf/scf/_response_functions.py
+++ b/pyscf/scf/_response_functions.py
@@ -92,6 +92,7 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
                 return v1
 
         elif singlet:
+            fxc *= .5
             def vind(dm1):
                 if hermi == 2:
                     v1 = numpy.zeros_like(dm1)
@@ -99,7 +100,6 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
                     # nr_rks_fxc_st requires alpha of dm1, dm1*.5 should be scaled
                     v1 = ni.nr_rks_fxc_st(mol, mf.grids, mf.xc, dm0, dm1, 0, True,
                                           rho0, vxc, fxc, max_memory=max_memory)
-                    v1 *= .5
                 if hybrid:
                     if hermi != 2:
                         vj, vk = mf.get_jk(mol, dm1, hermi=hermi)
@@ -113,6 +113,7 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
                     v1 += mf.get_j(mol, dm1, hermi=hermi)
                 return v1
         else:  # triplet
+            fxc *= .5
             def vind(dm1):
                 if hermi == 2:
                     v1 = numpy.zeros_like(dm1)
@@ -120,7 +121,6 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
                     # nr_rks_fxc_st requires alpha of dm1, dm1*.5 should be scaled
                     v1 = ni.nr_rks_fxc_st(mol, mf.grids, mf.xc, dm0, dm1, 0, False,
                                           rho0, vxc, fxc, max_memory=max_memory)
-                    v1 *= .5
                 if hybrid:
                     vk = mf.get_k(mol, dm1, hermi=hermi)
                     vk *= hyb

--- a/pyscf/scf/_response_functions.py
+++ b/pyscf/scf/_response_functions.py
@@ -42,7 +42,7 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
     if mo_occ is None: mo_occ = mf.mo_occ
     mol = mf.mol
     if isinstance(mf, hf.KohnShamDFT):
-        from pyscf.dft import numint
+        from pyscf.pbc.dft import multigrid
         ni = mf._numint
         ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
         if mf.do_nlc():
@@ -52,10 +52,8 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
         hybrid = ni.libxc.is_hybrid_xc(mf.xc)
 
-        # mf can be pbc.dft.RKS object with multigrid
-        if (not hybrid and
-            'MultiGridFFTDF' == getattr(mf, 'with_df', None).__class__.__name__):
-            from pyscf.pbc.dft import multigrid
+        # mf might be pbc.dft.RKS object with multigrid
+        if not hybrid and isinstance(getattr(mf, 'with_df', None), multigrid.MultiGridFFTDF):
             dm0 = mf.make_rdm1(mo_coeff, mo_occ)
             return multigrid._gen_rhf_response(mf, dm0, singlet, hermi)
 
@@ -153,6 +151,7 @@ def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None,
     if mo_occ is None: mo_occ = mf.mo_occ
     mol = mf.mol
     if isinstance(mf, hf.KohnShamDFT):
+        from pyscf.pbc.dft import multigrid
         ni = mf._numint
         ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
         if mf.do_nlc():
@@ -162,10 +161,8 @@ def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None,
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
         hybrid = ni.libxc.is_hybrid_xc(mf.xc)
 
-        # mf can be pbc.dft.UKS object with multigrid
-        if (not hybrid and
-            'MultiGridFFTDF' == getattr(mf, 'with_df', None).__class__.__name__):
-            from pyscf.pbc.dft import multigrid
+        # mf might be pbc.dft.RKS object with multigrid
+        if not hybrid and isinstance(getattr(mf, 'with_df', None), multigrid.MultiGridFFTDF):
             dm0 = mf.make_rdm1(mo_coeff, mo_occ)
             return multigrid._gen_uhf_response(mf, dm0, with_j, hermi)
 
@@ -224,6 +221,7 @@ def _gen_ghf_response(mf, mo_coeff=None, mo_occ=None,
     if mo_occ is None: mo_occ = mf.mo_occ
     mol = mf.mol
     if isinstance(mf, hf.KohnShamDFT):
+        from pyscf.pbc.dft import multigrid
         from pyscf.dft import numint2c, r_numint
         ni = mf._numint
         assert isinstance(ni, (numint2c.NumInt2C, r_numint.RNumInt))
@@ -233,9 +231,7 @@ def _gen_ghf_response(mf, mo_coeff=None, mo_occ=None,
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
         hybrid = ni.libxc.is_hybrid_xc(mf.xc)
 
-        # mf can be pbc.dft.UKS object with multigrid
-        if (not hybrid and
-            'MultiGridFFTDF' == getattr(mf, 'with_df', None).__class__.__name__):
+        if not hybrid and isinstance(getattr(mf, 'with_df', None), multigrid.MultiGridFFTDF):
             raise NotImplementedError
 
         rho0, vxc, fxc = ni.cache_xc_kernel(mol, mf.grids, mf.xc, mo_coeff, mo_occ, 1)

--- a/pyscf/soscf/newton_ah.py
+++ b/pyscf/soscf/newton_ah.py
@@ -508,10 +508,14 @@ def kernel(mf, mo_coeff=None, mo_occ=None, dm=None,
     # Save mo_coeff and mo_occ because they are needed by function rotate_mo
     mf.mo_coeff, mf.mo_occ = mo_coeff, mo_occ
 
+    scf_conv = False
     e_tot = mf._scf.energy_tot(dm, h1e, vhf)
     fock = mf.get_fock(h1e, s1e, vhf, dm, level_shift_factor=0)
     log.info('Initial guess E= %.15g  |g|= %g', e_tot,
              numpy.linalg.norm(mf._scf.get_grad(mo_coeff, mo_occ, fock)))
+
+    if mf.max_cycle <= 0:
+        return scf_conv, e_tot, mo_energy, mo_coeff, mo_occ
 
     if dump_chk and mf.chkfile:
         chkfile.save_mol(mol, mf.chkfile)
@@ -525,7 +529,6 @@ def kernel(mf, mo_coeff=None, mo_occ=None, dm=None,
     next(rotaiter)  # start the iterator
     kftot = jktot = 0
     norm_gorb = 0.
-    scf_conv = False
     cput1 = log.timer('initializing second order scf', *cput0)
 
     for imacro in range(max_cycle):

--- a/pyscf/soscf/test/test_newton_ah.py
+++ b/pyscf/soscf/test/test_newton_ah.py
@@ -146,11 +146,11 @@ class KnownValues(unittest.TestCase):
         nr1 = scf.newton(mf)
         nr1.max_cycle = 0 # Should reproduce energy of the initial guess
         nr1.kernel()
-        self.assertAlmostEqual(nr1.e_tot, mf.e_tot, 12)
+        self.assertAlmostEqual(nr1.e_tot, mf.e_tot, 10)
 
         nr1.max_cycle = 2
         nr1.kernel()
-        self.assertAlmostEqual(nr1.e_tot, nr.e_tot, 12)
+        self.assertAlmostEqual(nr1.e_tot, nr.e_tot, 10)
 
     def test_nr_uhf_cart(self):
         mol = h2o_z1.copy()

--- a/pyscf/soscf/test/test_newton_ah.py
+++ b/pyscf/soscf/test/test_newton_ah.py
@@ -143,6 +143,15 @@ class KnownValues(unittest.TestCase):
         nr.conv_tol_grad = 1e-5
         self.assertAlmostEqual(nr.kernel(), -75.58051984397145, 9)
 
+        nr1 = scf.newton(mf)
+        nr1.max_cycle = 0 # Should reproduce energy of the initial guess
+        nr1.kernel()
+        self.assertAlmostEqual(nr1.e_tot, mf.e_tot, 12)
+
+        nr1.max_cycle = 2
+        nr1.kernel()
+        self.assertAlmostEqual(nr1.e_tot, nr.e_tot, 12)
+
     def test_nr_uhf_cart(self):
         mol = h2o_z1.copy()
         mol.cart = True

--- a/pyscf/tdscf/_lr_eig.py
+++ b/pyscf/tdscf/_lr_eig.py
@@ -290,7 +290,6 @@ def eig(aop, x0, precond, tol_residual=1e-5, nroots=1, x0sym=None, pick=None,
     heff = None
     e = None
     v = None
-    conv_last = conv = np.zeros(nroots, dtype=bool)
 
     if x0sym is not None:
         x0_ir = np.asarray(x0sym)
@@ -299,6 +298,8 @@ def eig(aop, x0, precond, tol_residual=1e-5, nroots=1, x0sym=None, pick=None,
     fresh_start = True
     for icyc in range(max_cycle):
         if fresh_start:
+            vlast = None
+            conv_last = conv = np.zeros(nroots, dtype=bool)
             xs = np.zeros((0, x0_size))
             ax = np.zeros((0, x0_size))
             row1 = 0
@@ -370,7 +371,7 @@ def eig(aop, x0, precond, tol_residual=1e-5, nroots=1, x0sym=None, pick=None,
 
         w, e, elast = w[:space_inc], w[:nroots], e
         v = v[:,:space_inc]
-        if not fresh_start:
+        if not fresh_start and vlast is not None:
             elast, conv_last = _sort_elast(elast, conv, vlast, v[:,:nroots], log)
         vlast = v[:,:nroots]
 

--- a/pyscf/tdscf/_lr_eig.py
+++ b/pyscf/tdscf/_lr_eig.py
@@ -369,9 +369,10 @@ def eig(aop, x0, precond, tol_residual=1e-5, nroots=1, x0sym=None, pick=None,
             raise RuntimeError('Not enough eigenvalues')
 
         w, e, elast = w[:space_inc], w[:nroots], e
-        v, vlast = v[:,:space_inc], v[:,:nroots]
+        v = v[:,:space_inc]
         if not fresh_start:
             elast, conv_last = _sort_elast(elast, conv, vlast, v[:,:nroots], log)
+        vlast = v[:,:nroots]
 
         if elast is None:
             de = e

--- a/pyscf/tdscf/test/test_tduhf.py
+++ b/pyscf/tdscf/test/test_tduhf.py
@@ -56,20 +56,19 @@ class KnownValues(unittest.TestCase):
     def test_tdhf(self):
         td = mf.TDHF()
         td.nstates = 5
-        td.singlet = False
         td.conv_tol = 1e-5
         e = td.kernel()[0]
         ref = [10.89192986, 10.89192986, 11.83487865, 11.83487865, 12.6344099]
         self.assertAlmostEqual(abs(e * 27.2114 - ref).max(), 0, 4)
 
-    def test_tda_triplet(self):
+    def test_tda1(self):
         td = mf1.TDA()
         td.nstates = 5
         e = td.kernel()[0]
         ref = [3.32113736, 18.55977052, 21.01474222, 21.61501962, 25.0938973]
         self.assertAlmostEqual(abs(e * 27.2114 - ref).max(), 0, 4)
 
-    def test_tdhf_triplet(self):
+    def test_tdhf1(self):
         td = mf1.TDHF()
         td.nstates = 4
         e = td.kernel()[0]


### PR DESCRIPTION
* Handling the leading '#' in basis string
* Fix a TDDFT lr_eig convergence check bug
* Fix ASE interface
* Exclude kpt, kpts and some attributes from to_gpu function
* Change contraction order in eval_rho to reduce required FLOPs
* Fixes and updates error messages in pbc.dft.numint
* Set hermi=0 as the default for df_jk.get_jk
* Handle NumPy objects in Mole.dumps and cell.dumps
* Improve the output message when generating DF etb auxbasis
* Detect MultiGridFFTDF2 in scf._response_functions
* Add examples for DFT+U
* Update DFT-D3 example
* Fix SOSCF max_cycle=0 (fix #2529)
* Missing Dyall basis sets (fix #2516)