### PR TITLE
fix kpts_band error in RSDF

### DIFF
--- a/pyscf/pbc/df/rsdf.py
+++ b/pyscf/pbc/df/rsdf.py
@@ -295,6 +295,7 @@ cell.dimension=3 with large vacuum.""")
             kpts_union = unique(np.vstack([self.kpts, self.kpts_band]))[0]
         dfbuilder = _RSGDFBuilder(cell, auxcell, kpts_union)
         dfbuilder.__dict__.update(self.__dict__)
+        dfbuilder.kpts = kpts_union
         j_only = self._j_only or len(kpts_union) == 1
         dfbuilder.make_j3c(cderi_file, j_only=j_only, dataname=self._dataname,
                            kptij_lst=kptij_lst)

--- a/pyscf/pbc/df/test/test_band.py
+++ b/pyscf/pbc/df/test/test_band.py
@@ -58,6 +58,14 @@ class KnownValues(unittest.TestCase):
         mf.kernel()
         self.assertAlmostEqual(lib.fp(mf.get_bands(kband[0])[0]), 1.992205011752425, 7)
 
+    def test_rsdf_band(self):
+        mf = scf.RHF(cell)
+        mf.with_df = df.RSDF(cell).set(auxbasis='weigend')
+        mf.with_df.exp_to_discard = 0.518490303352116
+        mf.with_df.kpts_band = kband[0]
+        mf.kernel()
+        self.assertAlmostEqual(lib.fp(mf.get_bands(kband[0])[0]), 1.992205011752425, 7)
+
     def test_mdf_band(self):
         mf = scf.RHF(cell)
         mf.with_df = df.MDF(cell).set(auxbasis='weigend')
@@ -83,6 +91,16 @@ class KnownValues(unittest.TestCase):
     def test_df_bands(self):
         mf = scf.KRHF(cell)
         mf.with_df = df.DF(cell).set(auxbasis='weigend')
+        mf.with_df.kpts_band = kband
+        mf.with_df.exp_to_discard = 0.518490303352116
+        mf.kpts = cell.make_kpts([2,1,1])
+        mf.kernel()
+        self.assertAlmostEqual(lib.fp(mf.get_bands(kband[0])[0]), 1.9648945030342437, 7)
+        self.assertAlmostEqual(lib.fp(mf.get_bands(kband)[0]), 1.0455025876245683, 7)
+
+    def test_rsdf_bands(self):
+        mf = scf.KRHF(cell)
+        mf.with_df = df.RSDF(cell).set(auxbasis='weigend')
         mf.with_df.kpts_band = kband
         mf.with_df.exp_to_discard = 0.518490303352116
         mf.kpts = cell.make_kpts([2,1,1])


### PR DESCRIPTION
In rsdf.py, [line 297](https://github.com/pyscf/pyscf/blob/master/pyscf/pbc/df/rsdf.py#L297) overwrites the `dfbuilder.kpts` to be `self.kpts`. This causes an error when using RSDF and calling `mf.get_bands(kpts_bands)` because `self.kpts` does not contain band kpts information. This PR fixes this bug by adding
```python
dfbuilder.kpts = kpts_union
```
after L297. Tests for calculating bands using RSDF are also added to `test_band.py`.

Credits to @XiliangGong for finding this bug :pray: