### PR TITLE
Fix libxc interface for passing omega

### DIFF
--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -1055,7 +1055,6 @@ def _eval_xc(xc_code, rho, spin=0, deriv=1, omega=None):
         omega = [hyb[2]] * len(facs)
     else:
         omega = [0] * len(facs)
-    print(fn_ids, facs, omega)
     fn_ids_set = set(fn_ids)
     if fn_ids_set.intersection(PROBLEMATIC_XC):
         problem_xc = [PROBLEMATIC_XC[k]

--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -1055,6 +1055,7 @@ def _eval_xc(xc_code, rho, spin=0, deriv=1, omega=None):
         omega = [hyb[2]] * len(facs)
     else:
         omega = [0] * len(facs)
+    print(fn_ids, facs, omega)
     fn_ids_set = set(fn_ids)
     if fn_ids_set.intersection(PROBLEMATIC_XC):
         problem_xc = [PROBLEMATIC_XC[k]

--- a/pyscf/dft/test/test_libxc.py
+++ b/pyscf/dft/test/test_libxc.py
@@ -373,6 +373,14 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(float(vxc[1][0]), -0.003911167644579979, 7)
         self.assertEqual(dft.libxc.rsh_coeff('ityh,'), (0.2, 0.0, 0.0))
 
+    def test_lcwpbe(self):
+        rho = numpy.array([1., 1., 0.1, 0.1]).reshape(-1,1)
+        exc, vxc, fxc, kxc = dft.libxc.eval_xc('LC_wPBE', rho, 0, deriv=1)
+        exc1, vxc1, fxc1, kxc1 = dft.libxc.eval_xc('RSH(0.4,1.0,-1.0)+wpbeh,pbe', rho, 0, deriv=1)
+        self.assertAlmostEqual(float(exc[0]), float(exc1[0]), 7)
+        self.assertAlmostEqual(float(vxc[0][0]), float(vxc1[0][0]), 7)
+        self.assertAlmostEqual(float(vxc[1][0]), float(vxc1[1][0]), 7)
+
     def test_deriv_order(self):
         self.assertTrue(dft.libxc.test_deriv_order('lda', 3, raise_error=False))
         self.assertTrue(dft.libxc.test_deriv_order('m05', 2, raise_error=False))

--- a/pyscf/lib/dft/libxc_itrf.c
+++ b/pyscf/lib/dft/libxc_itrf.c
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <xc.h>
+#include <string.h>
 #include "config.h"
 #define MAX(X,Y) ((X) > (Y) ? (X) : (Y))
 #define MIN(X,Y) ((X) < (Y) ? (X) : (Y))
@@ -32,6 +33,19 @@
 
 // TODO: register python signal
 #define raise_error     return
+
+
+static int
+xc_func_find_ext_params_name(const xc_func_type *p, const char *name) {
+  int ii;
+  assert(p != NULL && p->info->ext_params.n > 0);
+  for(ii=0; ii<p->info->ext_params.n; ii++){
+    if(strcmp(p->info->ext_params.names[ii], name) == 0) {
+      return ii;
+    }
+  }
+  return -1;
+}
 
 /* Extracted from comments of libxc:gga.c
 
@@ -1024,7 +1038,8 @@ void LIBXC_eval_xc(int nfn, int *fn_id, double *fac, double *omega,
                 if (omega[i] != 0) {
                         // skip if func is not a RSH functional
 #if XC_MAJOR_VERSION <= 7
-                        if (1) {
+                        if ( xc_func_find_ext_params_name(&func, "_omega") >= 0 ) {
+                                //fprintf(stdout, "change omega to %f", omega[i]);
                                 xc_func_set_ext_params_name(&func, "_omega", omega[i]);
                                 //func.cam_omega = omega[i];
                         }

--- a/pyscf/lib/dft/libxc_itrf.c
+++ b/pyscf/lib/dft/libxc_itrf.c
@@ -1024,8 +1024,9 @@ void LIBXC_eval_xc(int nfn, int *fn_id, double *fac, double *omega,
                 if (omega[i] != 0) {
                         // skip if func is not a RSH functional
 #if XC_MAJOR_VERSION <= 7
-                        if (func.cam_omega != 0) {
-                                func.cam_omega = omega[i];
+                        if (1) {
+                                xc_func_set_ext_params_name(&func, "_omega", omega[i]);
+                                //func.cam_omega = omega[i];
                         }
 #else
                         if (func.hyb_omega != NULL && func.hyb_omega[0] != 0) {

--- a/pyscf/lib/dft/libxc_itrf.c
+++ b/pyscf/lib/dft/libxc_itrf.c
@@ -34,7 +34,9 @@
 // TODO: register python signal
 #define raise_error     return
 
-
+/* Extracted from libxc:functionals.c since this function is not exposed
+ * currently. See issue #2756.
+ */
 static int
 xc_func_find_ext_params_name(const xc_func_type *p, const char *name) {
   int ii;
@@ -1037,29 +1039,15 @@ void LIBXC_eval_xc(int nfn, int *fn_id, double *fac, double *omega,
                 // set the range-separated parameter
                 if (omega[i] != 0) {
                         // skip if func is not a RSH functional
-#if XC_MAJOR_VERSION <= 7
                         if ( xc_func_find_ext_params_name(&func, "_omega") >= 0 ) {
-                                //fprintf(stdout, "change omega to %f", omega[i]);
                                 xc_func_set_ext_params_name(&func, "_omega", omega[i]);
-                                //func.cam_omega = omega[i];
                         }
-#else
-                        if (func.hyb_omega != NULL && func.hyb_omega[0] != 0) {
-                                func.hyb_omega[0] = omega[i];
-                        }
-#endif
                         // Recursively set the sub-functionals if they are RSH
                         // functionals
                         for (j = 0; j < func.n_func_aux; j++) {
-#if XC_MAJOR_VERSION <= 7
-                                if (func.func_aux[j]->cam_omega != 0) {
-                                        func.func_aux[j]->cam_omega = omega[i];
+                                if ( xc_func_find_ext_params_name(func.func_aux[j], "_omega") >= 0 ) {
+                                        xc_func_set_ext_params_name(func.func_aux[j], "_omega", omega[i]);
                                 }
-#else
-                                if (func.func_aux[j]->hyb_omega != NULL && func.func_aux[j]->hyb_omega[0] != 0) {
-                                        func.func_aux[j]->hyb_omega[0] = omega[i];
-                                }
-#endif
                         }
                 }
 


### PR DESCRIPTION
Fix #2756. The original implementation of changing omega does not work when libxc's default omega is 0 and thus cannot correctly calculate `RSH(0.4,1.0,-1.0)+wpbeh,pbe` which should be identical to `LC_wPBE`. This PR actually re-factors this since using `xc_func_set_ext_params_name` is more recommended. Thanks @susilehtola 's advice.