### PR TITLE
[FEATURE TRANSFER] Transfer MC-PDFT from PySCF-Forge (1/2)

### DIFF
--- a/examples/mcpdft/03-metaGGA_functionals.py
+++ b/examples/mcpdft/03-metaGGA_functionals.py
@@ -17,14 +17,14 @@ mc = mcpdft.CASCI(mf, 'tM06L', 6, 8).run ()
 tM06L0 = 't' + mcpdft.hyb('M06L',0.25, hyb_type='average')
 mc = mcpdft.CASCI(mf, tM06L0, 6, 8).run ()
 
-## MC23: meta-hybrid on-top functional [PNAS, 122, 1, 2025, e2419413121; https://doi.org/10.1073/pnas.2419413121]
-#
-## State-Specific
-#mc = mcpdft.CASCI(mf, 'MC23', 6, 8)
-#mc.kernel()
-#
-## State-average
-#nroots=2
-#mc = mcpdft.CASCI(mf, 'MC23', 6, 8)
-#mc.fcisolver.nroots=nroots
-#mc.kernel()[0]
+# MC23: meta-hybrid on-top functional [PNAS, 122, 1, 2025, e2419413121; https://doi.org/10.1073/pnas.2419413121]
+
+# State-Specific
+mc = mcpdft.CASCI(mf, 'MC23', 6, 8)
+mc.kernel()
+
+# State-average
+nroots=2
+mc = mcpdft.CASCI(mf, 'MC23', 6, 8)
+mc.fcisolver.nroots=nroots
+mc.kernel()[0]

--- a/pyscf/dft/test/test_libxc.py
+++ b/pyscf/dft/test/test_libxc.py
@@ -21,8 +21,7 @@ import ctypes
 import unittest
 import numpy
 from pyscf import gto, scf
-from pyscf import dft2 as dft
-from pyscf import dft as dft1
+from pyscf import dft
 from pyscf import lib
 
 def setUpModule():
@@ -35,14 +34,14 @@ def setUpModule():
     mol.build()
     #dm = scf.RHF(mol).run(conv_tol=1e-14).make_rdm1()
     dm = numpy.load(os.path.realpath(os.path.join(__file__, '..', 'dm_h4.npy')))
-    with lib.temporary_env(dft1.radi, ATOM_SPECIFIC_TREUTLER_GRIDS=False):
-        mf = dft1.RKS(mol)
+    with lib.temporary_env(dft.radi, ATOM_SPECIFIC_TREUTLER_GRIDS=False):
+        mf = dft.RKS(mol)
         mf.grids.atom_grid = {"H": (50, 110)}
         mf.prune = None
         mf.grids.build(with_non0tab=False)
         nao = mol.nao_nr()
-        ao = dft1.numint.eval_ao(mol, mf.grids.coords, deriv=1)
-        rho = dft1.numint.eval_rho(mol, ao, dm, xctype='GGA')
+        ao = dft.numint.eval_ao(mol, mf.grids.coords, deriv=1)
+        rho = dft.numint.eval_rho(mol, ao, dm, xctype='GGA')
 
 def tearDownModule():
     global mol, mf, ao, rho
