### PR TITLE
Fix XYZ file parse; close #3103

### DIFF
--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2148,8 +2148,8 @@ def fromstring(string, format='xyz'):
     if format == 'zmat':
         return string
     elif format == 'xyz':
-        line, title, geom = string.split('\n', 2)
-        return geom
+        atom_number_str, title, geom = string.split('\n', 2)
+        return geom[:int(atom_number_str)]
     elif format == 'sdf':
         raw = string.splitlines()
         natoms, nbonds = raw[3].split()[:2]

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2149,7 +2149,7 @@ def fromstring(string, format='xyz'):
         return string
     elif format == 'xyz':
         atom_number_str, title, geom = string.split('\n', 2)
-        return geom[:int(atom_number_str)]
+        return '\n'.join(geom.splitlines()[:int(atom_number_str)])
     elif format == 'sdf':
         raw = string.splitlines()
         natoms, nbonds = raw[3].split()[:2]


### PR DESCRIPTION
This fixes what is mainly described in issue #3103 by restricting the number of lines considered for the molecular configuration, respecting the XYZ specification (i.e. the first line), allowing "comment" or extra contents to be added at the end.