### PR TITLE
Fix dfmp2 for prebuilt df object

### DIFF
--- a/pyscf/mp/dfmp2.py
+++ b/pyscf/mp/dfmp2.py
@@ -231,7 +231,7 @@ def _make_df_eris(mp, mo_coeff=None, ovL=None, ovL_to_save=None, verbose=None):
     # determine incore or outcore
     nocc = occ_coeff.shape[1]
     nvir = vir_coeff.shape[1]
-    naux = with_df.auxmol.nao_nr()
+    naux = with_df.get_naoaux()
 
     if ovL is not None:
         if isinstance(ovL, np.ndarray):

--- a/pyscf/mp/dfump2.py
+++ b/pyscf/mp/dfump2.py
@@ -245,7 +245,7 @@ def _make_df_eris(mp, mo_coeff=None, ovL=None, ovL_to_save=None, verbose=None):
     # determine incore or outcore
     nocc = np.asarray([x.shape[1] for x in occ_coeff])
     nvir = np.asarray([x.shape[1] for x in vir_coeff])
-    naux = with_df.auxmol.nao_nr()
+    naux = with_df.get_naoaux()
 
     if ovL is not None:
         if isinstance(ovL, (np.ndarray,list,tuple)):


### PR DESCRIPTION
For calculations with prebuilt `df` object, `auxmol` may be `None`.