### PR TITLE
Low-Memory and Efficient Implementation of RCCSD(T) lambda-equation and RDM Intermediates

### DIFF
--- a/pyscf/cc/ccsd_t_lambda.py
+++ b/pyscf/cc/ccsd_t_lambda.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+# Copyright 2014-2021 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Qiming Sun <osirpt.sun@gmail.com>
+#         Yu Jin <jinyuchem@uchicago.edu>
+#
+
+'''
+Spin-free lambda equation of RHF-CCSD(T)
+
+Ref:
+JCP 147, 044104 (2017); DOI:10.1063/1.4994918
+'''
+
+import ctypes
+import numpy
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf.cc import ccsd, ccsd_lambda, _ccsd
+
+# Note: not support fov != 0
+
+def kernel(mycc, eris=None, t1=None, t2=None, l1=None, l2=None,
+           max_cycle=50, tol=1e-8, verbose=logger.INFO):
+    return ccsd_lambda.kernel(mycc, eris, t1, t2, l1, l2, max_cycle, tol,
+                              verbose, make_intermediates, update_lambda)
+
+def make_intermediates(mycc, t1, t2, eris):
+    if numpy.iscomplexobj(t1) or numpy.iscomplexobj(t2) or numpy.iscomplexobj(eris):
+        raise ValueError("make_intermediates does not support complex-valued inputs (t1, t2, or eris)")
+
+    imds = ccsd_lambda.make_intermediates(mycc, t1, t2, eris)
+
+    nocc, nvir = t1.shape
+    eris_ovvv = numpy.asarray(eris.get_ovvv())
+    eris_ovoo = numpy.asarray(eris.ovoo)
+    eris_ovov = numpy.asarray(eris.ovov)
+
+    mo_e = eris.mo_energy
+    eia = lib.direct_sum('i-a->ia', mo_e[:nocc], mo_e[nocc:])
+
+    imds.l1_t = numpy.zeros((nocc, nvir), dtype=t1.dtype)
+    joovv = numpy.zeros((nocc, nocc, nvir, nvir), dtype=t1.dtype)
+
+    mem_now = lib.current_memory()[0]
+    max_memory = max(0, mycc.max_memory - mem_now)
+    blksize = min(nvir, int(((max_memory * 0.9e6/8) / 6.0 / (nocc**3))**(1/3)))
+    if blksize < nvir:
+        blksize = min(blksize, (nvir + 1) // 2)
+        blksize = max(blksize, 1)
+    print('blksize', blksize)
+
+    w_blk = numpy.empty((blksize, blksize, blksize, nocc, nocc, nocc), dtype=t1.dtype)
+    v_blk = numpy.empty((blksize, blksize, blksize, nocc, nocc, nocc), dtype=t1.dtype)
+
+    for c0, c1 in lib.prange(0, nvir, blksize):
+        bc = c1 - c0
+        for b0, b1 in lib.prange(0, nvir, blksize):
+            bb = b1 - b0
+            for a0, a1 in lib.prange(0, nvir, blksize):
+                ba = a1 - a0
+
+                w_blk[:ba, :bb, :bc] = lib.einsum('iafb,kjcf->abcijk',
+                    eris_ovvv[:, a0:a1, :, b0:b1], t2[:, :, c0:c1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('iafc,jkbf->abcijk',
+                    eris_ovvv[:, a0:a1, :, c0:c1], t2[:, :, b0:b1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('jbfa,kicf->abcijk',
+                    eris_ovvv[:, b0:b1, :, a0:a1], t2[:, :, c0:c1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('jbfc,ikaf->abcijk',
+                    eris_ovvv[:, b0:b1, :, c0:c1], t2[:, :, a0:a1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('kcfa,jibf->abcijk',
+                    eris_ovvv[:, c0:c1, :, a0:a1], t2[:, :, b0:b1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('kcfb,ijaf->abcijk',
+                    eris_ovvv[:, c0:c1, :, b0:b1], t2[:, :, a0:a1, :])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('iajm,mkbc->abcijk',
+                    eris_ovoo[:, a0:a1, :, :], t2[:, :, b0:b1, c0:c1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('iakm,mjcb->abcijk',
+                    eris_ovoo[:, a0:a1, :, :], t2[:, :, c0:c1, b0:b1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('jbim,mkac->abcijk',
+                    eris_ovoo[:, b0:b1, :, :], t2[:, :, a0:a1, c0:c1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('jbkm,mica->abcijk',
+                    eris_ovoo[:, b0:b1, :, :], t2[:, :, c0:c1, a0:a1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('kcim,mjab->abcijk',
+                    eris_ovoo[:, c0:c1, :, :], t2[:, :, a0:a1, b0:b1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('kcjm,miba->abcijk',
+                    eris_ovoo[:, c0:c1, :, :], t2[:, :, b0:b1, a0:a1])
+
+                v_blk[:ba, :bb, :bc] = lib.einsum('iajb,kc->abcijk',
+                    eris_ovov[:, a0:a1, :, b0:b1], t1[:, c0:c1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('iakc,jb->abcijk',
+                    eris_ovov[:, a0:a1, :, c0:c1], t1[:, b0:b1])
+                v_blk[:ba, :bb, :bc] += lib. einsum('jbkc,ia->abcijk',
+                    eris_ovov[:, b0:b1, :, c0:c1], t1[:, a0:a1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('ck,ijab->abcijk',
+                    eris.fock[nocc + c0:nocc + c1, :nocc], t2[:, :, a0:a1, b0:b1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('ai,jkbc->abcijk',
+                    eris.fock[nocc + a0:nocc + a1, :nocc], t2[:, :, b0:b1, c0:c1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('bj,kica->abcijk',
+                    eris.fock[nocc + b0:nocc + b1, :nocc], t2[:, :, c0:c1, a0:a1])
+
+                d3_blk = lib.direct_sum('ia,jb,kc->abcijk', eia[:, a0:a1], eia[:, b0:b1], eia[:, c0:c1])
+                w_blk[:ba, :bb, :bc] /= d3_blk
+                v_blk[:ba, :bb, :bc] /= d3_blk
+
+                v_blk += 2.0 * w_blk
+                t3_symm_ip_py(v_blk, blksize**3, nocc, "2-1000-1", 1.0, 0.0)
+                joovv[:, :, a0:a1, :] += lib.einsum('kceb,abcijk->ijae',
+                    eris_ovvv[:, c0:c1, :, b0:b1], v_blk[:ba, :bb, :bc, :, :, :])
+                joovv[:, :, a0:a1, b0:b1] -= lib.einsum('ncmj,abcimn->ijab',
+                    eris_ovoo[:, c0:c1, :, :], v_blk[:ba, :bb, :bc, :, :, :])
+
+                w_blk_r6 = numpy.copy(w_blk)
+                t3_symm_ip_py(w_blk_r6, blksize**3, nocc, "4-2-211-2", 0.5, 0.0)
+                imds.l1_t[:, a0:a1] += lib.einsum('jbkc,abcijk->ia',
+                    eris_ovov[:, b0:b1, :, c0:c1], w_blk_r6[:ba, :bb, :bc, :, :, :])
+
+                t3_symm_ip_py(w_blk, blksize**3, nocc, "2-1000-1", 0.5, 0.0)
+                joovv[:, :, a0:a1, b0:b1] += lib.einsum('kc,abcijk->ijab',
+                    eris.fock[:nocc, nocc + c0:nocc + c1], w_blk[:ba, :bb, :bc, :, :, :])
+
+    w_blk = None
+    v_blk = None
+
+    imds.l1_t /= eia
+
+    joovv = joovv + joovv.transpose(1, 0, 3, 2)
+    imds.l2_t = joovv / lib.direct_sum('ia+jb->ijab', eia, eia)
+
+    return imds
+
+def update_lambda(mycc, t1, t2, l1, l2, eris=None, imds=None):
+    if eris is None: eris = mycc.ao2mo()
+    if imds is None: imds = make_intermediates(mycc, t1, t2, eris)
+    l1, l2 = ccsd_lambda.update_lambda(mycc, t1, t2, l1, l2, eris, imds)
+    l1 += imds.l1_t
+    l2 += imds.l2_t
+    return l1, l2
+
+def t3_symm_ip_py(A, nocc3, nvir, pattern, alpha=1.0, beta=0.0):
+    assert A.dtype == numpy.float64 and A.flags['C_CONTIGUOUS'], "A must be a contiguous float64 array"
+
+    pattern_c = pattern.encode('utf-8')
+
+    drv = _ccsd.libcc.t3_symm_ip
+    drv(
+        A.ctypes.data_as(ctypes.c_void_p),
+        ctypes.c_int64(nocc3),
+        ctypes.c_int64(nvir),
+        ctypes.c_char_p(pattern_c),
+        ctypes.c_double(alpha),
+        ctypes.c_double(beta)
+    )
+    return A
+
+
+if __name__ == '__main__':
+    from pyscf import gto
+    from pyscf import scf
+
+    mol = gto.Mole()
+    mol.verbose = 0
+    mol.atom = [
+        [8 , (0. , 0.     , 0.)],
+        [1 , (0. , -0.757 , 0.587)],
+        [1 , (0. , 0.757  , 0.587)]]
+
+    mol.basis = 'cc-pvdz'
+    mol.build()
+    rhf = scf.RHF(mol)
+    rhf.conv_tol = 1e-16
+    rhf.scf()
+
+    mcc = ccsd.CCSD(rhf)
+    mcc.conv_tol = 1e-12
+    ecc, t1, t2 = mcc.kernel()
+    #l1, l2 = mcc.solve_lambda()
+    #print(numpy.linalg.norm(l1)-0.0132626841292)
+    #print(numpy.linalg.norm(l2)-0.212575609057)
+
+    conv, l1, l2 = kernel(mcc, mcc.ao2mo(), t1, t2, tol=1e-8)
+    print(numpy.linalg.norm(l1)-0.013575484203926739)
+    print(numpy.linalg.norm(l2)-0.22029981372536928)

--- a/pyscf/cc/ccsd_t_rdm.py
+++ b/pyscf/cc/ccsd_t_rdm.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python
+# Copyright 2014-2021 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Qiming Sun <osirpt.sun@gmail.com>
+#         Yu Jin <jinyuchem@uchicago.edu>
+#
+
+import ctypes
+import numpy
+from pyscf import lib
+from pyscf.cc import ccsd_rdm, _ccsd
+
+def _gamma1_intermediates(mycc, t1, t2, l1, l2, eris=None, for_grad=False):
+
+    if (numpy.iscomplexobj(t1) or numpy.iscomplexobj(t2) or numpy.iscomplexobj(eris)
+        or numpy.iscomplexobj(l1) or numpy.iscomplexobj(l2)):
+        raise ValueError("_gamma1_intermediates does not support complex-valued inputs (t1, t2, l1, l2, or eris)")
+
+    doo, dov, dvo, dvv = ccsd_rdm._gamma1_intermediates(mycc, t1, t2, l1, l2)
+
+    if eris is None: eris = mycc.ao2mo()
+    nocc, nvir = t1.shape
+    eris_ovvv = numpy.asarray(eris.get_ovvv())
+    eris_ovoo = numpy.asarray(eris.ovoo)
+    eris_ovov = numpy.asarray(eris.ovov)
+
+    mo_e = eris.mo_energy
+    eia = lib.direct_sum('i-a->ia', mo_e[:nocc], mo_e[nocc:])
+
+    mem_now = lib.current_memory()[0]
+    max_memory = max(0, mycc.max_memory - mem_now)
+    blksize = min(nvir, int(((max_memory * 0.9e6/8) / 6.0 / (nocc**3))**(1/3)))
+    if blksize < nvir:
+        blksize = min(blksize, (nvir + 1) // 2)
+        blksize = max(blksize, 1)
+    print('blksize', blksize)
+
+    goo = numpy.zeros((nocc, nocc), dtype=t1.dtype)
+    w_blk = numpy.empty((blksize, blksize, blksize, nocc, nocc, nocc), dtype=t1.dtype)
+    v_blk = numpy.empty((blksize, blksize, blksize, nocc, nocc, nocc), dtype=t1.dtype)
+
+    for a0, a1 in lib.prange(0, nvir, blksize):
+        ba = a1 - a0
+        for b0, b1 in lib.prange(0, nvir, blksize):
+            bb = b1 - b0
+            for c0, c1 in lib.prange(0, nvir, blksize):
+                bc = c1 - c0
+
+                w_blk[:ba, :bb, :bc] = lib.einsum('iafb,kjcf->abcijk',
+                    eris_ovvv[:, a0:a1, :, b0:b1], t2[:, :, c0:c1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('iafc,jkbf->abcijk',
+                    eris_ovvv[:, a0:a1, :, c0:c1], t2[:, :, b0:b1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('jbfa,kicf->abcijk',
+                    eris_ovvv[:, b0:b1, :, a0:a1], t2[:, :, c0:c1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('jbfc,ikaf->abcijk',
+                    eris_ovvv[:, b0:b1, :, c0:c1], t2[:, :, a0:a1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('kcfa,jibf->abcijk',
+                    eris_ovvv[:, c0:c1, :, a0:a1], t2[:, :, b0:b1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('kcfb,ijaf->abcijk',
+                    eris_ovvv[:, c0:c1, :, b0:b1], t2[:, :, a0:a1, :])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('iajm,mkbc->abcijk',
+                    eris_ovoo[:, a0:a1, :, :], t2[:, :, b0:b1, c0:c1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('iakm,mjcb->abcijk',
+                    eris_ovoo[:, a0:a1, :, :], t2[:, :, c0:c1, b0:b1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('jbim,mkac->abcijk',
+                    eris_ovoo[:, b0:b1, :, :], t2[:, :, a0:a1, c0:c1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('jbkm,mica->abcijk',
+                    eris_ovoo[:, b0:b1, :, :], t2[:, :, c0:c1, a0:a1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('kcim,mjab->abcijk',
+                    eris_ovoo[:, c0:c1, :, :], t2[:, :, a0:a1, b0:b1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('kcjm,miba->abcijk',
+                    eris_ovoo[:, c0:c1, :, :], t2[:, :, b0:b1, a0:a1])
+
+                v_blk[:ba, :bb, :bc] = lib.einsum('iajb,kc->abcijk',
+                    eris_ovov[:, a0:a1, :, b0:b1], t1[:, c0:c1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('iakc,jb->abcijk',
+                    eris_ovov[:, a0:a1, :, c0:c1], t1[:, b0:b1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('jbkc,ia->abcijk',
+                    eris_ovov[:, b0:b1, :, c0:c1], t1[:, a0:a1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('ck,ijab->abcijk',
+                    eris.fock[(nocc + c0):(nocc + c1), :nocc], t2[:, :, a0:a1, b0:b1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('ai,jkbc->abcijk',
+                    eris.fock[(nocc + a0):(nocc + a1), :nocc], t2[:, :, b0:b1, c0:c1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('bj,kica->abcijk',
+                    eris.fock[(nocc + b0):(nocc + b1), :nocc], t2[:, :, c0:c1, a0:a1])
+
+                d3_blk = lib.direct_sum('ia,jb,kc->abcijk', eia[:, a0:a1], eia[:, b0:b1], eia[:, c0:c1])
+                w_blk[:ba, :bb, :bc] /= d3_blk
+                v_blk[:ba, :bb, :bc] /= d3_blk
+
+                v_blk += w_blk
+
+                t3_symm_ip_py(w_blk, blksize**3, nocc, "4-2-211-2", 1.0, 0.0)
+                goo[:, :] += lib.einsum('abcikl,abcjkl->ij',
+                    v_blk[:ba, :bb, :bc, :, :, :], w_blk[:ba, :bb, :bc, :, :, :])
+
+    w_blk = None
+    v_blk = None
+
+    mem_now = lib.current_memory()[0]
+    max_memory = max(0, mycc.max_memory - mem_now)
+    blksize = min(nocc, int(((max_memory * 0.9e6/8) / 6.0 / (nvir**3))**(1/3)))
+    if blksize < nocc:
+        blksize = min(blksize, (nocc + 1) // 2)
+        blksize = max(blksize, 1)
+    print('blksize', blksize)
+
+    gvv = numpy.zeros((nvir, nvir), dtype=t1.dtype)
+    w_blk = numpy.empty((blksize, blksize, blksize, nvir, nvir, nvir), dtype=t1.dtype)
+    v_blk = numpy.empty((blksize, blksize, blksize, nvir, nvir, nvir), dtype=t1.dtype)
+
+    for k0, k1 in lib.prange(0, nocc, blksize):
+        bk = k1 - k0
+        for j0, j1 in lib.prange(0, nocc, blksize):
+            bj = j1 - j0
+            for i0, i1 in lib.prange(0, nocc, blksize):
+                bi = i1 - i0
+
+                w_blk[:bi, :bj, :bk] = lib.einsum('iafb,kjcf->ijkabc',
+                    eris_ovvv[i0:i1, :, :, :], t2[k0:k1, j0:j1, :, :])
+                w_blk[:bi, :bj, :bk] += lib.einsum('iafc,jkbf->ijkabc',
+                    eris_ovvv[i0:i1, :, :, :], t2[j0:j1, k0:k1, :, :])
+                w_blk[:bi, :bj, :bk] += lib.einsum('jbfa,kicf->ijkabc',
+                    eris_ovvv[j0:j1, :, :, :], t2[k0:k1, i0:i1, :, :])
+                w_blk[:bi, :bj, :bk] += lib.einsum('jbfc,ikaf->ijkabc',
+                    eris_ovvv[j0:j1, :, :, :], t2[i0:i1, k0:k1, :, :])
+                w_blk[:bi, :bj, :bk] += lib.einsum('kcfa,jibf->ijkabc',
+                    eris_ovvv[k0:k1, :, :, :], t2[j0:j1, i0:i1, :, :])
+                w_blk[:bi, :bj, :bk] += lib.einsum('kcfb,ijaf->ijkabc',
+                    eris_ovvv[k0:k1, :, :, :], t2[i0:i1, j0:j1, :, :])
+                w_blk[:bi, :bj, :bk] -= lib.einsum('iajm,mkbc->ijkabc',
+                    eris_ovoo[i0:i1, :, j0:j1, :], t2[:, k0:k1, :, :])
+                w_blk[:bi, :bj, :bk] -= lib.einsum('iakm,mjcb->ijkabc',
+                    eris_ovoo[i0:i1, :, k0:k1, :], t2[:, j0:j1, :, :])
+                w_blk[:bi, :bj, :bk] -= lib.einsum('jbim,mkac->ijkabc',
+                    eris_ovoo[j0:j1, :, i0:i1, :], t2[:, k0:k1, :, :])
+                w_blk[:bi, :bj, :bk] -= lib.einsum('jbkm,mica->ijkabc',
+                    eris_ovoo[j0:j1, :, k0:k1, :], t2[:, i0:i1, :, :])
+                w_blk[:bi, :bj, :bk] -= lib.einsum('kcim,mjab->ijkabc',
+                    eris_ovoo[k0:k1, :, i0:i1, :], t2[:, j0:j1, :, :])
+                w_blk[:bi, :bj, :bk] -= lib.einsum('kcjm,miba->ijkabc',
+                    eris_ovoo[k0:k1, :, j0:j1, :], t2[:, i0:i1, :, :])
+
+                v_blk[:bi, :bj, :bk] = lib.einsum('iajb,kc->ijkabc',
+                    eris_ovov[i0:i1, :, j0:j1, :], t1[k0:k1, :])
+                v_blk[:bi, :bj, :bk] += lib.einsum('iakc,jb->ijkabc',
+                    eris_ovov[i0:i1, :, k0:k1, :], t1[j0:j1, :])
+                v_blk[:bi, :bj, :bk] += lib.einsum('jbkc,ia->ijkabc',
+                    eris_ovov[j0:j1, :, k0:k1, :], t1[i0:i1, :])
+                v_blk[:bi, :bj, :bk] += lib.einsum('ck,ijab->ijkabc',
+                    eris.fock[nocc:, k0:k1], t2[i0:i1, j0:j1, :, :])
+                v_blk[:bi, :bj, :bk] += lib.einsum('ai,jkbc->ijkabc',
+                    eris.fock[nocc:, i0:i1], t2[j0:j1, k0:k1, :, :])
+                v_blk[:bi, :bj, :bk] += lib.einsum('bj,kica->ijkabc',
+                    eris.fock[nocc:, j0:j1], t2[k0:k1, i0:i1, :, :])
+
+                d3_blk = lib.direct_sum('ia,jb,kc->ijkabc', eia[i0:i1, :], eia[j0:j1, :], eia[k0:k1, :])
+                w_blk[:bi, :bj, :bk] /= d3_blk
+                v_blk[:bi, :bj, :bk] /= d3_blk
+
+                v_blk += w_blk
+
+                t3_symm_ip_py(w_blk, blksize**3, nvir, "4-2-211-2", 1.0, 0.0)
+
+                gvv[:, :] += lib.einsum('ijkacd,ijkbcd->ab',
+                    v_blk[:bi, :bj, :bk, :, :, :], w_blk[:bi, :bj, :bk, :, :, :])
+                dvo[:, k0:k1] += 0.5 * lib.einsum('ijab,ijkabc->ck',
+                    t2[i0:i1, j0:j1, :, :], w_blk[:bi, :bj, :bk, :, :, :])
+
+    w_blk = None
+    v_blk = None
+
+    if not for_grad:
+        # t3 amplitudes in CCSD(T) is computed non-iteratively. The
+        # off-diagonal blocks of fock matrix does not contribute to CCSD(T)
+        # energy. To make Tr(H,D) consistent to the CCSD(T) total energy, the
+        # density matrix off-diagonal parts are excluded.
+        doo[numpy.diag_indices(nocc)] -= goo.diagonal() * .5
+        dvv[numpy.diag_indices(nvir)] += gvv.diagonal() * .5
+
+    else:
+        # The off-diagonal blocks of fock matrix have small contributions to
+        # analytical nuclear gradients.
+        doo -= goo * .5
+        dvv += gvv * .5
+
+    return doo, dov, dvo, dvv
+
+def _gamma2_intermediates(mycc, t1, t2, l1, l2, eris=None,
+                          compress_vvvv=False):
+    '''intermediates tensors for gamma2 are sorted in Chemist's notation
+    '''
+
+    if (numpy.iscomplexobj(t1) or numpy.iscomplexobj(t2) or numpy.iscomplexobj(eris)
+        or numpy.iscomplexobj(l1) or numpy.iscomplexobj(l2)):
+        raise ValueError("_gamma2_intermediates does not support complex-valued inputs (t1, t2, l1, l2, or eris)")
+
+    dovov, dvvvv, doooo, doovv, dovvo, dvvov, dovvv, dooov = \
+            ccsd_rdm._gamma2_intermediates(mycc, t1, t2, l1, l2)
+    if eris is None: eris = mycc.ao2mo()
+
+    nocc, nvir = t1.shape
+    eris_ovvv = numpy.asarray(eris.get_ovvv())
+    eris_ovoo = numpy.asarray(eris.ovoo)
+    eris_ovov = numpy.asarray(eris.ovov)
+
+    mo_e = eris.mo_energy
+    eia = lib.direct_sum('i-a->ia', mo_e[:nocc], mo_e[nocc:])
+
+    mem_now = lib.current_memory()[0]
+    max_memory = max(0, mycc.max_memory - mem_now)
+    blksize = min(nvir, int(((max_memory * 0.9e6/8) / 6.0 / (nocc**3))**(1/3)))
+    if blksize < nvir:
+        blksize = min(blksize, (nvir + 1) // 2)
+        blksize = max(blksize, 1)
+    print('blksize', blksize)
+
+    w_blk = numpy.empty((blksize, blksize, blksize, nocc, nocc, nocc), dtype=t1.dtype)
+    v_blk = numpy.empty((blksize, blksize, blksize, nocc, nocc, nocc), dtype=t1.dtype)
+
+    for c0, c1 in lib.prange(0, nvir, blksize):
+        bc = c1 - c0
+        for b0, b1 in lib.prange(0, nvir, blksize):
+            bb = b1 - b0
+            for a0, a1 in lib.prange(0, nvir, blksize):
+                ba = a1 - a0
+
+                w_blk[:ba, :bb, :bc] = lib.einsum('iafb,kjcf->abcijk',
+                    eris_ovvv[:, a0:a1, :, b0:b1], t2[:, :, c0:c1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('iafc,jkbf->abcijk',
+                    eris_ovvv[:, a0:a1, :, c0:c1], t2[:, :, b0:b1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('jbfa,kicf->abcijk',
+                    eris_ovvv[:, b0:b1, :, a0:a1], t2[:, :, c0:c1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('jbfc,ikaf->abcijk',
+                    eris_ovvv[:, b0:b1, :, c0:c1], t2[:, :, a0:a1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('kcfa,jibf->abcijk',
+                    eris_ovvv[:, c0:c1, :, a0:a1], t2[:, :, b0:b1, :])
+                w_blk[:ba, :bb, :bc] += lib.einsum('kcfb,ijaf->abcijk',
+                    eris_ovvv[:, c0:c1, :, b0:b1], t2[:, :, a0:a1, :])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('iajm,mkbc->abcijk',
+                    eris_ovoo[:, a0:a1, :, :], t2[:, :, b0:b1, c0:c1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('iakm,mjcb->abcijk',
+                    eris_ovoo[:, a0:a1, :, :], t2[:, :, c0:c1, b0:b1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('jbim,mkac->abcijk',
+                    eris_ovoo[:, b0:b1, :, :], t2[:, :, a0:a1, c0:c1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('jbkm,mica->abcijk',
+                    eris_ovoo[:, b0:b1, :, :], t2[:, :, c0:c1, a0:a1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('kcim,mjab->abcijk',
+                    eris_ovoo[:, c0:c1, :, :], t2[:, :, a0:a1, b0:b1])
+                w_blk[:ba, :bb, :bc] -= lib.einsum('kcjm,miba->abcijk',
+                    eris_ovoo[:, c0:c1, :, :], t2[:, :, b0:b1, a0:a1])
+
+                v_blk[:ba, :bb, :bc] = lib.einsum('iajb,kc->abcijk',
+                    eris_ovov[:, a0:a1, :, b0:b1], t1[:, c0:c1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('iakc,jb->abcijk',
+                    eris_ovov[:, a0:a1, :, c0:c1], t1[:, b0:b1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('jbkc,ia->abcijk',
+                    eris_ovov[:, b0:b1, :, c0:c1], t1[:, a0:a1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('ck,ijab->abcijk',
+                    eris.fock[nocc + c0:nocc + c1, :nocc], t2[:, :, a0:a1, b0:b1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('ai,jkbc->abcijk',
+                    eris.fock[nocc + a0:nocc + a1, :nocc], t2[:, :, b0:b1, c0:c1])
+                v_blk[:ba, :bb, :bc] += lib.einsum('bj,kica->abcijk',
+                    eris.fock[nocc + b0:nocc + b1, :nocc], t2[:, :, c0:c1, a0:a1])
+
+                d3_blk = lib.direct_sum('ia,jb,kc->abcijk', eia[:, a0:a1], eia[:, b0:b1], eia[:, c0:c1])
+                w_blk[:ba, :bb, :bc] /= d3_blk
+                v_blk[:ba, :bb, :bc] /= d3_blk
+
+                v_blk += 2.0 * w_blk
+                t3_symm_ip_py(v_blk, blksize**3, nocc, "4-2-211-2", 1.0, 0.0)
+                t3_symm_ip_py(w_blk, blksize**3, nocc, "4-2-211-2", 0.5, 0.0)
+
+                dovov[:, a0:a1, :, b0:b1] += lib.einsum('kc,abcijk->iajb',
+                    t1[:, c0:c1], w_blk[:ba, :bb, :bc, :, :, :])
+                dooov[:, :, :, a0:a1] -= lib.einsum('mkbc,abcijk->jmia',
+                    t2[:, :, b0:b1, c0:c1], v_blk[:ba, :bb, :bc, :, :, :])
+                dovvv[:, a0:a1, :, b0:b1] += lib.einsum('kjcf,abcijk->iafb',
+                    t2[:, :, c0:c1, :], v_blk[:ba, :bb, :bc, :, :, :])
+
+    w_blk = None
+    v_blk = None
+
+    dvvov = dovvv.transpose(2,3,0,1)
+
+    if compress_vvvv:
+        nvir = mycc.nmo - mycc.nocc
+        idx = numpy.tril_indices(nvir)
+        vidx = idx[0] * nvir + idx[1]
+        dvvvv = dvvvv + dvvvv.transpose(1,0,2,3)
+        dvvvv = dvvvv + dvvvv.transpose(0,1,3,2)
+        dvvvv = lib.take_2d(dvvvv.reshape(nvir**2,nvir**2), vidx, vidx)
+        dvvvv *= .25
+
+    return dovov, dvvvv, doooo, doovv, dovvo, dvvov, dovvv, dooov
+
+def _gamma2_outcore(mycc, t1, t2, l1, l2, eris, h5fobj, compress_vvvv=False):
+    return _gamma2_intermediates(mycc, t1, t2, l1, l2, eris, compress_vvvv)
+
+def make_rdm1(mycc, t1, t2, l1, l2, eris=None, ao_repr=False):
+    d1 = _gamma1_intermediates(mycc, t1, t2, l1, l2, eris)
+    return ccsd_rdm._make_rdm1(mycc, d1, True, ao_repr=ao_repr)
+
+# rdm2 in Chemist's notation
+def make_rdm2(mycc, t1, t2, l1, l2, eris=None):
+    d1 = _gamma1_intermediates(mycc, t1, t2, l1, l2, eris)
+    d2 = _gamma2_intermediates(mycc, t1, t2, l1, l2, eris)
+    return ccsd_rdm._make_rdm2(mycc, d1, d2, True, True)
+
+def t3_symm_ip_py(A, nocc3, nvir, pattern, alpha=1.0, beta=0.0):
+    assert A.dtype == numpy.float64 and A.flags['C_CONTIGUOUS'], "A must be a contiguous float64 array"
+
+    pattern_c = pattern.encode('utf-8')
+
+    drv = _ccsd.libcc.t3_symm_ip
+    drv(
+        A.ctypes.data_as(ctypes.c_void_p),
+        ctypes.c_int64(nocc3),
+        ctypes.c_int64(nvir),
+        ctypes.c_char_p(pattern_c),
+        ctypes.c_double(alpha),
+        ctypes.c_double(beta)
+    )
+    return A

--- a/pyscf/cc/test/test_rccsd_t_lambda.py
+++ b/pyscf/cc/test/test_rccsd_t_lambda.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+# Copyright 2014-2018 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy
+import numpy as np
+from functools import reduce
+
+from pyscf import lib
+from pyscf import gto
+from pyscf import scf
+from pyscf import ao2mo
+from pyscf.cc import rccsd
+
+from pyscf.cc import ccsd_t_lambda
+from pyscf.cc import ccsd_t_rdm
+from pyscf.cc import ccsd_t_lambda_slow
+from pyscf.cc import ccsd_t_rdm_slow
+
+
+def setUpModule():
+    global mol, mf, mycc
+    mol = gto.Mole()
+    mol.atom = [
+        [8 , (0. , 0.     , 0.)],
+        [1 , (0. , -0.757 , 0.587)],
+        [1 , (0. , 0.757  , 0.587)]]
+    mol.basis = '631g'
+    mol.verbose = 5
+    mol.output = '/dev/null'
+    mol.build()
+    mf = scf.RHF(mol).run()
+    mycc = rccsd.RCCSD(mf)
+
+def tearDownModule():
+    global mol, mf, mycc
+    mol.stdout.close()
+    del mol, mf, mycc
+
+class KnownValues(unittest.TestCase):
+    def test_lambda_intermediates_real(self):
+        mycc = rccsd.RCCSD(mf)
+        np.random.seed(12)
+        nocc = 5
+        nmo = 12
+        nvir = nmo - nocc
+        eri0 = np.random.random((nmo,nmo,nmo,nmo))
+        eri0 = ao2mo.restore(1, ao2mo.restore(8, eri0, nmo), nmo)
+        fock0 = np.random.random((nmo,nmo))
+        fock0 = fock0 + fock0.T + np.diag(range(nmo))*2
+        t1 = np.random.random((nocc,nvir))
+        t2 = np.random.random((nocc,nocc,nvir,nvir))
+        t2 = t2 + t2.transpose(1,0,3,2)
+
+        eris = rccsd._ChemistsERIs(mol)
+        eris.oooo = eri0[:nocc,:nocc,:nocc,:nocc].copy()
+        eris.ovoo = eri0[:nocc,nocc:,:nocc,:nocc].copy()
+        eris.oovv = eri0[:nocc,:nocc,nocc:,nocc:].copy()
+        eris.ovvo = eri0[:nocc,nocc:,nocc:,:nocc].copy()
+        eris.ovov = eri0[:nocc,nocc:,:nocc,nocc:].copy()
+        idx = np.tril_indices(nvir)
+        eris.ovvv = eri0[:nocc,nocc:,nocc:,nocc:].copy()
+        eris.vvvv = eri0[nocc:,nocc:,nocc:,nocc:].copy()
+        eris.fock = fock0
+        eris.mo_energy = fock0.diagonal()
+
+        imds_ref = ccsd_t_lambda_slow.make_intermediates(mycc, t1, t2, eris)
+
+        imds = ccsd_t_lambda.make_intermediates(mycc, t1, t2, eris)
+        self.assertAlmostEqual(lib.fp(imds.l1_t), 19.765863433294747, 9)
+        self.assertAlmostEqual(lib.fp(imds.l2_t), -5.307912647007477, 9)
+        self.assertAlmostEqual(abs(imds.l2_t-imds.l2_t.transpose(1,0,3,2)).max(), 0, 12)
+        self.assertTrue(np.allclose(imds.l1_t, imds_ref.l1_t, rtol=1e-12, atol=1e-15))
+        self.assertTrue(np.allclose(imds.l2_t, imds_ref.l2_t, rtol=1e-12, atol=1e-15))
+
+        mycc.max_memory = 118
+        imds = ccsd_t_lambda.make_intermediates(mycc, t1, t2, eris)
+        self.assertAlmostEqual(lib.fp(imds.l1_t), 19.765863433294747, 9)
+        self.assertAlmostEqual(lib.fp(imds.l2_t), -5.307912647007477, 9)
+        self.assertAlmostEqual(abs(imds.l2_t-imds.l2_t.transpose(1,0,3,2)).max(), 0, 12)
+        self.assertTrue(np.allclose(imds.l1_t, imds_ref.l1_t, rtol=1e-12, atol=1e-15))
+        self.assertTrue(np.allclose(imds.l2_t, imds_ref.l2_t, rtol=1e-12, atol=1e-15))
+
+        mycc.max_memory = 0
+        imds = ccsd_t_lambda.make_intermediates(mycc, t1, t2, eris)
+        self.assertAlmostEqual(lib.fp(imds.l1_t), 19.765863433294747, 9)
+        self.assertAlmostEqual(lib.fp(imds.l2_t), -5.307912647007477, 9)
+        self.assertAlmostEqual(abs(imds.l2_t-imds.l2_t.transpose(1,0,3,2)).max(), 0, 12)
+        self.assertTrue(np.allclose(imds.l1_t, imds_ref.l1_t, rtol=1e-12, atol=1e-15))
+        self.assertTrue(np.allclose(imds.l2_t, imds_ref.l2_t, rtol=1e-12, atol=1e-15))
+
+    def test_rdm_intermediates_real(self):
+        mycc = rccsd.RCCSD(mf)
+        np.random.seed(12)
+        nocc = 5
+        nmo = 12
+        nvir = nmo - nocc
+        eri0 = np.random.random((nmo,nmo,nmo,nmo))
+        eri0 = ao2mo.restore(1, ao2mo.restore(8, eri0, nmo), nmo)
+        fock0 = np.random.random((nmo,nmo))
+        fock0 = fock0 + fock0.T + np.diag(range(nmo))*2
+        t1 = np.random.random((nocc,nvir))
+        t2 = np.random.random((nocc,nocc,nvir,nvir))
+        t2 = t2 + t2.transpose(1,0,3,2)
+        l1 = np.random.random((nocc,nvir))
+        l2 = np.random.random((nocc,nocc,nvir,nvir))
+        l2 = l2 + l2.transpose(1,0,3,2)
+
+        eris = rccsd._ChemistsERIs(mol)
+        eris.oooo = eri0[:nocc,:nocc,:nocc,:nocc].copy()
+        eris.ovoo = eri0[:nocc,nocc:,:nocc,:nocc].copy()
+        eris.oovv = eri0[:nocc,:nocc,nocc:,nocc:].copy()
+        eris.ovvo = eri0[:nocc,nocc:,nocc:,:nocc].copy()
+        eris.ovov = eri0[:nocc,nocc:,:nocc,nocc:].copy()
+        idx = np.tril_indices(nvir)
+        eris.ovvv = eri0[:nocc,nocc:,nocc:,nocc:].copy()
+        eris.vvvv = eri0[nocc:,nocc:,nocc:,nocc:].copy()
+        eris.fock = fock0
+        eris.mo_energy = fock0.diagonal()
+
+        d1_ref = ccsd_t_rdm_slow._gamma1_intermediates(mycc, t1, t2, l1, l2, eris, for_grad=False)
+        d1_ref = np.concatenate([d.ravel() for d in d1_ref])
+        d1_g_ref = ccsd_t_rdm_slow._gamma1_intermediates(mycc, t1, t2, l1, l2, eris, for_grad=True)
+        d1_g_ref = np.concatenate([d.ravel() for d in d1_g_ref])
+        d2_ref = ccsd_t_rdm_slow._gamma2_intermediates(mycc, t1, t2, l1, l2, eris, compress_vvvv=False)
+        d2_ref = np.concatenate([d.ravel() for d in d2_ref])
+
+        d1 = ccsd_t_rdm._gamma1_intermediates(mycc, t1, t2, l1, l2, eris, for_grad=False)
+        d1 = np.concatenate([d.ravel() for d in d1])
+        self.assertAlmostEqual(lib.fp(d1), -1383.6462141528182, 9)
+        d1_g = ccsd_t_rdm._gamma1_intermediates(mycc, t1, t2, l1, l2, eris, for_grad=True)
+        d1_g = np.concatenate([d.ravel() for d in d1_g])
+        self.assertAlmostEqual(lib.fp(d1_g), -1305.4979081481401, 9)
+        d2 = ccsd_t_rdm._gamma2_intermediates(mycc, t1, t2, l1, l2, eris, compress_vvvv=False)
+        d2 = np.concatenate([d.ravel() for d in d2])
+        self.assertAlmostEqual(lib.fp(d2), 13025.265198471607, 9)
+        self.assertTrue(np.allclose(d1, d1_ref, rtol=1e-12, atol=1e-15))
+        self.assertTrue(np.allclose(d1_g, d1_g_ref, rtol=1e-12, atol=1e-15))
+        self.assertTrue(np.allclose(d2, d2_ref, rtol=1e-12, atol=1e-15))
+
+        mycc.max_memory = 118
+        d1 = ccsd_t_rdm._gamma1_intermediates(mycc, t1, t2, l1, l2, eris, for_grad=False)
+        d1 = np.concatenate([d.ravel() for d in d1])
+        self.assertAlmostEqual(lib.fp(d1), -1383.6462141528182, 9)
+        d1_g = ccsd_t_rdm._gamma1_intermediates(mycc, t1, t2, l1, l2, eris, for_grad=True)
+        d1_g = np.concatenate([d.ravel() for d in d1_g])
+        self.assertAlmostEqual(lib.fp(d1_g), -1305.4979081481401, 9)
+        d2 = ccsd_t_rdm._gamma2_intermediates(mycc, t1, t2, l1, l2, eris, compress_vvvv=False)
+        d2 = np.concatenate([d.ravel() for d in d2])
+        self.assertAlmostEqual(lib.fp(d2), 13025.265198471607, 9)
+        self.assertTrue(np.allclose(d1, d1_ref, rtol=1e-12, atol=1e-15))
+        self.assertTrue(np.allclose(d1_g, d1_g_ref, rtol=1e-12, atol=1e-15))
+        self.assertTrue(np.allclose(d2, d2_ref, rtol=1e-12, atol=1e-15))
+
+        mycc.max_memory = 0
+        d1 = ccsd_t_rdm._gamma1_intermediates(mycc, t1, t2, l1, l2, eris, for_grad=False)
+        d1 = np.concatenate([d.ravel() for d in d1])
+        self.assertAlmostEqual(lib.fp(d1), -1383.6462141528182, 9)
+        d1_g = ccsd_t_rdm._gamma1_intermediates(mycc, t1, t2, l1, l2, eris, for_grad=True)
+        d1_g = np.concatenate([d.ravel() for d in d1_g])
+        self.assertAlmostEqual(lib.fp(d1_g), -1305.4979081481401, 9)
+        d2 = ccsd_t_rdm._gamma2_intermediates(mycc, t1, t2, l1, l2, eris, compress_vvvv=False)
+        d2 = np.concatenate([d.ravel() for d in d2])
+        self.assertAlmostEqual(lib.fp(d2), 13025.265198471607, 9)
+        self.assertTrue(np.allclose(d1, d1_ref, rtol=1e-12, atol=1e-15))
+        self.assertTrue(np.allclose(d1_g, d1_g_ref, rtol=1e-12, atol=1e-15))
+        self.assertTrue(np.allclose(d2, d2_ref, rtol=1e-12, atol=1e-15))
+
+if __name__ == "__main__":
+    print("Tests for RCCSD(T) lambda and rdm intermediates")
+    unittest.main()

--- a/pyscf/grad/ccsd_t_slow.py
+++ b/pyscf/grad/ccsd_t_slow.py
@@ -17,7 +17,7 @@
 #
 
 from pyscf import lib
-from pyscf.cc import ccsd_t_rdm as ccsd_t_rdm
+from pyscf.cc import ccsd_t_rdm_slow as ccsd_t_rdm
 from pyscf.grad import ccsd as ccsd_grad
 
 # Only works with canonical orbitals
@@ -48,7 +48,7 @@ if __name__ == '__main__':
     from pyscf import scf
     from pyscf import cc
     from pyscf.cc import ccsd_t
-    from pyscf.cc import ccsd_t_lambda as ccsd_t_lambda
+    from pyscf.cc import ccsd_t_lambda_slow as ccsd_t_lambda
 
     mol = gto.M(
         verbose = 0,

--- a/pyscf/grad/test/test_ccsd_t.py
+++ b/pyscf/grad/test/test_ccsd_t.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+# Copyright 2014-2018 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy
+from pyscf import gto, lib
+from pyscf import scf, dft
+from pyscf import ao2mo
+from pyscf import cc
+from pyscf.cc import ccsd_t
+from pyscf import grad
+from pyscf.grad import ccsd_t as ccsd_t_grad
+from pyscf.grad import ccsd_t_slow as ccsd_t_grad_slow
+from pyscf.cc import ccsd_t_lambda, ccsd_t_lambda_slow
+
+def setUpModule():
+    global mol, mf
+    mol = gto.Mole()
+    mol.verbose = 7
+    mol.output = '/dev/null'
+    mol.atom = [
+        [8 , (0. , 0.     , 0.)],
+        [1 , (0. , -0.757 , 0.587)],
+        [1 , (0. , 0.757  , 0.587)]]
+
+    mol.basis = '631g'
+    mol.build()
+    mf = scf.RHF(mol)
+    mf.conv_tol_grad = 1e-8
+    mf.kernel()
+
+def tearDownModule():
+    global mol, mf
+    mol.stdout.close()
+    del mol, mf
+
+
+class KnownValues(unittest.TestCase):
+    def test_ccsd_t_grad(self):
+        mycc = cc.ccsd.CCSD(mf)
+        mycc.max_memory = 1
+        mycc.conv_tol = 1e-10
+        eris = mycc.ao2mo()
+        ecc, t1, t2 = mycc.kernel(eris=eris)
+        e3ref = ccsd_t.kernel(mycc, eris, t1, t2)
+        conv, l1, l2 = ccsd_t_lambda.kernel(mycc, eris, t1, t2)
+        g1 = ccsd_t_grad.Gradients(mycc).kernel(t1, t2, l1, l2, eris=eris)
+
+        conv, l1_slow, l2_slow = ccsd_t_lambda_slow.kernel(mycc, eris, t1, t2)
+        g1_slow = ccsd_t_grad_slow.Gradients(mycc).kernel(t1, t2, l1_slow, l2_slow, eris=eris)
+#[[ 1.43232988e-16 -1.28285681e-16  1.12044750e-02]
+# [-2.57370534e-16  2.34464042e-02 -5.60223751e-03]
+# [ 1.14137546e-16 -2.34464042e-02 -5.60223751e-03]]
+        self.assertAlmostEqual(lib.fp(g1), -0.03843861359532726, 9)
+        self.assertTrue(numpy.allclose(g1, g1_slow, rtol=1e-9, atol=1e-12))
+
+        myccs = mycc.as_scanner()
+        mol.atom[0] = ["O" , (0., 0., 0.001)]
+        mol.build(0, 0)
+        e1 = myccs(mol)
+        e1 += myccs.ccsd_t()
+        mol.atom[0] = ["O" , (0., 0.,-0.001)]
+        mol.build(0, 0)
+        e2 = myccs(mol)
+        e2 += myccs.ccsd_t()
+        fd = (e1-e2)/0.002*lib.param.BOHR
+        self.assertAlmostEqual(g1[0,2], fd, 5)
+
+    def test_ccsd_t_frozen(self):
+        mycc = cc.ccsd.CCSD(mf)
+        mycc.frozen = [0,1,10,11,12]
+        mycc.diis_start_cycle = 1
+        mycc.max_memory = 1
+        eris = mycc.ao2mo()
+        ecc, t1, t2 = mycc.kernel(eris=eris)
+        e3ref = ccsd_t.kernel(mycc, eris, t1, t2)
+        conv, l1, l2 = ccsd_t_lambda.kernel(mycc, eris, t1, t2)
+        g1 = ccsd_t_grad.Gradients(mycc).kernel(t1, t2, l1, l2, eris=eris)
+
+        conv, l1_slow, l2_slow = ccsd_t_lambda_slow.kernel(mycc, eris, t1, t2)
+        g1_slow = ccsd_t_grad_slow.Gradients(mycc).kernel(t1, t2, l1_slow, l2_slow, eris=eris)
+#[[ 1.07308036e-16 -2.51504538e-15  1.24240141e-02]
+# [-2.21953002e-18 -7.92491838e-02 -6.21200703e-03]
+# [-1.05088506e-16  7.92491838e-02 -6.21200703e-03]]
+        self.assertAlmostEqual(lib.fp(g1), 0.10551838331192571, 9)
+        self.assertTrue(numpy.allclose(g1, g1_slow, rtol=1e-9, atol=1e-12))
+
+if __name__ == "__main__":
+    print("Tests for CCSD(T) gradients")
+    unittest.main()

--- a/pyscf/lib/cc/CMakeLists.txt
+++ b/pyscf/lib/cc/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_library(cc SHARED
-  ccsd_pack.c ccsd_grad.c ccsd_t.c uccsd_t.c)
+  ccsd_pack.c ccsd_grad.c ccsd_t.c ccsd_t_lambda.c uccsd_t.c)
 add_dependencies(cc np_helper ao2mo)
 
 set_target_properties(cc PROPERTIES

--- a/pyscf/lib/cc/ccsd_t_lambda.c
+++ b/pyscf/lib/cc/ccsd_t_lambda.c
@@ -1,0 +1,149 @@
+/* Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+  
+   Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+ 
+        http://www.apache.org/licenses/LICENSE-2.0
+ 
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+ *
+ * Author: Yu Jin <jinyuchem@uchicago.edu>
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "config.h"
+
+/*
+ * A unified function for the symmetrization of T3-like object
+ * A = beta * A + alpha * op(A)
+ */
+void t3_symm_ip(double *A, int64_t nocc3, int64_t nvir, char *pattern, double alpha, double beta) {
+    int64_t bl = 16;
+    int64_t nvv = nvir * nvir;
+    double p0 = 0.0, p1 = 0.0, p2 = 0.0, p3 = 0.0, p4 = 0.0;
+
+    if (strcmp(pattern, "111111") == 0) {
+        // abc + acb + bac + bca + cab + cba
+        // (1 + P_a^b) (1 + P_c^b + P_c^a) abc
+        p0 = 1.0;
+        p1 = 1.0;
+        p2 = 1.0;
+        p3 = 1.0;
+        p4 = 1.0;
+
+    } else if (strcmp(pattern, "4-2-211-2") == 0) {
+        // 4 abc - 2 acb - 2 bac + bca + cab - 2 cba
+        // (2 - P_a^b) (2 - P_c^b - P_c^a) abc
+        p0 = 2.0;
+        p1 = -1.0;
+        p2 = -1.0;
+        p3 = 2.0;
+        p4 = -1.0;
+
+    } else if (strcmp(pattern, "2-1000-1") == 0) {
+        // 2 abc - acb + 0 bac + 0 bca + 0 cab - cba
+        // (1 - 0 P_a^b) (2 - P_c^b - P_c^a) abc
+        p0 = 2.0;
+        p1 = -1.0;
+        p2 = -1.0;
+        p3 = 1.0;
+        p4 = 0.0;
+
+    } else {
+        fprintf(stderr, "Error: unrecognized pattern \"%s\"\n", pattern);
+        return;
+    }
+
+#pragma omp parallel for schedule(static)
+    for (int64_t ijk = 0; ijk < nocc3; ijk++) {
+        int64_t h = ijk * nvir * nvir * nvir;
+        for (int64_t a0 = 0; a0 < nvir; a0 += bl) {
+            for (int64_t b0 = 0; b0 <= a0; b0 += bl) {
+                for (int64_t c0 = 0; c0 <= b0; c0 += bl) {
+                    for (int64_t a = a0; a < a0 + bl && a < nvir; a++) {
+                        for (int64_t b = b0; b < b0 + bl && b <= a; b++) {
+                            for (int64_t c = c0; c < c0 + bl && c <= b; c++) {
+
+                                if (a > b && b > c) {
+                                    double T_local[6];
+
+                                    int64_t idx1 = a * nvv + b * nvir + c; // abc
+                                    int64_t idx2 = c * nvv + b * nvir + a; // cba
+                                    int64_t idx3 = a * nvv + c * nvir + b; // acb
+                                    int64_t idx4 = b * nvv + a * nvir + c; // bac
+                                    int64_t idx5 = b * nvv + c * nvir + a; // bca
+                                    int64_t idx6 = c * nvv + a * nvir + b; // cab
+
+                                    T_local[0] = p0 * A[h + idx1] + p1 * A[h + idx2] + p2 * A[h + idx3]; // abc -> cba -> acb
+                                    T_local[1] = p0 * A[h + idx2] + p1 * A[h + idx1] + p2 * A[h + idx6]; // cba -> abc -> cab
+                                    T_local[2] = p0 * A[h + idx3] + p1 * A[h + idx5] + p2 * A[h + idx1]; // acb -> bca -> abc
+                                    T_local[3] = p0 * A[h + idx4] + p1 * A[h + idx6] + p2 * A[h + idx5]; // bac -> cab -> bca
+                                    T_local[4] = p0 * A[h + idx5] + p1 * A[h + idx3] + p2 * A[h + idx4]; // bca -> acb -> bac
+                                    T_local[5] = p0 * A[h + idx6] + p1 * A[h + idx4] + p2 * A[h + idx2]; // cab -> bac -> cba
+
+                                    A[h + idx1] = beta * A[h + idx1] + alpha * (p3 * T_local[0] + p4 * T_local[3]); // abc -> bac
+                                    A[h + idx2] = beta * A[h + idx2] + alpha * (p3 * T_local[1] + p4 * T_local[4]); // cba -> bca
+                                    A[h + idx3] = beta * A[h + idx3] + alpha * (p3 * T_local[2] + p4 * T_local[5]); // acb -> cab
+                                    A[h + idx4] = beta * A[h + idx4] + alpha * (p3 * T_local[3] + p4 * T_local[0]); // bac -> abc
+                                    A[h + idx5] = beta * A[h + idx5] + alpha * (p3 * T_local[4] + p4 * T_local[1]); // bca -> cba
+                                    A[h + idx6] = beta * A[h + idx6] + alpha * (p3 * T_local[5] + p4 * T_local[2]); // cab -> acb
+                                }
+
+                                else if (a > b && b == c) {
+                                    double T_local[3];
+
+                                    int64_t idx1 = a * nvv + b * nvir + b; // abb
+                                    int64_t idx2 = b * nvv + b * nvir + a; // bba
+                                    int64_t idx4 = b * nvv + a * nvir + b; // bab
+
+                                    T_local[0] = p0 * A[h + idx1] + p1 * A[h + idx2] + p2 * A[h + idx1]; // abb -> bba -> abb
+                                    T_local[1] = p0 * A[h + idx2] + p1 * A[h + idx1] + p2 * A[h + idx4]; // bba -> abb -> bab
+                                    T_local[2] = p0 * A[h + idx4] + p1 * A[h + idx4] + p2 * A[h + idx2]; // bab -> bab -> bba
+
+                                    A[h + idx1] = beta * A[h + idx1] + alpha * (p3 * T_local[0] + p4 * T_local[2]); // abb -> bab
+                                    A[h + idx2] = beta * A[h + idx2] + alpha * (p3 * T_local[1] + p4 * T_local[1]); // bba -> bba
+                                    A[h + idx4] = beta * A[h + idx4] + alpha * (p3 * T_local[2] + p4 * T_local[0]); // bab -> abb
+                                }
+
+                                else if (a == b && b > c) {
+
+                                    double T_local[3];
+
+                                    int64_t idx1 = a * nvv + a * nvir + c; // aac
+                                    int64_t idx2 = c * nvv + a * nvir + a; // caa
+                                    int64_t idx3 = a * nvv + c * nvir + a; // aca
+
+                                    T_local[0] = p0 * A[h + idx1] + p1 * A[h + idx2] + p2 * A[h + idx3]; // aac -> caa -> aca
+                                    T_local[1] = p0 * A[h + idx2] + p1 * A[h + idx1] + p2 * A[h + idx2]; // caa -> aac -> caa
+                                    T_local[2] = p0 * A[h + idx3] + p1 * A[h + idx3] + p2 * A[h + idx1]; // aca -> aca -> aac
+
+                                    A[h + idx1] = beta * A[h + idx1] + alpha * (p3 * T_local[0] + p4 * T_local[0]); // aac -> aac
+                                    A[h + idx2] = beta * A[h + idx2] + alpha * (p3 * T_local[1] + p4 * T_local[2]); // caa -> aca
+                                    A[h + idx3] = beta * A[h + idx3] + alpha * (p3 * T_local[2] + p4 * T_local[1]); // aca -> caa
+
+                                } else if (a == b && b == c) {
+                                    double T_local[1];
+
+                                    int64_t idx1 = a * nvv + a * nvir + a; // aaa
+
+                                    T_local[0] = p0 * A[h + idx1] + p1 * A[h + idx1] + p2 * A[h + idx1]; // abc -> cba -> acb
+
+                                    A[h + idx1] = beta * A[h + idx1] + alpha * (p3 * T_local[0] + p4 * T_local[0]); // abc -> bac
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Dear PySCF Developers,

This pull request implements a low-memory and efficient version for computing the intermediates required in the RCCSD(T) lambda-equation and RDM calculations. The key improvement is the avoidance of explicit construction of T3 amplitudes, significantly reducing memory usage.

Two new Python modules have been added:

- `ccsd_t_lambda.py`: for computing RCCSD(T) lambda equation.
- `ccsd_t_rdm.py`: for computing RCCSD(T) RDM intermediates.

Additionally, a new C function has been introduced in `lib/cc/ccsd_t_lambda.c` to perform the permuted sum operations in place, as a fast re-implementation of the existing Python-based approach. This further reduces memory overhead and improves efficiency.

These improvements can be used to speed up RCCSD(T) gradients. The original gradient implementation has been renamed to `ccsd_t_slow.py`, while `ccsd_t.py` now utilizes the new efficient functions from the fast implementation.

Benchmark (wall time in seconds) on ethanol molecule using the cc-pVTZ basis and frozen core. Number of orbitals: `nocc = 10`, `nmo = 171`. Hardware: 96-core AMD Genoa node. (The block size for unpacking is automatically determined by checking the current available memory.)

| Allocated Memory | `ccsd_t_lambda_slow.py`<br>`make_intermediates` | `ccsd_t_rdm_slow.py`<br>`_gamma1_intermediates`<br>`_gamma2_intermediates` | `ccsd_t_lambda.py`<br>`make_intermediates` | `ccsd_t_rdm.py`<br>`_gamma1_intermediates`<br>`_gamma2_intermediates` |
|------------------|-----------------------------------------------|------------------------------------------------------------------------|------------------------------------------|----------------------------------------------------------------|
| 300 GB           | 851                                           | 1043                                                                   | 176                                      | 510                                                            |
| 200 GB           | 846                                           | out-of-memory                                                          | 173                                      | 497                                                            |
| 100 GB           | out-of-memory                                 | out-of-memory                                                          | 175                                      | 522                                                            |
| 50 GB            | out-of-memory                                 | out-of-memory                                                          | 178                                      | 493                                                            |
| 40 GB            | out-of-memory                                 | out-of-memory                                                          | 192                                      | 523                                                            |
| 30 GB            | out-of-memory                                 | out-of-memory                                                          | 187                                      | 505                                                            |
| 20 GB            | out-of-memory                                 | out-of-memory                                                          | 250                                      | 590                                                            |
