### PR TITLE
Make ``fci_dhf_slow.make_rdm1`` Faster

### DIFF
--- a/pyscf/fci/fci_dhf_slow.py
+++ b/pyscf/fci/fci_dhf_slow.py
@@ -76,7 +76,7 @@ def kernel(h1e, eri, norb, nelec, ecore=0, nroots=1, verbose=3):
 
 
 # dm_pq = <|p^+ q|>
-def make_rdm1(fcivec, norb, nelec, link_index=None):
+def make_rdm1_slow(fcivec, norb, nelec, link_index=None):
     if link_index is None:
         link_index = cistring.gen_linkstr_index(range(norb), nelec)
     rdm1 = numpy.zeros((norb, norb), dtype=fcivec.dtype)
@@ -84,6 +84,20 @@ def make_rdm1(fcivec, norb, nelec, link_index=None):
         for a, i, str1, sign in tab:
             rdm1[a, i] += sign * numpy.dot(fcivec[str1].conj(), fcivec[str0])
     return rdm1
+
+
+# dm_pq = <|p^+ q|>
+def make_rdm1(fcivec, norb, nelec, link_index=None):
+    if nelec == 0:
+        return numpy.zeros((norb, norb), dtype=fcivec.dtype)
+    nd = cistring.num_strings(norb, nelec - 1)
+    index_d = cistring.gen_des_str_index(range(norb), nelec)
+    dci = numpy.zeros((nd, norb), dtype=fcivec.dtype)
+    for str0, tab in enumerate(index_d):
+        for _, i, str1, sign in tab:
+            dci[str1, i] += sign * fcivec[str0]
+    return dci.conj().T @ dci
+
 
 # dm_pq,rs = <|p^+ q r^+ s|>
 def make_rdm12(fcivec, norb, nelec, link_index=None, reorder=True):

--- a/pyscf/fci/test/test_dhf_slow.py
+++ b/pyscf/fci/test/test_dhf_slow.py
@@ -70,6 +70,8 @@ class KnownValues(unittest.TestCase):
 
     def test_rdm1(self):
         dm1 = fci.fci_dhf_slow.make_rdm1(ci0, norb, nelec)
+        dm1_slow = fci.fci_dhf_slow.make_rdm1_slow(ci0, norb, nelec)
+        self.assertAlmostEqual(numpy.linalg.norm(dm1 - dm1_slow), 0.0, 12)
         self.assertAlmostEqual(abs(lib.fp(dm1)), 0.23702307574649528, 8)
 
     def test_rdm12(self):


### PR DESCRIPTION
This pull request fixes #2770, by using an alternative implementation for ``fci_dhf_slow.make_rdm1``.

For N2 with sto3g basis and DHF orbitals (14 electrons in 20 spin orbitals), the time cost of ``fci_dhf_slow.make_rdm1`` is improved from 19 sec to 1 sec.

<details>

<summary>Benchmark script and output</summary>

```python3
import pyscf
from pyscf.fci.fci_dhf_slow import make_rdm1_slow
import numpy as np
import time

mol = pyscf.M(atom='N 0 0 0; N 0 0 1.1', basis='sto3g', verbose=3)
mf = mol.DHF().run()
mfci = pyscf.fci.FCI(mf)
e, ci = mfci.kernel()

tx = time.perf_counter()
dm1x = make_rdm1_slow(ci, mfci.norb, mfci.nelec)
print('T dm1 (old) = ', time.perf_counter() - tx)

tx = time.perf_counter()
dm1 = mfci.make_rdm1(ci, mfci.norb, mfci.nelec)
print('T dm1 (new) = ', time.perf_counter() - tx)

print('diff = ', np.linalg.norm(dm1x - dm1))
```

The output on 16-core cascadelake:

```
converged SCF energy = -107.544314972681
T dm1 (old) =  19.073628762736917
T dm1 (new) =  1.0015934612601995
diff =  5.5707362585370314e-14
```

</details>