### PR TITLE
Fix DF auxiliary basis assignment for dict and ghost

### DIFF
--- a/pyscf/df/addons.py
+++ b/pyscf/df/addons.py
@@ -171,9 +171,9 @@ def make_auxbasis(mol, mp2fit=False):
     uniq_atoms = {a[0] for a in mol._atom}
     if isinstance(mol.basis, str):
         _basis = {a: mol.basis for a in uniq_atoms}
-    elif isinstance(mol.basis, dict):
-        if all([isinstance(basis, str) for basis in mol.basis.values()]):
-            _basis = {a: mol.basis[a] for a in uniq_atoms}
+    elif (isinstance(mol.basis, dict) and 
+          if all([isinstance(basis, str) for basis in mol.basis.values()])):
+        _basis = {a: mol.basis[a] for a in uniq_atoms}
     elif 'default' in mol.basis:
         default_basis = mol.basis['default']
         _basis = {a: default_basis for a in uniq_atoms}

--- a/pyscf/df/addons.py
+++ b/pyscf/df/addons.py
@@ -171,14 +171,14 @@ def make_auxbasis(mol, mp2fit=False):
     uniq_atoms = {a[0] for a in mol._atom}
     if isinstance(mol.basis, str):
         _basis = {a: mol.basis for a in uniq_atoms}
-    elif (isinstance(mol.basis, dict) and
-        all([isinstance(basis, str) for basis in mol.basis.values()])):
-        _basis = {a: mol.basis[a] for a in uniq_atoms}
     elif 'default' in mol.basis:
         default_basis = mol.basis['default']
         _basis = {a: default_basis for a in uniq_atoms}
         _basis.update(mol.basis)
         del (_basis['default'])
+    elif (isinstance(mol.basis, dict) and
+            all([isinstance(basis, str) for basis in mol.basis.values()])):
+        _basis = {a: mol.basis[a] for a in uniq_atoms}
     else:
         _basis = mol._basis or {}
 

--- a/pyscf/df/addons.py
+++ b/pyscf/df/addons.py
@@ -171,6 +171,9 @@ def make_auxbasis(mol, mp2fit=False):
     uniq_atoms = {a[0] for a in mol._atom}
     if isinstance(mol.basis, str):
         _basis = {a: mol.basis for a in uniq_atoms}
+    elif isinstance(mol.basis, dict):
+        if all([isinstance(basis, str) for basis in mol.basis.values()]):
+            _basis = {a: mol.basis[a] for a in uniq_atoms}
     elif 'default' in mol.basis:
         default_basis = mol.basis['default']
         _basis = {a: default_basis for a in uniq_atoms}
@@ -193,7 +196,7 @@ def make_auxbasis(mol, mp2fit=False):
                 if auxb is not None:
                     try:
                         # Test if basis auxb for element k is available
-                        gto.basis.load(auxb, k)
+                        gto.basis.load(auxb, elements._std_symbol_without_ghost(k))
                     except BasisNotFoundError:
                         pass
                     else:

--- a/pyscf/df/addons.py
+++ b/pyscf/df/addons.py
@@ -171,8 +171,8 @@ def make_auxbasis(mol, mp2fit=False):
     uniq_atoms = {a[0] for a in mol._atom}
     if isinstance(mol.basis, str):
         _basis = {a: mol.basis for a in uniq_atoms}
-    elif (isinstance(mol.basis, dict) and 
-          if all([isinstance(basis, str) for basis in mol.basis.values()])):
+    elif (isinstance(mol.basis, dict) and
+        all([isinstance(basis, str) for basis in mol.basis.values()])):
         _basis = {a: mol.basis[a] for a in uniq_atoms}
     elif 'default' in mol.basis:
         default_basis = mol.basis['default']

--- a/pyscf/df/test/test_addons.py
+++ b/pyscf/df/test/test_addons.py
@@ -46,7 +46,7 @@ class KnownValues(unittest.TestCase):
         self.assertEqual(len(auxbasis['O']), 37)
         # If basis-set-exchange pacakge is installed, this test will fail.
         # bse-0.9 produces 13 shells due to round-off errors.
