### PR TITLE
Fix: use atom_pure_symbol for geometric elem

### DIFF
--- a/pyscf/geomopt/geometric_solver.py
+++ b/pyscf/geomopt/geometric_solver.py
@@ -53,7 +53,7 @@ class PySCFEngine(geometric.engine.Engine):
     def __init__(self, scanner):
         molecule = geometric.molecule.Molecule()
         self.mol = mol = scanner.mol
-        molecule.elem = [mol.atom_symbol(i) for i in range(mol.natm)]
+        molecule.elem = [mol.atom_pure_symbol(i) for i in range(mol.natm)]
         # Molecule is the geometry parser for a bunch of formats which use
         # Angstrom for Cartesian coordinates by default.
         molecule.xyzs = [mol.atom_coords()*lib.param.BOHR]  # In Angstrom


### PR DESCRIPTION
geomeTRIC does not support decorated atom symbol, like 'C1', so use `atom_pure_symbol` for it. 

Otherwise there will be an error like
```
Traceback (most recent call last):
  File "/share/home/srwang/xxx/scan_mcpdft/relax.py", line 44, in <module>
    mol_eq = mc.nuc_grad_method().optimizer().kernel({'constraints': f'cons_{name}.txt'})
  File "/share/home/srwang/pyscf2/pyscf/geomopt/geometric_solver.py", line 239, in kernel
    kernel(self.method, callback=self.callback,
  File "/share/home/srwang/pyscf2/pyscf/geomopt/geometric_solver.py", line 160, in kernel
    geometric.optimize.run_optimizer(customengine=engine, input=tmpf,
  File "/share/home/srwang/anaconda3/envs/py310-cf/lib/python3.10/site-packages/geometric/optimize.py", line 1249, in run_optimizer
    IC = CoordClass(M, build=True, connect=connect, addcart=addcart, constraints=Cons, cvals=CVals[0] if CVals is not None else None,
  File "/share/home/srwang/anaconda3/envs/py310-cf/lib/python3.10/site-packages/geometric/internal.py", line 2987, in __init__
    self.Prims = PrimitiveInternalCoordinates(molecule, connect=connect, addcart=addcart, constraints=constraints, cvals=cvals, connect_isolated=connect_isolated)
  File "/share/home/srwang/anaconda3/envs/py310-cf/lib/python3.10/site-packages/geometric/internal.py", line 2185, in __init__
    self.mass = np.repeat([PeriodicTable[i] for i in self.elem], 3)
  File "/share/home/srwang/anaconda3/envs/py310-cf/lib/python3.10/site-packages/geometric/internal.py", line 2185, in <listcomp>
    self.mass = np.repeat([PeriodicTable[i] for i in self.elem], 3)
KeyError: 'C1'
```