### PR TITLE
Fix bug for KUKS calculations with hybrids

### DIFF
--- a/pyscf/pbc/dft/kuks_ksymm.py
+++ b/pyscf/pbc/dft/kuks_ksymm.py
@@ -78,7 +78,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=0, vhf_last=0, hermi=1,
         if ground_state:
             ecoul = np.einsum('K,nKij,Kji->', weight, dm, vj) * .5
     if ni.libxc.is_hybrid_xc(ks.xc):
-        vxc = np.array([vxc - vk[0], vxc - vk[1]]) 
+        vxc -= vk
         if ground_state:
             exc -= np.einsum('K,nKij,nKji->', weight, dm, vk).real * .5
     vxc = lib.tag_array(vxc, ecoul=ecoul, exc=exc, vj=None, vk=None)

--- a/pyscf/pbc/dft/numint.py
+++ b/pyscf/pbc/dft/numint.py
@@ -428,11 +428,14 @@ def nr_uks(ni, cell, grids, xc_code, dms, spin=1, relativity=0, hermi=1,
     '''
     if kpts is None:
         kpts = numpy.zeros((1,3))
-    elif isinstance(kpts, KPoints):
+    if isinstance(kpts, KPoints):
         if kpts.kpts.size > 3: # multiple k points
             dms = kpts.transform_dm(dms)
+        nkpts = len(kpts)
         kpts = kpts.kpts
-    kpts = kpts.reshape(-1,3)
+    else:
+        kpts = kpts.reshape(-1,3)
+        nkpts = len(kpts)
 
     xctype = ni._xc_type(xc_code)
     if xctype == 'LDA':
@@ -496,7 +499,8 @@ def nr_uks(ni, cell, grids, xc_code, dms, spin=1, relativity=0, hermi=1,
             excsum = excsum[0]
             vmat = vmat[:,0]
     else:
-        nelec = excsum = vmat = 0
+        nelec = excsum = 0
+        vmat = numpy.zeros((2, nkpts, nao, nao), dtype=numpy.complex128)
     return nelec, excsum, vmat
 
 def _format_uks_dm(dms):

--- a/pyscf/pbc/dft/test/test_kuks.py
+++ b/pyscf/pbc/dft/test/test_kuks.py
@@ -114,6 +114,29 @@ C, 0.8917,  2.6751,  2.6751'''
         self.assertTrue(not a_hf.with_df._j_only)
         self.assertTrue(isinstance(a_hf, pbcscf.kuhf.KUHF))
 
+    # issue 2993
+    def test_kuks_as_kuhf(self):
+        cell = pbcgto.Cell()
+        cell.atom = "He 0 0 0; He 1 1 1"
+        cell.basis = [[0, [1, 1]], [0, [.5, 1]]]
+        cell.spin = 2
+        cell.a = np.eye(3) * 3
+        cell.build()
+
+        kmesh = [3, 1, 1]
+        kpts = cell.make_kpts(kmesh, time_reversal_symmetry=True)
+        mf = pbcdft.KUKS(cell, kpts, xc="hf")
+        mf.max_cycle = 1
+        mf.kernel()
+        self.assertAlmostEqual(mf.e_tot, -4.213403459087, 9)
+
+        kmesh = [3, 1, 1]
+        kpts = cell.make_kpts(kmesh)
+        mf = pbcdft.KUKS(cell, kpts, xc="hf")
+        mf.max_cycle = 1
+        mf.kernel()
+        self.assertAlmostEqual(mf.e_tot, -4.213403459087, 9)
+
 
 if __name__ == '__main__':
     print("Full Tests for pbc.dft.kuks")


### PR DESCRIPTION
Running KUKS calculations with hybrid functionals crashes.

This is a minimal example to reproduce the problem.

```import numpy as np
from pyscf.pbc import dft, gto

cell = gto.Cell()
cell.atom = "He 0 0 0; He 1 1 1"
cell.basis = "6-31g"
cell.spin = 2
cell.a = np.eye(3) * 3
cell.verbose = 0
cell.build()

kmesh = [3, 1, 1]
kpts = cell.make_kpts(kmesh, time_reversal_symmetry=True)

mf = dft.KUKS(cell, kpts, xc="hf")
mf = mf.density_fit(auxbasis="weigend")
mf.kernel()
```
Which results in the following error:
```
Traceback (most recent call last):
  File "tmp.py", line 18, in <module>
    mf.kernel()
  File "<string>", line 2, in kernel
  File "~/pyscf/pyscf/scf/hf.py", line 2018, in scf
    kernel(self, self.conv_tol, self.conv_tol_grad,
  File "~/pyscf/pyscf/scf/hf.py", line 129, in kernel
    vhf = mf.get_veff(mol, dm)
          ^^^^^^^^^^^^^^^^^^^^
  File "~/pyscf/pyscf/pbc/dft/kuks_ksymm.py", line 81, in get_veff
    vxc -= vk
ValueError: non-broadcastable output operand with shape (2,4,4) doesn't match the broadcast shape (2,2,4,4)
```

The fix by updates vxc to become spin dependent when using hybrid functionals.