### PR TITLE
Lattice sum range check

### DIFF
--- a/pyscf/pbc/cc/test/test_kgccsd.py
+++ b/pyscf/pbc/cc/test/test_kgccsd.py
@@ -239,7 +239,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(ecc, cc_311, 6)
 
     def test_211_n3(self):
-        cell = make_test_cell.test_cell_n3_diffuse()
+        cell = make_test_cell.test_cell_n3_diffuse(precision=1e-9)
         nk = (2, 1, 1)
 
         abs_kpts = cell.make_kpts(nk, wrap_around=True)
@@ -348,7 +348,7 @@ class KnownValues(unittest.TestCase):
 
     def test_cu_metallic_high_cost(self):
         mesh = 7
-        cell = make_test_cell.test_cell_cu_metallic([mesh]*3)
+        cell = make_test_cell.test_cell_cu_metallic([mesh]*3, precision=1e-9)
         nk = [1,1,2]
 
         ehf_bench = -52.5393701339723

--- a/pyscf/pbc/df/mdf.py
+++ b/pyscf/pbc/df/mdf.py
@@ -36,7 +36,7 @@ from pyscf.pbc.df import df
 from pyscf.pbc.df import aft
 from pyscf.pbc.df.aft import _check_kpts
 from pyscf.pbc.df.gdf_builder import _CCGDFBuilder
-from pyscf.pbc.df.rsdf_builder import _RSGDFBuilder
+from pyscf.pbc.df.rsdf_builder import _RSGDFBuilder, estimate_rs_2c2e_rcut
 from pyscf.pbc.df.incore import libpbc, make_auxcell
 from pyscf.pbc.lib.kpts import KPoints
 from pyscf.pbc.lib.kpts_helper import is_zero, member, unique
@@ -228,9 +228,11 @@ class _RSMDFBuilder(_RSGDFBuilder):
         #    <g|g> - 2 <g|G><G|g> + <g|G><G|G><G|g> = <g|g> - <g|G><G|g>
         auxcell = self.auxcell
         omega = self.omega
-        rs_auxcell = self.rs_auxcell
+        rs_auxcell = self.rs_auxcell.copy()
         auxcell_c = rs_auxcell.compact_basis_cell()
+
         if auxcell_c.nbas > 0:
+            auxcell_c.rcut = estimate_rs_2c2e_rcut(auxcell_c, omega)
             with auxcell_c.with_short_range_coulomb(omega):
                 sr_j2c = list(auxcell_c.pbc_intor('int2c2e', hermi=1, kpts=uniq_kpts))
 

