### PR TITLE
Release 2.13.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+PySCF 2.13.1 (2026-06-01)
+-------------------------
+* Fixes
+  - Missing CP2K basis set data in wheel distributions
+  - Small-rotor error.
+  - Corrected SG1 grid radii handling for ghost atoms.
+  - Fixed ECP loading to correctly fall back to Basis Set Exchange when local data is unavailable.
+
+
 PySCF 2.13.0 (2026-04-20)
 -------------------------
 * Added

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Python-based Simulations of Chemistry Framework
 [![Build Status](https://github.com/pyscf/pyscf/workflows/CI/badge.svg)](https://github.com/pyscf/pyscf/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/pyscf/pyscf/branch/master/graph/badge.svg)](https://codecov.io/gh/pyscf/pyscf)
 
-2026-04-20
+2026-06-01
 
-* [Stable release 2.13.0](https://github.com/pyscf/pyscf/releases/tag/v2.13.0)
+* [Stable release 2.13.0](https://github.com/pyscf/pyscf/releases/tag/v2.13.1)
 * [Changelog](../master/CHANGELOG)
 * [Documentation](http://www.pyscf.org)
 * [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Python-based Simulations of Chemistry Framework
 
 2026-06-01
 
-* [Stable release 2.13.0](https://github.com/pyscf/pyscf/releases/tag/v2.13.1)
+* [Stable release 2.13.1](https://github.com/pyscf/pyscf/releases/tag/v2.13.1)
 * [Changelog](../master/CHANGELOG)
 * [Documentation](http://www.pyscf.org)
 * [Installation](#installation)

--- a/pyscf/__init__.py
+++ b/pyscf/__init__.py
@@ -35,7 +35,7 @@ to try out the package::
 
 '''
 
-__version__ = '2.13.0'
+__version__ = '2.13.1'
 
 import os
 import sys


### PR DESCRIPTION
This patch release fixes:
  - Missing CP2K basis set data in wheel distributions
  - Small-rotor error.
  - Corrected SG1 grid radii handling for ghost atoms.
  - Fixed ECP loading to correctly fall back to Basis Set Exchange when local data is unavailable.
