### PR TITLE
Update log message for excitation energies

### DIFF
--- a/pyscf/tdscf/rhf.py
+++ b/pyscf/tdscf/rhf.py
@@ -910,7 +910,7 @@ class TDBase(lib.StreamObject):
         if not all(self.converged):
             logger.note(self, 'TD-SCF states %s not converged.',
                         [i for i, x in enumerate(self.converged) if not x])
-        logger.note(self, 'Excited State energies (eV)\n%s', self.e * nist.HARTREE2EV)
+        logger.note(self, 'Excitation energies (eV)\n%s', self.e * nist.HARTREE2EV)
         return self
 
     def to_gpu(self):


### PR DESCRIPTION
Since the groundstate SCF energy is not included in this printout, I feel like this changed message better conveys the meaning.