### PR TITLE
Fix(x2c): Use complex128 dtype for x-matrix in ATOM1E approximation

### DIFF
--- a/pyscf/x2c/test/test_x2c.py
+++ b/pyscf/x2c/test/test_x2c.py
@@ -217,6 +217,17 @@ C     F
         self.assertAlmostEqual(mf.e_tot, ref.e_tot, 9)
         self.assertAlmostEqual(abs(mf.dip_moment() - ref.dip_moment()).max(), 0, 9)
 
+    def test_ghf_atom(self):
+        # Test whether the result of spinor X2C is a solution of .GHF().x2c()
+        mol = gto.M(atom='C', basis='ccpvdz-dk')
+        mf_1e = mol.GHF().x2c1e()
+        mf_1e.kernel()
+        mf_atom1e = mol.GHF().x2c1e()
+        mf_atom1e.with_x2c.approx = 'ATOM1E'
+        mf_atom1e.kernel()
+        self.assertAlmostEqual(abs(mf_1e.e_tot - mf_atom1e.e_tot).max(), 0, 9)
+        self.assertAlmostEqual(abs(mf_1e.mo_energy - mf_atom1e.mo_energy).max(), 0, 9)
+
     def test_gks(self):
         mol = gto.M(atom='C', basis='ccpvdz-dk')
         ref = mol.DKS(xc='b3lyp').x2c().run()

--- a/pyscf/x2c/x2c.py
+++ b/pyscf/x2c/x2c.py
@@ -313,7 +313,7 @@ class SpinOrbitalX2CHelper(X2CHelperBase):
             # spin-orbital basis is twice the size of NR basis
             atom_slices[:,2:] *= 2
             nao = xmol.nao_nr() * 2
-            x = numpy.zeros((nao,nao))
+            x = numpy.zeros((nao,nao), dtype=numpy.complex128)
             for ia in range(xmol.natm):
                 ish0, ish1, p0, p1 = atom_slices[ia]
                 shls_slice = (ish0, ish1, ish0, ish1)
@@ -375,7 +375,7 @@ class SpinOrbitalX2CHelper(X2CHelperBase):
             # spin-orbital basis is twice the size of NR basis
             atom_slices[:,2:] *= 2
             nao = xmol.nao_nr() * 2
-            x = numpy.zeros((nao,nao))
+            x = numpy.zeros((nao,nao), dtype=numpy.complex128)
             for ia in range(xmol.natm):
                 ish0, ish1, p0, p1 = atom_slices[ia]
                 shls_slice = (ish0, ish1, ish0, ish1)


### PR DESCRIPTION
This PR addresses a bug in the x2c module where the ATOM1E approximation produced incorrect results due to a data type mismatch.

