### PR TITLE
fix a problem in determining the rotor type

### DIFF
--- a/pyscf/hessian/test/test_thermo.py
+++ b/pyscf/hessian/test/test_thermo.py
@@ -63,9 +63,20 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(c[1] == numpy.inf)
         self.assertTrue(c[2] == numpy.inf)
 
+    def test_rotor_type(self):
+        mol = gto.M(atom='O 6.49389522e-15 -2.57224363e-14 -3.70463374e-03; O -6.49389522e-15 2.57224363e-14 1.21370463e+00')
+        mass = mol.atom_mass_list(isotope_avg=True)
+        atom_coords = mol.atom_coords()
+        mass_center = numpy.einsum('z,zx->x', mass, atom_coords) / mass.sum()
+        atom_coords = atom_coords - mass_center
+        rot_const = thermo.rotation_const(mass, atom_coords)
+        self.assertEqual(rot_const[0], numpy.inf)
+        rotor_type = thermo._get_rotor_type(rot_const)
+        self.assertEqual(rotor_type, 'LINEAR')
+
     def test_thermo(self):
         mol = gto.M(atom='O 0 0 0; H 0 .757 .587; H 0 -.757 .587')
-        mf = mol.HF.run(conv_tol=1e-11)
+        mf = mol.HF().run(conv_tol=1e-11)
         hess = mf.Hessian().kernel()
         results = thermo.harmonic_analysis(mol, hess)
         self.assertAlmostEqual(lib.fp(abs(results['norm_mode'])), 0.1144453655, 6)

--- a/pyscf/hessian/thermo.py
+++ b/pyscf/hessian/thermo.py
@@ -119,6 +119,7 @@ def rotation_const(mass, atom_coords, unit='GHz'):
     im = numpy.einsum('z,zr,zs->rs', mass, r, r)
     im = numpy.eye(3) * im.trace() - im
     e = numpy.sort(numpy.linalg.eigvalsh(im))
+    e[e < 1e-6] = 0.0
 
     unit_im = nist.ATOMIC_MASS * (nist.BOHR_SI)**2
     unit_hz = nist.HBAR / (4 * numpy.pi * unit_im)

--- a/pyscf/hessian/thermo.py
+++ b/pyscf/hessian/thermo.py
@@ -119,7 +119,7 @@ def rotation_const(mass, atom_coords, unit='GHz'):
     im = numpy.einsum('z,zr,zs->rs', mass, r, r)
     im = numpy.eye(3) * im.trace() - im
     e = numpy.sort(numpy.linalg.eigvalsh(im))
-    e[e < 1e-6] = 0.0
+    e[abs(e) < 1e-9] = 0.0
 
     unit_im = nist.ATOMIC_MASS * (nist.BOHR_SI)**2
     unit_hz = nist.HBAR / (4 * numpy.pi * unit_im)


### PR DESCRIPTION
Fix #2967 Fix #2401.
the rotation const will be numpy.inf if its reciprocal is very close to 0.