@@ -51,12 +50,12 @@ def tearDownModule():
 class KnownValues(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.original_grids = dft1.radi.ATOM_SPECIFIC_TREUTLER_GRIDS
-        dft1.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = False
+        cls.original_grids = dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS
+        dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = False
 
     @classmethod
     def tearDownClass(cls):
-        dft1.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = cls.original_grids
+        dft.radi.ATOM_SPECIFIC_TREUTLER_GRIDS = cls.original_grids
 
     def test_parse_xc(self):
         hyb, fn_facs = dft.libxc.parse_xc('.5*HF+.5*B3LYP5,VWN*.5')
@@ -269,7 +268,7 @@ class KnownValues(unittest.TestCase):
             kxc = None  # 3rd order functional derivative
             return exc, vxc, fxc, kxc
 
-        mf = dft1.RKS(mol)
+        mf = dft.RKS(mol)
         ni = dft.libxc.define_xc(mf._numint, eval_xc, 'GGA', hyb=0.2)
         numpy.random.seed(1)
         rho = numpy.random.random((4,10))
@@ -322,7 +321,7 @@ class KnownValues(unittest.TestCase):
             kxc = None  # 3rd order functional derivative
             return exc, vxc, fxc, kxc
 
-        mf = dft1.RKS(mol)
+        mf = dft.RKS(mol)
         ni = dft.libxc.define_xc(mf._numint, eval_mgga_xc, 'MGGA')
         numpy.random.seed(1)
         rho = numpy.random.random((5,10))

--- a/pyscf/grad/test/test_metagga_mcpdft.py
+++ b/pyscf/grad/test/test_metagga_mcpdft.py
@@ -120,7 +120,6 @@ class KnownValues(unittest.TestCase):
                 de = mc.kernel(state=state)[1, 0] / BOHR
                 self.assertAlmostEqual(de, DE_REF[state], 5)
 
-    @unittest.skip("MC23 fnal requires PySCF-Forge dft2 libxc interface")
     def test_grad_lih_ssmc2322_sto3g(self):
         mc = diatomic("Li", "H", 0.8, "MC23", "STO-3G", 2, 2, 1, grids_level=1)
         de = mc.kernel()[1, 0] / BOHR
@@ -132,7 +131,6 @@ class KnownValues(unittest.TestCase):
 
         self.assertAlmostEqual(de, DE_REF, 5)
 
-    @unittest.skip("MC23 fnal requires PySCF-Forge dft2 libxc interface")
     def test_grad_lih_sa2mc2322_sto3g(self):
         mc = diatomic("Li", "H", 0.8, "MC23", "STO-3G", 2, 2, 2, grids_level=1)
 
@@ -146,7 +144,6 @@ class KnownValues(unittest.TestCase):
                 de = mc.kernel(state=state)[1, 0] / BOHR
                 self.assertAlmostEqual(de, DE_REF[state], 5)
 
-    @unittest.skip("MC23 fnal requires PySCF-Forge dft2 libxc interface")
     def test_grad_lih_sa2mc2322_sto3g_df(self):
         mc = diatomic(
             "Li", "H", 0.8, "MC23", "STO-3G", 2, 2, 2, grids_level=1, density_fit=df

--- a/pyscf/mcpdft/test/test_cmspdft.py
+++ b/pyscf/mcpdft/test/test_cmspdft.py
@@ -152,7 +152,6 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(mc2.converged)
         self.assertAlmostEqual(lib.fp(mc1.e_states), lib.fp(mc2.e_states), 6)
 
-    @unittest.skip("MC23 fnal requires PySCF-Forge dft2 libxc interface")
     def test_lih_cms2mc2322(self):
         mc = get_lih(1.5, fnal="MC23")
         e_mcscf_avg = np.dot(mc.e_mcscf, mc.weights)

--- a/pyscf/mcpdft/test/test_lpdft.py
+++ b/pyscf/mcpdft/test/test_lpdft.py
@@ -97,7 +97,7 @@ def setUpModule():
     lih_4 = get_lih(1.5, n_states=4, basis="6-31G")
     lih_tpbe = get_lih(1.5, functional="tPBE")
     lih_tpbe0 = get_lih(1.5, functional="tPBE0")
-    lih_mc23 = None #get_lih(1.5, functional="MC23")
+    lih_mc23 = get_lih(1.5, functional="MC23")
     water = get_water()
     t_water = get_water_triplet()
 
@@ -108,6 +108,7 @@ def tearDownModule():
     lih_4.mol.stdout.close()
     lih_tpbe0.mol.stdout.close()
     lih_tpbe.mol.stdout.close()
+    lih_mc23.mol.stdout.close()
     water.mol.stdout.close()
     t_water.mol.stdout.close()
     del lih, lih_4, lih_tpbe0, lih_tpbe, t_water, water, original_grids, lih_mc23
@@ -184,7 +185,6 @@ class KnownValues(unittest.TestCase):
         self.assertListAlmostEqual(lih_tpbe0.e_states, e_hlpdft, 9)
         self.assertListAlmostEqual(hlpdft_ham.flatten(), lih_tpbe0.lpdft_ham.flatten(), 9)
 
-    @unittest.skip("MC23 fnal requires PySCF-Forge dft2 libxc interface")
     def test_lih_mc23_adiabat(self):
         e_mcscf_mc23_avg = np.dot(lih_mc23.e_mcscf, lih_mc23.weights)
         hcoup = abs(lih_mc23.lpdft_ham[1,0])

--- a/pyscf/mcpdft/test/test_mgga.py
+++ b/pyscf/mcpdft/test/test_mgga.py
@@ -116,19 +116,19 @@ def setUpModule():
     global lih_tmc23_2, lih_tmc23_sa2_2, water_tmc23_2
 
     # register otfnal tMC23_2 which is identical to MC23
-    #mc232_preset = mcpdft.otfnal.OT_PRESET['MC23']
-    #mcpdft.otfnal.register_otfnal('MC23_2', mc232_preset)
+    mc232_preset = mcpdft.otfnal.OT_PRESET['MC23']
+    mcpdft.otfnal.register_otfnal('MC23_2', mc232_preset)
 
     lih_tm06l = get_lih(1.5, functional='tM06L')
-    lih_tmc23 = None #get_lih(1.5, functional='MC23')
-    lih_tmc23_2 = None #get_lih(1.5, functional='tMC23_2')
+    lih_tmc23 = get_lih(1.5, functional='MC23')
+    lih_tmc23_2 = get_lih(1.5, functional='tMC23_2')
     lih_tm06l_sa2 = get_lih(1.5, stateaverage=True, functional='tM06L')
-    lih_tmc23_sa2 = None #get_lih(1.5, stateaverage=True, functional='MC23')
-    lih_tmc23_sa2_2 = None #get_lih(1.5, stateaverage=True, functional='tmc23_2')
+    lih_tmc23_sa2 = get_lih(1.5, stateaverage=True, functional='MC23')
+    lih_tmc23_sa2_2 = get_lih(1.5, stateaverage=True, functional='tmc23_2')
     lih_tm06l0 = get_lih(1.5, functional='tM06L0')
     water_tm06l = get_water_triplet()
-    water_tmc23 = None #get_water_triplet(functional='MC23')
-    water_tmc23_2 = None #get_water_triplet(functional='TMc23_2')
+    water_tmc23 = get_water_triplet(functional='MC23')
+    water_tmc23_2 = get_water_triplet(functional='TMc23_2')
 
 def tearDownModule():
     global lih_tm06l, lih_tmc23, lih_tm06l_sa2, lih_tmc23_sa2
@@ -136,17 +136,17 @@ def tearDownModule():
     global lih_tmc23_2, lih_tmc23_sa2_2, water_tmc23_2
 
     lih_tm06l.mol.stdout.close()
-    #lih_tmc23.mol.stdout.close()
-    #lih_tmc23_2.mol.stdout.close()
+    lih_tmc23.mol.stdout.close()
+    lih_tmc23_2.mol.stdout.close()
     lih_tm06l_sa2.mol.stdout.close()
-    #lih_tmc23_sa2.mol.stdout.close()
-    #lih_tmc23_sa2_2.mol.stdout.close()
+    lih_tmc23_sa2.mol.stdout.close()
+    lih_tmc23_sa2_2.mol.stdout.close()
     lih_tm06l0.mol.stdout.close()
     water_tm06l.mol.stdout.close()
-    #water_tmc23.mol.stdout.close()
-    #water_tmc23_2.mol.stdout.close()
+    water_tmc23.mol.stdout.close()
+    water_tmc23_2.mol.stdout.close()
 
-    #mcpdft.otfnal.unregister_otfnal('tMC23_2')
+    mcpdft.otfnal.unregister_otfnal('tMC23_2')
 
     del lih_tm06l, lih_tmc23, lih_tm06l_sa2, lih_tmc23_sa2
     del lih_tm06l0, water_tm06l, water_tmc23
@@ -190,43 +190,43 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e_mcscf, E_CASSCF_EXPECTED, 6)
         self.assertAlmostEqual(epdft, E_MCPDFT_EXPECTED, 6)
 
-    #def test_tmc23(self):
-    #    e_mcscf = lih_tmc23.e_mcscf
-    #    epdft = lih_tmc23.e_tot
+    def test_tmc23(self):
+        e_mcscf = lih_tmc23.e_mcscf
+        epdft = lih_tmc23.e_tot
 
-    #    sa_e_mcscf = lih_tmc23_sa2.e_mcscf
-    #    sa_epdft = lih_tmc23_sa2.e_states
+        sa_e_mcscf = lih_tmc23_sa2.e_mcscf
+        sa_epdft = lih_tmc23_sa2.e_states
 
-    #    # The CAS and MCPDFT reference values are generated using
-    #    # OpenMolcas v24.10, tag 682-gf74be507d
-    #    E_CASSCF_EXPECTED = -7.88214917
-    #    E_MCPDFT_EXPECTED = -7.95098727
-    #    SA_E_CASSCF_EXPECTED = [-7.88205449, -7.74391704]
-    #    SA_E_MCPDFT_EXPECTED = [-7.95093826, -7.80604012]
+        # The CAS and MCPDFT reference values are generated using
+        # OpenMolcas v24.10, tag 682-gf74be507d
+        E_CASSCF_EXPECTED = -7.88214917
+        E_MCPDFT_EXPECTED = -7.95098727
+        SA_E_CASSCF_EXPECTED = [-7.88205449, -7.74391704]
+        SA_E_MCPDFT_EXPECTED = [-7.95093826, -7.80604012]
 
-    #    self.assertAlmostEqual(e_mcscf, E_CASSCF_EXPECTED, 6)
-    #    self.assertAlmostEqual(epdft, E_MCPDFT_EXPECTED, 6)
-    #    self.assertListAlmostEqual(sa_e_mcscf, SA_E_CASSCF_EXPECTED, 6)
-    #    self.assertListAlmostEqual(sa_epdft, SA_E_MCPDFT_EXPECTED, 6)
+        self.assertAlmostEqual(e_mcscf, E_CASSCF_EXPECTED, 6)
+        self.assertAlmostEqual(epdft, E_MCPDFT_EXPECTED, 6)
+        self.assertListAlmostEqual(sa_e_mcscf, SA_E_CASSCF_EXPECTED, 6)
+        self.assertListAlmostEqual(sa_epdft, SA_E_MCPDFT_EXPECTED, 6)
 
-    #def test_tmc23_2(self):
-    #    e_mcscf = lih_tmc23_2.e_mcscf
-    #    epdft = lih_tmc23_2.e_tot
+    def test_tmc23_2(self):
+        e_mcscf = lih_tmc23_2.e_mcscf
+        epdft = lih_tmc23_2.e_tot
 
-    #    sa_e_mcscf = lih_tmc23_sa2_2.e_mcscf
-    #    sa_epdft = lih_tmc23_sa2_2.e_states
+        sa_e_mcscf = lih_tmc23_sa2_2.e_mcscf
+        sa_epdft = lih_tmc23_sa2_2.e_states
 
-    #    # The CAS and MCPDFT reference values are generated using
-    #    # OpenMolcas v24.10, tag 682-gf74be507d
-    #    E_CASSCF_EXPECTED = -7.88214917
-    #    E_MCPDFT_EXPECTED = -7.95098727
-    #    SA_E_CASSCF_EXPECTED = [-7.88205449, -7.74391704]
-    #    SA_E_MCPDFT_EXPECTED = [-7.95093826, -7.80604012]
+        # The CAS and MCPDFT reference values are generated using
+        # OpenMolcas v24.10, tag 682-gf74be507d
+        E_CASSCF_EXPECTED = -7.88214917
+        E_MCPDFT_EXPECTED = -7.95098727
+        SA_E_CASSCF_EXPECTED = [-7.88205449, -7.74391704]
+        SA_E_MCPDFT_EXPECTED = [-7.95093826, -7.80604012]
 
-    #    self.assertAlmostEqual(e_mcscf, E_CASSCF_EXPECTED, 6)
-    #    self.assertAlmostEqual(epdft, E_MCPDFT_EXPECTED, 6)
-    #    self.assertListAlmostEqual(sa_e_mcscf, SA_E_CASSCF_EXPECTED, 6)
-    #    self.assertListAlmostEqual(sa_epdft, SA_E_MCPDFT_EXPECTED, 6)
+        self.assertAlmostEqual(e_mcscf, E_CASSCF_EXPECTED, 6)
+        self.assertAlmostEqual(epdft, E_MCPDFT_EXPECTED, 6)
+        self.assertListAlmostEqual(sa_e_mcscf, SA_E_CASSCF_EXPECTED, 6)
+        self.assertListAlmostEqual(sa_epdft, SA_E_MCPDFT_EXPECTED, 6)
 
     def test_water_triplet_tm06l(self):
         e_mcscf = water_tm06l.e_mcscf
@@ -240,29 +240,29 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e_mcscf, E_CASSCF_EXPECTED, 6)
         self.assertAlmostEqual(epdft, E_MCPDFT_EXPECTED, 6)
 
