### PR TITLE
Fix `import pyscf` under Python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.0", "wheel", "cmake<4.0"]
+requires = ["setuptools>=61.0", "wheel", "cmake<4.0"]
 build-backend = "setuptools.build_meta"
 
 
@@ -21,6 +21,8 @@ classifiers = [
   'Programming Language :: Python :: 3.10',
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
+  'Programming Language :: Python :: 3.13',
+  'Programming Language :: Python :: 3.14',
   'Topic :: Software Development',
   'Topic :: Scientific/Engineering',
   'Operating System :: POSIX',
@@ -34,6 +36,7 @@ authors = [{ name = "Qiming Sun", email = "osirpt.sun@gmail.com" }]
 
 license = { text = "Apache-2.0" }
 
+requires-python = ">=3.7"
 dependencies = [
   'numpy>=1.13,!=1.16,!=1.17',
   'scipy>=1.6.0',

--- a/pyscf/lib/misc.py
+++ b/pyscf/lib/misc.py
@@ -91,7 +91,7 @@ c_double_p = ctypes.POINTER(ctypes.c_double)
 c_int_p = ctypes.POINTER(ctypes.c_int)
 c_null_ptr = ctypes.POINTER(ctypes.c_void_p)
 
-@functools.lru_cache
+@functools.lru_cache(128)
 def load_library(libname):
     try:
         _loaderpath = os.path.dirname(__file__)


### PR DESCRIPTION
While there is probably almost no one left using Python 3.7, one simple fix allows the execution of PySCF under it.
The current PySCF versions (2.12.x) fail during the import.
While at it, I have also updated the version classifiers and added a bound for the supported Python version, since PySCF does not run under Python 3.6 anyway.