### PR TITLE
temporary fix for cmake fail in ci build

### DIFF
--- a/pyscf/lib/CMakeLists.txt
+++ b/pyscf/lib/CMakeLists.txt
@@ -237,6 +237,7 @@ if(ENABLE_LIBXC AND BUILD_LIBXC)
             -DCMAKE_C_CREATE_SHARED_LIBRARY=${C_LINK_TEMPLATE}
             -DENABLE_XHOST:STRING=${BUILD_MARCH_NATIVE}
             -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
+	    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 # remove when libxc update version min in next release
   )
   add_dependencies(xc_itrf libxc)
   add_dependencies(dft libxc)


### PR DESCRIPTION
CI on macos is failing due to cmake fail in building libxc 7.0.0. This is actually fixed in [libxc!696](https://gitlab.com/libxc/libxc/-/merge_requests/696). We could temporarily use a workaround for it before libxc's next release.