### PR TITLE
force real orbitals for TRS KSCF

### DIFF
--- a/pyscf/pbc/lib/kpts_helper.py
+++ b/pyscf/pbc/lib/kpts_helper.py
@@ -32,6 +32,32 @@ def is_zero(kpt):
     return abs(np.asarray(kpt)).sum() < KPT_DIFF_TOL
 is_gamma_point = gamma_point = is_zero
 
+def is_trim(cell, kpts, tol=KPT_DIFF_TOL):
+    ''' Check whether k-points are time-reversal invariant momenta (TRIM),
+        i.e., k = -k mod G.
+
+    Args:
+        cell : Cell object
+        kpts : (3,) or (nk,3) array_like
+        tol : float
+            Numerical tolerance for deciding whether 2*k_scaled is an integer
+            vector (mod 1). Default is :data:`KPT_DIFF_TOL`.
+
+    Returns:
+        mask : bool or ndarray of bool
+            Boolean mask indicating whether each k-point is a TRIM. If ``kpts``
+            corresponds to a single kpt, a single boolean is returned.
+            Otherwise an array of shape (nk,) is returned.
+    '''
+    logtol = np.ceil(-np.log10(tol)).astype(int)
+    kpts_reshape = kpts.reshape(-1,3)
+    scaled_kpts = cell.get_scaled_kpts(kpts_reshape)
+    scaled_k2 = np.round(2*scaled_kpts, logtol+1)%1
+    mask = scaled_k2.max(axis=1) < tol
+    if kpts.ndim == 1:
+        mask = mask[0]
+    return mask
+
 def round_to_fbz(kpts, wrap_around=False, tol=KPT_DIFF_TOL):
     '''
     Round scaled k-points to the first Brillouin zone.

--- a/pyscf/pbc/scf/test/test_khf_ksym.py
+++ b/pyscf/pbc/scf/test/test_khf_ksym.py
@@ -338,6 +338,15 @@ class KnownValues(unittest.TestCase):
         kmf = pscf.KUHF(cell, kpts=kpts).newton().run()
         self.assertAlmostEqual(kmf.e_tot, kmf0.e_tot, 6)
 
+    def test_trs_real_orb(self):
+        from pyscf.pbc.lib.kpts_helper import is_trim
+        kpts = cell.make_kpts([2,2,1], time_reversal_symmetry=True)
+        kmf = pscf.KRHF(cell, kpts=kpts).run()
+        mask = is_trim(kmf.cell, kmf.kpts.kpts_ibz)
+        for k,mo in enumerate(kmf.mo_coeff):
+            if mask[k]:
+                self.assertAlmostEqual(abs(kmf.mo_coeff[k].imag).max(), 0, 8)
+
 if __name__ == '__main__':
     print("Full Tests for HF with k-point symmetry")
     unittest.main()


### PR DESCRIPTION
This PR enforces real-valued orbitals at time-reversal invariant momenta (TRIM), i.e., `k = -k mod G`, in KSCF calculations with time-reversal symmetry enabled.

In the current KSCF implementation, complex orbitals can be generated even at TRIM due to a numerical instability in the `scipy.linalg.eigh` eigenvalue solver. See the discussion here:
[https://github.com/scipy/scipy/issues/21445](https://github.com/scipy/scipy/issues/21445)

To address this issue, this PR forces `eigh` to operate on `h.real` and `s.real` whenever the corresponding k-point is a TRIM and `time_reversal_symmetry` is set to `True`. This ensures real-valued orbitals at TRIM while leaving the behavior at non-TRIM k-points or in non-time-reversal-symmetric calculations unchanged.
