### PR TITLE
Fix S_abs example

### DIFF
--- a/examples/1-advanced/40-mole_api_and_numba_jit.py
+++ b/examples/1-advanced/40-mole_api_and_numba_jit.py
@@ -110,7 +110,7 @@ def primitive_overlap(li, lj, ai, aj, ci, cj, Ra, Rb, roots, weights) -> np.ndar
 @njit(cache=True, parallel=True)
 def primitive_overlap_matrix(ls, exps, norm_coef, bas_coords, roots, weights):
     nbas = len(ls)
-    dims = [(ls[k] + 1) * (ls[k] + 2) // 2 for k in range(nbas)]
+    dims = [(l + 1) * (l + 2) // 2 for l in ls]
     nao = sum(dims)
     smat = np.zeros((nao, nao))
 

--- a/examples/1-advanced/40-mole_api_and_numba_jit.py
+++ b/examples/1-advanced/40-mole_api_and_numba_jit.py
@@ -17,7 +17,7 @@ polynomials. A large number of quadrature roots are required to accurately
 evaluate the integrals. In the current implementation, the error is estimated
 around ~1e-3.
 
-This example is created to provide an implementation for issue 
+This example is created to provide an implementation for issue
 https://github.com/pyscf/pyscf/issues/2805
 
 For more technical discussions, please refer to:
@@ -97,9 +97,9 @@ def primitive_overlap(li, lj, ai, aj, ci, cj, Ra, Rb, roots, weights) -> np.ndar
                     Iy = 0
                     Iz = 0
                     for n in range(nroots):
-                        Ix += mu[ix,0,n] * nu[jx,0,n] * weights[n]
-                        Iy += mu[iy,1,n] * nu[jy,1,n] * weights[n]
-                        Iz += mu[iz,2,n] * nu[jz,2,n] * weights[n]
+                        Ix += abs(mu[ix,0,n] * nu[jx,0,n] * weights[n])
+                        Iy += abs(mu[iy,1,n] * nu[jy,1,n] * weights[n])
+                        Iz += abs(mu[iz,2,n] * nu[jz,2,n] * weights[n])
                     s[i,j] = Ix * Iy * Iz * norm_fac
                     j += 1
             i += 1

--- a/examples/1-advanced/40-mole_api_and_numba_jit.py
+++ b/examples/1-advanced/40-mole_api_and_numba_jit.py
@@ -51,6 +51,7 @@ def unravel_symmetric(i: int) -> tuple[int, int]:
 @njit(cache=True, fastmath=True, nogil=True)
 def primitive_overlap(li, lj, ai, aj, ci, cj, Ra, Rb, roots, weights) -> np.ndarray:
     norm_fac = ci * cj
+    # Unconventional normalization for Cartesian functions in PySCF
     if li <= 1:
         norm_fac *= ((2 * li + 1) / (4 * np.pi)) ** 0.5
     if lj <= 1:

--- a/examples/1-advanced/40-mole_api_and_numba_jit.py
+++ b/examples/1-advanced/40-mole_api_and_numba_jit.py
@@ -110,7 +110,7 @@ def primitive_overlap(li, lj, ai, aj, ci, cj, Ra, Rb, roots, weights) -> np.ndar
 @njit(cache=True, parallel=True)
 def primitive_overlap_matrix(ls, exps, norm_coef, bas_coords, roots, weights):
     nbas = len(ls)
-    dims = [(l + 1) * (l + 2) // 2 for l in ls]
+    dims = [(ls[k] + 1) * (ls[k] + 2) // 2 for k in range(nbas)]
     nao = sum(dims)
     smat = np.zeros((nao, nao))
 
@@ -119,15 +119,14 @@ def primitive_overlap_matrix(ls, exps, norm_coef, bas_coords, roots, weights):
     for idx in prange(npairs):
         i, j = unravel_symmetric(idx)
 
-        li, lj = ls[i], ls[j]
-        ai, aj = exps[i], exps[j]
-        ci, cj = norm_coef[i], norm_coef[j]
-        Ri, Rj = bas_coords[i], bas_coords[j]
+        i0 = sum(dims[:i])
+        j0 = sum(dims[:j])
+        ni = dims[i]
+        nj = dims[j]
 
-        i0, j0 = sum(dims[:i]), sum(dims[:j])
-        ni, nj = dims[i], dims[j]
-
-        s = primitive_overlap(li, lj, ai, aj, ci, cj, Ri, Rj, roots, weights)
+        s = primitive_overlap(
+            ls[i], ls[j], exps[i], exps[j], norm_coef[i], norm_coef[j], bas_coords[i], bas_coords[j], roots, weights
+        )
         smat[i0 : i0 + ni, j0 : j0 + nj] = s
         if i != j:
             smat[j0 : j0 + nj, i0 : i0 + ni] = s.T

--- a/examples/1-advanced/40-mole_api_and_numba_jit.py
+++ b/examples/1-advanced/40-mole_api_and_numba_jit.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-'''
+"""
 Calculates the overlap integral between the absolute values of Cartesian GTOs.
 
 This example demonstrates some APIs of the Mole class and utilizes Numba JIT
@@ -24,106 +24,116 @@ For more technical discussions, please refer to:
 "Enhancing PySCF-based Quantum Chemistry Simulations with Modern Hardware,
 Algorithms, and Python Tools", arXiv:2506.06661.
 This example provides a complete implementation of the code discussed in that paper.
-'''
+"""
 
 import numpy as np
-import numba
+from numba import njit, prange
 from scipy.special import roots_hermite
+
 from pyscf import gto
 
-@numba.njit(cache=True, fastmath=True)
+
+@njit(cache=True, nogil=True)
+def gauss_sum(n: int) -> int:
+    return n * (n + 1) // 2
+
+
+@njit(cache=True, nogil=True)
+def unravel_symmetric(i: int) -> tuple[int, int]:
+    a = int((np.sqrt(8 * i + 1) - 1) // 2)
+    offset = gauss_sum(a)
+    b = i - offset
+    if b > a:
+        a, b = b, a
+    return a, b
+
+
+@njit(cache=True, fastmath=True, nogil=True)
 def primitive_overlap(li, lj, ai, aj, ci, cj, Ra, Rb, roots, weights) -> np.ndarray:
     norm_fac = ci * cj
-    # Unconventional normalization for Cartesian functions in PySCF
-    if li <= 1: norm_fac *= ((li*2+1)/(4*np.pi))**.5
-    if lj <= 1: norm_fac *= ((lj*2+1)/(4*np.pi))**.5
+    if li <= 1:
+        norm_fac *= ((2 * li + 1) / (4 * np.pi)) ** 0.5
+    if lj <= 1:
+        norm_fac *= ((2 * lj + 1) / (4 * np.pi)) ** 0.5
 
     aij = ai + aj
     Rab = Ra - Rb
     Rp = (ai * Ra + aj * Rb) / aij
     theta_ij = ai * aj / aij
-    scale = 1./np.sqrt(aij)
-    norm_fac *= scale**3 * np.exp(-theta_ij * Rab.dot(Rab))
-    x = roots * scale + Rp[:,None]
-    xa = x - Ra[:,None]
-    xb = x - Rb[:,None]
+    scale = 1.0 / np.sqrt(aij)
+    norm_fac *= scale**3 * np.exp(-theta_ij * (Rab @ Rab))
 
-    # Build mu = xa ** np.arange(li+1)[:,None,None]
-    # Build nu = xb ** np.arange(lj+1)[:,None,None]
     nroots = len(weights)
-    mu = np.empty((li+1,3,nroots))
-    nu = np.empty((lj+1,3,nroots))
-    for n in range(nroots):
-        powx = 1.
-        powy = 1.
-        powz = 1.
-        mu[0,0,n] = 1.
-        mu[0,1,n] = 1.
-        mu[0,2,n] = 1.
-        for i in range(1, li+1):
-            powx = powx * xa[0,n]
-            powy = powy * xa[1,n]
-            powz = powz * xa[2,n]
-            mu[i,0,n] = powx
-            mu[i,1,n] = powy
-            mu[i,2,n] = powz
+    x = roots * scale + Rp[:, None]
+    xa = x - Ra[:, None]
+    xb = x - Rb[:, None]
 
-        powx = 1.
-        powy = 1.
-        powz = 1.
-        nu[0,0,n] = 1.
-        nu[0,1,n] = 1.
-        nu[0,2,n] = 1.
-        for i in range(1, lj+1):
-            powx = powx * xb[0,n]
-            powy = powy * xb[1,n]
-            powz = powz * xb[2,n]
-            nu[i,0,n] = powx
-            nu[i,1,n] = powy
-            nu[i,2,n] = powz
+    mu = np.empty((li + 1, 3, nroots))
+    nu = np.empty((lj + 1, 3, nroots))
+    mu[0, :, :] = 1.0
+    nu[0, :, :] = 1.0
 
-    nfi = (li+1)*(li+2)//2
-    nfj = (lj+1)*(lj+2)//2
+    for d in range(3):
+        for p in range(1, li + 1):
+            mu[p, d, :] = mu[p - 1, d, :] * xa[d, :]
+        for p in range(1, lj + 1):
+            nu[p, d, :] = nu[p - 1, d, :] * xb[d, :]
+
+    nfi = (li + 1) * (li + 2) // 2
+    nfj = (lj + 1) * (lj + 2) // 2
     s = np.empty((nfi, nfj))
+
     i = 0
     for ix in range(li, -1, -1):
-        for iy in range(li-ix, -1, -1):
+        for iy in range(li - ix, -1, -1):
             iz = li - ix - iy
             j = 0
             for jx in range(lj, -1, -1):
-                for jy in range(lj-jx, -1, -1):
+                for jy in range(lj - jx, -1, -1):
                     jz = lj - jx - jy
-                    Ix = 0
-                    Iy = 0
-                    Iz = 0
+
+                    Ix = 0.0
+                    Iy = 0.0
+                    Iz = 0.0
                     for n in range(nroots):
-                        Ix += abs(mu[ix,0,n] * nu[jx,0,n] * weights[n])
-                        Iy += abs(mu[iy,1,n] * nu[jy,1,n] * weights[n])
-                        Iz += abs(mu[iz,2,n] * nu[jz,2,n] * weights[n])
-                    s[i,j] = Ix * Iy * Iz * norm_fac
+                        w = weights[n]
+                        Ix += abs(mu[ix, 0, n] * nu[jx, 0, n] * w)
+                        Iy += abs(mu[iy, 1, n] * nu[jy, 1, n] * w)
+                        Iz += abs(mu[iz, 2, n] * nu[jz, 2, n] * w)
+
+                    s[i, j] = Ix * Iy * Iz * norm_fac
                     j += 1
             i += 1
     return s
 
-@numba.njit(cache=True)
+
+@njit(cache=True, parallel=True)
 def primitive_overlap_matrix(ls, exps, norm_coef, bas_coords, roots, weights):
     nbas = len(ls)
     dims = [(l + 1) * (l + 2) // 2 for l in ls]
     nao = sum(dims)
-    smat = np.empty((nao, nao))
-    i0 = 0
-    for i in range(nbas):
-        j0 = 0
-        for j in range(i+1):
-            s = primitive_overlap(ls[i], ls[j], exps[i], exps[j],
-                                  norm_coef[i], norm_coef[j],
-                                  bas_coords[i], bas_coords[j], roots, weights)
-            smat[i0:i0+dims[i], j0:j0+dims[j]] = s
-            # smat is a symmetric matrix
-            if i != j: smat[j0:j0+dims[j], i0:i0+dims[i]] = s.T
-            j0 += dims[j]
-        i0 += dims[i]
+    smat = np.zeros((nao, nao))
+
+    npairs = gauss_sum(nbas)
+
+    for idx in prange(npairs):
+        i, j = unravel_symmetric(idx)
+
+        li, lj = ls[i], ls[j]
+        ai, aj = exps[i], exps[j]
+        ci, cj = norm_coef[i], norm_coef[j]
+        Ri, Rj = bas_coords[i], bas_coords[j]
+
+        i0, j0 = sum(dims[:i]), sum(dims[:j])
+        ni, nj = dims[i], dims[j]
+
+        s = primitive_overlap(li, lj, ai, aj, ci, cj, Ri, Rj, roots, weights)
+        smat[i0 : i0 + ni, j0 : j0 + nj] = s
+        if i != j:
+            smat[j0 : j0 + nj, i0 : i0 + ni] = s.T
+
     return smat
+
 
 def absolute_overlap_matrix(mol, nroots=500):
     assert mol.cart
@@ -140,7 +150,8 @@ def absolute_overlap_matrix(mol, nroots=500):
     bas_coords = np.array([pmol.bas_coord(i) for i in range(pmol.nbas)])
     r, w = roots_hermite(nroots)
     s = primitive_overlap_matrix(ls, exps, norm_coef, bas_coords, r, w)
-    return ctr_mat.T.dot(s).dot(ctr_mat)
+    return ctr_mat.T @ s @ ctr_mat
+
 
 def find_instr(func, keyword, sig=0, limit=5):
     count = 0
@@ -153,8 +164,10 @@ def find_instr(func, keyword, sig=0, limit=5):
     if count == 0:
         print('No instructions found')
 
+
 if __name__ == '__main__':
     import pyscf
+
     mol = pyscf.M(atom='H 0 0 0; H 0 0 1', basis='def2-svp', cart=True)
     pmol, ctr_mat = mol.decontract_basis(to_cart=True, aggregate=True)
     absolute_overlap_matrix(mol)


### PR DESCRIPTION
In #2825 an example to compute the absolute overlap matrix 

$$ S_{ij} = \int | \phi_i(r)||\phi_j(r)| \mathrm{d}r $$

was added. Unfortunately it still missed the absolute values in the inner loop and produced wrong results already for the H2 dimer, e.g. the absolute overlap between the 1s and 2p functions on the same atom was zero.

The loop to be changed was this here:
```python3
                    for n in range(nroots):
                        w = weights[n]
                        Ix += abs(mu[ix, 0, n] * nu[jx, 0, n] * w)
                        Iy += abs(mu[iy, 1, n] * nu[jy, 1, n] * w)
                        Iz += abs(mu[iz, 2, n] * nu[jz, 2, n] * w)
```

In addition, this PR is written in a more vectorized manner and uses parallelization where possible.
This gives a speedup by a factor of four for non-trivial molecules.

(e.g. 160 carbon polyacetylene chain with cc-pvdz goes down from 40s to 10s.)