### PR TITLE
Fix mo_coeff reshape size in pbc/scf/hf DF JK

### DIFF
--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -698,8 +698,9 @@ class SCF(mol_hf.SCF):
             dm_shape = dm.shape
             dm = dm.reshape(-1, nao, nao)
             if mo_coeff is not None:
-                dm = lib.tag_array(dm, mo_coeff=mo_coeff.reshape(-1, nao, nao),
-                                   mo_occ=mo_occ.reshape(-1, nao))
+                nmo = mo_occ.shape[-1]
+                dm = lib.tag_array(dm, mo_coeff=mo_coeff.reshape(-1, nao, nmo),
+                                   mo_occ=mo_occ.reshape(-1, nmo))
             vj, vk = self.with_df.get_jk(dm, hermi, kpt, kpts_band,
                                          with_j, with_k, omega, exxdiv=self.exxdiv)
             dm = dm.reshape(dm_shape)


### PR DESCRIPTION
This fixes #3149.

Summary: For PBC calculations, when DF is used and memory isn't enough to store ERIs, the initial SCF cycle can fail due to the non-square shape of mo_coeff produced by the minao init_guess. The fixed code is now the same logic as in the molecular DF JK [here](https://github.com/pyscf/pyscf/blob/master/pyscf/df/df_jk.py#L341). I don't even know if this mo_coeff that is tagged to dm is actually used or not.