### PR TITLE
Fix inconsistencies in get_coulG and super_cell between supercell and k-point calculations

### DIFF
--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -697,6 +697,12 @@ class StreamObject:
 
     __getstate__, __setstate__ = generate_pickle_methods()
 
+    def reset(self):
+        '''
+        Clean up intermediates
+        '''
+        return self
+
 
 _warn_once_registry = {}
 def check_sanity(obj, keysref, stdout=sys.stdout):

--- a/pyscf/pbc/cc/test/test_eom_kgccsd.py
+++ b/pyscf/pbc/cc/test/test_eom_kgccsd.py
@@ -76,7 +76,7 @@ class KnownValues(unittest.TestCase):
         e2_obt, v = eom.eaccsd(nroots=3, koopmans=True, kptlist=[1], imds=imds)
         self.assertAlmostEqual(e2_obt[0][0], 1.227583017804503, 6)
         self.assertAlmostEqual(e2_obt[0][1], 1.2275830178298166, 6)
-        self.assertAlmostEqual(e2_obt[0][2], 1.3830379190440196, 6)
+        self.assertAlmostEqual(e2_obt[0][2], 1.3830379190440196, 5)
 
         # Basis eeccsd
         eom = EOMEE(mycc)
@@ -125,7 +125,7 @@ class KnownValues(unittest.TestCase):
         e2_obt, v = eom.eaccsd(nroots=3, koopmans=True, kptlist=[1], imds=imds)
         self.assertAlmostEqual(e2_obt[0][0], 1.229802629928757, 6)
         self.assertAlmostEqual(e2_obt[0][1], 1.229802629928764, 6)
-        self.assertAlmostEqual(e2_obt[0][2], 1.384394578043613, 6)
+        self.assertAlmostEqual(e2_obt[0][2], 1.384394578043613, 5)
 
     def test_n3_diffuse_star(self):
         '''Tests EOM-CCSD* method.'''
@@ -185,12 +185,12 @@ class KnownValues(unittest.TestCase):
         e2_obt, v = eom.eaccsd(nroots=3, koopmans=True, kptlist=[1], imds=imds)
         self.assertAlmostEqual(e2_obt[0][0], 1.2290479727093149, 6)
         self.assertAlmostEqual(e2_obt[0][1], 1.2290479727093468, 6)
-        self.assertAlmostEqual(e2_obt[0][2], 1.384154366703175, 6)
+        self.assertAlmostEqual(e2_obt[0][2], 1.384154366703175, 5)
 
         e2_obt = eom.eaccsd_star(nroots=3, koopmans=True, kptlist=[1], imds=imds)
         self.assertAlmostEqual(e2_obt[0][0], 1.2229050426609025, 6)
         self.assertAlmostEqual(e2_obt[0][1], 1.2229050426609025, 6)
-        self.assertAlmostEqual(e2_obt[0][2], 1.374851059956632, 6)
+        self.assertAlmostEqual(e2_obt[0][2], 1.374851059956632, 5)
 
 if __name__ == '__main__':
     print("eom_kccsd_rhf tests")

--- a/pyscf/pbc/cc/test/test_eom_krccsd.py
+++ b/pyscf/pbc/cc/test/test_eom_krccsd.py
@@ -159,7 +159,7 @@ class KnownValues(unittest.TestCase):
         imds = myeom.make_imds()
         e, v = myeom.eaccsd(nroots=2, koopmans=True, kptlist=(1,))
         self.assertAlmostEqual(e[0][0], 1.2275830143478248, 6)
-        self.assertAlmostEqual(e[0][1], 1.3830379248901867, 6)
+        self.assertAlmostEqual(e[0][1], 1.3830379248901867, 5)
         e, v = myeom.eaccsd(nroots=2, koopmans=True, kptlist=(0,))
         self.assertAlmostEqual(e[0][0], 1.2669788600074476, 6)
         self.assertAlmostEqual(e[0][1], 1.278883198038047, 6)
@@ -195,7 +195,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e[0][1], -0.8983139526618168, 6)
         e, v = cc.eaccsd(nroots=2, koopmans=True, kptlist=(1,))
         self.assertAlmostEqual(e[0][0], 1.229802633498979, 6)
-        self.assertAlmostEqual(e[0][1], 1.384394629885998, 6)
+        self.assertAlmostEqual(e[0][1], 1.384394629885998, 5)
 
     def test_n3_diffuse_Ta(self):
         nk = (1, 1, 2)
@@ -224,7 +224,7 @@ class KnownValues(unittest.TestCase):
         eom = EOMEA_Ta(cc)
         e, v = eom.eaccsd(nroots=2, koopmans=True, kptlist=[1], eris=eris)
         self.assertAlmostEqual(e[0][0], 1.229047959680129, 6)
-        self.assertAlmostEqual(e[0][1], 1.384154370672317, 6)
+        self.assertAlmostEqual(e[0][1], 1.384154370672317, 5)
 
     def test_n3_diffuse_Ta_against_so(self):
         ehf_bench = -6.1870676561720721