-    #def test_water_triplet_tmc23(self):
-    #    e_mcscf = water_tmc23.e_mcscf
-    #    epdft = water_tmc23.e_tot
+    def test_water_triplet_tmc23(self):
+        e_mcscf = water_tmc23.e_mcscf
+        epdft = water_tmc23.e_tot
 
-    #    # The CAS and MCPDFT reference values are generated using
-    #    # OpenMolcas v24.10, tag 682-gf74be507d
-    #    E_CASSCF_EXPECTED = -75.72365496
-    #    E_MCPDFT_EXPECTED = -76.02630019
+        # The CAS and MCPDFT reference values are generated using
+        # OpenMolcas v24.10, tag 682-gf74be507d
+        E_CASSCF_EXPECTED = -75.72365496
+        E_MCPDFT_EXPECTED = -76.02630019
 
-    #    self.assertAlmostEqual(e_mcscf, E_CASSCF_EXPECTED, 6)
-    #    self.assertAlmostEqual(epdft, E_MCPDFT_EXPECTED, 6)
+        self.assertAlmostEqual(e_mcscf, E_CASSCF_EXPECTED, 6)
+        self.assertAlmostEqual(epdft, E_MCPDFT_EXPECTED, 6)
 
-    #def test_water_triplet_tmc23_2(self):
-    #    e_mcscf = water_tmc23_2.e_mcscf
-    #    epdft = water_tmc23_2.e_tot
+    def test_water_triplet_tmc23_2(self):
+        e_mcscf = water_tmc23_2.e_mcscf
+        epdft = water_tmc23_2.e_tot
 
