### PR TITLE
remove doc saying direct_nosym requires real numbers

### DIFF
--- a/pyscf/fci/__init__.py
+++ b/pyscf/fci/__init__.py
@@ -25,11 +25,10 @@ direct_spin1_symm   Yes           No             Yes                Yes
 direct_spin0        No            Yes            Yes                Yes
 direct_spin1        No            No             Yes                Yes
 direct_uhf          No            No             Yes                No
-direct_nosym        No            No             No**               Yes
+direct_nosym        No            No             No                 Yes
 fci_dhf_slow        No            No             No***              No
 
 *  Real hermitian Hamiltonian implies (ij|kl) = (ji|kl) = (ij|lk) = (ji|lk)
-** Hamiltonian is real but not hermitian, (ij|kl) != (ji|kl) ...
 *** Hamiltonian is complex hermitian (DHF case) or real hermitian (GHF case)
 '''
 

--- a/pyscf/fci/direct_nosym.py
+++ b/pyscf/fci/direct_nosym.py
@@ -25,10 +25,9 @@ direct_spin1_symm   Yes           No             Yes                Yes
 direct_spin0        No            Yes            Yes                Yes
 direct_spin1        No            No             Yes                Yes
 direct_uhf          No            No             Yes                No
-direct_nosym        No            No             No**               Yes
+direct_nosym        No            No             No                 Yes
 
 *  Real hermitian Hamiltonian implies (ij|kl) = (ji|kl) = (ij|lk) = (ji|lk)
-** Hamiltonian is real but not hermitian, (ij|kl) != (ji|kl) ...
 '''
 
 import warnings

--- a/pyscf/fci/direct_spin0.py
+++ b/pyscf/fci/direct_spin0.py
@@ -27,10 +27,9 @@ direct_spin1_symm   Yes           No             Yes                Yes
 direct_spin0        No            Yes            Yes                Yes
 direct_spin1        No            No             Yes                Yes
 direct_uhf          No            No             Yes                No
-direct_nosym        No            No             No**               Yes
+direct_nosym        No            No             No                 Yes
 
 *  Real hermitian Hamiltonian implies (ij|kl) = (ji|kl) = (ij|lk) = (ji|lk)
-** Hamiltonian is real but not hermitian, (ij|kl) != (ji|kl) ...
 
 direct_spin0 solver is specified for singlet state. However, calling this
 solver sometimes ends up with the error "State not singlet x.xxxxxxe-06" due

--- a/pyscf/fci/direct_spin0_symm.py
+++ b/pyscf/fci/direct_spin0_symm.py
@@ -25,10 +25,9 @@ direct_spin1_symm   Yes           No             Yes                Yes
 direct_spin0        No            Yes            Yes                Yes
 direct_spin1        No            No             Yes                Yes
 direct_uhf          No            No             Yes                No
-direct_nosym        No            No             No**               Yes
+direct_nosym        No            No             No                 Yes
 
 *  Real hermitian Hamiltonian implies (ij|kl) = (ji|kl) = (ij|lk) = (ji|lk)
-** Hamiltonian is real but not hermitian, (ij|kl) != (ji|kl) ...
 '''
 
 import sys

--- a/pyscf/fci/direct_spin1.py
+++ b/pyscf/fci/direct_spin1.py
@@ -32,10 +32,9 @@ direct_spin1_symm   Yes           No             Yes                Yes
 direct_spin0        No            Yes            Yes                Yes
 direct_spin1        No            No             Yes                Yes
 direct_uhf          No            No             Yes                No
-direct_nosym        No            No             No**               Yes
+direct_nosym        No            No             No                 Yes
 
 *  Real hermitian Hamiltonian implies (ij|kl) = (ji|kl) = (ij|lk) = (ji|lk)
-** Hamiltonian is real but not hermitian, (ij|kl) != (ji|kl) ...
 '''
 
 import sys

--- a/pyscf/fci/direct_spin1_symm.py
+++ b/pyscf/fci/direct_spin1_symm.py
@@ -25,10 +25,9 @@ direct_spin1_symm   Yes           No             Yes                Yes
 direct_spin0        No            Yes            Yes                Yes
 direct_spin1        No            No             Yes                Yes
 direct_uhf          No            No             Yes                No
-direct_nosym        No            No             No**               Yes
+direct_nosym        No            No             No                 Yes
 
 *  Real hermitian Hamiltonian implies (ij|kl) = (ji|kl) = (ij|lk) = (ji|lk)
-** Hamiltonian is real but not hermitian, (ij|kl) != (ji|kl) ...
 '''
 
 import sys

--- a/pyscf/fci/direct_uhf.py
+++ b/pyscf/fci/direct_uhf.py
@@ -25,10 +25,9 @@ direct_spin1_symm   Yes           No             Yes                Yes
 direct_spin0        No            Yes            Yes                Yes
 direct_spin1        No            No             Yes                Yes
 direct_uhf          No            No             Yes                No
-direct_nosym        No            No             No**               Yes
+direct_nosym        No            No             No                 Yes
 
 *  Real hermitian Hamiltonian implies (ij|kl) = (ji|kl) = (ij|lk) = (ji|lk)
-** Hamiltonian is real but not hermitian, (ij|kl) != (ji|kl) ...
 '''
 
 import ctypes


### PR DESCRIPTION
https://github.com/pyscf/pyscf/pull/2122 added support for complex numbers to `direct_nosym`.