-        # The correct number of generated basis functions should be 12. 
+        # The correct number of generated basis functions should be 12.
         self.assertEqual(len(auxbasis['H']), 12)
 
         mol = gto.M(
@@ -69,6 +69,31 @@ class KnownValues(unittest.TestCase):
         self.assertEqual(len(auxbasis['H']), 20)
 
     def test_make_auxbasis(self):
+        mol = gto.M(
+            verbose = 0,
+            atom = '''O     0    0.       0.
+                      H     0    -0.757   0.587
+                      H     0    0.757    0.587
+                GHOST-H     0    0.       0.587''',
+            basis = 'cc-pvdz'
+        )
+        auxbasis = df.addons.make_auxbasis(mol)
+        self.assertEqual(auxbasis['O'], 'cc-pvdz-jkfit')
+        self.assertEqual(auxbasis['H'], 'cc-pvdz-jkfit')
+        self.assertEqual(auxbasis['GHOST-H'], 'cc-pvdz-jkfit')
+        self.assertEqual(len(auxbasis['GHOST-H']), len(auxbasis['H']))
+
+        mol = gto.M(
+            verbose = 0,
+            atom = '''O     0    0.       0.
+                      H     0    -0.757   0.587
+                      H     0    0.757    0.587''',
+            basis = {'O':'cc-pvdz', 'H':'cc-pvtz'}
+        )
+        auxbasis = df.addons.make_auxbasis(mol)
+        self.assertEqual(auxbasis['O'], 'cc-pvdz-jkfit')
+        self.assertEqual(auxbasis['H'], 'cc-pvtz-jkfit')
+
         mol = gto.M(
             verbose = 0,
             atom = '''O     0    0.       0.

--- a/pyscf/mcscf/test/test_mc1step.py
+++ b/pyscf/mcscf/test/test_mc1step.py
@@ -191,7 +191,7 @@ class KnownValues(unittest.TestCase):
         mc1.max_cycle_micro = 6
         mc1.fcisolver.pspace_size = 0
         mc1.kernel(mo)
-        self.assertAlmostEqual(mc1.e_tot, -105.82833244029327, 6)
+        self.assertAlmostEqual(mc1.e_tot, -105.82833497389831, 6)
 
     # FIXME: How to test ci_response_space? The test below seems numerical instable
     #def test_ci_response_space(self):

--- a/pyscf/mp/test/test_dfmp2.py
+++ b/pyscf/mp/test/test_dfmp2.py
@@ -55,17 +55,17 @@ class KnownValues(unittest.TestCase):
         # incore
         mmp = mp.dfmp2.DFMP2(mf)
         mmp.kernel()
-        self.assertAlmostEqual(mmp.e_corr, -0.2040090597718413, 8)
+        self.assertAlmostEqual(mmp.e_corr, -0.20400482102770082, 8)
 
         # outcore
         mmp = mp.dfmp2.DFMP2(mf).set(force_outcore=True)
         mmp.kernel()
-        self.assertAlmostEqual(mmp.e_corr, -0.2040090597718413, 8)
+        self.assertAlmostEqual(mmp.e_corr, -0.20400482102770082, 8)
 
     def test_dfmp2_frozen(self):
         mmp = mp.dfmp2.DFMP2(mf, frozen=[0,1,5])
         mmp.kernel()
-        self.assertAlmostEqual(mmp.e_corr, -0.13844448336139464, 8)
+        self.assertAlmostEqual(mmp.e_corr, -0.13844381496025246, 8)
 
     def test_dfmp2_mf_with_df(self):
         mmpref = mp.mp2.MP2(dfmf)
@@ -110,7 +110,7 @@ class KnownValues(unittest.TestCase):
         # incore
         mmp = dfmp2_slow.DFMP2(mf)
         mmp.kernel()
-        self.assertAlmostEqual(mmp.e_corr, -0.2040090597718413, 8)
+        self.assertAlmostEqual(mmp.e_corr, -0.20400482102770082, 8)
 
 
 

--- a/pyscf/mp/test/test_dfump2.py
+++ b/pyscf/mp/test/test_dfump2.py
@@ -57,17 +57,17 @@ class KnownValues(unittest.TestCase):
         # incore
         mmp = mp.dfump2.DFUMP2(mf)
         mmp.kernel()
-        self.assertAlmostEqual(mmp.e_corr, -0.15323136917179633, 8)
+        self.assertAlmostEqual(mmp.e_corr, -0.15321910903780497, 8)
 
         # outcore
         mmp = mp.dfump2.DFUMP2(mf).set(force_outcore=True)
         mmp.kernel()
-        self.assertAlmostEqual(mmp.e_corr, -0.15323136917179633, 8)
+        self.assertAlmostEqual(mmp.e_corr, -0.15321910903780497, 8)
 
     def test_dfmp2_frozen(self):
         mmp = mp.dfump2.DFUMP2(mf, frozen=[[0,1,5], [1]])
         mmp.kernel()
-        self.assertAlmostEqual(mmp.e_corr, -0.09397465616240533, 8)
+        self.assertAlmostEqual(mmp.e_corr, -0.09397152054462676, 8)
 
     def test_dfmp2_mf_with_df(self):
         mmpref = mp.ump2.UMP2(dfmf)
@@ -114,7 +114,7 @@ class KnownValues(unittest.TestCase):
         # incore
         mmp = dfump2_slow.DFUMP2(mf)
         mmp.kernel()
-        self.assertAlmostEqual(mmp.e_corr, -0.15323136917179633, 8)
+        self.assertAlmostEqual(mmp.e_corr, -0.15321910903780497, 8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The default assignments of auxiliary basis sets has unexpected behavior if the basis set is specified as a dict or if ghost basis functions are used. For example,
```
from pyscf import gto, scf

mol = gto.M(atom='N 0 0 0; N 0 0 1.2', basis='ccpvdz')
mf = scf.RHF(mol).density_fit().run()  # uses ccpvdz-jkfit, expected
# converged SCF energy = -108.913710743723

mol = gto.M(atom='N 0 0 0; N 0 0 1.2', basis={'N':'ccpvdz'})
mf = scf.RHF(mol).density_fit().run()  # uses ETB, unexpected
# WARN: Even tempered Gaussians are generated as DF auxbasis for  N
# converged SCF energy = -108.914115346246
```
and
```
mol = gto.M(atom='N 0 0 0; N 0 0 1.2; GHOST-N 0 0 2.4', basis='ccpvdz')
mf = scf.RHF(mol).density_fit().run()  # uses ETB for GHOST-N, unexpected
# WARN: Even tempered Gaussians are generated as DF auxbasis for  GHOST-N
```

This PR fixes both problems.
