### PR TITLE
Fix RHF exchange performance by preserving MO information

### DIFF
--- a/pyscf/pbc/df/fft_jk.py
+++ b/pyscf/pbc/df/fft_jk.py
@@ -444,7 +444,7 @@ def get_jk(mydf, dm, hermi=1, kpt=np.zeros(3), kpts_band=None,
         density matrix (both order and shape).
     '''
     if getattr(dm, "mo_coeff", None) is not None:
-        dm = lib.tag_array(np.asarray(dm, order='C'), mo_coeff=dm.mo_coeff, 
+        dm = lib.tag_array(np.asarray(dm, order='C'), mo_coeff=dm.mo_coeff,
                            mo_occ=dm.mo_occ)
     else:
         dm = np.asarray(dm, order='C')

--- a/pyscf/pbc/df/fft_jk.py
+++ b/pyscf/pbc/df/fft_jk.py
@@ -443,7 +443,11 @@ def get_jk(mydf, dm, hermi=1, kpt=np.zeros(3), kpts_band=None,
         The function returns one J and one K matrix, corresponding to the input
         density matrix (both order and shape).
     '''
-    dm = np.asarray(dm, order='C')
+    if getattr(dm, "mo_coeff", None) is not None:
+        dm = lib.tag_array(np.asarray(dm, order='C'), mo_coeff=dm.mo_coeff, 
+                           mo_occ=dm.mo_occ)
+    else:
+        dm = np.asarray(dm, order='C')
     vj = vk = None
     if with_j:
         vj = get_j(mydf, dm, hermi, kpt, kpts_band)
@@ -508,9 +512,17 @@ def get_k(mydf, dm, hermi=1, kpt=np.zeros(3), kpts_band=None, exxdiv=None):
         The function returns one J and one K matrix, corresponding to the input
         density matrix (both order and shape).
     '''
+    if getattr(dm, "mo_coeff", None) is not None:
+        mo_coeff = dm.mo_coeff
+        mo_occ = dm.mo_occ
+    else:
+        mo_coeff = None
+        mo_occ = None
+
     dm = np.asarray(dm, order='C')
     nao = dm.shape[-1]
     dm_kpts = dm.reshape(-1,1,nao,nao)
+    dm_kpts = lib.tag_array(dm_kpts, mo_coeff=mo_coeff, mo_occ=mo_occ)
     vk = get_k_kpts(mydf, dm_kpts, hermi, kpt.reshape(1,3), kpts_band, exxdiv)
     if kpts_band is None:
         vk = vk[:,0,:,:]

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -654,6 +654,11 @@ class SCF(mol_hf.SCF):
         if kpt is None: kpt = self.kpt
 
         cpu0 = (logger.process_clock(), logger.perf_counter())
+        if getattr(dm, "mo_coeff", None) is not None:
+            mo_coeff = np.asarray(dm.mo_coeff)
+            mo_occ = np.asarray(dm.mo_occ)
+        else:
+            mo_coeff = mo_occ = None
         dm = np.asarray(dm)
         nao = dm.shape[-1]
 
@@ -681,8 +686,15 @@ class SCF(mol_hf.SCF):
             vj, vk = self.rsjk.get_jk(dm.reshape(-1,nao,nao), hermi, kpt, kpts_band,
                                       with_j, with_k, omega, exxdiv=self.exxdiv)
         else:
-            vj, vk = self.with_df.get_jk(dm.reshape(-1,nao,nao), hermi, kpt, kpts_band,
+            dm_shape = dm.shape
+            dm = dm.reshape(-1, nao, nao)
+            if mo_coeff is not None:
+                dm = lib.tag_array(dm, mo_coeff=mo_coeff.reshape(-1, nao, nao), 
+                                   mo_occ=mo_occ.reshape(-1, nao))
+            vj, vk = self.with_df.get_jk(dm, hermi, kpt, kpts_band,
                                          with_j, with_k, omega, exxdiv=self.exxdiv)
+            dm = dm.reshape(dm_shape)
+
         if with_j:
             vj = _format_jks(vj, dm, kpts_band)
         if with_k:

--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -689,7 +689,7 @@ class SCF(mol_hf.SCF):
             dm_shape = dm.shape
             dm = dm.reshape(-1, nao, nao)
             if mo_coeff is not None:
-                dm = lib.tag_array(dm, mo_coeff=mo_coeff.reshape(-1, nao, nao), 
+                dm = lib.tag_array(dm, mo_coeff=mo_coeff.reshape(-1, nao, nao),
                                    mo_occ=mo_occ.reshape(-1, nao))
             vj, vk = self.with_df.get_jk(dm, hermi, kpt, kpts_band,
                                          with_j, with_k, omega, exxdiv=self.exxdiv)


### PR DESCRIPTION
### Problem
  RHF exchange calculations were significantly slower than KRHF at the gamma pt for the same system due to calls like np.asarray(dm) and dm.reshape(-1,nao,nao)

  This caused `get_k_kpts` in `pyscf/pbc/df/fft_jk.py` to use different algorithms:
  - **Without `mo_coeff`**: AO-based algorithm scaling as O(N_ao² × N_grid × log N_grid)  
  - **With `mo_coeff`**: MO-based algorithm scaling as O(N_occ² × N_grid × log N_grid)

  ### Solution
  Preserve `mo_coeff` and `mo_occ` attributes when calling `get_jk()` in RHF, matching KRHF's approach.

  ### Performance Impact  
  - **Before**: RHF exchange significantly slower than KRHF for same system
  - **After**: RHF and KRHF have comparable performance

  ### Testing
  - All existing tests pass (`python -m pytest pyscf/pbc/scf/test/`)
  - No changes to numerical results (same energies to machine precision)
  - Performance verified with benchmark showing expected improvement (see example in comment)

  ### Files Changed
  - `pyscf/pbc/scf/hf.py`: Modified `get_jk()` to preserve MO attributes
  -  `pyscf/pbc/df/fft_jk.py`: Modified `get_jk()` and `get_k()` to preserve MO attributes