### PR TITLE
Fix two links to the libxc website

### DIFF
--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -19,7 +19,7 @@
 
 '''
 XC functional, the interface to libxc
-(http://www.tddft.org/programs/octopus/wiki/index.php/Libxc)
+(https://libxc.gitlab.io)
 '''
 
 import sys

--- a/pyscf/lib/dft/libxc_itrf.c
+++ b/pyscf/lib/dft/libxc_itrf.c
@@ -18,7 +18,7 @@
  *          Xing Zhang <zhangxing.nju@gmail.com>
  *
  * libxc from
- * http://www.tddft.org/programs/octopus/wiki/index.php/Libxc:manual
+ * https://libxc.gitlab.io
  */
 
 #include <stdio.h>


### PR DESCRIPTION
The libxc website was moved years ago to libxc.gitlab.io