### PR TITLE
Fix twine version in the release pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           ls ${{ github.workspace }}/linux-wheels
       - name: Publish to PyPI
         run: |
-            pip3 install twine
+            pip3 install twine==6.0.1
             export TWINE_USERNAME=__token__
             export TWINE_PASSWORD="${{ secrets.PYPI_API_TOKEN }}"
             twine upload --verbose linux-wheels/*
@@ -64,7 +64,7 @@ jobs:
         ls ${{ github.workspace }}/linux-wheels
     - name: Publish to PyPI
       run: |
-          pip3 install twine
+          pip3 install twine==6.0.1
           export TWINE_USERNAME=__token__
           export TWINE_PASSWORD="${{ secrets.PYPI_API_TOKEN }}"
           twine upload --verbose linux-wheels/*
@@ -91,7 +91,7 @@ jobs:
         run: |
             python -m venv ci-env
             source ci-env/bin/activate
-            python -m pip install twine
+            python -m pip install twine=6.0.1
             export TWINE_USERNAME=__token__
             export TWINE_PASSWORD="${{ secrets.PYPI_API_TOKEN }}"
             twine upload --verbose mac-wheels/*
@@ -121,7 +121,7 @@ jobs:
         run: |
             python -m venv ci-env
             source ci-env/bin/activate
-            python -m pip install twine
+            python -m pip install twine==6.0.1
             export TWINE_USERNAME=__token__
             export TWINE_PASSWORD="${{ secrets.PYPI_API_TOKEN }}"
             twine upload --verbose mac-wheels/*
@@ -141,7 +141,7 @@ jobs:
           ls ${{ github.workspace }}/dist
       - name: Publish to PyPI
         run: |
-            pip3 install twine
+            pip3 install twine==6.0.1
             export TWINE_USERNAME=__token__
             export TWINE_PASSWORD="${{ secrets.PYPI_API_TOKEN }}"
             twine upload --verbose dist/*


### PR DESCRIPTION
The recently released twine 6.1.0 is not compatible with the building tools in docker image. A temporary solution is fixing twine==6.0.1. Please see the issue below.

https://github.com/pypa/twine/issues/1216