### PR TITLE
fix near-symmetry issue with fromstring/tostring

### DIFF
--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2088,7 +2088,7 @@ def tostring(mol, format='raw'):
         for i in range(mol.natm):
             symb = mol.atom_pure_symbol(i)
             x, y, z = coords[i]
-            output.append('%-4s %14.5f %14.5f %14.5f' %
+            output.append('%-4s %17.8f %17.8f %17.8f' %
                           (symb, x, y, z))
         return '\n'.join(output)
     elif format == 'zmat':

--- a/pyscf/gto/test/test_mole.py
+++ b/pyscf/gto/test/test_mole.py
@@ -956,9 +956,9 @@ O    SP
         out1 = mol.tofile(tmpfile.name, format='xyz')
         ref = '''3
 XYZ from PySCF
-H           0.00000        1.00000        1.00000
-O           0.00000        0.00000        0.00000
-H           1.00000        1.00000        0.00000
+H           0.00000000        1.00000000        1.00000000
+O           0.00000000        0.00000000        0.00000000
+H           1.00000000        1.00000000        0.00000000
 '''
         with open(tmpfile.name, 'r') as f:
             self.assertEqual(f.read(), ref)

--- a/pyscf/pbc/gto/test/test_cell.py
+++ b/pyscf/pbc/gto/test/test_cell.py
@@ -556,6 +556,9 @@ class KnownValues(unittest.TestCase):
         cell.fromstring(cl.tostring('poscar'), 'vasp')
         r0 = cell.atom_coords()
         self.assertAlmostEqual(abs(ref - r0).max(), 0, 12)
+        cell.fromstring(cl.tostring('xyz'), 'xyz')
+        r0 = cell.atom_coords()
+        self.assertAlmostEqual(abs(ref - r0).max(), 0, 12)
 
     def test_fromfile(self):
         ref = cl.atom_coords().copy()


### PR DESCRIPTION
The default symmetry tolerance in the `pbc` module is `1e-6`, while `fromfile` truncates the atomic coordinates to five decimal places. When symmetry is turned on, this leads to "near-symmetry issues" where the symmetrized mesh can be huge (e.g. 500000 x 500000 x 500000) and cause memory issues. I made two changes to address this:

- All the `fromstring` and `tostring` functions for isolated and periodic systems use 8 decimals for float formatting now.
- If symmetrizing `mesh` to `mesh1` results in the condition `m1size > 8 * msize and m1size > 1000 + msize`, a warning is raised suggesting that the user symmetrize the structure, increase symmetry tolerance, or turn off symmetry.

Please let me know if you would like anything done differently, want more tests, etc. I realize the condition above is a bit arbitrary; I just picked what seemed intuitively reasonable.

I have included a script below that fails with out-of-memory error in the previous version and runs smoothly in this version.
```
from pyscf.pbc import gto, scf
from pyscf.pbc.gto.cell import fromfile

a, atom = fromfile("Li.poscar")
# Uncomment in new version to trigger warning and OOM error
# atom = atom.replace("1.71965623", "1.71966")

cell = gto.Cell(
    a=a,
    atom=atom,
    basis='gth-szv',
    pseudo='gth-pade',
    verbose=4,
    space_group_symmetry=True,
    symmorphic=False,
)
cell.build()


kpts = cell.make_kpts(
    [2, 2, 2],
    space_group_symmetry=True,
    time_reversal_symmetry=True,
)
kmf = scf.KRHF(cell, kpts).density_fit()
ehf = kmf.kernel()
```

And here is `Li.poscar`:
```
Li2
1.0
   3.4393124531669552    0.0000000000000000    0.0000000000000002
  -0.0000000000000002    3.4393124531669552    0.0000000000000002
   0.0000000000000000    0.0000000000000000    3.4393124531669552
Li
2
direct
   0.0000000000000000    0.0000000000000000    0.0000000000000000 Li0+
   0.5000000000000000    0.5000000000000000    0.5000000000000000 Li0+
```