### PR TITLE
Change default breaksym to False in _from_rhf_init_dm to improve GHF convergence

### DIFF
--- a/pyscf/scf/ghf.py
+++ b/pyscf/scf/ghf.py
@@ -553,7 +553,7 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
 
     to_gpu = lib.to_gpu
 
-def _from_rhf_init_dm(dm, breaksym=True):
+def _from_rhf_init_dm(dm, breaksym=False):
     dma = dm * .5
     dm = scipy.linalg.block_diag(dma, dma)
     if breaksym:


### PR DESCRIPTION
This PR changes the default value of the `breaksym` argument in the `_from_rhf_init_dm` function (in `pyscf/scf/ghf.py`) from True to False.

Currently, when initializing a GHF density matrix from an RHF density matrix, the function defaults to `breaksym=True`, which introduces a perturbation to the off-diagonal blocks ($\alpha$-$\beta$ coupling). While testing, I observed that for certain closed-shell systems, this forced symmetry breaking in the initial guess can lead to SCF convergence issues or instabilities. In these cases, starting from a clean RHF guess (without spin-mixing) provides a more stable starting point.