### PR TITLE
Fix issue #2856 by taking real part of subspace matrices

### DIFF
--- a/pyscf/soscf/ciah.py
+++ b/pyscf/soscf/ciah.py
@@ -224,19 +224,19 @@ def davidson_cc(h_op, g_op, precond, x0, tol=1e-10, xs=[], ax=[],
     else:
         for i in range(1, nx+1):
             for j in range(1, i+1):
-                heff[i,j] = dot(xs[i-1].conj(), ax[j-1])
-                ovlp[i,j] = dot(xs[i-1].conj(), xs[j-1])
-            heff[1:i,i] = heff[i,1:i].conj()
-            ovlp[1:i,i] = ovlp[i,1:i].conj()
+                heff[i,j] = dot(xs[i-1].conj(), ax[j-1]).real
+                ovlp[i,j] = dot(xs[i-1].conj(), xs[j-1]).real
+            heff[1:i,i] = heff[i,1:i]
+            ovlp[1:i,i] = ovlp[i,1:i]
 
     w_t = 0
     for istep in range(max_cycle):
         g = g_op()
         nx = len(xs)
         for i in range(nx):
-            heff[i+1,0] = dot(xs[i].conj(), g)
-            heff[nx,i+1] = dot(xs[nx-1].conj(), ax[i])
-            ovlp[nx,i+1] = dot(xs[nx-1].conj(), xs[i])
+            heff[i+1,0] = dot(xs[i].conj(), g).real
+            heff[nx,i+1] = dot(xs[nx-1].conj(), ax[i]).real
+            ovlp[nx,i+1] = dot(xs[nx-1].conj(), xs[i]).real
         heff[0,:nx+1] = heff[:nx+1,0].conj()
         heff[1:nx,nx] = heff[nx,1:nx].conj()
         ovlp[1:nx,nx] = ovlp[nx,1:nx].conj()

--- a/pyscf/soscf/ciah.py
+++ b/pyscf/soscf/ciah.py
@@ -222,6 +222,13 @@ def davidson_cc(h_op, g_op, precond, x0, tol=1e-10, xs=[], ax=[],
         xs.append(x0)
         ax.append(h_op(x0))
     else:
+        # Note, the subspace H must be real even for Hessian of complex orbitals.
+        # See https://doi.org/10.1063/1.5036594 .
+        # In the case of complex orbitals, the subspace H should be constructed as
+        # a 2N x 2N real matrix, where N is the number of parameters in rotation.
+        # The extended space corresponds to the t^dagger for rotation parameters.
+        # This function only constructs one diagonal block of the Hessian matrix.
+        # This is an effective approximation to the solution from the standard Hessian.
         for i in range(1, nx+1):
             for j in range(1, i+1):
                 heff[i,j] = dot(xs[i-1].conj(), ax[j-1]).real


### PR DESCRIPTION
In the current soscf implementation, the subspace matrices take complex conjugate form, the gradient was only evaluated with respect to orbital rotation parameters kappa instead of both kappa and kappa^dagger as was done in second optimization for complex valued wavefunctions e.g. in https://doi.org/10.1063/1.5036594. If doing properly, the subspace matrices should end up equal the real part of the current implementation. The same argument should hold for other complex valued mean-field reference. Therefore, taking the real part in the davidson_cc function should be an adequate fix.