### PR TITLE
Update the manual installation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Python-based Simulations of Chemistry Framework
         pip install pyscf[dispersion]
 
 * More details of custom installation can be found in
-  [installation manual](http://pyscf.org/install.html#compiling-from-source-code)
+  [installation manual](http://pyscf.org/user/install.html#build-from-source)
 
 
 # Citing PySCF


### PR DESCRIPTION
Addressing #3052  (the manual installation link which needed to be updated due to  https://github.com/pyscf/pyscf.github.io/commit/c4f4c09558036d0479b9db54d4a420011303a872)