### PR TITLE
Bug fix in C-PCM and SS(V)PE gradient

### DIFF
--- a/pyscf/solvent/test/test_pcm_grad.py
+++ b/pyscf/solvent/test/test_pcm_grad.py
@@ -156,11 +156,14 @@ class KnownValues(unittest.TestCase):
 
     def test_grad_SSVPE(self):
         grad = _grad_with_solvent('SS(V)PE')
-        g0 = numpy.asarray(
-            [[ 3.42479745e-15, -1.00280742e-16, -1.61117735e+00],
-            [ 1.07135985e+00, -6.97375148e-16,  8.05588676e-01],
-            [-1.07135985e+00,  7.91425487e-16,  8.05588676e-01]]
-        )
+        # Note: This reference value is obtained via finite difference with dx = 1e-5
+        #       QChem 6.1 has a bug in SSVPE gradient, they use the IEFPCM gradient algorithm
+        #       to compute SSVPE gradient, which is wrong.
+        g0 = numpy.asarray([
+            [ 0.00000000e+00, -7.10542736e-10, -1.63195623e+00],
+            [ 1.07705138e+00,  2.13162821e-09,  8.15978117e-01],
+            [-1.07705138e+00, -2.13162821e-09,  8.15978116e-01],
+        ])
         print(f"Gradient error in RHF with SS(V)PE: {numpy.linalg.norm(g0 - grad)}")
         assert numpy.linalg.norm(g0 - grad) < 1e-6
 


### PR DESCRIPTION
- Bug fix in C-PCM gradient. The absolute error is at 1e-9 level for a gradient calculation, but will be magnified to 1e-4 level when computing hessian using finite difference.
- Bug fix in SS(V)PE gradient. SS(V)PE and IEF-PCM do not share gradient algorithm. We were misled by QChem 6.1 implementation.

Sync from https://github.com/pyscf/gpu4pyscf/pull/302