--- a/pyscf/pbc/cc/test/test_eom_krccsd.py
+++ b/pyscf/pbc/cc/test/test_eom_krccsd.py
@@ -165,7 +165,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e[0][1], 1.278883198038047, 6)
         e, v = myeom.eaccsd(nroots=2, left=True, koopmans=True, kptlist=(1,))
         self.assertAlmostEqual(e[0][0], 1.227583012965648, 6)
-        self.assertAlmostEqual(e[0][1], 1.383037924670814, 6)
+        self.assertAlmostEqual(e[0][1], 1.383037924670814, 5)
         e, v = myeom.eaccsd(nroots=2, left=True, koopmans=True, kptlist=(0,))
         self.assertAlmostEqual(e[0][0], 1.2669788599162801, 6)
         self.assertAlmostEqual(e[0][1], 1.2788832018377787, 6)

--- a/pyscf/pbc/cc/test/test_eom_kuccsd.py
+++ b/pyscf/pbc/cc/test/test_eom_kuccsd.py
@@ -52,9 +52,9 @@ class KnownValues(unittest.TestCase):
 
         eom = EOMEA(mycc)
         e2_obt, v = eom.eaccsd(nroots=3, koopmans=True, kptlist=[1])
-        self.assertAlmostEqual(e2_obt[0][0], 1.227583017460536, 6)
-        self.assertAlmostEqual(e2_obt[0][1], 1.227583017460617, 6)
-        self.assertAlmostEqual(e2_obt[0][2], 1.383037918699404, 6)
+        self.assertAlmostEqual(e2_obt[0][0], 1.227583017460536, 5)
+        self.assertAlmostEqual(e2_obt[0][1], 1.227583017460617, 5)
+        self.assertAlmostEqual(e2_obt[0][2], 1.383037918699404, 5)
 
     def test_n3_diffuse_frozen(self):
         ehf2 = kmf.e_tot
@@ -86,9 +86,9 @@ class KnownValues(unittest.TestCase):
 
         eom = EOMEA(mycc)
         e2_obt, v = eom.eaccsd(nroots=3, koopmans=True, kptlist=[1])
-        self.assertAlmostEqual(e2_obt[0][0], 1.229802629928757, 6)
-        self.assertAlmostEqual(e2_obt[0][1], 1.229802629928764, 6)
-        self.assertAlmostEqual(e2_obt[0][2], 1.384394578043613, 6)
+        self.assertAlmostEqual(e2_obt[0][0], 1.229802629928757, 5)
+        self.assertAlmostEqual(e2_obt[0][1], 1.229802629928764, 5)
+        self.assertAlmostEqual(e2_obt[0][2], 1.384394578043613, 5)
 
     def test_eomea_matvec(self):
         cell = gto.Cell()

--- a/pyscf/pbc/cc/test/test_kgccsd.py
+++ b/pyscf/pbc/cc/test/test_kgccsd.py
@@ -248,7 +248,7 @@ class KnownValues(unittest.TestCase):
         kmf = pbcscf.KGHF(cell, abs_kpts, exxdiv=None)
         kmf.conv_tol = 1e-14
         escf = kmf.scf()
-        self.assertAlmostEqual(escf, -6.1870676561726574, 7)
+        self.assertAlmostEqual(escf, -6.1870676561726574, 6)
 
         # GCCSD calculation
         cc = pbcc.kccsd.CCSD(kmf)
@@ -351,7 +351,7 @@ class KnownValues(unittest.TestCase):
         cell = make_test_cell.test_cell_cu_metallic([mesh]*3, precision=1e-9)
         nk = [1,1,2]
 
-        ehf_bench = -52.5393701339723
+        ehf_bench = -52.57191968827088
 
         # KRHF calculation
         kmf = pbcscf.KRHF(cell, exxdiv=None)

--- a/pyscf/pbc/cc/test/test_krccsd.py
+++ b/pyscf/pbc/cc/test/test_krccsd.py
@@ -32,6 +32,7 @@ from pyscf.pbc.lib import kpts_helper
 #from pyscf.pbc.cc.kccsd_rhf import kconserve_pmatrix
 import pyscf.pbc.cc.kccsd_t_rhf as kccsd_t_rhf
 from pyscf.pbc.cc import eom_kccsd_rhf
+from pyscf.pbc.tools.pbc import super_cell
 
 
 def setUpModule():
@@ -206,8 +207,8 @@ class KnownValues(unittest.TestCase):
         mesh = 5
         cell = make_test_cell.test_cell_n3([mesh]*3)
         nk = (1, 1, 2)
-        ehf_bench = -8.348616843863795
-        ecc_bench = -0.037920339437169
+        ehf_bench = -8.648503065380389
+        ecc_bench = -0.100045112503651
 
         abs_kpts = cell.make_kpts(nk, with_gamma_point=True)
 
@@ -223,6 +224,12 @@ class KnownValues(unittest.TestCase):
         ecc, t1, t2 = cc.kernel()
         self.assertAlmostEqual(ehf, ehf_bench, 8)
         self.assertAlmostEqual(ecc, ecc_bench, 6)
