### PR TITLE
Fix TypeError when cc.frozen is nonzero numpy.integer

### DIFF
--- a/pyscf/grad/ccsd.py
+++ b/pyscf/grad/ccsd.py
@@ -33,7 +33,7 @@ from pyscf.cc import ccsd_rdm
 from pyscf.ao2mo import _ao2mo
 from pyscf.scf import cphf
 from pyscf.grad import rhf as rhf_grad
-from pyscf.grad.mp2 import _shell_prange, _index_frozen_active
+from pyscf.grad.mp2 import _shell_prange, _index_frozen_active, has_frozen_orbitals
 
 
 #
@@ -71,9 +71,7 @@ def grad_elec(cc_grad, t1=None, t2=None, l1=None, l2=None, eris=None, atmlst=Non
     mo_energy = mycc._scf.mo_energy
     nao, nmo = mo_coeff.shape
     nocc = numpy.count_nonzero(mycc.mo_occ > 0)
-    with_frozen = not ((mycc.frozen is None)
-                       or (isinstance(mycc.frozen, (int, numpy.integer)) and mycc.frozen == 0)
-                       or (hasattr(mycc.frozen, '__len__') and len(mycc.frozen) == 0))
+    with_frozen = has_frozen_orbitals(mycc)
     OA, VA, OF, VF = _index_frozen_active(mycc.get_frozen_mask(), mycc.mo_occ)
 
     log.debug('symmetrized rdm2 and MO->AO transformation')
@@ -267,9 +265,7 @@ class CCSD_GradScanner(lib.GradScanner):
 def _response_dm1(mycc, Xvo, eris=None):
     nvir, nocc = Xvo.shape
     nmo = nocc + nvir
-    with_frozen = not ((mycc.frozen is None)
-                       or (isinstance(mycc.frozen, (int, numpy.integer)) and mycc.frozen == 0)
-                       or (hasattr(mycc.frozen, '__len__') and len(mycc.frozen) == 0))
+    with_frozen = has_frozen_orbitals(mycc)
     if eris is None or with_frozen:
         mo_energy = mycc._scf.mo_energy
         mo_occ = mycc.mo_occ

--- a/pyscf/grad/ccsd.py
+++ b/pyscf/grad/ccsd.py
@@ -73,7 +73,7 @@ def grad_elec(cc_grad, t1=None, t2=None, l1=None, l2=None, eris=None, atmlst=Non
     nocc = numpy.count_nonzero(mycc.mo_occ > 0)
     with_frozen = not ((mycc.frozen is None)
                        or (isinstance(mycc.frozen, (int, numpy.integer)) and mycc.frozen == 0)
-                       or (len(mycc.frozen) == 0))
+                       or (hasattr(mycc.frozen, '__len__') and len(mycc.frozen) == 0))
     OA, VA, OF, VF = _index_frozen_active(mycc.get_frozen_mask(), mycc.mo_occ)
 
     log.debug('symmetrized rdm2 and MO->AO transformation')

--- a/pyscf/grad/ccsd.py
+++ b/pyscf/grad/ccsd.py
@@ -269,7 +269,7 @@ def _response_dm1(mycc, Xvo, eris=None):
     nmo = nocc + nvir
     with_frozen = not ((mycc.frozen is None)
                        or (isinstance(mycc.frozen, (int, numpy.integer)) and mycc.frozen == 0)
-                       or (len(mycc.frozen) == 0))
+                       or (hasattr(mycc.frozen, '__len__') and len(mycc.frozen) == 0))
     if eris is None or with_frozen:
         mo_energy = mycc._scf.mo_energy
         mo_occ = mycc.mo_occ

--- a/pyscf/grad/ccsd_slow.py
+++ b/pyscf/grad/ccsd_slow.py
@@ -29,6 +29,7 @@ from pyscf import lib
 from pyscf import ao2mo
 from pyscf.cc import ccsd_rdm
 from pyscf.grad import ccsd as ccsd_grad
+from pyscf.grad.mp2 import has_frozen_orbitals
 
 def kernel(cc, t1, t2, l1, l2, eris=None):
     if eris is None:
@@ -40,9 +41,7 @@ def kernel(cc, t1, t2, l1, l2, eris=None):
     nocc = numpy.count_nonzero(cc.mo_occ > 0)
     mo_e_o = mo_energy[:nocc]
     mo_e_v = mo_energy[nocc:]
