### PR TITLE
Make adc work with pytblis

### DIFF
--- a/pyscf/adc/radc.py
+++ b/pyscf/adc/radc.py
@@ -359,7 +359,7 @@ class RADC(lib.StreamObject):
 
         charges = self.mol.atom_charges()
         coords  = self.mol.atom_coords()
-        self.dip_mom_nuc = lib.einsum('i,ix->x', charges, coords)
+        self.dip_mom_nuc = np.einsum('i,ix->x', charges, coords)
 
     compute_amplitudes = radc_amplitudes.compute_amplitudes
     compute_energy = radc_amplitudes.compute_energy

--- a/pyscf/adc/uadc.py
+++ b/pyscf/adc/uadc.py
@@ -616,7 +616,7 @@ class UADC(lib.StreamObject):
 
         charges = self.mol.atom_charges()
         coords  = self.mol.atom_coords()
-        self.dip_mom_nuc = lib.einsum('i,ix->x', charges, coords)
+        self.dip_mom_nuc = np.einsum('i,ix->x', charges, coords)
 
     compute_amplitudes = uadc_amplitudes.compute_amplitudes
     compute_energy = uadc_amplitudes.compute_energy


### PR DESCRIPTION
`charges` is an `int` array, which leads to an assertion when using `pytblis` as `lib.einsum` kernel. 
Since there is no performance problem, I replaced `lib.einsum` with `np.einsum`, similar to what is done elsewhere in the code. 