### PR TITLE
parallel broadcasted elementwise multiplication

### DIFF
--- a/pyscf/lib/np_helper/CMakeLists.txt
+++ b/pyscf/lib/np_helper/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_library(np_helper SHARED 
-  transpose.c pack_tril.c npdot.c condense.c omp_reduce.c np_helper.c imatcopy.c)
+  transpose.c pack_tril.c npdot.c condense.c omp_reduce.c np_helper.c imatcopy.c np_broadcast.c)
 
 set_target_properties(np_helper PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})

--- a/pyscf/lib/np_helper/imatcopy.c
+++ b/pyscf/lib/np_helper/imatcopy.c
@@ -20,8 +20,8 @@
 #include <math.h>
 #include "np_helper.h"
 
-const int TILESIZE = 32;
-const int TILESIZE_CPLX = 16;
+static const int TILESIZE = 32;
+static const int TILESIZE_CPLX = 16;
 
 /*
  * Calculate the largest integer i such that

--- a/pyscf/lib/np_helper/np_broadcast.c
+++ b/pyscf/lib/np_helper/np_broadcast.c
@@ -1,0 +1,91 @@
+/* Copyright 2025 The PySCF Developers. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+#include "np_helper/np_helper.h"
+#include <complex.h>
+#include <stdlib.h>
+
+static const int BLOCKSIZE = 32;
+static const int BLOCKSIZE_CPLX = 16;
+
+/*
+ * Performs the operation
+ * C[:, i, j] += A[:, i, j] * B[i, j]
+ * where A and C are 3D arrays and B is a 2D array.
+ */
+void NPomp_dmul_12(const size_t m, const size_t n, const size_t k,
+                   const double *__restrict a, const size_t a_stride_0,
+                   const size_t a_stride_1, double *__restrict b,
+                   const size_t b_stride, double *__restrict c,
+                   const size_t c_stride_0, const size_t c_stride_1) {
+  const size_t kclean = k - k % BLOCKSIZE;
+  const size_t k_rem = k - kclean;
+#pragma omp parallel for schedule(static)
+  for (size_t midx = 0; midx < m; midx++) {
+    for (size_t tileidx = 0; tileidx < kclean; tileidx += BLOCKSIZE) {
+      for (size_t nidx = 0; nidx < n; nidx++) {
+#pragma omp simd
+        for (size_t kidx = 0; kidx < BLOCKSIZE; kidx++) {
+          c[midx * c_stride_0 + (tileidx + kidx) + c_stride_1 * nidx] +=
+              a[midx * a_stride_0 + (tileidx + kidx) + a_stride_1 * nidx] *
+              b[(tileidx + kidx) + b_stride * nidx];
+        }
+      }
+    }
+    for (size_t nidx = 0; nidx < n; nidx++) {
+#pragma omp simd
+      for (size_t kidx = 0; kidx < k_rem; kidx++) {
+        c[midx * c_stride_0 + (kclean + kidx) + c_stride_1 * nidx] +=
+            a[midx * a_stride_0 + (kclean + kidx) + a_stride_1 * nidx] *
+            b[(kclean + kidx) + b_stride * nidx];
+      }
+    }
+  }
+}
+
+/*
+ * Performs the operation
+ * C[:, i, j] += A[:, i, j] * B[i, j]
+ * where A and C are 3D arrays and B is a 2D array.
+ */
+void NPomp_zmul_12(const size_t m, const size_t n, const size_t k,
+                   const double complex *__restrict a, const size_t a_stride_0,
+                   const size_t a_stride_1, double complex *__restrict b,
+                   const size_t b_stride, double complex *__restrict c,
+                   const size_t c_stride_0, const size_t c_stride_1) {
+  const size_t kclean = k - k % BLOCKSIZE_CPLX;
+  const size_t k_rem = k - kclean;
+#pragma omp parallel for schedule(static)
+  for (size_t midx = 0; midx < m; midx++) {
+    for (size_t tileidx = 0; tileidx < kclean; tileidx += BLOCKSIZE_CPLX) {
+      for (size_t nidx = 0; nidx < n; nidx++) {
+#pragma omp simd
+        for (size_t kidx = 0; kidx < BLOCKSIZE_CPLX; kidx++) {
+          c[midx * c_stride_0 + (tileidx + kidx) + c_stride_1 * nidx] +=
+              a[midx * a_stride_0 + (tileidx + kidx) + a_stride_1 * nidx] *
+              b[(tileidx + kidx) + b_stride * nidx];
+        }
+      }
+    }
+    for (size_t nidx = 0; nidx < n; nidx++) {
+#pragma omp simd
+      for (size_t kidx = 0; kidx < k_rem; kidx++) {
+        c[midx * c_stride_0 + (kclean + kidx) + c_stride_1 * nidx] +=
+            a[midx * a_stride_0 + (kclean + kidx) + a_stride_1 * nidx] *
+            b[(kclean + kidx) + b_stride * nidx];
+      }
+    }
+  }
+}

