### PR TITLE
Fix a bunch of warnings

### DIFF
--- a/pyscf/agf2/chempot.py
+++ b/pyscf/agf2/chempot.py
@@ -154,7 +154,7 @@ def minimize_chempot(se, fock, nelec, occupancy=2, x0=0.0, tol=1e-6, maxiter=200
     buf = np.zeros((se.nphys+se.naux, se.nphys+se.naux), dtype=dtype)
     fargs = (se, fock, nelec, occupancy, buf)
 
-    options = {'maxiter': maxiter, 'ftol': tol, 'xtol': tol, 'gtol': tol}
+    options = {'maxfun': maxiter, 'ftol': tol, 'xtol': tol, 'gtol': tol}
     kwargs = {'x0': x0, 'method': 'TNC', 'jac': jac, 'options': options}
     fun = _objective if not jac else _gradient
 

--- a/pyscf/dft/test/test_numint.py
+++ b/pyscf/dft/test/test_numint.py
@@ -552,14 +552,14 @@ class KnownValues(unittest.TestCase):
         ni.omega = 0.4
         omega = 0.2
         exc, vxc, fxc, kxc = ni.eval_xc('ITYH,', rho0, 0, 0, 1, omega)
-        self.assertAlmostEqual(float(exc), -0.6359945579326314, 7)
-        self.assertAlmostEqual(float(vxc[0]), -0.8712041561251518, 7)
-        self.assertAlmostEqual(float(vxc[1]), -0.003911167644579979, 7)
+        self.assertAlmostEqual(float(exc[0]), -0.6359945579326314, 7)
+        self.assertAlmostEqual(float(vxc[0][0]), -0.8712041561251518, 7)
+        self.assertAlmostEqual(float(vxc[1][0]), -0.003911167644579979, 7)
 
         exc, vxc, fxc, kxc = ni.eval_xc('ITYH,', rho0, 0, 0, 1)
-        self.assertAlmostEqual(float(exc), -0.5406095865415561, 7)
-        self.assertAlmostEqual(float(vxc[0]), -0.772123720263471, 7)
-        self.assertAlmostEqual(float(vxc[1]), -0.00301639097170439, 7)
+        self.assertAlmostEqual(float(exc[0]), -0.5406095865415561, 7)
+        self.assertAlmostEqual(float(vxc[0][0]), -0.772123720263471, 7)
+        self.assertAlmostEqual(float(vxc[1][0]), -0.00301639097170439, 7)
 
     def test_cache_xc_kernel(self):
         mf = dft.RKS(h2o)

--- a/pyscf/fci/selected_ci.py
+++ b/pyscf/fci/selected_ci.py
@@ -915,7 +915,7 @@ class SCIvector(numpy.ndarray):
         self._strs = getattr(obj, '_strs', None)
 
     # Special cases for ndarray when the array was modified (through ufunc)
-    def __array_wrap__(self, out):
+    def __array_wrap__(self, out, context=None, return_scalar=False):
         if out.shape == self.shape:
             return out
         elif out.shape == ():  # if ufunc returns a scalar

--- a/pyscf/lib/gto/test/test_ecp.py
+++ b/pyscf/lib/gto/test/test_ecp.py
@@ -16,11 +16,11 @@
 import ctypes
 import unittest
 import numpy
-import scipy.misc
 import scipy.special
 try:
     from scipy.special import factorial2
 except ImportError:
+    import scipy.misc
     from scipy.misc import factorial2
 from pyscf import lib
 from pyscf import gto

--- a/pyscf/solvent/test/test_cosmors.py
+++ b/pyscf/solvent/test/test_cosmors.py
@@ -71,10 +71,10 @@ class TestCosmoRS(unittest.TestCase):
         self.assertRaises(ValueError, save_cosmo_file, mf1)
 
     def test_cosmo_file(self):
-        with io.StringIO() as outp: 
+        with io.StringIO() as outp:
             cosmors.write_cosmo_file(outp, mf0)
             text = outp.getvalue()
-        E_diel = float(re.search('Dielectric energy \[a.u.\] += +(-*\d+\.\d+)', text).group(1))
+        E_diel = float(re.search(r'Dielectric energy \[a.u.\] += +(-*\d+\.\d+)', text).group(1))
         self.assertAlmostEqual(E_diel, -0.0023256022, 5)
 
     def test_pcm_parameters(self):


### PR DESCRIPTION
This PR addresses numerous warnings in the test suite to make PySCF a bit more future-proof.
All of these fixes should be backwards compatible with all supported Python/NumPy/SciPy versions.
A small overview of changes:
* `import scipy.misc` is deprecated and will be removed in SciPy 2.0
* TNC does not use the `maxiter` keyword, `maxfun` is used instead
* Conversion of 0-D arrays to floats is deprecated (and will fail with the newest dependencies under Python 3.14)
* `__array_wrap__` must accept `context` and `return_scalar` arguments (positionally) in the future
* And a small (less important) `cosmors` warning fix was made
