### PR TITLE
Corner case for krylov solver

### DIFF
--- a/pyscf/lib/linalg_helper.py
+++ b/pyscf/lib/linalg_helper.py
@@ -1283,7 +1283,10 @@ def krylov(aop, b, x0=None, tol=1e-10, max_cycle=30, dot=numpy.dot,
         x1, rmat = _qr(x1, dot)
         x1 *= rmat.diagonal()[:,None]
         innerprod = (rmat.diagonal().real ** 2).tolist()
-        max_innerprod = max(innerprod)
+        if innerprod:
+            max_innerprod = max(innerprod)
+        else:
+            max_innerprod = 0
     else:
         max_innerprod = dot(x1[0].conj(), x1[0]).real
         innerprod = [max_innerprod]

--- a/pyscf/lib/test/test_linalg_helper.py
+++ b/pyscf/lib/test/test_linalg_helper.py
@@ -146,6 +146,19 @@ class KnownValues(unittest.TestCase):
         c = linalg_helper.krylov(aop, b, lindep=1e-14)
         self.assertAlmostEqual(abs(ref - c).max(), 0, 7)
 
+    def test_krylov_zero_force(self):
+        numpy.random.seed(10)
+        n = 2
+        a = numpy.random.rand(n,n) * .1
+        a = a.dot(a.T)
+        a_diag = numpy.random.rand(n)
+        b = numpy.zeros((3, n))
+        a -= numpy.eye(n)
+
+        aop = lambda x: (a.dot(x.T).T/a_diag)
+        c = linalg_helper.krylov(aop, b/a_diag, max_cycle=18, lindep=1e-15)
+        self.assertAlmostEqual(abs(c).max(), 0, 9)
+
     def test_dgeev(self):
         numpy.random.seed(12)
         n = 100


### PR DESCRIPTION
The krylov solver crashes when the rhs of `(I-A)x=b` equals to zero.