--- a/pyscf/lib/np_helper/np_helper.h
+++ b/pyscf/lib/np_helper/np_helper.h
@@ -88,6 +88,17 @@ void NPomp_zmul(const size_t m, const size_t n,
                 double complex *b, const size_t b_stride,
                 double complex *out, const size_t out_stride);
 
+void NPomp_dmul_12(const size_t m, const size_t n, const size_t k,
+                   const double *a, const size_t a_stride_0,
+                   const size_t a_stride_1, double *b,
+                   const size_t b_stride, double *c,
+                   const size_t c_stride_0, const size_t c_stride_1);
+void NPomp_zmul_12(const size_t m, const size_t n, const size_t k,
+                   const double complex *a, const size_t a_stride_0,
+                   const size_t a_stride_1, double complex *b,
+                   const size_t b_stride, double complex *c,
+                   const size_t c_stride_0, const size_t c_stride_1);
+
 void NPdgemm(const char trans_a, const char trans_b,
              const int m, const int n, const int k,
              const int lda, const int ldb, const int ldc,

--- a/pyscf/lib/test/test_numpy_helper.py
+++ b/pyscf/lib/test/test_numpy_helper.py
@@ -290,6 +290,30 @@ class KnownValues(unittest.TestCase):
         lib.entrywise_mul(a, b, out=b)
         self.assertTrue(numpy.allclose(prod, b))
 
+    def test_broadcast_mul(self):
+        a = numpy.random.random((3,101,39))
+        b = numpy.random.random((101,39))
+        testval = lib.broadcast_mul(a, b)
+        self.assertTrue(numpy.allclose(testval, a * b[None, ...]))
+
+        a = numpy.random.random((3,101,39))
+        b = numpy.random.random((101,39))
+        c = numpy.random.random((3,101,39))
+        refval = a * b[None, ...] + c
+        testval = lib.broadcast_mul(a, b, out=c)
+        self.assertTrue(numpy.allclose(testval, refval))
+
+        a = numpy.random.random((3,101,39)) + 1j * numpy.random.random((3,101,39))
+        b = numpy.random.random((101,39)) + 1j * numpy.random.random((101,39))
+        testval = lib.broadcast_mul(a, b)
+        self.assertTrue(numpy.allclose(testval, a * b[None, ...]))
+
+        a = numpy.random.random((3,101,39)) + 1j * numpy.random.random((3,101,39))
+        b = numpy.random.random((101,39)) + 1j * numpy.random.random((101,39))
+        c = numpy.random.random((3,101,39)) + 1j * numpy.random.random((3,101,39))
+        refval = a * b[None, ...] + c
+        testval = lib.broadcast_mul(a, b, out=c)
+        self.assertTrue(numpy.allclose(testval, refval))
 if __name__ == "__main__":
     print("Full Tests for numpy_helper")
     unittest.main()


### PR DESCRIPTION
The operation
```python
C[:, :, :] += A[:, :, :] * B[None, :, :]
```
is common in RPA and GW with density fitting. The current [GW code](https://github.com/pyscf/pyscf/blob/a22dc3149807a81d69a3882d9f19b600caee9e1c/pyscf/gw/gw_ac.py#L154) does it using einsum, whereas the [RPA code](https://github.com/pyscf/pyscf/blob/a22dc3149807a81d69a3882d9f19b600caee9e1c/pyscf/gw/rpa.py#L121) uses np.multiply. On certain hardware at large system sizes, the single-core memory bandwidth (perhaps also cache-coherent interconnect bandwidth) can be a bottleneck if this step is not parallelized.

Tianyu Zhu's group plans to submit some GW-related pull requests soon, but the group's code depends on numexpr for parallel broadcasted arithmetic. To avoid adding a dependency on numexpr, this PR provides C implementations `NPomp_dmul_12` and `NPomp_zmul_12` together with Python wrappers. Within parallel tasks, the outermost loop is over blocks of `B` which are sized to fit into the L1 cache. 

Please feel free to leave comments or feedback below!