### PR TITLE
Symmetry detection bug due to np.round tolerance

### DIFF
--- a/pyscf/symm/geom.py
+++ b/pyscf/symm/geom.py
@@ -59,7 +59,7 @@ def parallel_vectors(v1, v2, tol=TOLERANCE):
 def argsort_coords(coords, decimals=None, tol=0.05):
     # * np.round for decimal places can lead to more errors than the actual
     # difference between two numbers. For example,
-    # np.round([0.1249999999,0.1250000001], 2) => [0.124, 0.125]
+    # np.round([0.1249999999,0.1250000001], 2) => [0.12, 0.13]
     # np.round([0.1249999999,0.1250000001], 3) => [0.125, 0.125]
     # When loosen tolerance is used, compared to the more strict tolerance,
     # the coordinates might look more different.

--- a/pyscf/symm/geom.py
+++ b/pyscf/symm/geom.py
@@ -566,8 +566,8 @@ def is_identical_geometry(coords1, coords2, weights):
     if coords1.shape != coords2.shape:
         return False
     for order in range(1, 4):
-        if abs(casimir_tensors(coords1[lst], weights, order) -
-               casimir_tensors(coords2[lst], weights, order)).max() > TOLERANCE:
+        if abs(casimir_tensors(coords1, weights, order) -
+               casimir_tensors(coords2, weights, order)).max() > TOLERANCE:
             return False
     return True
 

--- a/pyscf/symm/geom.py
+++ b/pyscf/symm/geom.py
@@ -79,10 +79,8 @@ def argsort_coords(coords, decimals=None, tol=0.05):
     return idx
 
 def sort_coords(coords, decimals=None, tol=0.05):
-    if decimals is None:
-        decimals = int(-numpy.log10(tol)) - 1
     coords = numpy.asarray(coords)
-    idx = argsort_coords(coords, decimals)
+    idx = argsort_coords(coords, tol=tol)
     return coords[idx]
 
 # ref. http://en.wikipedia.org/wiki/Rotation_matrix

--- a/pyscf/symm/test/test_basis.py
+++ b/pyscf/symm/test/test_basis.py
@@ -163,6 +163,10 @@ class KnowValues(unittest.TestCase):
                  ['O',  ( 0.000000  , 2.572496  , 1.441607 )],
                  ['O',  ( 2.227847  , -1.286248 , 1.441607 )],
                  ['O',  ( -2.227847 , -1.286248 , 1.441607 )],]
+        numpy.random.seed(2)
+        u = numpy.linalg.svd(numpy.random.rand(3,3))[0]
+        r = numpy.array([a[1] for a in atoms])
+        atoms = [[a[0], x] for a, x in zip(atoms, r.dot(u))]
         basis = {'Fe':gto.basis.load('def2svp', 'C'),
                  'C': gto.basis.load('def2svp', 'C'),
                  'H': gto.basis.load('def2svp', 'C'),

--- a/pyscf/symm/test/test_basis.py
+++ b/pyscf/symm/test/test_basis.py
@@ -141,6 +141,11 @@ class KnowValues(unittest.TestCase):
         self.assertEqual(get_so(atoms,basis)[0], 220)
 
     def test_symm_orb_c3v_as_cs(self):
+        # This molecule has an approximate C3v symmetry for TOLERANCE>1e-5
+        # When using its subgroup cs, a mirror perpedicular to [-.5, -.866, 0]
+        # will be adopted as the mirror. This mirror leads to more errors in
+        # atomic coordinates than the yz-mirror. In this case, one can adjust
+        # TOLERANCE to pass the check_symm or symm_identical_atoms functions.
         atoms = [['Fe', ( 0.000000  , 0.000000  , 0.015198 )],
                  ['C',  ( 0.000000  , 0.000000  , -1.938396)],
                  ['C',  ( 0.000000  , -1.394127 , -1.614155)],

--- a/pyscf/symm/test/test_geom.py
+++ b/pyscf/symm/test/test_geom.py
@@ -886,6 +886,16 @@ H   2.041481  -0.080642  -0.024174''')
         self.assertEqual(l, 'C2v')
         self.assertAlmostEqual(abs(axes - numpy.diag(axes.diagonal())).max(), 0, 9)
 
+    def test_geometry_small_discrepancy(self):
+        # issue 2713
+        mol = gto.M(
+            atom='''
+                O        0.000000    0.000000    0.900000
+                H        0.000000    0.000000    0.000000
+                H        0.914864    0.000000    1.249646
+                H       -0.498887    0.766869    1.249646''',
+            charge=1, symmetry=True)
+        self.assertEqual(mol.groupname, 'Cs')
 
 def ring(n, start=0):
     r = 1. / numpy.sin(numpy.pi/n)


### PR DESCRIPTION
This PR fixes a bug in the symmetry detection caused by the np.round function. The issue arises when the error is smaller than the tolerance but the significant digits are different:
```
np.round([0.24999, 0.25001], 1)  # => [0.2, 0.3]
```
This error causes the symmetry detection code incorrectly label symmetry identical atoms. Fix #2713 