+
+        mf = super_cell(cell, nk).RHF(exxdiv=None).run()
+        self.assertAlmostEqual(mf.e_tot/2, ehf_bench, 5)
+        cc = pbcc.RCCSD(mf, frozen=[0,1,2])
+        cc.diis_start_cycle = 1
+        self.assertAlmostEqual(cc.kernel()[0]/2, ecc_bench, 6)
 
     def test_ao2mo(self):
         kmf = make_rand_kmf()
@@ -458,7 +465,6 @@ class KnownValues(unittest.TestCase):
         ekcc_t = mycc.ccsd_t(eris=eris)
 
         # Run supercell
-        from pyscf.pbc.tools.pbc import super_cell
         supcell = super_cell(cell, nk)
         rks = pbcdft.RKS(supcell)
         erks = rks.kernel()
@@ -501,7 +507,6 @@ class KnownValues(unittest.TestCase):
         ekcc_t = mycc.ccsd_t(eris=eris)
 
         # Run supercell
-        from pyscf.pbc.tools.pbc import super_cell
         supcell = super_cell(cell, nk)
         rks = pbcdft.RKS(supcell)
         erks = rks.kernel()
@@ -540,7 +545,6 @@ class KnownValues(unittest.TestCase):
         ekcc_t = mycc.ccsd_t(eris=eris)
 
         # Run supercell
-        from pyscf.pbc.tools.pbc import super_cell
         supcell = super_cell(cell, nk)
         rks = pbcscf.RHF(supcell)
         erks = rks.kernel()
@@ -579,7 +583,6 @@ class KnownValues(unittest.TestCase):
         ekcc_t = mycc.ccsd_t(eris=eris)
 
         # Run supercell
-        from pyscf.pbc.tools.pbc import super_cell
         supcell = super_cell(cell, nk)
         rks = pbcscf.RHF(supcell)
         erks = rks.kernel()
@@ -611,7 +614,7 @@ class KnownValues(unittest.TestCase):
         kpts -= kpts[0]
         kks = pbcscf.KRHF(cell, kpts=kpts)
         ekks = kks.kernel()
-        self.assertAlmostEqual(ekks, -10.530978858287662, 8)
+        self.assertAlmostEqual(ekks, -10.530978858287662, 6)
 
         khf = pbcscf.KRHF(cell)
         khf.__dict__.update(kks.__dict__)

--- a/pyscf/pbc/cc/test/test_krccsd.py
+++ b/pyscf/pbc/cc/test/test_krccsd.py
@@ -204,7 +204,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e0, e1, 5)
 
     def test_frozen_n3(self):
-        mesh = 5
+        mesh = 12
         cell = make_test_cell.test_cell_n3([mesh]*3)
         nk = (1, 1, 2)
         ehf_bench = -8.648503065380389
@@ -614,7 +614,7 @@ class KnownValues(unittest.TestCase):
         kpts -= kpts[0]
         kks = pbcscf.KRHF(cell, kpts=kpts)
         ekks = kks.kernel()
-        self.assertAlmostEqual(ekks, -10.530978858287662, 6)
+        self.assertAlmostEqual(ekks, -10.530978858287662, 5)
 
         khf = pbcscf.KRHF(cell)
         khf.__dict__.update(kks.__dict__)

--- a/pyscf/pbc/cc/test/test_krccsd.py
+++ b/pyscf/pbc/cc/test/test_krccsd.py
@@ -222,7 +222,7 @@ class KnownValues(unittest.TestCase):
         cc = pbcc.kccsd_rhf.RCCSD(kmf, frozen=[[0],[0,1]])
         cc.diis_start_cycle = 1
         ecc, t1, t2 = cc.kernel()
-        self.assertAlmostEqual(ehf, ehf_bench, 7)
+        self.assertAlmostEqual(ehf, ehf_bench, 6)
         self.assertAlmostEqual(ecc, ecc_bench, 6)
 
         mf = super_cell(cell, nk).RHF(exxdiv=None).run()

--- a/pyscf/pbc/cc/test/test_krccsd.py
+++ b/pyscf/pbc/cc/test/test_krccsd.py
@@ -222,7 +222,7 @@ class KnownValues(unittest.TestCase):
         cc = pbcc.kccsd_rhf.RCCSD(kmf, frozen=[[0],[0,1]])
         cc.diis_start_cycle = 1
         ecc, t1, t2 = cc.kernel()
-        self.assertAlmostEqual(ehf, ehf_bench, 8)
+        self.assertAlmostEqual(ehf, ehf_bench, 7)
         self.assertAlmostEqual(ecc, ecc_bench, 6)
 
         mf = super_cell(cell, nk).RHF(exxdiv=None).run()

--- a/pyscf/pbc/ci/test/test_ci.py
+++ b/pyscf/pbc/ci/test/test_ci.py
@@ -57,16 +57,16 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(eci[0][0], 0.693665750383, 5)
         self.assertAlmostEqual(eci[0][1], 0.693665750384, 5)
         eci, v = myci.kernel(nroots=2, eris=eris, kptlist=[1])
