### PR TITLE
Fix pair_mask bug in _dot_aow_ao_frac

### DIFF
--- a/pyscf/dft/test/test_numint.py
+++ b/pyscf/dft/test/test_numint.py
@@ -177,10 +177,20 @@ class KnownValues(unittest.TestCase):
         ao = dft.numint.eval_ao(mol, mf.grids.coords, deriv=1)
         nao = ao.shape[1]
         ao_loc = mol.ao_loc_nr()
+        cutoff = mf.grids.cutoff * 1e2
+        cutoff2 = numint.CUTOFF * 1e2
+        nbins = numint.NBINS * 2 - int(numint.NBINS * numpy.log(cutoff)
+                                       / numpy.log(mf.grids.cutoff))
+        pair_mask = mol.get_overlap_cond() < -numpy.log(cutoff2)
+        wv = numpy.ones(ao.shape[1])
         res0 = lib.dot(ao[0].T, ao[1])
         res1 = dft.numint._dot_ao_ao(mol, ao[0], ao[1], non0tab,
                                      shls_slice=(0,mol.nbas), ao_loc=ao_loc)
+        res2 = dft.numint._dot_ao_ao_sparse(ao[0], ao[1], wv, nbins,
+                                            non0tab, pair_mask, ao_loc,
+                                            hermi=0)
         self.assertAlmostEqual(abs(res0 - res1).max(), 0, 9)
+        self.assertAlmostEqual(abs(res0 - res2).max(), 0, 9)
 
     def test_eval_rho(self):
         numpy.random.seed(10)

--- a/pyscf/lib/dft/nr_numint_sparse.c
+++ b/pyscf/lib/dft/nr_numint_sparse.c
@@ -499,7 +499,7 @@ for (n = 0; n < ALIGNMENT; n++) {
 
 for (jsh = jsh0; jsh < jsh1; jsh++) {
         si_j = screen_index[gblk0 * nbas + jsh];
-        if (si_j >= nbins_j && pair_mask[ish+nbas+jsh]) {
+        if (si_j >= nbins_j && pair_mask[ish*nbas+jsh]) {
                 j0 = ao_loc[jsh];
                 j1 = ao_loc[jsh+1];
                 ij = (i - ioff) * nj - joff;


### PR DESCRIPTION
There is a bug in the `_dot_aow_ao_frac` function in `nr_numint_sparse.c`, where the pair mask screens integrals incorrectly due to accessing the wrong mask index. I changed
```
if (si_j >= nbins_j && pair_mask[ish+nbas+jsh]) {
```
to
```
if (si_j >= nbins_j && pair_mask[ish*nbas+jsh]) {
```
(i.e. `ish+nbas` changed to the correct `ish*nbas`) and added a unit test to check that `_dot_ao_ao_sparse` works when `wv` is passed.