### PR TITLE
Fix truncated Coulomb potential for 0-dimension cell

### DIFF
--- a/examples/pbc/31-low_dimensional_pbc.py
+++ b/examples/pbc/31-low_dimensional_pbc.py
@@ -88,6 +88,7 @@ cell.build(unit = 'B',
            mesh = [10,20,20],
            atom = 'H 0 0 0; H 0 0 1.8',
            dimension=1,
+           low_dim_ft_type='inf_vacuum', # This setting must be specified for 1D system
            verbose = 0,
            basis='sto3g')
 mf = pbchf.KRHF(cell)

--- a/examples/pbc/41-pbc1d_real_space_sum.py
+++ b/examples/pbc/41-pbc1d_real_space_sum.py
@@ -118,5 +118,5 @@ if __name__ == '__main__':
 
     from pyscf.pbc import gto, scf, tools, df
     cell = gto.M(atom='H 0 0 0; H 1.8 0 0', a=numpy.eye(3)*R, unit='bohr',
-                 dimension=1)#, basis='321g')
+                 dimension=1, low_dim_ft_type='inf_vacuum')#, basis='321g')
     mf = scf.KRHF(cell, cell.make_kpts([1,1,1])).density_fit().run()

--- a/pyscf/gto/test/test_ecp.py
+++ b/pyscf/gto/test/test_ecp.py
@@ -203,6 +203,7 @@ class KnownValues(unittest.TestCase):
         from pyscf.pbc import gto as pbcgto
         from pyscf.pbc import scf as pbcscf
         from pyscf.pbc import df
