### PR TITLE
Support specifying "autoaux" as a key for auxiliary basis set

### DIFF
--- a/examples/df/01-auxbasis.py
+++ b/examples/df/01-auxbasis.py
@@ -71,6 +71,12 @@ mf = scf.RHF(mol).density_fit()
 mf.with_df.auxbasis = df.autoaux(mol)
 mf.kernel()
 
+# 'autoaux' can be specified directly as a keyword for the basis set
+mf.with_df.auxbasis = 'autoaux'
+
+# It also supports defining mixed auxiliary bases, e.g.
+mf.with_df.auxbasis = {'default': 'autoaux', 'N2': 'weigend'}
+
 # The automatic generation of auxiliary basis set (see also 10.1021/acs.jctc.3c00670)
 mf = scf.RHF(mol).density_fit()
 mf.with_df.auxbasis = df.autoabs(mol)

--- a/pyscf/df/addons.py
+++ b/pyscf/df/addons.py
@@ -25,7 +25,7 @@ from pyscf.gto.basis import _format_basis_name
 from pyscf import ao2mo
 from pyscf.data import elements
 from pyscf.lib.exceptions import BasisNotFoundError
-from pyscf.df.autoaux import autoaux, autoabs
+from pyscf.df.autoaux import autoaux, autoabs, _auto_aux_element
 from pyscf.data.elements import _rm_digit
 from pyscf import __config__
 
@@ -260,6 +260,17 @@ def make_auxmol(mol, auxbasis=None):
             del (_basis['default'])
         else:
             _basis = auxbasis
+
+    for key, val in _basis.items():
+        if val == 'autoaux' and key in mol._basis:
+            etb = _auto_aux_element(gto.charge(key), mol._basis[key])
+            if etb:
+                for l, n, emin, beta in etb:
+                    logger.info(mol, 'ETB for %s: l = %d, exps = %s * %g^n , n = 0..%d',
+                                key, l, emin, beta, n-1)
+                _basis[key] = gto.expand_etbs(etb)
+            else:
+                raise RuntimeError(f'Failed to generate autoaux basis for {key} {val}')
 
     try:
         pmol._basis = pmol.format_basis(_basis)

--- a/pyscf/df/test/test_addons.py
+++ b/pyscf/df/test/test_addons.py
@@ -154,6 +154,15 @@ class KnownValues(unittest.TestCase):
             dat = np.array([float(f'{x:.6e}') for x in dat])
             self.assertAlmostEqual(abs(np.array(ref) - dat).max(), 0, 6)
 
+    def test_auto_aux_as_basis_set_name(self):
+        mol = gto.M(atom='Li 0 0 0; F 0 0 0', basis='STO-3G')
+        auxmol = df.addons.make_auxmol(mol, auxbasis='autoaux')
+        self.assertEqual(auxmol.nbas, 52)
+        auxmol = df.addons.make_auxmol(mol, auxbasis={'Li': 'autoaux', 'F': 'autoaux'})
+        self.assertEqual(auxmol.nbas, 52)
+        auxmol = df.addons.make_auxmol(mol, auxbasis={'default': 'autoaux', 'S': 'ano'})
+        self.assertEqual(auxmol.nbas, 52)
+
 def flatten(lst):
     if not isinstance(lst, list):
         return [lst]


### PR DESCRIPTION
Previously, specifying autoaux requires an explicit import `pyscf.df.autoaux.autoaux` and executing `autoaux(mol)`

This PR allows users to specify autoaux as a regular basis set:
```
mf = mol.RKS(xc).density_fit()
mf.with_df.auxbasis = 'autoaux'
```