-    with_frozen = not ((cc.frozen is None)
-                       or (isinstance(cc.frozen, (int, numpy.integer)) and cc.frozen == 0)
-                       or (len(cc.frozen) == 0))
+    with_frozen = has_frozen_orbitals(cc)
 
     d1 = _gamma1_intermediates(cc, t1, t2, l1, l2)
     d2 = _gamma2_intermediates(cc, t1, t2, l1, l2)

--- a/pyscf/grad/mp2.py
+++ b/pyscf/grad/mp2.py
@@ -46,9 +46,7 @@ def grad_elec(mp_grad, t2, atmlst=None, verbose=logger.INFO):
 # nocc, nvir should be updated to include the frozen orbitals when proceeding
 # the 1-particle quantities later.
     mol = mp_grad.mol
-    with_frozen = not ((mp.frozen is None)
-                       or (isinstance(mp.frozen, (int, numpy.integer)) and mp.frozen == 0)
-                       or (len(mp.frozen) == 0))
+    with_frozen = has_frozen_orbitals(mp)
     OA, VA, OF, VF = _index_frozen_active(mp.get_frozen_mask(), mp.mo_occ)
     orbo = mp.mo_coeff[:,OA]
     orbv = mp.mo_coeff[:,VA]
@@ -188,6 +186,17 @@ def grad_elec(mp_grad, t2, atmlst=None, verbose=logger.INFO):
     log.timer('%s gradients' % mp.__class__.__name__, *time0)
     return de
 
