### PR TITLE
dfmp2: fix invocation of mf.get_veff

### DIFF
--- a/pyscf/mp/dfmp2.py
+++ b/pyscf/mp/dfmp2.py
@@ -203,7 +203,7 @@ def get_mo_energy(mf, mo_coeff, mo_occ, mo_energy=None):
 
     # rebuild fock
     dm = mf.make_rdm1(mo_coeff, mo_occ)
-    vhf = mf.get_veff(dm)
+    vhf = mf.get_veff(dm=dm)
     fockao = mf.get_fock(vhf=vhf, dm=dm)
     if np.asarray(dm).ndim == 2:    # RHF
         return np.diag(reduce(lib.dot, (mo_coeff.T.conj(), fockao, mo_coeff))).real


### PR DESCRIPTION
I encountered a bug in DFMP2 caused by the line `vhf = mf.get_veff(dm)`.
Fixed it by passing `dm` as a [keyword argument](https://github.com/pyscf/pyscf/blob/c58968907adc96bc748591c9d72f1bc2c8ee66dc/pyscf/scf/hf.py#L2073).