### PR TITLE
Using scipy sph_harm_y to replace sph_harm

### DIFF
--- a/pyscf/lib/numpy_helper.py
+++ b/pyscf/lib/numpy_helper.py
@@ -949,7 +949,9 @@ def _zgemm(trans_a, trans_b, m, n, k, a, b, c, alpha=1, beta=0,
                        (ctypes.c_double*2)(beta.real, beta.imag))
     return c
 
-if hasattr(scipy.special, 'sph_harm'):
+if hasattr(scipy.special, 'sph_harm_y'):
+    Ylm = scipy.special.sph_harm_y
+else:
     def Ylm(l,m,theta,phi):
         '''
         Spherical harmonics; returns a complex number
@@ -959,73 +961,6 @@ if hasattr(scipy.special, 'sph_harm'):
         '''
         #return scipy.special.sph_harm(m=m,n=l,theta=phi,phi=theta)
         return scipy.special.sph_harm(m,l,phi,theta)
-else:
-    def Ylm(l,m,theta,phi):
-        # A workaround due to scipy sph_harm_y bug https://github.com/scipy/scipy/issues/24383
-        #return scipy.special.sph_harm_y(m,l,phi,theta)
-        from pyscf import gto
-        sintheta = numpy.sin(theta)
-        x = sintheta * numpy.cos(phi)
-        y = sintheta * numpy.sin(phi)
-        z = numpy.cos(theta)
-        r = numpy.column_stack((x, y, z)).reshape(-1, 3)
-
-        ngrid = r.shape[0]
-        xs = numpy.ones((l+1,ngrid))
-        ys = numpy.ones((l+1,ngrid))
-        zs = numpy.ones((l+1,ngrid))
-        for i in range(1,l+1):
-            xs[i] = xs[i-1] * r[:,0]
-            ys[i] = ys[i-1] * r[:,1]
-            zs[i] = zs[i-1] * r[:,2]
-        nd = (l+1)*(l+2)//2
-        c = numpy.empty((nd,ngrid))
-        k = 0
-        for lx in reversed(range(0, l+1)):
-            for ly in reversed(range(0, l-lx+1)):
-                lz = l - lx - ly
-                c[k] = xs[lx] * ys[ly] * zs[lz]
-                k += 1
-        ylm_real = gto.cart2sph(l, c.T).T
-        if l == 1:
-            # libcint returns p functions in px,py,pz order.
-            # reorder px,py,pz to p(-1),p(0),p(1)
-            ylm_real = ylm_real[[1,2,0]]
-
-        s = 2**-.5
-        #:ylm = numpy.empty(ylm_real.shape, dtype=numpy.complex128)
-        #:ylm[l] = ylm_real[l]
-        #:for m in range(1, l+1):
-        #:    a = ylm_real[l-m] * s
-        #:    b = ylm_real[l+m] * s
-        #:    if m % 2 == 0:
-        #:        ylm[l-m].real = b
-        #:        ylm[l+m].real = b
-        #:        ylm[l-m].imag = -a
-        #:        ylm[l+m].imag = a
-        #:    else:
-        #:        ylm[l-m].real = b
-        #:        ylm[l+m].real = -b
-        #:        ylm[l-m].imag = -a
-        #:        ylm[l+m].imag = -a
-        if m == 0:
-            ylm = ylm_real[l].astype(numpy.complex128)
-        else:
-            a = ylm_real[l-abs(m)] * s
-            b = ylm_real[l+abs(m)] * s
-            if m % 2 == 0:
-                if m < 0:
-                    ylm = b - 1j*a
-                else:
-                    ylm = b + 1j*a
-            else:
-                if m < 0:
-                    ylm = b - 1j*a
-                else:
-                    ylm = -b - 1j*a
-        if theta.ndim == 0:
-            ylm = ylm[0]
-        return ylm
 
 def frompointer(pointer, count, dtype=float):
     '''Interpret a buffer that the pointer refers to as a 1-dimensional array.


### PR DESCRIPTION
A follow-up to PR #3089 . scipy provides sph_harm_y which employs normal Ylm convention (https://github.com/scipy/scipy/issues/24383)