### PR TITLE
Update 09-talk_to_ase.py

### DIFF
--- a/examples/pbc/09-talk_to_ase.py
+++ b/examples/pbc/09-talk_to_ase.py
@@ -15,7 +15,7 @@ import ase
 import ase.lattice
 from ase.lattice.cubic import Diamond
 from ase.units import kJ
-from ase.utils.eos import EquationOfState
+from ase.eos import EquationOfState
 
 
 ase_atom=Diamond(symbol='C', latticeconstant=3.5668)


### PR DESCRIPTION
Corrected the location of `EquationofState` in `ase.eos module`.

Instead of            `from ase.utils.eos import EquationOfState`
the correct one is `from ase.eos import EquationOfState`

https://github.com/pyscf/pyscf/blob/master/examples/pbc/09-talk_to_ase.py
It works now.
![image](https://github.com/user-attachments/assets/b8676a58-0e9a-4344-a4b2-b799cdac1216)




