### PR TITLE
Better DFR/UMP2 support for PBC mf

### DIFF
--- a/pyscf/mp/dfmp2.py
+++ b/pyscf/mp/dfmp2.py
@@ -219,11 +219,18 @@ def _make_df_eris(mp, mo_coeff=None, ovL=None, ovL_to_save=None, verbose=None):
     assert( with_df is not None )
 
     if with_df._cderi is None:
-        log.debug('Caching ovL-type integrals directly')
-        if with_df.auxmol is None:
-            with_df.auxmol = df.addons.make_auxmol(with_df.mol, with_df.auxbasis)
+        if getattr(with_df, 'cell', None) is not None:  # PBC
+            log.warn('PBC mean-field does not support direct DFMP2. Caching AO 3c integrals now.')
+            with_df.build()
+            naux = with_df.get_naoaux()
+        else:
+            log.debug('Caching ovL-type integrals directly')
+            if with_df.auxmol is None:
+                with_df.auxmol = df.addons.make_auxmol(with_df.mol, with_df.auxbasis)
+            naux = with_df.auxmol.nao_nr()
     else:
         log.debug('Caching ovL-type integrals by transforming saved AO 3c integrals.')
+        naux = with_df.get_naoaux()
 
     if mo_coeff is None: mo_coeff = mp.mo_coeff
     occ_coeff, vir_coeff = mp.split_mo_coeff()[1:3]
@@ -231,7 +238,6 @@ def _make_df_eris(mp, mo_coeff=None, ovL=None, ovL_to_save=None, verbose=None):
     # determine incore or outcore
     nocc = occ_coeff.shape[1]
     nvir = vir_coeff.shape[1]
-    naux = with_df.get_naoaux()
 
     if ovL is not None:
         if isinstance(ovL, np.ndarray):


### PR DESCRIPTION
Bug fix for using molecular DFMP2 code for Gamma-point PBC mean-field when `mf.with_df._cderi` is None. New tests are added.