+def has_frozen_orbitals(post_hf):
+    '''Test if frozen orbitlas are enabled in a post-HF object.'''
+    with_frozen = False
+    if getattr(post_hf, 'frozen', None) is not None:
+        if isinstance(post_hf.frozen, (int, numpy.integer)):
+            with_frozen = post_hf.frozen != 0
+        elif hasattr(post_hf.frozen, '__len__'):
+            with_frozen = len(post_hf.frozen) != 0
+        else:
+            raise TypeError(f'Unsupported .frozen attribute {post_hf.frozen}')
+    return with_frozen
 
 def as_scanner(grad_mp):
     '''Generating a nuclear gradients scanner/solver (for geometry optimizer).

--- a/pyscf/grad/test/test_casci.py
+++ b/pyscf/grad/test/test_casci.py
@@ -16,7 +16,7 @@ from pyscf.scf import cphf
 from pyscf.grad import rhf as rhf_grad
 from pyscf.grad import casci as casci_grad
 from pyscf.grad import ccsd as ccsd_grad
-from pyscf.grad.mp2 import _shell_prange
+from pyscf.grad.mp2 import _shell_prange, has_frozen_orbitals
 
 
 def kernel(mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=None,
@@ -215,9 +215,7 @@ def kernel(mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=None,
 def _response_dm1(mycc, Xvo, eris=None):
     nvir, nocc = Xvo.shape
     nmo = nocc + nvir
-    with_frozen = not ((mycc.frozen is None)
-                       or (isinstance(mycc.frozen, (int, numpy.integer)) and mycc.frozen == 0)
-                       or (len(mycc.frozen) == 0))
+    with_frozen = has_frozen_orbitals(mycc)
     if eris is None or with_frozen:
         mo_energy = mycc._scf.mo_energy
         mo_occ = mycc.mo_occ

--- a/pyscf/grad/test/test_ccsd.py
+++ b/pyscf/grad/test/test_ccsd.py
@@ -93,12 +93,12 @@ class KnownValues(unittest.TestCase):
         mycc.frozen = [0,1]
         g_scan = mycc.nuc_grad_method().as_scanner()
         e, g1 = g_scan(mol)
-        self.assertAlmostEqual(e, -76.07649382891177, 8)
+        self.assertAlmostEqual(e, -76.07649382891177, 7)
         self.assertAlmostEqual(lib.fp(g1), -0.03152584, 6)
 
         mycc.frozen = 2
         g1 = mycc.nuc_grad_method().kernel()
-        self.assertAlmostEqual(e, -76.07649382891177, 8)
+        self.assertAlmostEqual(e, -76.07649382891177, 7)
         self.assertAlmostEqual(lib.fp(g1), -0.03152584, 6)
 
     def test_rdm2_mo2ao(self):

--- a/pyscf/grad/test/test_ccsd.py
+++ b/pyscf/grad/test/test_ccsd.py
@@ -72,6 +72,7 @@ class KnownValues(unittest.TestCase):
         mycc1= cc.ccsd.CCSD(mf1).run(conv_tol=1e-10)
         mol.set_geom_('H 0 0 0; H 0 0 1.705', unit='Bohr')
         mycc2 = cc.ccsd.CCSD(scf.RHF(mol))
+        mycc2.frozen = [] # test has_frozen_orbitals
         g_scanner = mycc2.nuc_grad_method().as_scanner().as_scanner()
         g1 = g_scanner(mol)[1]
         self.assertTrue(g_scanner.converged)
@@ -87,6 +88,18 @@ class KnownValues(unittest.TestCase):
 # [  1.73095055e-16  -7.94568837e-02  -6.02077699e-03]
 # [ -9.49844615e-17   7.94568837e-02  -6.02077699e-03]]
         self.assertAlmostEqual(lib.fp(g1), 0.10599503839207361, 6)
+
+        mycc = mf.CCSD()
+        mycc.frozen = [0,1]
+        g_scan = mycc.nuc_grad_method().as_scanner()
+        e, g1 = g_scan(mol)
+        self.assertAlmostEqual(e, -76.07649382891177, 8)
+        self.assertAlmostEqual(lib.fp(g1), -0.03152584, 6)
+
+        mycc.frozen = 2
+        g1 = mycc.nuc_grad_method().kernel()
+        self.assertAlmostEqual(e, -76.07649382891177, 8)
+        self.assertAlmostEqual(lib.fp(g1), -0.03152584, 6)
 
     def test_rdm2_mo2ao(self):
         mycc = cc.ccsd.CCSD(mf)

--- a/pyscf/grad/test/test_mp2.py
+++ b/pyscf/grad/test/test_mp2.py
@@ -107,6 +107,21 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e, -76.025166662910223, 9)
         self.assertAlmostEqual(lib.fp(g1), 0.12457973399092415, 6)
 
+        pt = mf.MP2()
+        pt.frozen = [0, 1]
+        gscan = pt.nuc_grad_method().as_scanner()
+        e, g1 = gscan(mol)
+        self.assertTrue(gscan.converged)
+        self.assertAlmostEqual(e, -76.07095754926583, 9)
+        self.assertAlmostEqual(lib.fp(g1), -0.028399476189179818, 6)
+
+        pt.frozen = 2
+        gscan = pt.nuc_grad_method().as_scanner()
+        e, g1 = gscan(mol)
+        self.assertTrue(gscan.converged)
+        self.assertAlmostEqual(e, -76.07095754926583, 9)
+        self.assertAlmostEqual(lib.fp(g1), -0.028399476189179818, 6)
+
     def test_with_x2c_scanner(self):
         with lib.light_speed(20.):
             pt = mp.mp2.MP2(mf.x2c())

--- a/pyscf/grad/uccsd.py
+++ b/pyscf/grad/uccsd.py
@@ -33,7 +33,7 @@ from pyscf.ao2mo import _ao2mo
 from pyscf.scf import ucphf
 from pyscf.grad import rhf as rhf_grad
 from pyscf.grad import ccsd as ccsd_grad
-
+from pyscf.grad.mp2 import has_frozen_orbitals
 
 #
 # Note: only works with canonical orbitals
@@ -72,9 +72,7 @@ def grad_elec(cc_grad, t1=None, t2=None, l1=None, l2=None, eris=None, atmlst=Non
     nmob = mo_b.shape[1]
     nocca = numpy.count_nonzero(mycc.mo_occ[0] > 0)
     noccb = numpy.count_nonzero(mycc.mo_occ[1] > 0)
-    with_frozen = not ((mycc.frozen is None)
-                       or (isinstance(mycc.frozen, (int, numpy.integer)) and mycc.frozen == 0)
-                       or (len(mycc.frozen) == 0))
+    with_frozen = has_frozen_orbitals(mycc)
     moidx = mycc.get_frozen_mask()
     OA_a, VA_a, OF_a, VF_a = ccsd_grad._index_frozen_active(moidx[0], mycc.mo_occ[0])
     OA_b, VA_b, OF_b, VF_b = ccsd_grad._index_frozen_active(moidx[1], mycc.mo_occ[1])
@@ -249,9 +247,7 @@ def _response_dm1(mycc, Xvo, eris=None):
     nmoa = nocca + nvira
     nmob = noccb + nvirb
     nova = nocca * nvira
-    with_frozen = not ((mycc.frozen is None)
-                       or (isinstance(mycc.frozen, (int, numpy.integer)) and mycc.frozen == 0)
-                       or (len(mycc.frozen) == 0))
+    with_frozen = has_frozen_orbitals(mycc)
     if eris is None or with_frozen:
         mo_energy = mycc._scf.mo_energy
         mo_occ = mycc.mo_occ

--- a/pyscf/grad/ump2.py
+++ b/pyscf/grad/ump2.py
@@ -30,7 +30,7 @@ from pyscf.ao2mo import _ao2mo
 from pyscf.mp import ump2
 from pyscf.grad import rhf as rhf_grad
 from pyscf.grad import mp2 as mp2_grad
-
+from pyscf.grad.mp2 import has_frozen_orbitals
 
 def grad_elec(mp_grad, t2, atmlst=None, verbose=logger.INFO):
     mp = mp_grad.base
@@ -43,9 +43,7 @@ def grad_elec(mp_grad, t2, atmlst=None, verbose=logger.INFO):
     log.debug('Build ump2 rdm2 intermediates')
 
     mol = mp_grad.mol
-    with_frozen = not ((mp.frozen is None)
-                       or (isinstance(mp.frozen, (int, numpy.integer)) and mp.frozen == 0)
-                       or (len(mp.frozen) == 0))
+    with_frozen = has_frozen_orbitals(mp)
     moidx = mp.get_frozen_mask()
     OA_a, VA_a, OF_a, VF_a = mp2_grad._index_frozen_active(moidx[0], mp.mo_occ[0])
     OA_b, VA_b, OF_b, VF_b = mp2_grad._index_frozen_active(moidx[1], mp.mo_occ[1])

--- a/pyscf/mp/mp2.py
+++ b/pyscf/mp/mp2.py
@@ -359,7 +359,7 @@ def get_nocc(mp):
         nocc = numpy.count_nonzero(mp.mo_occ > 0) - mp.frozen
         assert (nocc > 0)
         return nocc
-    elif isinstance(mp.frozen[0], (int, numpy.integer)):
+    elif hasattr(mp.frozen, '__len__'):
         occ_idx = mp.mo_occ > 0
         occ_idx[list(mp.frozen)] = False
         nocc = numpy.count_nonzero(occ_idx)
@@ -375,7 +375,7 @@ def get_nmo(mp):
         return len(mp.mo_occ)
     elif isinstance(mp.frozen, (int, numpy.integer)):
         return len(mp.mo_occ) - mp.frozen
-    elif isinstance(mp.frozen[0], (int, numpy.integer)):
+    elif hasattr(mp.frozen, '__len__'):
         return len(mp.mo_occ) - len(set(mp.frozen))
     else:
         raise NotImplementedError
@@ -393,7 +393,7 @@ def get_frozen_mask(mp):
         pass
     elif isinstance(mp.frozen, (int, numpy.integer)):
         moidx[:mp.frozen] = False
-    elif len(mp.frozen) > 0:
+    elif hasattr(mp.frozen, '__len__'):
         moidx[list(mp.frozen)] = False
     else:
         raise NotImplementedError

--- a/pyscf/mp/test/test_mp2.py
+++ b/pyscf/mp/test/test_mp2.py
@@ -66,7 +66,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(t2 - t2ref0).max(), 0, 8)
 
         pt.max_memory = 1
-        pt.frozen = None
+        pt.frozen = []
         emp2, t2 = pt.kernel()
         self.assertAlmostEqual(emp2, -0.204019967288338, 8)
         self.assertAlmostEqual(pt.e_corr_ss, -0.05153088565639835, 8)
@@ -129,6 +129,7 @@ class KnownValues(unittest.TestCase):
         nmo = mf.mo_energy.size
 
         pt = mp.mp2.MP2(mf)
+        pt.frozen = 0
         emp2, t2 = pt.kernel()
         eri = ao2mo.restore(1, ao2mo.kernel(mf._eri, mf.mo_coeff), nmo)
         hcore = mf.get_hcore()

--- a/pyscf/mp/test/test_ump2.py
+++ b/pyscf/mp/test/test_ump2.py
@@ -53,7 +53,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(pt.e_corr_os, -0.12312431898078077, 8)
 
         pt.max_memory = 1
-        pt.frozen = None
+        pt.frozen = []
         emp2, t2 = pt.kernel()
         self.assertAlmostEqual(emp2, -0.16575150552336643, 8)
         self.assertAlmostEqual(pt.e_corr_ss, -0.042627186675330754, 8)
@@ -167,6 +167,7 @@ class KnownValues(unittest.TestCase):
 
     def test_ump2_ao2mo_ovov(self):
         pt = mp.UMP2(mf)
+        pt.frozen = 0
         nocca, noccb = mol.nelec
         orboa = mf.mo_coeff[0][:,:nocca]
         orbva = mf.mo_coeff[0][:,nocca:]

--- a/pyscf/mp/ump2.py
+++ b/pyscf/mp/ump2.py
@@ -179,14 +179,15 @@ def get_nocc(mp):
         nocca = numpy.count_nonzero(mp.mo_occ[0] > 0) - frozen
         noccb = numpy.count_nonzero(mp.mo_occ[1] > 0) - frozen
         #assert (nocca > 0 and noccb > 0)
-    elif isinstance(frozen[0], (int, numpy.integer, list, numpy.ndarray)):
-        if len(frozen) > 0 and isinstance(frozen[0], (int, numpy.integer)):
-            # The same frozen orbital indices for alpha and beta orbitals
-            frozen = [frozen, frozen]
+    elif hasattr(mp.frozen, '__len__'):
         occidxa = mp.mo_occ[0] > 0
-        occidxa[list(frozen[0])] = False
         occidxb = mp.mo_occ[1] > 0
-        occidxb[list(frozen[1])] = False
+        if len(frozen) > 0:
+            if isinstance(frozen[0], (int, numpy.integer)):
+                # The same frozen orbital indices for alpha and beta orbitals
+                frozen = [frozen, frozen]
+            occidxa[list(frozen[0])] = False
+            occidxb[list(frozen[1])] = False
         nocca = numpy.count_nonzero(occidxa)
         noccb = numpy.count_nonzero(occidxb)
     else:
@@ -203,11 +204,14 @@ def get_nmo(mp):
     elif isinstance(frozen, (int, numpy.integer)):
         nmoa = mp.mo_occ[0].size - frozen
         nmob = mp.mo_occ[1].size - frozen
-    elif isinstance(frozen[0], (int, numpy.integer, list, numpy.ndarray)):
-        if isinstance(frozen[0], (int, numpy.integer)):
-            frozen = (frozen, frozen)
-        nmoa = len(mp.mo_occ[0]) - len(set(frozen[0]))
-        nmob = len(mp.mo_occ[1]) - len(set(frozen[1]))
+    elif hasattr(mp.frozen, '__len__'):
+        nmoa = mp.mo_occ[0].size
+        nmob = mp.mo_occ[1].size
+        if len(frozen) > 0:
+            if isinstance(frozen[0], (int, numpy.integer)):
+                frozen = (frozen, frozen)
+            nmoa -= len(set(frozen[0]))
+            nmob -= len(set(frozen[1]))
     else:
         raise NotImplementedError
     return nmoa, nmob
@@ -231,11 +235,12 @@ def get_frozen_mask(mp):
     elif isinstance(frozen, (int, numpy.integer)):
         moidxa[:frozen] = False
         moidxb[:frozen] = False
-    elif isinstance(frozen[0], (int, numpy.integer, list, numpy.ndarray)):
-        if isinstance(frozen[0], (int, numpy.integer)):
-            frozen = (frozen, frozen)
-        moidxa[list(frozen[0])] = False
-        moidxb[list(frozen[1])] = False
+    elif hasattr(mp.frozen, '__len__'):
+        if len(frozen) > 0:
+            if isinstance(frozen[0], (int, numpy.integer)):
+                frozen = (frozen, frozen)
+            moidxa[list(frozen[0])] = False
+            moidxb[list(frozen[1])] = False
     else:
         raise NotImplementedError
     return moidxa,moidxb


### PR DESCRIPTION
The current implementation of the frozen orbital check can raise a `TypeError` when cc.frozen is set to a nonzero `numpy.integer` value. This occurs because the logic attempts to call `len()` on the `numpy.int64` value.

This PR adds a `hasattr` check to properly validate if an object supports `len()` before attempting to call it, fixing the `TypeError` while maintaining the existing behavior for all valid input types (None, 0, sequences).

Changes:
- Add `hasattr(frozen, '__len__')` check before attempting `len()`
- Maintain existing behavior for all valid input types

Test Plan:
- Tested with `cc.frozen = None  # Works as before`
- Tested with `cc.frozen = 0     # Works as before`
- Tested with `cc.frozen = []    # Works as before`
- Tested with `cc.frozen = np.int64(1)  # Now works correctly`