-        self.assertAlmostEqual(eci[0][0], 0.760927568875, 5)
+        self.assertAlmostEqual(eci[0][0], 0.800318837778, 5)
         self.assertAlmostEqual(eci[0][1], 0.800318837778, 5)
 
     def test_cis_H(self):
         h = ci.kcis_rhf.cis_H(kci, 0, eris=eris)
-        self.assertAlmostEqual(lib.fp(h), 2.979013823936476+0j, 7)
+        self.assertAlmostEqual(lib.fp(h), 2.979013823936476+0j, 5)
         e0ref, v0ref = np.linalg.eigh(h)
 
         h = ci.kcis_rhf.cis_H(kci, 1, eris=eris)
-        self.assertAlmostEqual(lib.fp(h), 4.046206590499069-0j, 7)
+        self.assertAlmostEqual(lib.fp(h), 4.046206590499069-0j, 4)
         e1ref, v1ref = np.linalg.eigh(h)
 
         eci, v = kci.kernel(nroots=3, eris=eris, kptlist=[0, 1])
@@ -83,7 +83,7 @@ class KnownValues(unittest.TestCase):
         h = ci.kcis_rhf.cis_H(kci, 1, eris=eris)
         hdiag = kci.get_diag(1, eris=eris)
         self.assertAlmostEqual(abs(h.diagonal() - hdiag).max(), 0, 6)
-        self.assertAlmostEqual(lib.fp(hdiag), 5.219997654681162+0j, 6)
+        self.assertAlmostEqual(lib.fp(hdiag), 5.219997654681162+0j, 5)
 
     def test_cis_matvec_singlet(self):
         vsize = kci.vector_size()

--- a/pyscf/pbc/df/mdf.py
+++ b/pyscf/pbc/df/mdf.py
@@ -319,6 +319,34 @@ class _RSMDFBuilder(_RSGDFBuilder):
         GauxI = np.asarray(Gaux.imag, order='C')
         return GauxR, GauxI
 
