### PR TITLE
Adjust auxbasis basis response level in density fitting hessian methods

### DIFF
--- a/pyscf/df/hessian/rhf.py
+++ b/pyscf/df/hessian/rhf.py
@@ -486,7 +486,7 @@ class Hessian(rhf_hess.Hessian):
     def __init__(self, mf):
         rhf_hess.Hessian.__init__(self, mf)
 
-    auxbasis_response = 1
+    auxbasis_response = 2
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
 

--- a/pyscf/df/hessian/rks.py
+++ b/pyscf/df/hessian/rks.py
@@ -124,7 +124,7 @@ class Hessian(rks_hess.Hessian):
     def __init__(self, mf):
         rks_hess.Hessian.__init__(self, mf)
 
-    auxbasis_response = 1
+    auxbasis_response = 2
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
 

--- a/pyscf/df/hessian/uhf.py
+++ b/pyscf/df/hessian/uhf.py
@@ -528,7 +528,7 @@ class Hessian(uhf_hess.Hessian):
     def __init__(self, mf):
         uhf_hess.Hessian.__init__(self, mf)
 
-    auxbasis_response = 1
+    auxbasis_response = 2
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
 

--- a/pyscf/df/hessian/uks.py
+++ b/pyscf/df/hessian/uks.py
@@ -132,7 +132,7 @@ class Hessian(uks_hess.Hessian):
     def __init__(self, mf):
         uks_hess.Hessian.__init__(self, mf)
 
-    auxbasis_response = 1
+    auxbasis_response = 2
     partial_hess_elec = partial_hess_elec
     make_h1 = make_h1
 


### PR DESCRIPTION
The second-order response of the auxiliary basis in density-fitting Hessian methods was previously disabled by default. Although its contribution is generally minor, excluding it can lead to noticeable errors in low-frequency vibrational modes.

This PR changes the default behavior to enable the full auxiliary basis response.