+        from pyscf.gto import pp_int
         cell = pbcgto.Cell()
         cell.atom = 'He 1. .5 .5; C .1 1.3 2.1'
         cell.basis = {'He': [(0, (2.5, 1)), (0, (1., 1))],
@@ -218,8 +219,9 @@ class KnownValues(unittest.TestCase):
          0.32235865    2     2.25670239    -0.39677748
                                             0.93894690
                                                      ''')}
-        cell.a = numpy.eye(3)
+        cell.a = numpy.eye(3) * 10
         cell.dimension = 0
+        cell.low_dim_ft_type = 'inf_vacuum'
         cell.build()
         mol = cell.to_mol()
 
@@ -236,6 +238,13 @@ class KnownValues(unittest.TestCase):
 
         e_tot = scf.RHF(mol).run().e_tot
         self.assertAlmostEqual(abs(e_ref-e_tot).max(), 0, 5)
+
+        cell.low_dim_ft_type = None
+        cell.build(False, False)
+        dat = pp_int.get_gth_pp(mol)
+        mydf = df.FFTDF(cell)
+        ref = mydf.get_pp()
+        self.assertAlmostEqual(abs(dat-ref).max(), 0, 2)
 
     def test_scalar_vs_int1e_rinv(self):
         mol = gto.M(atom='''

--- a/pyscf/pbc/df/aft_jk.py
+++ b/pyscf/pbc/df/aft_jk.py
@@ -282,9 +282,7 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None,
 
     # Add ewald_exxdiv contribution because G=0 was not included in the
     # non-uniform grids
-    if (exxdiv == 'ewald' and
-        (cell.dimension < 2 or  # 0D and 1D are computed with inf_vacuum
-         (cell.dimension == 2 and cell.low_dim_ft_type == 'inf_vacuum'))):
+    if exxdiv == 'ewald' and cell.low_dim_ft_type == 'inf_vacuum':
         _ewald_exxdiv_for_G0(cell, kpts, dms, vk_kpts, kpts)
 
     if time_reversal_symmetry:
@@ -360,9 +358,7 @@ def get_k_for_bands(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=N
 
     # Add ewald_exxdiv contribution because G=0 was not included in the
     # non-uniform grids
-    if (exxdiv == 'ewald' and
-        (cell.dimension < 2 or  # 0D and 1D are computed with inf_vacuum
-         (cell.dimension == 2 and cell.low_dim_ft_type == 'inf_vacuum'))):
+    if exxdiv == 'ewald' and cell.low_dim_ft_type == 'inf_vacuum':
         _ewald_exxdiv_for_G0(cell, kpts, dms, vk_kpts, kpts_band)
 
     return _format_jks(vk_kpts, dm_kpts, input_band, kpts)
@@ -751,9 +747,7 @@ def get_jk(mydf, dm, hermi=1, kpt=numpy.zeros(3),
             vk = vkR + vkI * 1j
         # Add ewald_exxdiv contribution because G=0 was not included in the
         # non-uniform grids
-        if (exxdiv == 'ewald' and
-            (cell.dimension < 2 or  # 0D and 1D are computed with inf_vacuum
-             (cell.dimension == 2 and cell.low_dim_ft_type == 'inf_vacuum'))):
+        if exxdiv == 'ewald' and cell.low_dim_ft_type == 'inf_vacuum':
             _ewald_exxdiv_for_G0(cell, kpt, dms, vk)
         vk = vk.reshape(dm.shape)
     return vj, vk

--- a/pyscf/pbc/df/fft.py
+++ b/pyscf/pbc/df/fft.py
@@ -42,7 +42,7 @@ def get_nuc(mydf, kpts=None):
     kpts, is_single_kpt = _check_kpts(mydf, kpts)
     cell = mydf.cell
     assert cell.low_dim_ft_type != 'inf_vacuum'
-    assert cell.dimension > 1
+    assert cell.dimension != 1
     mesh = mydf.mesh
     charge = -cell.atom_charges()
     Gv = cell.get_Gv(mesh)
@@ -71,7 +71,7 @@ def get_pp(mydf, kpts=None):
     kpts, is_single_kpt = _check_kpts(mydf, kpts)
     cell = mydf.cell
     assert cell.low_dim_ft_type != 'inf_vacuum'
-    assert cell.dimension > 1
+    assert cell.dimension != 1
     mesh = mydf.mesh
     Gv = cell.get_Gv(mesh)
     SI = cell.get_SI(mesh=mesh)
@@ -262,8 +262,7 @@ class FFTDF(lib.StreamObject):
         if kpts is None: kpts = self.kpts
         kpts = numpy.asarray(kpts)
 
-        if (cell.dimension < 2 or
-            (cell.dimension == 2 and cell.low_dim_ft_type == 'inf_vacuum')):
+        if cell.dimension <= 2 and cell.low_dim_ft_type == 'inf_vacuum':
             raise RuntimeError('FFTDF method does not support low-dimension '
                                'PBC system.  DF, MDF or AFTDF methods should '
                                'be used.\nSee also examples/pbc/31-low_dimensional_pbc.py')

--- a/pyscf/pbc/df/fft_jk.py
+++ b/pyscf/pbc/df/fft_jk.py
@@ -51,7 +51,7 @@ def get_j_kpts(mydf, dm_kpts, hermi=1, kpts=np.zeros((1,3)), kpts_band=None):
     cell = mydf.cell
     mesh = mydf.mesh
     assert cell.low_dim_ft_type != 'inf_vacuum'
-    assert cell.dimension > 1
+    assert cell.dimension != 1
 
     ni = mydf._numint
     dm_kpts = lib.asarray(dm_kpts, order='C')
@@ -117,7 +117,7 @@ def get_j_e1_kpts(mydf, dm_kpts, kpts=np.zeros((1,3)), kpts_band=None):
     cell = mydf.cell
     mesh = mydf.mesh
     assert cell.low_dim_ft_type != 'inf_vacuum'
-    assert cell.dimension > 1
+    assert cell.dimension != 1
 
     ni = mydf._numint
     dm_kpts = lib.asarray(dm_kpts, order='C')
@@ -205,7 +205,7 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=np.zeros((1,3)), kpts_band=None,
     cell = mydf.cell
     mesh = mydf.mesh
     assert cell.low_dim_ft_type != 'inf_vacuum'
-    assert cell.dimension > 1
+    assert cell.dimension != 1
     coords = cell.gen_uniform_grids(mesh)
     ngrids = coords.shape[0]
 
@@ -302,7 +302,7 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=np.zeros((1,3)), kpts_band=None,
     # different for 1D/2D and 3D systems.  The special treatments for 1D and 2D
     # can only be used with AFTDF/GDF/MDF method.  In the FFTDF method, 1D, 2D
     # and 3D should use the ewald probe charge correction.
-    if exxdiv == 'ewald':
+    if exxdiv == 'ewald' and cell.dimension != 0:
         _ewald_exxdiv_for_G0(cell, kpts, dms, vk_kpts, kpts_band=kpts_band)
 
     return _format_jks(vk_kpts, dm_kpts, input_band, kpts)
@@ -315,7 +315,7 @@ def get_k_e1_kpts(mydf, dm_kpts, kpts=np.zeros((1,3)), kpts_band=None,
     cell = mydf.cell
     mesh = mydf.mesh
     assert cell.low_dim_ft_type != 'inf_vacuum'
-    assert cell.dimension > 1
+    assert cell.dimension != 1
     coords = cell.gen_uniform_grids(mesh)
     ngrids = coords.shape[0]
 

--- a/pyscf/pbc/df/test/test_aft.py
+++ b/pyscf/pbc/df/test/test_aft.py
@@ -534,6 +534,7 @@ class KnownValues(unittest.TestCase):
         cell.basis = {'He': [(0, (2.5, 1)), (0, (1., 1))]}
         cell.a = np.eye(3) * 2.5
         cell.dimension = 1
+        cell.low_dim_ft_type = 'inf_vacuum'
         cell.mesh = [3, 3, 3]
         cell.build()
         f = aft.AFTDF(cell)

--- a/pyscf/pbc/df/test/test_df_ao2mo.py
+++ b/pyscf/pbc/df/test/test_df_ao2mo.py
@@ -121,13 +121,13 @@ class KnownValues(unittest.TestCase):
         with_df.mesh = [11]*3
         mo =(numpy.random.random((nao,nao)) +
              numpy.random.random((nao,nao))*1j)
-        with lib.temporary_env(cell, dimension = 1):
+        with lib.temporary_env(cell, dimension=1, low_dim_ft_type='inf_vacuum'):
             eri = with_df.get_eri(kpts).reshape((nao,)*4)
         eri0 = numpy.einsum('pjkl,pi->ijkl', eri , mo.conj())
         eri0 = numpy.einsum('ipkl,pj->ijkl', eri0, mo       )
         eri0 = numpy.einsum('ijpl,pk->ijkl', eri0, mo.conj())
         eri0 = numpy.einsum('ijkp,pl->ijkl', eri0, mo       )
-        with lib.temporary_env(cell, dimension = 1):
+        with lib.temporary_env(cell, dimension=1, low_dim_ft_type='inf_vacuum'):
             eri1 = with_df.ao2mo(mo, kpts)
         self.assertAlmostEqual(abs(eri1.reshape(eri0.shape)-eri0).sum(), 0, 9)
 

--- a/pyscf/pbc/df/test/test_gdf_builder.py
+++ b/pyscf/pbc/df/test/test_gdf_builder.py
@@ -179,6 +179,7 @@ class KnownValues(unittest.TestCase):
         cell = pgto.M(atom='He 0 0 0; He 0.9 0 0',
                       basis=basis,
                       a=np.eye(3) * 2.8,
+                      low_dim_ft_type='inf_vacuum',
                       dimension=1)
         auxcell = df.make_auxcell(cell, auxbasis)
         dfbuilder = gdf_builder._CCGDFBuilder(cell, auxcell).build()

--- a/pyscf/pbc/df/test/test_mdf_jk.py
+++ b/pyscf/pbc/df/test/test_mdf_jk.py
@@ -338,14 +338,15 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(lib.fp(vj0), 0.08265798268352553, 9)
         self.assertAlmostEqual(lib.fp(vk0), 0.2375705823780625 , 9)
         vj1, vk1 = pbcdf.GDF(cell).get_jk(dm, hermi=0, omega=0.5, exxdiv=None)
-        vj2, vk2 = pbcdf.MDF(cell).get_jk(dm, hermi=0, omega=0.5, exxdiv=None)
-        vj3, vk3 = pbcdf.AFTDF(cell).get_jk(dm, hermi=0, omega=0.5, exxdiv=None)
-        self.assertAlmostEqual(abs(vj0-vj1).max(), 0, 3)
-        self.assertAlmostEqual(abs(vj0-vj2).max(), 0, 3)
-        self.assertAlmostEqual(abs(vj0-vj3).max(), 0, 3)
-        self.assertAlmostEqual(abs(vk0-vk1).max(), 0, 3)
-        self.assertAlmostEqual(abs(vk0-vk2).max(), 0, 3)
-        self.assertAlmostEqual(abs(vk0-vk3).max(), 0, 3)
+        self.assertAlmostEqual(abs(vj0-vj1).max(), 0, 9)
+        self.assertAlmostEqual(abs(vk0-vk1).max(), 0, 9)
+        # The previous implementation of LR Coulomb kernel for dimension=0 is incorrect
+        #vj2, vk2 = pbcdf.MDF(cell).get_jk(dm, hermi=0, omega=0.5, exxdiv=None)
+        #vj3, vk3 = pbcdf.AFTDF(cell).get_jk(dm, hermi=0, omega=0.5, exxdiv=None)
+        #self.assertAlmostEqual(abs(vj0-vj2).max(), 0, 3)
+        #self.assertAlmostEqual(abs(vj0-vj3).max(), 0, 3)
+        #self.assertAlmostEqual(abs(vk0-vk2).max(), 0, 3)
+        #self.assertAlmostEqual(abs(vk0-vk3).max(), 0, 3)
 
 
 if __name__ == '__main__':

--- a/pyscf/pbc/df/test/test_rsdf_ao2mo.py
+++ b/pyscf/pbc/df/test/test_rsdf_ao2mo.py
@@ -120,13 +120,13 @@ class KnownValues(unittest.TestCase):
         with_df.kpts = kpts
         mo =(numpy.random.random((nao,nao)) +
              numpy.random.random((nao,nao))*1j)
-        with lib.temporary_env(cell, dimension = 1):
+        with lib.temporary_env(cell, dimension=1, low_dim_ft_type='inf_vacuum'):
             eri = with_df.get_eri(kpts).reshape((nao,)*4)
         eri0 = numpy.einsum('pjkl,pi->ijkl', eri , mo.conj())
         eri0 = numpy.einsum('ipkl,pj->ijkl', eri0, mo       )
         eri0 = numpy.einsum('ijpl,pk->ijkl', eri0, mo.conj())
         eri0 = numpy.einsum('ijkp,pl->ijkl', eri0, mo       )
-        with lib.temporary_env(cell, dimension = 1):
+        with lib.temporary_env(cell, dimension=1, low_dim_ft_type='inf_vacuum'):
             eri1 = with_df.ao2mo(mo, kpts)
         self.assertAlmostEqual(abs(eri1.reshape(eri0.shape)-eri0).sum(), 0, 9)
 

--- a/pyscf/pbc/df/test/test_rsdf_builder.py
+++ b/pyscf/pbc/df/test/test_rsdf_builder.py
@@ -219,6 +219,7 @@ class KnownValues(unittest.TestCase):
         cell = pgto.M(atom='He 0 0 0; He 0.9 0 0',
                       basis=basis,
                       a=np.eye(3) * 2.8,
+                      low_dim_ft_type='inf_vacuum',
                       dimension=1)
         auxcell = df.make_auxcell(cell, auxbasis)
         dfbuilder = rsdf_builder._RSGDFBuilder(cell, auxcell).build()
@@ -227,7 +228,6 @@ class KnownValues(unittest.TestCase):
             v2 = load(tmpf.name, kpts[[0, 0]])
             self.assertAlmostEqual(lib.fp(v2), 1.7171973261620863, 5)
 
-    @unittest.skip('_RSGDFBuilder for dimension=0 not accurate')
     def test_make_j3c_gamma_0d(self):
         from pyscf.df.incore import cholesky_eri
         cell = pgto.M(atom='He 0 0 0; He 0.9 0 0',

--- a/pyscf/pbc/dft/test/test_rks.py
+++ b/pyscf/pbc/dft/test/test_rks.py
@@ -183,7 +183,7 @@ class KnownValues(unittest.TestCase):
         mf.kernel()
         self.assertAlmostEqual(mf.e_tot, -2.4745140705800446, 7)
 
-    def test_rsh_0d(self):
+    def test_rsh_0d_df(self):
         L = 4.
         cell = pbcgto.Cell()
         cell.verbose = 0
@@ -205,25 +205,31 @@ class KnownValues(unittest.TestCase):
         mf1.xc = 'camb3lyp'
         mf1.omega = '0.7'
         mf1.kernel()
-        self.assertAlmostEqual(mf1.e_tot-mf1.energy_nuc(), mf.e_tot-mf.energy_nuc(), 7)
+        self.assertAlmostEqual(mf1.e_tot, mf.e_tot, 7)
 
-    @unittest.skip('ewald should not be enabled for 0d')
-    def test_rsh_0d_ewald(self):
-        L = 4.
+    def test_rsh_0d(self):
         cell = pbcgto.Cell()
         cell.verbose = 0
-        cell.a = np.eye(3)*L
-        cell.atom =[['He' , ( L/2+0., L/2+0. ,   L/2+1.)],]
-        cell.basis = {'He': [[0, (4.0, 1.0)], [0, (1.0, 1.0)]]}
+        cell.a = np.eye(3)*7
+        cell.atom =[['H' , ( 0., 0. , 1.)],
+                    ['H' , ( .5, .4 , 1.)],]
+        cell.basis = {'H': [[0, (4.0, 1.0)], [0, (1.0, 1.0)]]}
         cell.dimension = 0
-        cell.mesh = [60]*3
+        cell.mesh = [85]*3
         cell.build()
-        mf = pbcdft.RKS(cell).density_fit()
+        mf = pbcdft.RKS(cell)
         mf.xc = 'camb3lyp'
-        mf.omega = '0.7'
-        mf.exxdiv = 'ewald'
+        mf.omega = 0.35
+        mf.exxdiv = None
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -2.47559566263186, 4)
+        self.assertAlmostEqual(mf.e_tot, -0.6034853818650204, 7)
+
+        mol = cell.to_mol()
+        mf1 = mol.RKS()
+        mf1.xc = 'camb3lyp'
+        mf1.omega = 0.35
+        mf1.kernel()
+        self.assertAlmostEqual(mf1.e_tot, mf.e_tot, 7)
 
 if __name__ == '__main__':
     print("Full Tests for pbc.dft.rks")

--- a/pyscf/pbc/gto/cell.py
+++ b/pyscf/pbc/gto/cell.py
@@ -556,8 +556,7 @@ def get_Gv_weights(cell, mesh=None, **kwargs):
     b = cell.reciprocal_vectors()
     weights = abs(np.linalg.det(b))
 
-    if (cell.dimension < 2 or
-        (cell.dimension == 2 and cell.low_dim_ft_type == 'inf_vacuum')):
+    if cell.dimension <= 2 and cell.low_dim_ft_type == 'inf_vacuum':
         if cell.dimension == 0:
             rx, wx = _non_uniform_Gv_base(mesh[0]//2)
             ry, wy = _non_uniform_Gv_base(mesh[1]//2)
@@ -673,8 +672,11 @@ def get_ewald_params(cell, precision=None, mesh=None):
     if precision is None:
         precision = cell.precision
 
-    if (cell.dimension < 2 or
-          (cell.dimension == 2 and cell.low_dim_ft_type == 'inf_vacuum')):
+    if (cell.dimension == 3 or
+        (cell.dimension == 0 and cell.low_dim_ft_type != 'inf_vacuum')):
+        ew_eta = 1./cell.vol**(1./6)
+        ew_cut = _estimate_rcut(ew_eta**2, 0, 1., precision)
+    elif cell.dimension <= 2 and cell.low_dim_ft_type == 'inf_vacuum':
         # Non-uniform PW grids are used for low-dimensional ewald summation.  The cutoff
         # estimation for long range part based on exp(G^2/(4*eta^2)) does not work for
         # non-uniform grids.  Smooth model density is preferred.
@@ -686,9 +688,8 @@ def get_ewald_params(cell, precision=None, mesh=None):
         # ewovrl ~ erfc(eta*rcut) / rcut ~ e^{(-eta**2 rcut*2)} < precision
         log_precision = np.log(precision / (cell.atom_charges().sum()*16*np.pi**2))
         ew_eta = (-log_precision)**.5 / ew_cut
-    else:  # dimension == 3
-        ew_eta = 1./cell.vol**(1./6)
-        ew_cut = _estimate_rcut(ew_eta**2, 0, 1., precision)
+    else:
+        raise RuntimeError(f'dimension={cell.dimension} not supported')
     return ew_eta, ew_cut
 
 def ewald(cell, ew_eta=None, ew_cut=None):
@@ -714,6 +715,9 @@ def ewald(cell, ew_eta=None, ew_cut=None):
     if cell.dimension == 3 and cell.use_particle_mesh_ewald:
         from pyscf.pbc.gto import ewald_methods
         return ewald_methods.particle_mesh_ewald(cell, ew_eta, ew_cut)
+
+    if cell.dimension == 0 and cell.low_dim_ft_type != 'inf_vacuum':
+        return mole.classical_coulomb_energy(cell)
 
     chargs = cell.atom_charges()
 
@@ -747,16 +751,15 @@ def ewald(cell, ew_eta=None, ew_cut=None):
     # where
     #   ZS_I(G) = \sum_a Z_a exp (i G.R_a)
 
-    if cell.dimension != 2 or cell.low_dim_ft_type == 'inf_vacuum':
+    if cell.dimension == 3 or cell.low_dim_ft_type == 'inf_vacuum':
         Gv, Gvbase, weights = cell.get_Gv_weights(mesh)
         absG2 = np.einsum('gi,gi->g', Gv, Gv)
         absG2[absG2==0] = 1e200
-
         coulG = 4*np.pi / absG2
         coulG *= weights
 
         #:ZSI = np.einsum('i,ij->j', chargs, cell.get_SI(Gv))
-        basex, basey, basez = cell.get_Gv_weights(mesh)[1]
+        basex, basey, basez = Gvbase
         b = cell.reciprocal_vectors()
         rb = np.dot(coords, b.T)
         SIx = np.exp(-1j*np.einsum('z,g->zg', rb[:,0], basex))
@@ -801,6 +804,13 @@ def ewald(cell, ew_eta=None, ew_cut=None):
         # Performing the G == 0 summation.
         ewg += np.einsum('i,j,ij->', chargs, chargs, gn0(ew_eta,rij[:,:,2]))
         ewg *= inv_area*0.5
+
+    elif cell.dimension == 0:
+        # The truncted Coulomb kernel 4*pi/G^2(1-cos(G*Rc)) should work for the
+        # ewg term. However, large errors may be introduced in ewovrl or ewself.
+        # For dimesion=0 with truncated Coulomb, the nuclear energy can be
+        # computed directly using the mole.classical_coulomb_energy function.
+        raise RuntimeError('Ewald with truncated Coulomb')
 
     else:
         logger.warn(cell, 'No method for PBC dimension %s, dim-type %s.'
@@ -1515,6 +1525,9 @@ class Cell(mole.MoleBase):
         if self.a is None:
             raise RuntimeError('Lattice parameters not specified')
 
+        if self.dimension == 1 and self.low_dim_ft_type != 'inf_vacuum':
+            raise RuntimeError('Uniform grids for dimension=1 not supported')
+
         _built = self._built
         mole.MoleBase.build(self, False, parse_arg, *args, **kwargs)
 
@@ -1603,7 +1616,7 @@ class Cell(mole.MoleBase):
   Lattice are not in right-handed coordinate system. This can cause wrong value for some integrals.
   It's recommended to resort the lattice vectors to\na = %s\n\n''' % _a[[0,2,1]])
 
-        if self.dimension == 2 and self.low_dim_ft_type != 'inf_vacuum':
+        if self.dimension <= 2 and self.low_dim_ft_type != 'inf_vacuum':
             # check vacuum size. See Fig 1 of PRB, 73, 2015119
             #Lz_guess = self.rcut*(1+np.sqrt(2))
             Lz_guess = self.rcut * 2
@@ -1619,8 +1632,7 @@ class Cell(mole.MoleBase):
                 ke_cutoff = self.ke_cutoff
             self._mesh = pbctools.cutoff_to_mesh(_a, ke_cutoff)
 
-            if (self.dimension < 2 or
-                (self.dimension == 2 and self.low_dim_ft_type == 'inf_vacuum')):
+            if self.dimension <= 2 and self.low_dim_ft_type == 'inf_vacuum':
                 self._mesh[self.dimension:] = _mesh_inf_vaccum(self)
             self._mesh_from_build = True
 

--- a/pyscf/pbc/gto/pseudo/pp_int.py
+++ b/pyscf/pbc/gto/pseudo/pp_int.py
@@ -25,6 +25,7 @@ For GTH/HGH PPs, see:
 
 import ctypes
 import numpy
+import numpy as np
 import scipy.special
 from pyscf import lib
 from pyscf import gto
@@ -56,7 +57,7 @@ def get_gth_vlocG_part1(cell, Gv):
     G2 = numpy.einsum('ix,ix->i', Gv, Gv)
     G0idx = numpy.where(G2==0)[0]
 
-    if cell.dimension != 2 or cell.low_dim_ft_type == 'inf_vacuum':
+    if cell.dimension == 3 or cell.dimension == 0 or cell.low_dim_ft_type == 'inf_vacuum':
         vlocG = numpy.zeros((cell.natm, len(G2)))
         for ia in range(cell.natm):
             Zia = cell.atom_charge(ia)
@@ -68,7 +69,7 @@ def get_gth_vlocG_part1(cell, Gv):
                 rloc, nexp, cexp = pp[1:3+1]
                 vlocG[ia] *= numpy.exp(-0.5*rloc**2 * G2)
                 # alpha parameters from the non-divergent Hartree+Vloc G=0 term.
-                vlocG[ia,G0idx] = -2*numpy.pi*Zia*rloc**2
+                vlocG[ia,G0idx] += -2*numpy.pi*Zia*rloc**2
 
     elif cell.dimension == 2:
         # The following 2D ewald summation is taken from:

--- a/pyscf/pbc/gto/test/test_rcut.py
+++ b/pyscf/pbc/gto/test/test_rcut.py
@@ -70,7 +70,8 @@ class KnownValues(unittest.TestCase):
 
     # For atoms out of the rcut on the non-periodic directions. See issue #2460
     def test_lattice_Ls_low_dim(self):
-        cell = gto.M(atom='H 0 9 9', a=numpy.diag([1.,2.,2.]), dimension=1)
+        cell = gto.M(atom='H 0 9 9', a=numpy.diag([1.,2.,2.]), dimension=1,
+                     low_dim_ft_type='inf_vacuum')
         Ls = eval_gto.get_lattice_Ls(cell)
         self.assertTrue(len(Ls) > 15)
 

--- a/pyscf/pbc/mp/test/test_dm.py
+++ b/pyscf/pbc/mp/test/test_dm.py
@@ -28,6 +28,7 @@ def setUpModule():
     cell.basis = 'sto-3g'
     cell.a = [[2.82, 0, 0], [0, 2.82, 0], [0, 0, 2.82]]
     cell.dimension = 1
+    cell.low_dim_ft_type = 'inf_vacuum'
     cell.output = '/dev/null'
     cell.build()
 

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -728,6 +728,13 @@ class SCF(mol_hf.SCF):
 
     def energy_nuc(self):
         cell = self.cell
+        if (cell.dimension == 0 and
+            # When computing CDERI for GDF (also RSJK), the LR part is not
+            # evaluated. CDERI is constructed with full-range Coulomb directly.
+            # Nuclear repulsion should be computed the same way.
+            isinstance(self.with_df, df.GDF) or self.rsjk is not None):
+            from pyscf.gto.mole import classical_coulomb_energy
+            return classical_coulomb_energy(cell)
         return cell.enuc
 
     @lib.with_doc(dip_moment.__doc__)

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -728,12 +728,6 @@ class SCF(mol_hf.SCF):
 
     def energy_nuc(self):
         cell = self.cell
-        if (cell.dimension == 0 and
-            # Integrals in GDF and RSJK are all computed in real space.
-            # Nuclear repulsion should be computed in real space.
-            not isinstance(self.with_df, df.AFTDF)):
-            from pyscf.gto.mole import classical_coulomb_energy
-            return classical_coulomb_energy(cell)
         return cell.enuc
 
     @lib.with_doc(dip_moment.__doc__)

--- a/pyscf/pbc/scf/test/test_hf.py
+++ b/pyscf/pbc/scf/test/test_hf.py
@@ -258,12 +258,13 @@ class KnownValues(unittest.TestCase):
 #        self.assertAlmostEqual(lib.fp(e1[0]), -6.8312867098806249, 7)
 #        self.assertAlmostEqual(lib.fp(e1[1]), -6.1120214505413086, 7)
 
-    def test_rhf_0d(self):
+    def test_rhf_0d_inf_vacuum(self):
         cell = pbcgto.Cell()
         cell.build(unit = 'B',
                    a = numpy.eye(3)*5,
                    atom = '''He 2 2 2; He 2 2 3''',
                    dimension = 0,
+                   low_dim_ft_type = 'inf_vacuum',
                    verbose = 0,
                    basis = { 'He': [[0, (0.8, 1.0)],
                                     [0, (1.0, 1.0)],
@@ -296,6 +297,7 @@ class KnownValues(unittest.TestCase):
                                                      ''')}
         cell.a = numpy.eye(3)
         cell.dimension = 0
+        cell.low_dim_ft_type = 'inf_vacuum'
         cell.build()
         mf = pscf.RHF(cell)
         mf.with_df = pdf.AFTDF(cell)
@@ -305,6 +307,30 @@ class KnownValues(unittest.TestCase):
         mf1 = mol.RHF().run()
         self.assertAlmostEqual(mf1.e_tot, -5.66198034773817, 8)
         self.assertAlmostEqual(mf1.e_tot, mf.e_tot, 4)
+
+    def test_rhf_0d(self):
+        cell = pbcgto.Cell()
+        cell.build(unit = 'B',
+                   a = numpy.eye(3)*15,
+                   atom = '''He 2 2 2; He 2 2 3''',
+                   dimension = 0,
+                   verbose = 0,
+                   basis = { 'He': [[0, (0.8, 1.0)],
+                                    [0, (1.0, 1.0)],
+                                    [0, (1.2, 1.0)]]})
+        eref = cell.to_mol().RHF().kernel()
+        mf = cell.RHF()
+        e1 = mf.kernel()
+        self.assertAlmostEqual(e1, eref, 7)
+
+        mf = cell.RHF()
+        mf.with_df = pdf.AFTDF(cell)
+        e1 = mf.kernel()
+        self.assertAlmostEqual(e1, eref, 7)
+
+        eref = cell.to_mol().RHF().density_fit().kernel()
+        e1 = cell.RHF().density_fit().kernel()
+        self.assertAlmostEqual(e1, eref, 8)
 
     def test_rhf_1d(self):
         L = 4

--- a/pyscf/pbc/scf/test/test_hf.py
+++ b/pyscf/pbc/scf/test/test_hf.py
@@ -514,7 +514,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(lib.fp(dm), 0.025922864381755062, 6)
 
     def test_init_guess_by_minao(self):
-        with lib.temporary_env(cell, dimension=1):
+        with lib.temporary_env(cell, dimension=1, low_dim_ft_type='inf_vacuum'):
             dm = mf.get_init_guess(key='minao')
             kdm = kmf.get_init_guess(key='minao')
 
@@ -524,7 +524,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(lib.fp(kdm), -1.714952331211208, 8)
 
     def test_init_guess_by_atom(self):
-        with lib.temporary_env(cell, dimension=1):
+        with lib.temporary_env(cell, dimension=1, low_dim_ft_type='inf_vacuum'):
             dm = mf.get_init_guess(key='atom')
             kdm = kmf.get_init_guess(key='atom')
 

--- a/pyscf/pbc/scf/test/test_rohf.py
+++ b/pyscf/pbc/scf/test/test_rohf.py
@@ -102,6 +102,7 @@ class KnownValues(unittest.TestCase):
     def test_get_init_guess(self):
         cell1 = cell.copy()
         cell1.dimension = 1
+        cell1.low_dim_ft_type = 'inf_vacuum'
         cell1.build(0, 0)
         mf = pscf.ROHF(cell1)
         dm = mf.get_init_guess(key='minao')

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -277,6 +277,28 @@ def get_coulG(cell, k=np.zeros(3), exx=False, mf=None, mesh=None, Gv=None,
     if Gv is None:
         Gv = cell.get_Gv(mesh)
 
+    if omega is None:
+        _omega = cell.omega
+    else:
+        _omega = omega
+
+    if cell.dimension == 0 and cell.low_dim_ft_type != 'inf_vacuum':
+        if _omega != 0:
+            raise NotImplementedError('coulG kernel for range-separated Coulomb potential')
+        a = cell.lattice_vectors()
+        assert abs(np.eye(3)*a[0,0] - a).max() < 1e-6, \
+                'Must be cubic box for cell.dimension=0'
+        # ensure the sphere is completely inside the box
+        Rc = a[0,0] / 2
+        absG = np.linalg.norm(Gv, axis=1)
+        with np.errstate(divide='ignore',invalid='ignore'):
+            coulG = 4*np.pi/absG**2 * (1. - np.cos(absG*Rc))
+        coulG[0] = 0.
+        # G=0 term carries the charge. This special term supports the charged
+        # system for dimension=0.
+        coulG[0] = 2*np.pi*Rc**2
+        return coulG
+
     if abs(k).sum() > 1e-9:
         kG = k + Gv
     else:
@@ -358,7 +380,7 @@ def get_coulG(cell, k=np.zeros(3), exx=False, mf=None, mesh=None, Gv=None,
         # error in exchange integrals
 
         G0_idx = np.where(absG2==0)[0]
-        if cell.dimension != 2 or cell.low_dim_ft_type == 'inf_vacuum':
+        if cell.dimension == 3 or cell.low_dim_ft_type == 'inf_vacuum':
             with np.errstate(divide='ignore'):
                 coulG = 4*np.pi/absG2
                 coulG[G0_idx] = 0
@@ -380,7 +402,7 @@ def get_coulG(cell, k=np.zeros(3), exx=False, mf=None, mesh=None, Gv=None,
             logger.warn(cell, 'No method for PBC dimension 1, dim-type %s.'
                         '  cell.low_dim_ft_type="inf_vacuum"  should be set.',
                         cell.low_dim_ft_type)
-            raise NotImplementedError
+            raise NotImplementedError('truncated coulG for dimension=1 is numerically inaccurate')
 
             # Carlo A. Rozzi, PRB 73, 205119 (2006)
             a = cell.lattice_vectors()
@@ -396,6 +418,9 @@ def get_coulG(cell, k=np.zeros(3), exx=False, mf=None, mesh=None, Gv=None,
                 # coulG[Gx==0] = -4*np.pi * (dr * r * scipy.special.j0(Gp*r) * np.log(r)).sum()
             if len(G0_idx) > 0:
                 coulG[G0_idx] = -np.pi*Rc**2 * (2*np.log(Rc) - 1)
+        else:
+            raise NotImplementedError(f'dimension={cell.dimension} with '
+                                      f'low_dim_ft_type={cell.low_dim_ft_type} is not supported')
 
     if equal2boundary is not None:
         coulG[equal2boundary] = 0
@@ -405,10 +430,9 @@ def get_coulG(cell, k=np.zeros(3), exx=False, mf=None, mesh=None, Gv=None,
     # being evaluated with regular Coulomb interaction (1/r12).
     # * cell.omega, which affects the ewald probe charge, is often set by
     # DFT-RSH functionals to build long-range HF-exchange for erf(omega*r12)/r12
-    if omega is None:
-        _omega = cell.omega
-    else:
-        _omega = omega
+    if _omega != 0 and cell.dimension != 3:
+        logger.warn(cell, 'The coulG kernel for range-separated Coulomb potential '
+                    f'for PBC {cell.dimension} is inaccurate.')
     if _omega > 0:
         # long range part
         coulG *= np.exp(-.25/_omega**2 * absG2)


### PR DESCRIPTION
This PR fixes the treatment of the truncated Coulomb potential for a 0-dimensional (0D) cell in the PBC module.

The 0D cell computed with the pbc integral code (including FFTDF, AFTDF, GDF, etc.) is fully consistent with the molecular code that uses analytical Coulomb integrals

(depends on #2814)
