### PR TITLE
Proposal: user-defined basis set aliases

### DIFF
--- a/examples/gto/04-input_basis.py
+++ b/examples/gto/04-input_basis.py
@@ -83,6 +83,25 @@ O    SP
 )
 
 #
+# You can define custom aliases for basis sets defined in files.
+# The variables USER_BASIS_DIR and USER_BASIS_ALIAS should be defined
+# in your PySCF configuration file (e.g. ~/.pyscf_conf.py) like this:
+
+USER_BASIS_DIR = dirnow
+USER_BASIS_ALIAS = {'customsto3g' : 'h_sto3g.dat'}
+
+# We need to override USER_BASIS_DIR and USER_BASIS_ALIAS so that the example can run.
+# Don't actually use the next two lines in your code.
+gto.basis.USER_BASIS_DIR = USER_BASIS_DIR
+gto.basis.USER_BASIS_ALIAS = USER_BASIS_ALIAS
+
+mol = gto.M(
+    atom = '''H 0 0 0; H 0 0 1''',
+    basis = 'customsto3g'
+)
+
+
+#
 # Uncontracted basis, decontracting basis.
 #
 mol = gto.M(

--- a/examples/gto/04-input_basis.py
+++ b/examples/gto/04-input_basis.py
@@ -8,11 +8,12 @@ This example covers different ways to input basis
 4. Default basis for all elements, except the given basis of specific element.
 5. gto.basis.parse and gto.basis.load functions to input user-specified basis.
 6. Reading the basis set from a given file.
-7. Uncontracted basis with prefix "unc-".
-8. Basis truncation and a subset of a basis set with notation "@".
-9. Even tempered gaussian basis.
-10. Combining multiple basis sets into one basis set.
-11. Internal format (not recommended)
+7. Defining custom aliases for basis sets stored in files.
+8. Uncontracted basis with prefix "unc-".
+9. Basis truncation and a subset of a basis set with notation "@".
+10. Even tempered gaussian basis.
+11. Combining multiple basis sets into one basis set.
+12. Internal format (not recommended)
 '''
 
 import os

--- a/pyscf/gto/basis/__init__.py
+++ b/pyscf/gto/basis/__init__.py
@@ -383,6 +383,13 @@ ALIAS = {
     'dyallv4z' : 'dyall-basis.dyall_v4z',
 }
 
+USER_BASIS_DIR = getattr(__config__, 'USER_BASIS_DIR', '')
+USER_BASIS_ALIAS = getattr(__config__, 'USER_BASIS_ALIAS', {})
+USER_GTH_ALIAS = getattr(__config__, 'USER_GTH_ALIAS', {})
+
+if USER_BASIS_ALIAS.keys() & ALIAS.keys():
+    raise KeyError('USER_BASIS_ALIAS keys conflict with predefined basis sets')
+
 GTH_ALIAS = {
     'gthaugdzvp'  : 'gth-aug-dzvp.dat',
     'gthaugqzv2p' : 'gth-aug-qzv2p.dat',
@@ -406,6 +413,9 @@ GTH_ALIAS = {
     'gthszvmoloptsr'    : 'gth-szv-molopt-sr.dat',
     'gthdzvpmoloptsr'   : 'gth-dzvp-molopt-sr.dat',
 }
+
+if USER_GTH_ALIAS.keys() & GTH_ALIAS.keys():
+    raise KeyError('USER_GTH_ALIAS keys conflict with predefined GTH basis sets')
 
 PP_ALIAS = {
     'gthblyp'    : 'gth-blyp.dat'   ,
@@ -610,10 +620,17 @@ def load(filename_or_basisname, symb, optimize=OPTIMIZE_CONTRACTION):
     basis_dir = _BASIS_DIR
     if name in ALIAS:
         basmod = ALIAS[name]
+    elif name in USER_BASIS_ALIAS:
+        basmod = USER_BASIS_ALIAS[name]
+        basis_dir = USER_BASIS_DIR
     elif name in GTH_ALIAS:
         basmod = GTH_ALIAS[name]
         fload = parse_cp2k.load
         basis_dir = _GTH_BASIS_DIR
+    elif name in USER_GTH_ALIAS:
+        basmod = USER_GTH_ALIAS[name]
+        fload = parse_cp2k.load
+        basis_dir = USER_BASIS_DIR
     elif _is_pople_basis(name):
         basmod = _parse_pople_basis(name, symb)
     elif name in SAP_ALIAS:


### PR DESCRIPTION
If you need to work with more than a handful of custom basis sets at a time, it can be cumbersome to refer to them by filename, so many users choose to add them directly to `pyscf/gto/basis`, then edit the `ALIAS` dictionary in `pyscf/gto/basis/__init__.py`.

However, if you installed PySCF with pip/conda, or you are using a cluster-wide installation, you might prefer not to edit those files, or you might not have permission to do so.

 A simple solution, implemented here, is to read `USER_BASIS_DIR`, `USER_BASIS_ALIAS`, etc, from `__config__`. Just put your basis set files in USER_BASIS_DIR, and register their names in USER_BASIS_ALIAS. It's a minor quality of life improvement, but I think it would be a nice feature to have.
 
 Feedback, suggestions for improvement, criticisms, etc. are welcome!