### PR TITLE
move state_average_mix to CASBase

### DIFF
--- a/examples/geomopt/12-mcscf_excited_states.py
+++ b/examples/geomopt/12-mcscf_excited_states.py
@@ -9,6 +9,7 @@ convergence issue in geometry optimizer.
 
 from pyscf import gto
 from pyscf import scf, mcscf
+import copy
 
 mol = gto.Mole()
 mol.atom="N; N 1, 1.1"
@@ -56,7 +57,6 @@ mol1 = excited_grad.optimizer().kernel()
 # 3. Geometry optimization for mixed FCI solvers.
 # Note the state-averaged gradients are optimized.
 #
-import copy
 mc = mcscf.CASSCF(mf, 4,4)
 solver1 = mc.fcisolver
 solver2 = copy.copy(mc.fcisolver)
@@ -81,7 +81,7 @@ mc = mcscf.CASSCF(mf, 4,4)
 solver1 = mc.fcisolver
 solver2 = copy.copy(mc.fcisolver)
 solver2.spin = 2
-mc = mc.state_average_mix_([solver1, solver2], (.5, .5))
+mc.state_average_mix_([solver1, solver2], (.5, .5))
 excited_grad = mc.nuc_grad_method().as_scanner(state=1)
 mol1 = excited_grad.optimizer().kernel()
 

--- a/examples/geomopt/12-mcscf_excited_states.py
+++ b/examples/geomopt/12-mcscf_excited_states.py
@@ -61,7 +61,7 @@ mc = mcscf.CASSCF(mf, 4,4)
 solver1 = mc.fcisolver
 solver2 = copy.copy(mc.fcisolver)
 solver2.spin = 2
-mc = mcscf.addons.state_average_mix_(mc, [solver1, solver2], (.5, .5))
+mc = mc.state_average_mix([solver1, solver2], (.5, .5))
 excited_grad = mc.nuc_grad_method().as_scanner()
 mol1 = excited_grad.optimizer().kernel()
 
@@ -81,7 +81,7 @@ mc = mcscf.CASSCF(mf, 4,4)
 solver1 = mc.fcisolver
 solver2 = copy.copy(mc.fcisolver)
 solver2.spin = 2
-mc = mcscf.addons.state_average_mix_(mc, [solver1, solver2], (.5, .5))
+mc = mc.state_average_mix_([solver1, solver2], (.5, .5))
 excited_grad = mc.nuc_grad_method().as_scanner(state=1)
 mol1 = excited_grad.optimizer().kernel()
 

--- a/examples/mcscf/41-state_average.py
+++ b/examples/mcscf/41-state_average.py
@@ -73,5 +73,6 @@ solver2.wfnsym= 'A2'
 solver2.spin = 0
 
 mc = mcscf.CASSCF(mf, 4, 4)
-mcscf.state_average_mix_(mc, [solver1, solver2], weights)
+# method attribute is also available
+mc.state_average_mix_([solver1, solver2], weights)
 mc.kernel()

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -19,8 +19,7 @@ from pyscf import ao2mo, fci, mcscf, lib, __config__
 from pyscf.lib import logger
 from pyscf.dft import gen_grid
 from pyscf.mcscf import mc1step
-from pyscf.mcscf.addons import StateAverageMCSCFSolver, state_average_mix
-from pyscf.mcscf.addons import state_average_mix_, StateAverageMixFCISolver
+from pyscf.mcscf.addons import StateAverageMCSCFSolver, StateAverageMixFCISolver
 from pyscf.mcscf.df import _DFCASSCF, _DFCAS
 from pyscf.mcpdft import pdft_veff, pdft_feff
 from pyscf.mcpdft.otfnal import transfnal, get_transfnal
@@ -745,13 +744,6 @@ class _PDFT:
             grids_level=grids_level, grids_attr=grids_attr,
             split_x_c=split_x_c, verbose=verbose
         )
-
-    def state_average_mix(self, fcisolvers=None, weights=(0.5, 0.5)):
-        return state_average_mix(self, fcisolvers, weights)
-
-    def state_average_mix_(self, fcisolvers=None, weights=(0.5, 0.5)):
-        state_average_mix_(self, fcisolvers, weights)
-        return self
 
     def multi_state_mix(self, fcisolvers=None, weights=(0.5, 0.5), method='LIN'):
         if method.upper() == "LIN":

--- a/pyscf/mcscf/casci.py
+++ b/pyscf/mcscf/casci.py
@@ -1024,6 +1024,13 @@ To enable the solvent model for CASCI, the following code needs to be called
     def state_average(self, weights=(0.5,0.5), wfnsym=None):
         return addons.state_average(self, weights, wfnsym)
 
+    def state_average_mix(self, fcisolvers=None, weights=(0.5, 0.5)):
+        return addons.state_average_mix(self, fcisolvers, weights)
+
+    def state_average_mix_(self, fcisolvers=None, weights=(0.5, 0.5)):
+        addons.state_average_mix_(self, fcisolvers, weights)
+        return self
+
     @lib.with_doc(addons.state_specific_.__doc__)
     def state_specific_(self, state=1):
         addons.state_specific(self, state)

--- a/pyscf/mcscf/test/test_addons.py
+++ b/pyscf/mcscf/test/test_addons.py
@@ -321,8 +321,7 @@ class KnownValues(unittest.TestCase):
         solver2.wfnsym = 'A1u'
         solver2.spin = 2
         mc = mcscf.CASSCF(mfr, 4, 4)
-        mc = mcscf.addons.state_average_mix_(mc, [solver1, solver2],
-                                             (0.25,0.25,0.5))
+        mc = mc.state_average_mix_([solver1, solver2], (0.25,0.25,0.5))
         mc.kernel()
         e = mc.e_states
         self.assertAlmostEqual(mc.e_tot, -108.80340952016508, 7)

--- a/pyscf/mcscf/test/test_mc1step.py
+++ b/pyscf/mcscf/test/test_mc1step.py
@@ -308,7 +308,7 @@ class KnownValues(unittest.TestCase):
         mc = mcscf.CASSCF(m, 4, 4)
         cis1 = mc.fcisolver.copy()
         cis1.spin = 2
-        mc = mcscf.addons.state_average_mix(mc, [cis1, mc.fcisolver], [.5, .5])
+        mc = mc.state_average_mix([cis1, mc.fcisolver], [.5, .5])
         mc.run()
         self.assertAlmostEqual(mc.e_states[0], -108.7506795311190, 5)
         self.assertAlmostEqual(mc.e_states[1], -108.8582272809495, 5)


### PR DESCRIPTION
This allows CASSCF using `mc.state_average_mix`, which is only supported for MCPDFT currently.