### PR TITLE
Restore user ability to select particular symmetry axes (#3166)

### DIFF
--- a/pyscf/fci/test/test_symm_init_guess.py
+++ b/pyscf/fci/test/test_symm_init_guess.py
@@ -36,7 +36,7 @@ def tearDownModule():
 class KnownValues(unittest.TestCase):
     def test_symm_spin0(self):
         fs = fci.FCI(mol, m.mo_coeff, singlet=True)
-        fs.wfnsym = 'B2'
+        fs.wfnsym = 'B1' # Had to switch this from B2 when trying to fix #3166
         fs.nroots = 3
         e, c = fs.kernel()
         self.assertAlmostEqual(e[0], -19.286003160337+mol.energy_nuc(), 9)
@@ -48,7 +48,7 @@ class KnownValues(unittest.TestCase):
 
     def test_symm_spin1(self):
         fs = fci.FCI(mol, m.mo_coeff, singlet=False)
-        fs.wfnsym = 'B2'
+        fs.wfnsym = 'B1' # Had to switch this from B2 when trying to fix #3166
         fs.nroots = 2
         e, c = fs.kernel()
         self.assertAlmostEqual(e[0], -19.303845373762+mol.energy_nuc(), 9)

--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2671,6 +2671,13 @@ class MoleBase(lib.StreamObject):
             self.symmetry = str(symm.std_symb(self.symmetry))
             groupname = None
             if abs(np.max(np.abs(axes),axis=0) - 1).max() < symm.TOLERANCE:
+                # MRH: Catch PointGroupSymmetryError before going into symm.check_symm
+                try:
+                    symm.as_subgroup(self.topgroup, axes, self.symmetry)
+                except PointGroupSymmetryError as e:
+                    raise PointGroupSymmetryError(
+                        'Unable to identify input symmetry %s. Try symmetry="%s"' %
+                        (self.symmetry, self.topgroup)) from e
                 if symm.check_symm(self.symmetry, self._atom, self._basis):
                     # Try to use original axes (issue #1209)
                     groupname = self.symmetry


### PR DESCRIPTION
This bit of code in HEAD

https://github.com/pyscf/pyscf/blob/e8642fb7220248bd750c34ef6adf88a9744977ee/pyscf/gto/mole.py#L2673-L2680

is supposed to empower the user to select their own symmetry axes rather than relying on PySCF's automated determination of symmetry axes. However, it's self-defeating, because the outer conditional only passes if those axes are the same as the automatically-determined symmetry axes anyway. I think the idea was supposed to be that the conditional passes if the input axes are some integer permutation of the automatically-determined axes, which this PR implements.