### PR TITLE
Adjust analyze() functions for UHF and ROHF to be compatible with msym

### DIFF
--- a/pyscf/scf/hf_symm.py
+++ b/pyscf/scf/hf_symm.py
@@ -838,12 +838,12 @@ class SymAdaptedROHF(rohf.ROHF):
                 ir_in_d2h = mol.irrep_id[k] % 10  # convert to D2h irreps
                 wfnsym ^= ir_in_d2h
 
-            if mol.groupname in ('SO3', 'Dooh', 'Coov'):
-                # TODO: check wave function symmetry
-                log.note('Wave-function symmetry = %s', mol.groupname)
-            else:
+            if mol.groupname in symm.param.POINTGROUP:
                 log.note('Wave-function symmetry = %s',
                          symm.irrep_id2name(mol.groupname, wfnsym))
+            else:
+                # TODO: check wave function symmetry for ('SO3', 'Dooh', 'Coov') etc
+                log.note('Wave-function symmetry = %s', mol.groupname)
             log.note('occupancy for each irrep:  ' + (' %4s'*nirrep),
                      *mol.irrep_name)
             log.note('double occ                 ' + (' %4d'*nirrep), *ndoccs)

--- a/pyscf/scf/uhf_symm.py
+++ b/pyscf/scf/uhf_symm.py
@@ -60,11 +60,11 @@ def analyze(mf, verbose=logger.DEBUG, with_meta_lowdin=WITH_META_LOWDIN,
         for i, ir in enumerate(mol.irrep_id):
             if (noccsa[i]+noccsb[i]) % 2:
                 tot_sym ^= ir
-        if mol.groupname in ('Dooh', 'Coov', 'SO3'):
-            log.note('TODO: total wave-function symmetry for %s', mol.groupname)
-        else:
+        if mol.groupname in symm.param.POINTGROUP:
             log.note('Wave-function symmetry = %s',
                      symm.irrep_id2name(mol.groupname, tot_sym))
+        else:
+            log.note('TODO: total wave-function symmetry for %s', mol.groupname)
         log.note('alpha occupancy for each irrep:  '+(' %4s'*nirrep),
                  *mol.irrep_name)
         log.note('                                 '+(' %4d'*nirrep),


### PR DESCRIPTION
I did not notice that there are different `analyze()` functions for ROHF and UHF.
There is quite some code duplication in those, especially confusing in `hf_symm.py`, where RHF uses the function from outside, while ROHF defines its own.

I also tested cmake to build msym, which can in principle be added to `pyscf/lib/CMakeLists.txt`.
```
option(BUILD_MSYM "Download and build libmsym library" OFF)
if(BUILD_MSYM)
   find_package(PythonInterp REQUIRED)
    # message(Python_EXECUTABLE ${PYTHON_EXECUTABLE})
#  if(NOT EXISTS "${PROJECT_SOURCE_DIR}/deps/include/libmsym/msym.h")
    ExternalProject_Add(libmsym
      GIT_REPOSITORY https://github.com/mcodev31/libmsym.git
      GIT_TAG master
      PREFIX ${PROJECT_BINARY_DIR}/deps
      INSTALL_DIR ${PROJECT_SOURCE_DIR}/deps
      CMAKE_ARGS -DMSYM_BUILD_PYTHON:BOOL=ON -DBUILD_SHARED_LIBS:BOOL=ON
            -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR> -DMSYM_BUILD_PYTHON=ON
            -DPYTHON=${PYTHON_EXECUTABLE} -DMSYM_PYTHON_INSTALL_OPTS="--prefix <INSTALL_DIR>"
    )
#  endif()
endif()
```

There is, however, a python wrapper that has to be copied somewhere to `PYTHONPATH`, but it is not clear to me how to do it properly.