-    #    # The CAS and MCPDFT reference values are generated using
-    #    # OpenMolcas v24.10, tag 682-gf74be507d
-    #    E_CASSCF_EXPECTED = -75.72365496
-    #    E_MCPDFT_EXPECTED = -76.02630019
+        # The CAS and MCPDFT reference values are generated using
+        # OpenMolcas v24.10, tag 682-gf74be507d
+        E_CASSCF_EXPECTED = -75.72365496
+        E_MCPDFT_EXPECTED = -76.02630019
 
-    #    self.assertAlmostEqual(e_mcscf, E_CASSCF_EXPECTED, 6)
-    #    self.assertAlmostEqual(epdft, E_MCPDFT_EXPECTED, 6)
+        self.assertAlmostEqual(e_mcscf, E_CASSCF_EXPECTED, 6)
+        self.assertAlmostEqual(epdft, E_MCPDFT_EXPECTED, 6)
 
 if __name__ == "__main__":
     print("Full Tests for MGGAs, Hybrid-MGGAs, and MC23")


### PR DESCRIPTION
Pursuant to the accepted feature transfer proposal, https://github.com/pyscf/pyscf-forge/issues/144. This is the second of two PRs in accordance with @sunqm's suggestion https://github.com/pyscf/pyscf-forge/issues/144#issuecomment-3079363462.

This PR transfers the libxc interface rewrite which allows PySCF to access the LibXC custom functional definition features in the Python layer, thereby enabling the MC23 functional of [*PNAS* **2024**, *122*, e2419413121] as well as functional customization features for all DFT and MC-PDFT calculations using `dft.libxc.register_custom_functional_`. Unittests and examples of MC23 as well as a unittest for functional customization in the DFT context are included.

[comment]: <> (Reference hyperlinks)
[*PNAS* **2024**, *122*, e2419413121]: http://dx.doi.org/10.1073/pnas.2419413121
