### PR TITLE
Fix the edge case for an empty array for df_jk construction in pbc df

### DIFF
--- a/pyscf/pbc/df/df_jk.py
+++ b/pyscf/pbc/df/df_jk.py
@@ -448,8 +448,12 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None,
         log.debug2('get_k_kpts: build K from symm mo coeff')
         nmo = skmoR[0,0].shape[1]
         log.debug2('get_k_kpts: rank(dm) = %d / %d', nmo, nao)
-        skmoI_mask = numpy.asarray([[abs(skmoI[i,k]).max() > cell.precision
-                                     for k in range(nkpts)] for i in range(nset)])
+        # Taking care of the case skmoI is empty array.
+        # skmoI_mask = numpy.asarray([[abs(skmoI[i,k]).max() > cell.precision
+        #                              for k in range(nkpts)] for i in range(nset)])
+        skmoI_mask = numpy.asarray(
+            [[(skmoI[i,k].size > 0) and (numpy.abs(skmoI[i,k]).max() > cell.precision)
+            for k in range(nkpts)] for i in range(nset)])
         bufR = numpy.empty((mydf.blockdim*nao**2))
         bufI = numpy.empty((mydf.blockdim*nao**2))
         max_memory = max(2000, mydf.max_memory-lib.current_memory()[0])


### PR DESCRIPTION
In this PR, I handled the edge case for the `jk` construction, which was throwing an error due to an empty array.

```python
# For this code: kmf is periodic mean field object
kmf.get_jk(cell, dmcore_kpts, kpts=kpts, hermi=1)

# This was the error:
/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/pyscf/pbc/df/df_jk.py:451: in <listcomp>
    skmoI_mask = numpy.asarray([[abs(skmoI[i,k]).max() > cell.precision
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

a = array([], shape=(18, 0), dtype=float64), axis = None, out = None
keepdims = False, initial = <no value>, where = True

    def _amax(a, axis=None, out=None, keepdims=False,
              initial=_NoValue, where=True):
>       return umr_maximum(a, axis, None, out, keepdims, initial, where)
E       ValueError: zero-size array to reduction operation maximum which has no identity
```

This PR fixes that.