--- a/pyscf/pbc/dft/multigrid/_backend_c.py
+++ b/pyscf/pbc/dft/multigrid/_backend_c.py
@@ -190,7 +190,6 @@ def grid_collocate(
     ao_loc0,
     ao_loc1,
     dimension,
-    Ls,
     a,
     b,
     ish_atm,
@@ -220,7 +219,7 @@ def grid_collocate(
     i0, i1, j0, j1 = shls_slice
     ao_loc0 = np.asarray(ao_loc0, order='C', dtype=np.int32)
     ao_loc1 = np.asarray(ao_loc1, order='C', dtype=np.int32)
-    Ls = np.asarray(Ls, order='C', dtype=np.double)
+    Ls = np.asarray(task_list.Ls, order='C', dtype=np.double)
     a = np.asarray(a, order='C', dtype=np.double)
     b = np.asarray(b, order='C', dtype=np.double)
     ish_atm = np.asarray(ish_atm, order='C', dtype=np.int32)
@@ -266,7 +265,6 @@ def grid_integrate(
     ao_loc0,
     ao_loc1,
     dimension,
-    Ls,
     a,
     b,
     ish_atm,
@@ -301,7 +299,7 @@ def grid_integrate(
         mat = np.zeros((comp, naoi, naoj))
 
     wv = np.asarray(wv, order='C', dtype=np.double)
-    Ls = np.asarray(Ls, order='C', dtype=np.double)
+    Ls = np.asarray(task_list.Ls, order='C', dtype=np.double)
     a = np.asarray(a, order='C', dtype=np.double)
     b = np.asarray(b, order='C', dtype=np.double)
     ish_atm = np.asarray(ish_atm, order='C', dtype=np.int32)
@@ -516,7 +514,13 @@ class TaskList:
         assert njsh == len(jsh_rcut)
 
         if Ls is None:
-            Ls = cell.get_lattice_Ls(rcut=ish_rcut.max()+jsh_rcut.max())
+            # The default cell.rcut might be insufficient to include all
+            # significant pairs
+            rcut = ish_rcut.max(initial=0) + jsh_rcut.max(initial=0)
+            Ls = cell.get_lattice_Ls(rcut=rcut)
+        # The lattice sum vectors must be consistent with the neighbor_list in
+        # the backend functions
+        self.Ls = Ls
         Ls = np.asarray(Ls, order='C', dtype=np.double)
 
         nl = build_neighbor_list_for_shlpairs(cell, cell1, Ls=Ls,

--- a/pyscf/pbc/dft/multigrid/_backend_c.py
+++ b/pyscf/pbc/dft/multigrid/_backend_c.py
@@ -480,10 +480,6 @@ class TaskList:
         if cell1 is None:
             cell1 = cell
 
-        if Ls is None:
-            Ls = cell.get_lattice_Ls()
-        Ls = np.asarray(Ls, order='C', dtype=np.double)
-
         if precision is None:
             precision = cell.precision
 
@@ -518,6 +514,10 @@ class TaskList:
             ptr_jpgf_rcut = lib.ndarray_pointer_2d(jpgf_rcut)
         njsh = len(jsh_bas)
         assert njsh == len(jsh_rcut)
+
+        if Ls is None:
+            Ls = cell.get_lattice_Ls(rcut=ish_rcut.max()+jsh_rcut.max())
+        Ls = np.asarray(Ls, order='C', dtype=np.double)
 
         nl = build_neighbor_list_for_shlpairs(cell, cell1, Ls=Ls,
                                               ish_rcut=ish_rcut, jsh_rcut=jsh_rcut,

--- a/pyscf/pbc/dft/multigrid/multigrid_pair.py
+++ b/pyscf/pbc/dft/multigrid/multigrid_pair.py
@@ -113,7 +113,7 @@ def _update_task_list(mydf, hermi=0, ntasks=None, ke_ratio=None, rel_cutoff=None
 
 
 def eval_rho(cell, dm, task_list, shls_slice=None, hermi=0, xctype='LDA', kpts=None,
-             dimension=None, cell1=None, shls_slice1=None, Ls=None,
+             dimension=None, cell1=None, shls_slice1=None,
              a=None, ignore_imag=False):
     '''Collocate density (and gradients) on the real-space grid.
 
@@ -174,11 +174,6 @@ def eval_rho(cell, dm, task_list, shls_slice=None, hermi=0, xctype='LDA', kpts=N
         dimension = cell0.dimension
     assert dimension == getattr(cell1, "dimension", None)
 
-    if Ls is None and dimension > 0:
-        Ls = cell0.get_lattice_Ls()
-    elif Ls is None and dimension == 0:
-        Ls = np.zeros((1,3))
-
     if dimension == 0 or kpts is None or gamma_point(kpts):
         dm = dm.reshape(-1,1,naoi,naoj)
     else:
@@ -200,7 +195,7 @@ def eval_rho(cell, dm, task_list, shls_slice=None, hermi=0, xctype='LDA', kpts=N
                     task_list, hermi,
                     (i0, i1, j0, j1),
                     ao_loc0, ao_loc1, dimension,
-                    Ls, a, b,
+                    a, b,
                     ish_atm, ish_bas, ish_env,
                     jsh_atm, jsh_bas, jsh_env,
                     cell0.cart)
@@ -284,7 +279,7 @@ def _eval_rhoG(mydf, dm_kpts, hermi=1, kpts=np.zeros((1,3)), deriv=0,
 
 def eval_mat(cell, weights, task_list, shls_slice=None, comp=1, hermi=0, deriv=0,
              xctype='LDA', kpts=None, grid_level=None, dimension=None, mesh=None,
-             cell1=None, shls_slice1=None, Ls=None, a=None):
+             cell1=None, shls_slice1=None, a=None):
     if deriv == 1:
         assert comp == 3
         assert hermi == 0
@@ -340,11 +335,6 @@ def eval_mat(cell, weights, task_list, shls_slice=None, comp=1, hermi=0, deriv=0
         dimension = cell0.dimension
     assert dimension == getattr(cell1, "dimension", None)
 
-    if Ls is None and dimension > 0:
-        Ls = cell0.get_lattice_Ls()
-    elif Ls is None and dimension == 0:
-        Ls = np.zeros((1,3))
-
     weights = np.asarray(weights)
     if dimension == 0 or kpts is None or gamma_point(kpts):
         assert weights.dtype == np.double
@@ -381,7 +371,7 @@ def eval_mat(cell, weights, task_list, shls_slice=None, comp=1, hermi=0, deriv=0
                 task_list, comp, hermi, grid_level,
                 (i0, i1, j0, j1),
                 ao_loc0, ao_loc1, dimension,
-                Ls, a, b,
+                a, b,
                 ish_atm, ish_bas, ish_env,
                 jsh_atm, jsh_bas, jsh_env,
                 cell0.cart)

--- a/pyscf/pbc/dft/test/test_multigrid2.py
+++ b/pyscf/pbc/dft/test/test_multigrid2.py
@@ -143,12 +143,12 @@ class KnownValues(unittest.TestCase):
             task_list = multi_grids_tasks(He_orth, hermi=1, ntasks=2)
             assert task_list.ntasks == [1150, 0]
             task_list = multi_grids_tasks(He_nonorth, hermi=1, ntasks=2)
-            assert task_list.ntasks == [2771, 732]
+            assert task_list.ntasks == [2806, 732]
         with with_grid_level_method("pyscf"):
             task_list = multi_grids_tasks(He_orth, hermi=1, ntasks=2)
             assert task_list.ntasks == [1150, 0]
             task_list = multi_grids_tasks(He_nonorth, hermi=1, ntasks=2)
-            assert task_list.ntasks == [3249, 254]
+            assert task_list.ntasks == [3284, 254]
 
     def test_orth_get_pp(self):
         ref = df.FFTDF(cell_orth).get_pp()

--- a/pyscf/pbc/gto/neighborlist.py
+++ b/pyscf/pbc/gto/neighborlist.py
@@ -77,10 +77,6 @@ def build_neighbor_list_for_shlpairs(cell, cell1=None, Ls=None,
     '''
     if cell1 is None:
         cell1 = cell
-    if Ls is None:
-        Ls = cell.get_lattice_Ls()
-    Ls = np.asarray(Ls, order='C', dtype=float)
-    nimgs = len(Ls)
 
     if hermi == 1 and cell1 is not cell:
         logger.warn(cell,
@@ -109,6 +105,11 @@ def build_neighbor_list_for_shlpairs(cell, cell1=None, Ls=None,
             jsh_rcut = cell1.rcut_by_shells(precision=precision)
     njsh = len(jsh_bas)
     assert njsh == len(jsh_rcut)
+
+    if Ls is None:
+        Ls = cell.get_lattice_Ls(rcut=ish_rcut.max()+jsh_rcut.max())
+    Ls = np.asarray(Ls, order='C', dtype=float)
+    nimgs = len(Ls)
 
     nl = ctypes.POINTER(_CNeighborList)()
     libpbc.build_neighbor_list(

--- a/pyscf/pbc/gto/neighborlist.py
+++ b/pyscf/pbc/gto/neighborlist.py
@@ -107,7 +107,8 @@ def build_neighbor_list_for_shlpairs(cell, cell1=None, Ls=None,
     assert njsh == len(jsh_rcut)
 
     if Ls is None:
-        Ls = cell.get_lattice_Ls(rcut=ish_rcut.max()+jsh_rcut.max())
+        rcut = ish_rcut.max(initial=0) + jsh_rcut.max(initial=0)
+        Ls = cell.get_lattice_Ls(rcut=rcut)
     Ls = np.asarray(Ls, order='C', dtype=float)
     nimgs = len(Ls)
 

--- a/pyscf/pbc/gto/test/test_cell.py
+++ b/pyscf/pbc/gto/test/test_cell.py
@@ -111,9 +111,9 @@ class KnownValues(unittest.TestCase):
         3.370137329  3.370137329  0.000000000''',
         mesh = [15]*3)
         rcut = max([cell.bas_rcut(ib, 1e-8) for ib in range(cell.nbas)])
-        self.assertEqual(cell.get_lattice_Ls(rcut=rcut).shape, (1439, 3))
-        #rcut = max([cell.bas_rcut(ib, 1e-9) for ib in range(cell.nbas)])
-        #self.assertEqual(cell.get_lattice_Ls(rcut=rcut).shape, (1499, 3))
+        Ls = cell.get_lattice_Ls(rcut=rcut)
+        r = pbctools.check_lattice_sum_range(cell, Ls)
+        self.assertTrue(r > rcut)
 
     def test_fractional_coordinates(self):
         cell = pgto.M(atom = '''

--- a/pyscf/pbc/tools/make_test_cell.py
+++ b/pyscf/pbc/tools/make_test_cell.py
@@ -110,7 +110,7 @@ def test_cell_n3(mesh=[9]*3):
     cell.build()
     return cell
 
-def test_cell_n3_diffuse():
+def test_cell_n3_diffuse(precision=1e-8):
     """
     Take ASE Diamond structure, input into PySCF and run
     """
@@ -125,13 +125,14 @@ def test_cell_n3_diffuse():
     cell.pseudo = "gth-pade"
 
     cell.verbose = 7
+    cell.precision = precision
     cell.mesh = [5] * 3
     cell.output = '/dev/null'
     cell.build()
     return cell
 
 
-def test_cell_cu_metallic(mesh=[9]*3):
+def test_cell_cu_metallic(mesh=[9]*3, precision=1e-8):
     """
     Copper unit cell w/ special basis giving non-equal number of occupied orbitals per k-point
     """
@@ -150,6 +151,7 @@ def test_cell_cu_metallic(mesh=[9]*3):
                           [1, (1.0, 1.0)],
                           [2, (1.2, 1.0)]] }
     cell.unit = 'B'
+    cell.precision = precision
     cell.mesh = mesh
     cell.verbose = 9
     cell.incore_anyway = True

--- a/pyscf/pbc/tools/test/test_pbc.py
+++ b/pyscf/pbc/tools/test/test_pbc.py
@@ -152,6 +152,17 @@ C  15.16687337 15.16687337 15.16687337
         r_discard = tools.check_lattice_sum_range(cell, Ls)
         self.assertTrue(r_discard > cell.rcut)
 
+    def test_get_lattice_Ls3(self):
+        numpy.random.seed(2)
+        cl1 = pbcgto.M(a = numpy.random.random((3,3))*3,
+                       mesh = [3]*3,
+                       atom ='''He .1 .0 .0''')
+        cl2 = tools.super_cell(cl1, [2,3,4])
+        rcut = 12
+        Ls = tools.get_lattice_Ls(cl2, rcut=rcut, discard=True)
+        r_discard = tools.check_lattice_sum_range(cl2, Ls)
+        self.assertTrue(r_discard > rcut)
+
     def test_super_cell(self):
         numpy.random.seed(2)
         cl1 = pbcgto.M(a = numpy.random.random((3,3))*3,

--- a/pyscf/pbc/tools/test/test_pbc.py
+++ b/pyscf/pbc/tools/test/test_pbc.py
@@ -14,6 +14,7 @@
 
 import unittest
 import numpy
+import numpy as np
 from pyscf import gto
 from pyscf.pbc import gto as pbcgto
 from pyscf.pbc import tools
@@ -101,7 +102,8 @@ class KnownValues(unittest.TestCase):
                        atom ='''He .1 .0 .0''',
                        basis = 'ccpvdz')
         Ls = tools.get_lattice_Ls(cl1)
-        self.assertEqual(Ls.shape, (2275,3))
+        r_discard = tools.check_lattice_sum_range(cl1, Ls)
+        self.assertTrue(r_discard > cl1.rcut)
 
         Ls = tools.get_lattice_Ls(cl1, rcut=0)
         self.assertEqual(Ls.shape, (1,3))
@@ -130,13 +132,25 @@ C  15.16687337 15.16687337 15.16687337
         cell.precision = 1e-10
         cell.build()
         Ls = cell.get_lattice_Ls()
-        self.assertTrue(Ls.shape[0] > 140)
+        r_discard = tools.check_lattice_sum_range(cell, Ls)
+        self.assertTrue(r_discard > cell.rcut)
 
         S = cell.pbc_intor('int1e_ovlp')
         w, v = numpy.linalg.eigh(S)
         self.assertTrue(w.min() > 0)
         self.assertAlmostEqual(abs(S - S.T.conj()).max(), 0, 13)
         self.assertAlmostEqual(w.min(), 0.0007176363230, 8)
+
+    def test_get_lattice_Ls2(self):
+        cell = pbcgto.Cell()
+        cell.unit = 'B'
+        cell.atom = 'He 0.,  0.,  0.; He 0.99    ,  0.    ,  0.    '
+        cell.a = np.diag([10, 10, 2])
+        cell.rcut = 2.01
+        cell.build()
+        Ls = tools.get_lattice_Ls(cell, discard=True)
+        r_discard = tools.check_lattice_sum_range(cell, Ls)
+        self.assertTrue(r_discard > cell.rcut)
 
     def test_super_cell(self):
         numpy.random.seed(2)


### PR DESCRIPTION
In previous implementations, certain important lattice images were discarded when generating lattice sum vectors for non-orthogonal cells. This PR updates the  lattice sum images using a more conservative criterion.
