### PR TITLE
Fix XYZ parsing to respect atom count line

### DIFF
--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2149,7 +2149,9 @@ def fromstring(string, format='xyz'):
         return string
     elif format == 'xyz':
         line, title, geom = string.split('\n', 2)
-        return geom[:int(line)]
+        natoms = int(line.strip())
+        geom_lines = geom.splitlines()
+        return '\n'.join(geom_lines[:natoms])
     elif format == 'sdf':
         raw = string.splitlines()
         natoms, nbonds = raw[3].split()[:2]


### PR DESCRIPTION
Fixes #3103 - XYZ parser now respects the atom count on the first line instead of reading all lines. This prevents errors with QM9 dataset files that have metadata after coordinates.