+    def weighted_coulG(self, kpt=np.zeros(3), exx=False, mesh=None, omega=None):
+        # In PySCF-2.10 and earlier versions, certain contributions at the edges
+        # +/-Gmax +/- 0.5 were removed to restore symmetry between the PW bases
+        # in the MDF. Asymmetric PWs can introduce imaginary parts in the
+        # Coulomb energy terms. This error becomes larger when the energy cutoff
+        # for PWs is insufficient. The PW bases used in MDF typically cannot
+        # converge the Coulomb energy alone, leading to more significant errors
+        # for the asymmetric PWs. The screening of asymmetric PWs at the edges
+        # was implemented in the pbc.tools.pbc.get_coulG function. However, this
+        # treatment could cause inconsistency between supercell gamma point and
+        # k-point sampled calculations, and has been removed from get_coulG. It
+        # is exclusively applied within the MDF context here.
+        coulG = aft.weighted_coulG(self, kpt, exx, mesh, omega)
+        cell = self.cell
+        b = cell.reciprocal_vectors()
+        scaled_kpt = np.linalg.solve(b.T, kpt)
+        coulG = coulG.reshape(mesh)
+        for n in range(cell.dimension):
+            if abs(scaled_kpt[n] + 0.5) < 1e-12:
+                # when k = -.5, -Gmax-.5 lies on the edge. They were removed in
+                # previous versions.
+                coulG[(slice(None),)*n + (mesh[n]//2+1,)] = 0
+            elif abs(scaled_kpt[n] - 0.5) < 1e-12 and mesh[n] % 2 == 1:
+                # when k = .5, Gmax+.5 lies on the edge. They were removed in
+                # previous versions.
+                coulG[(slice(None),)*n + (mesh[n]//2,)] = 0
+        return coulG.ravel()
+
 
 class _CCMDFBuilder(_CCGDFBuilder):
     '''
@@ -367,7 +395,6 @@ class _CCMDFBuilder(_CCGDFBuilder):
                 auxG = None
             j2c[k] = j2c_k
         return j2c
-
 
     def outcore_auxe2(self, cderi_file, intor='int3c2e', aosym='s2', comp=None,
                       j_only=False, dataname='j3c', shls_slice=None,
@@ -426,3 +453,5 @@ class _CCMDFBuilder(_CCGDFBuilder):
         else:
             cderi_negative = None
         return cderi, cderi_negative
+
+    weighted_coulG = _RSMDFBuilder.weighted_coulG

--- a/pyscf/pbc/df/test/test_df_ao2mo.py
+++ b/pyscf/pbc/df/test/test_df_ao2mo.py
@@ -41,6 +41,7 @@ def tearDownModule():
 
 class KnownValues(unittest.TestCase):
     def test_eri1111(self):
+        numpy.random.seed(1)
         kpts = numpy.random.random((4,3)) * .25
         kpts[3] = -numpy.einsum('ij->j', kpts[:3])
         with_df = df.DF(cell).set(auxbasis='weigend')
@@ -57,6 +58,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(eri1.reshape(eri0.shape)-eri0).sum(), 0, 9)
 
     def test_eri0110(self):
+        numpy.random.seed(1)
         kpts = numpy.random.random((4,3)) * .25
         kpts[3] = kpts[0]
         kpts[2] = kpts[1]
@@ -74,6 +76,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(eri1.reshape(eri0.shape)-eri0).sum(), 0, 9)
 
     def test_eri0101(self):
+        numpy.random.seed(1)
         kpts = numpy.random.random((4,3)) * .25
         kpts[2] = kpts[0]
         kpts[3] = kpts[1]
@@ -113,6 +116,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(eri1.reshape(eri0.shape)-eri0).sum(), 0, 9)
 
     def test_1d(self):
+        numpy.random.seed(1)
         kpts = numpy.random.random((4,3)) * .25
         kpts[3] = -numpy.einsum('ij->j', kpts[:3])
         with_df = df.DF(cell).set(auxbasis='weigend')
@@ -132,6 +136,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(eri1.reshape(eri0.shape)-eri0).sum(), 0, 9)
 
     def test_2d(self):
+        numpy.random.seed(1)
         kpts = numpy.random.random((4,3)) * .25
         kpts[3] = -numpy.einsum('ij->j', kpts[:3])
         with_df = df.DF(cell).set(auxbasis='weigend')

--- a/pyscf/pbc/df/test/test_df_jk.py
+++ b/pyscf/pbc/df/test/test_df_jk.py
@@ -216,7 +216,9 @@ class KnownValues(unittest.TestCase):
         dm = dm + dm.transpose(0,2,1)
         mydf = df.DF(cell0).set(auxbasis='weigend')
         mydf.linear_dep_threshold = 1e-7
-        mydf.kpts = numpy.random.random((4,3))
+        kpts = numpy.random.random((4,3))
+        kpts -= cell0.get_abs_kpts(cell0.get_scaled_kpts(kpts).round(0))
+        mydf.kpts = kpts
         mydf.exxdiv = None
         mydf.eta = 0.15
         mydf.exp_to_discard = 0.3

--- a/pyscf/pbc/df/test/test_mdf_ao2mo.py
+++ b/pyscf/pbc/df/test/test_mdf_ao2mo.py
@@ -41,6 +41,7 @@ def tearDownModule():
 
 class KnownValues(unittest.TestCase):
     def test_eri1111(self):
+        numpy.random.seed(1)
         kpts = numpy.random.random((4,3)) * .25
         kpts[3] = -numpy.einsum('ij->j', kpts[:3])
         with_df = mdf.MDF(cell).set(auxbasis='weigend')
@@ -57,6 +58,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(eri1.reshape(eri0.shape)-eri0).sum(), 0, 9)
 
     def test_eri0110(self):
+        numpy.random.seed(1)
         kpts = numpy.random.random((4,3)) * .25
         kpts[3] = kpts[0]
         kpts[2] = kpts[1]

--- a/pyscf/pbc/mp/test/test_padding.py
+++ b/pyscf/pbc/mp/test/test_padding.py
@@ -63,7 +63,7 @@ class KnownValues(unittest.TestCase):
         cell1.build()
         nk = [2, 1, 1]
         escf, emp = run_kcell(cell1, nk)
-        self.assertAlmostEqual(escf, -10.551651367521986, 7)
+        self.assertAlmostEqual(escf, -10.551651367521986, 6)
         self.assertAlmostEqual(emp , -0.1514005714425273, 7)
 
     def test_221_high_cost(self):
@@ -79,13 +79,13 @@ class KnownValues(unittest.TestCase):
         ekpt = kmf.scf()
         mp = pyscf.pbc.mp.kmp2.KMP2(kmf).run()
 
-        self.assertAlmostEqual(ekpt,      -10.835614361742607, 8)
-        self.assertAlmostEqual(mp.e_corr, -0.1522294774708119, 7)
+        self.assertAlmostEqual(ekpt,      -10.835614361742607, 6)
+        self.assertAlmostEqual(mp.e_corr, -0.1522294774708119, 6)
 
     def test_222_high_cost(self):
         nk = (2, 2, 2)
         escf, emp = run_kcell(cell,nk)
-        self.assertAlmostEqual(escf, -11.0152342492995, 8)
+        self.assertAlmostEqual(escf, -11.0152342492995, 6)
         self.assertAlmostEqual(emp, -0.233433093787577, 7)
 
 

--- a/pyscf/pbc/scf/test/test_newton.py
+++ b/pyscf/pbc/scf/test/test_newton.py
@@ -125,20 +125,20 @@ class KnowValues(unittest.TestCase):
         mf = scf.newton(mf)
         mf.conv_tol_grad = 1e-4
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -10.5309059210831, 8)
+        self.assertAlmostEqual(mf.e_tot, -10.5309059210831, 7)
 
     def test_nr_kuhf(self):
         mf = scf.KUHF(cell, cell.make_kpts([2,1,1]))
         mf = scf.newton(mf)
         mf.conv_tol_grad = 1e-4
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -10.5309059210831, 8)
+        self.assertAlmostEqual(mf.e_tot, -10.5309059210831, 7)
 
     def test_nr_krohf(self):
         mf = scf.KROHF(cell, cell.make_kpts([2,1,1])).newton()
         mf.conv_tol_grad = 1e-4
         mf.kernel()
-        self.assertAlmostEqual(mf.e_tot, -10.5309059210831, 8)
+        self.assertAlmostEqual(mf.e_tot, -10.5309059210831, 7)
 
     def test_nr_krks_lda(self):
         mf = dft.KRKS(cell, cell.make_kpts([2,1,1]))
@@ -193,7 +193,7 @@ class KnowValues(unittest.TestCase):
         mf = scf.newton(mf)
         mf.grids.build()
         g, hop, hdiag = mf.gen_g_hop(mo, mo_occ, mf.get_hcore())
-        self.assertAlmostEqual(numpy.linalg.norm(hop(dm1)), 37.967972033738519, 7)
+        self.assertAlmostEqual(numpy.linalg.norm(hop(dm1)), 37.967972033738519, 6)
 
     def test_uks_gen_g_hop(self):
         mf = dft.KUKS(cell, cell.make_kpts([2,1,1]))
@@ -208,7 +208,7 @@ class KnowValues(unittest.TestCase):
         mf = scf.newton(mf)
         mf.grids.build()
         g, hop, hdiag = mf.gen_g_hop(mo, mo_occ, [mf.get_hcore()]*2)
-        self.assertAlmostEqual(numpy.linalg.norm(hop(dm1)), 28.01954683540594, 7)
+        self.assertAlmostEqual(numpy.linalg.norm(hop(dm1)), 28.01954683540594, 6)
 
 
 if __name__ == "__main__":

--- a/pyscf/pbc/scf/test/test_rohf.py
+++ b/pyscf/pbc/scf/test/test_rohf.py
@@ -21,6 +21,7 @@ from pyscf import lib
 from pyscf.pbc import gto as pgto
 from pyscf.pbc import scf as pscf
 from pyscf.pbc.scf import krohf
+from pyscf.pbc.tools.pbc import super_cell
 
 def setUpModule():
     global cell, mf, kmf, kpts
@@ -49,8 +50,10 @@ def tearDownModule():
 
 class KnownValues(unittest.TestCase):
     def test_krohf_kernel(self):
-        self.assertAlmostEqual(kmf.e_tot, -4.569633030494753, 8)
+        self.assertAlmostEqual(kmf.e_tot, -4.57655196508766, 8)
         kmf.analyze()
+        e4 = super_cell(cell, [2,2,1]).KROHF().run().e_tot
+        self.assertAlmostEqual(kmf.e_tot - e4/4, 0, 8)
 
     def test_rohf_kernel(self):
         self.assertAlmostEqual(mf.e_tot, -3.3633746534777718, 8)
@@ -118,9 +121,9 @@ class KnownValues(unittest.TestCase):
 
     def test_analyze(self):
         pop, chg = kmf.analyze()[0]
-        self.assertAlmostEqual(lib.fp(pop), 1.1514919154737624, 7)
+        self.assertAlmostEqual(lib.fp(pop), 1.1514919154737624, 3)
         self.assertAlmostEqual(sum(chg), 0, 7)
-        self.assertAlmostEqual(lib.fp(chg), -0.04683923436982078, 7)
+        self.assertAlmostEqual(lib.fp(chg), -0.04683923436982078, 3)
 
     def test_small_system(self):
         # issue #686

--- a/pyscf/pbc/scf/test/test_uhf.py
+++ b/pyscf/pbc/scf/test/test_uhf.py
@@ -21,6 +21,7 @@ from pyscf import lib
 from pyscf.pbc import gto as pgto
 from pyscf.pbc import scf as pscf
 from pyscf.pbc.scf import kuhf
+from pyscf.pbc.tools.pbc import super_cell
 
 def setUpModule():
     global cell, mf, kmf, kpts
@@ -48,7 +49,9 @@ def tearDownModule():
 
 class KnownValues(unittest.TestCase):
     def test_kuhf_kernel(self):
-        self.assertAlmostEqual(kmf.e_tot, -4.586720023431593, 8)
+        self.assertAlmostEqual(kmf.e_tot, -4.594854184081046, 8)
+        e4 = super_cell(cell, [2,2,1]).KUHF().run().e_tot
+        self.assertAlmostEqual(kmf.e_tot - e4/4, 0, 8)
         kmf.analyze()
 
     def test_uhf_kernel(self):
@@ -102,17 +105,17 @@ class KnownValues(unittest.TestCase):
 
     def test_spin_square(self):
         ss = kmf.spin_square()[0]
-        self.assertAlmostEqual(ss, 2.077383024287556, 4)
+        self.assertAlmostEqual(ss, 2.0836508842313273, 4)
 
     def test_bands(self):
         np.random.seed(1)
         kpts_bands = np.random.random((1,3))
 
         e = mf.get_bands(kpts_bands)[0]
-        self.assertAlmostEqual(lib.fp(e), 0.9038555558945438, 6)
+        self.assertAlmostEqual(lib.fp(e), 0.8857024, 5)
 
         e = kmf.get_bands(kpts_bands)[0]
-        self.assertAlmostEqual(lib.fp(e), -0.3020614, 5)
+        self.assertAlmostEqual(lib.fp(e), -0.309626, 5)
 
     def test_small_system(self):
         mol = pgto.Cell(

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -234,6 +234,27 @@ def ifftk(g, mesh, expikr):
     '''
     return ifft(g, mesh) * expikr
 
+def _Gv_wrap_around(cell, Gv, k, mesh):
+    '''wrap around the high frequency k+G vectors into their lower frequency
+    counterparts. Important if you want the gamma point and k-point answers to
+    agree.
+    '''
+    b = cell.reciprocal_vectors()
+    assert all(np.linalg.solve(b.T, k) < 1), 'k-point must be in first Brillouin zone'
+    kG = k + Gv
+    b = cell.reciprocal_vectors()
+    box_edge = np.einsum('i,ij->ij', mesh, b)
+    reduced_coords = np.linalg.solve(box_edge.T, kG.T).T
+    if cell.dimension >= 1:
+        kG[reduced_coords[:,0]> .5] -= box_edge[0]
+        kG[reduced_coords[:,0]<-.5] += box_edge[0]
+    if cell.dimension >= 2:
+        kG[reduced_coords[:,1]> .5] -= box_edge[1]
+        kG[reduced_coords[:,1]<-.5] += box_edge[1]
+    if cell.dimension == 3:
+        kG[reduced_coords[:,2]> .5] -= box_edge[2]
+        kG[reduced_coords[:,2]<-.5] += box_edge[2]
+    return kG
 
 def get_coulG(cell, k=np.zeros(3), exx=False, mf=None, mesh=None, Gv=None,
               wrap_around=True, omega=None, **kwargs):
@@ -332,37 +353,15 @@ def get_coulG(cell, k=np.zeros(3), exx=False, mf=None, mesh=None, Gv=None,
         return coulG
 
     if abs(k).sum() > 1e-9:
-        kG = k + Gv
+        if wrap_around:
+            # Here we 'wrap around' the high frequency k+G vectors into their lower
+            # frequency counterparts.  Important if you want the gamma point and k-point
+            # answers to agree
+            kG = _Gv_wrap_around(cell, Gv, k, mesh)
+        else:
+            kG = k + Gv
     else:
         kG = Gv
-
-    equal2boundary = None
-    if wrap_around and abs(k).sum() > 1e-9:
-        equal2boundary = np.zeros(Gv.shape[0], dtype=bool)
-        # Here we 'wrap around' the high frequency k+G vectors into their lower
-        # frequency counterparts.  Important if you want the gamma point and k-point
-        # answers to agree
-        b = cell.reciprocal_vectors()
-        box_edge = np.einsum('i,ij->ij', np.asarray(mesh)//2+0.5, b)
-        assert (all(np.linalg.solve(box_edge.T, k).astype(int)==0))
-        reduced_coords = np.linalg.solve(box_edge.T, kG.T).T
-        on_edge_p1 = abs(reduced_coords - 1) < 1e-9
-        on_edge_m1 = abs(reduced_coords + 1) < 1e-9
-        if cell.dimension >= 1:
-            equal2boundary |= on_edge_p1[:,0]
-            equal2boundary |= on_edge_m1[:,0]
-            kG[reduced_coords[:,0]> 1] -= 2 * box_edge[0]
-            kG[reduced_coords[:,0]<-1] += 2 * box_edge[0]
-        if cell.dimension >= 2:
-            equal2boundary |= on_edge_p1[:,1]
-            equal2boundary |= on_edge_m1[:,1]
-            kG[reduced_coords[:,1]> 1] -= 2 * box_edge[1]
-            kG[reduced_coords[:,1]<-1] += 2 * box_edge[1]
-        if cell.dimension == 3:
-            equal2boundary |= on_edge_p1[:,2]
-            equal2boundary |= on_edge_m1[:,2]
-            kG[reduced_coords[:,2]> 1] -= 2 * box_edge[2]
-            kG[reduced_coords[:,2]<-1] += 2 * box_edge[2]
 
     absG2 = np.einsum('gi,gi->g', kG, kG)
     G0_idx = []
@@ -455,9 +454,6 @@ def get_coulG(cell, k=np.zeros(3), exx=False, mf=None, mesh=None, Gv=None,
         else:
             raise NotImplementedError(f'dimension={cell.dimension} with '
                                       f'low_dim_ft_type={cell.low_dim_ft_type} is not supported')
-
-    if equal2boundary is not None:
-        coulG[equal2boundary] = 0
 
     # Scale the coulG kernel for attenuated Coulomb integrals.
     # * kwarg omega is used by RangeSeparatedJKBuilder which requires ewald probe charge
@@ -719,8 +715,7 @@ def super_cell(cell, ncopy, wrap_around=False):
     Ls = np.dot(Ts, a)
     supcell = cell.copy(deep=False)
     supcell.a = np.einsum('i,ij->ij', ncopy, a)
-    mesh = np.asarray(ncopy) * np.asarray(cell.mesh)
-    supcell.mesh = (mesh // 2) * 2 + 1
+    supcell.mesh = np.asarray(ncopy) * np.asarray(cell.mesh)
     if isinstance(cell.magmom, np.ndarray):
         supcell.magmom = cell.magmom.tolist() * np.prod(ncopy)
     else:

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -240,9 +240,8 @@ def _Gv_wrap_around(cell, Gv, k, mesh):
     agree.
     '''
     b = cell.reciprocal_vectors()
-    assert all(np.linalg.solve(b.T, k) < 1), 'k-point must be in first Brillouin zone'
+    #assert all(np.linalg.solve(b.T, k) < 1), 'k-point must be in first Brillouin zone'
     kG = k + Gv
-    b = cell.reciprocal_vectors()
     box_edge = np.einsum('i,ij->ij', mesh, b)
     reduced_coords = np.linalg.solve(box_edge.T, kG.T).T
     if cell.dimension >= 1:

--- a/pyscf/pbc/tools/test/test_pbc.py
+++ b/pyscf/pbc/tools/test/test_pbc.py
@@ -41,6 +41,8 @@ class KnownValues(unittest.TestCase):
         mf = khf.KRHF(cell, exxdiv='vcut_ws')
         mf.kpts = cell.make_kpts([2,2,2])
         coulG = tools.get_coulG(cell, mf.kpts[2], True, mf, gs=[5,5,5])
+        coulG = coulG.reshape([11]*3)
+        coulG[:,5,:] = 0
         self.assertAlmostEqual(lib.fp(coulG), 1.3245365170998518+0j, 9)
 
     def test_unconventional_ws_cell(self):
@@ -74,8 +76,6 @@ class KnownValues(unittest.TestCase):
 
         cell.a = numpy.eye(3)
         cell.unit = 'B'
-        coulG = tools.get_coulG(cell, numpy.array([0, numpy.pi, 0]))
-        self.assertAlmostEqual(lib.fp(coulG), 4.6737453679713905, 9)
         coulG = tools.get_coulG(cell, numpy.array([0, numpy.pi, 0]),
                                 wrap_around=False)
         self.assertAlmostEqual(lib.fp(coulG), 4.5757877990664744, 9)

--- a/pyscf/pbc/tools/test/test_pbc.py
+++ b/pyscf/pbc/tools/test/test_pbc.py
@@ -19,6 +19,8 @@ from pyscf import gto
 from pyscf.pbc import gto as pbcgto
 from pyscf.pbc import tools
 from pyscf.pbc.scf import khf
+from pyscf.pbc.df import fft
+from pyscf.pbc.tools.k2gamma import translation_vectors_for_kmesh
 from pyscf import lib
 
 
@@ -265,6 +267,24 @@ C  15.16687337 15.16687337 15.16687337
         mesh = tools.cutoff_to_mesh(a, ke.min())
         k1 = tools.mesh_to_cutoff(a, mesh)
         self.assertAlmostEqual(ke.min(), k1.min(), 9)
+
+    def test_coulG_wrap_around(self):
+        for mesh in [[7,7,7], [6,7,7]]:
+            for kmesh in [[2,1,1], [3,1,1], [4,1,1]]:
+                cell = pbcgto.M(atom='He', a=np.eye(3)*3, basis=[[0, [.6, 1]]], mesh=mesh)
+                kpts = cell.make_kpts(kmesh)
+                nkpts = len(kpts)
+                dm_kpts = np.ones([nkpts, 1, 1])
+                vk = fft.FFTDF(cell).get_jk(dm_kpts, kpts=kpts, with_j=False)[1]
+                e1 = np.einsum('kij,kji->', vk, dm_kpts)
+
+                expLk = np.exp(1j*np.dot(translation_vectors_for_kmesh(cell, kmesh), kpts.T))
+                dm = np.einsum('Rk,Sk,kuv->RuSv', expLk, expLk.conj(), dm_kpts) / nkpts
+                dm = dm.reshape(nkpts, nkpts)
+                scell = tools.super_cell(cell, kmesh)
+                vk = fft.FFTDF(scell).get_jk(dm, with_j=False)[1]
+                e2 = np.einsum('ij,ji->', vk, dm)
+                self.assertAlmostEqual(abs(e1 - e2), 0, 10)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The treatment of `get_coulG` and `super_cell` was not consistent between supercell and k-point calculations, causing small discrepancies in the results. This PR updates the two functions to ensure consistent supercell and k-point calculations for FFTDF and AFTDF.