### PR TITLE
Fix potential bug of 6th order derivative in `dft.xc_deriv.transform_xc`

### DIFF
--- a/pyscf/dft/test/test_xc_deriv.py
+++ b/pyscf/dft/test/test_xc_deriv.py
@@ -567,6 +567,28 @@ class KnownValues(unittest.TestCase):
             kxc1 = xc_deriv.transform_xc(rhop, xcp, xctype, spin, deriv-1)
             self.assertAlmostEqual(abs((kxc0-kxc1)/delta - lxc[t]).max(), 0, 7)
 
+    def test_diagonal_indices(self):
+        nabla_idx = [1, 2, 3]
+        len_idx = 3
+
+        # case of order = 2, corresponds to 4th/5th xc derivative
+        order = 2
+        indices = xc_deriv._diagonal_indices(nabla_idx, order)
+        trans_dims = [(0, 1), (1, 0)]
+        for o, trans in zip(range(order), trans_dims):
+            self.assertTrue((indices[2 * o] == indices[2 * o + 1]).all())
+            ref = np.repeat(nabla_idx, len_idx**(order - 1)).reshape([len_idx] * order).transpose(trans).reshape(-1)
+            self.assertTrue((indices[2 * o] == ref).all())
+
+        # case of order = 4, corresponds to 8th/9th xc derivative
+        order = 4
+        indices = xc_deriv._diagonal_indices(nabla_idx, order)
+        trans_dims = [(0, 1, 2, 3), (1, 0, 2, 3), (2, 1, 0, 3), (3, 2, 1, 0)]
+        for o, trans in zip(range(order), trans_dims):
+            self.assertTrue((indices[2 * o] == indices[2 * o + 1]).all())
+            ref = np.repeat(nabla_idx, len_idx**(order - 1)).reshape([len_idx] * order).transpose(trans).reshape(-1)
+            self.assertTrue((indices[2 * o] == ref).all())
+
 if __name__ == "__main__":
     print("Test xc_deriv")
     unittest.main()

--- a/pyscf/dft/xc_deriv.py
+++ b/pyscf/dft/xc_deriv.py
@@ -521,7 +521,7 @@ def _diagonal_indices(idx, order):
     diag_idx = [np.asarray(idx)]
     for i in range(1, order):
         last_dim = diag_idx[-1]
-        diag_idx = [np.repeat(idx, n) for x in diag_idx]
+        diag_idx = [np.repeat(x, n) for x in diag_idx]
         diag_idx.append(np.tile(last_dim, n))
     # repeat(diag_idx, 2)
     return tuple(x for x in diag_idx for i in range(2))


### PR DESCRIPTION
Hi devs!

This PR relates to issue https://github.com/pyscf/pyscf/issues/2783.

This code change will not affect 0th-5th order derivative. Previous code is behaves correct (but theoretically flaw) on these cases.

For 6th order derivative, I believe that updated `transform_xc` works well.
I have tested xcfun 6th order derivative on my computer locally (not in CI tests) based on the following forked branch:
https://github.com/ajz34/pyscf/tree/order_6