### PR TITLE
Fix bug in GTH PP with qcint

### DIFF
--- a/pyscf/pbc/df/incore.py
+++ b/pyscf/pbc/df/incore.py
@@ -261,7 +261,7 @@ class Int3cBuilder(lib.StreamObject):
             # Add penalty 1e-2 to reduce the screening error
             log_cutoff = int(np.log(cutoff*1e-2) * LOG_ADJUST)
         else:
-            cintopt = _vhf.make_cintopt(supmol._atm, supmol._bas, supmol._env, intor)
+            cintopt = _vhf.make_cintopt(atm, bas, env, intor)
 
         sindex = self.get_q_cond(supmol)
         ovlp_mask = sindex > log_cutoff


### PR DESCRIPTION
This PR fixes a bug where qcint miscalculates 3c1e integrals for GTH pseudopotentials.

explanation from @sunqm:
> In the libcint implementation, the additional information for auxiliary functions was not utilized in the int3c1e functions. Only the precomputed orbital basis part (supmol in this case) is used. Using the cintopt of supmol in libcint will not cause errors. However, these functions in qcint still runs an old implementation which reads certain auxiliary basis data from the cintopt.

Example script:
[minimal_example.py.txt](https://github.com/user-attachments/files/20494021/minimal_example.py.txt)
