### PR TITLE
scf: fix init_guess_by_mod_huckel signature so it can be called without arguments

### DIFF
--- a/pyscf/scf/__init__.py
+++ b/pyscf/scf/__init__.py
@@ -36,11 +36,12 @@ to control the SCF method.
     chkfile : str
         checkpoint file to save MOs, orbital energies etc.
     conv_tol : float
-        converge threshold.  Default is 1e-10
+        converge threshold.  Default is 1e-9
     max_cycle : int
         max number of iterations.  Default is 50
     init_guess : str
-        initial guess method.  It can be one of 'minao', 'atom', '1e', 'chkfile'.
+        initial guess method.  It can be one of 'minao', 'atom', 'huckel',
+        'mod_huckel', '1e', 'hcore', 'sap', 'chkfile'.
         Default is 'minao'
     DIIS : class listed in :mod:`scf.diis`
         Default is :class:`diis.SCF_DIIS`. Set it to None/False to turn off DIIS.

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -766,7 +766,7 @@ def get_init_guess(mol, key='minao', **kwargs):
 
     Kwargs:
         key : str
-            One of 'minao', 'atom', 'huckel', 'hcore', '1e', 'sap', 'chkfile'.
+            One of 'minao', 'atom', 'huckel', 'mod_huckel', 'hcore', '1e', 'sap', 'chkfile'.
     '''
     return RHF(mol).get_init_guess(mol, key, **kwargs)
 
@@ -1654,7 +1654,8 @@ class SCF(lib.StreamObject):
             be skipped and the kernel function will compute only the total
             energy based on the initial guess. Default value is 50.
         init_guess : str
-            initial guess method.  It can be one of 'minao', 'atom', 'huckel', 'hcore', '1e', 'sap', 'chkfile'.
+            initial guess method.  It can be one of 'minao', 'atom', 'huckel',
+            'mod_huckel', 'hcore', '1e', 'sap', 'chkfile'.
             Default is 'minao'
         sap_basis : str or dict
             basis for SAP initial guess, either filename or path as str or
@@ -1946,7 +1947,7 @@ class SCF(lib.StreamObject):
         return self.make_rdm1(mo_coeff, mo_occ)
 
     @lib.with_doc(init_guess_by_mod_huckel.__doc__)
-    def init_guess_by_mod_huckel(self, updated_rule, mol=None):
+    def init_guess_by_mod_huckel(self, mol=None):
         if mol is None: mol = self.mol
         logger.info(self, '''Initial guess from on-the-fly Huckel, doi:10.1021/acs.jctc.8b01089,
 employing the updated GWH rule from doi:10.1021/ja00480a005.''')

--- a/pyscf/scf/test/test_rhf.py
+++ b/pyscf/scf/test/test_rhf.py
@@ -248,6 +248,12 @@ class KnownValues(unittest.TestCase):
         dm = scf.hf.RHF(mol).get_init_guess(mol, key='mod_huckel')
         self.assertAlmostEqual(lib.fp(dm), 3.233072986208057, 5)
 
+        # init_guess_by_mod_huckel should be callable without arguments,
+        # consistent with init_guess_by_huckel and the UHF/ROHF/GHF/DHF
+        # implementations.
+        dm = scf.hf.RHF(mol).init_guess_by_mod_huckel()
+        self.assertAlmostEqual(lib.fp(dm), 3.233072986208057, 5)
+
         dm = scf.ROHF(mol).init_guess_by_mod_huckel()
         self.assertAlmostEqual(lib.fp(dm[0]), 3.233072986208057/2, 5)
 


### PR DESCRIPTION
Hi PySCF maintainers,

Thank you for developing and maintaining PySCF. I'm a user from Korea and
have been relying on it in my day-to-day work. This is my first contribution
to the project, so please bear with me if I have missed any conventions —
I'm happy to adjust.

While reading through the SCF initial-guess methods I noticed that
`SCF.init_guess_by_mod_huckel` has a required positional argument
`updated_rule` that the method body never uses — it always calls
`_init_guess_huckel_orbitals(mol, updated_rule=True)`. Because of this,
`scf.RHF(mol).init_guess_by_mod_huckel()` raises `TypeError` when called
without arguments, while the sibling `init_guess_by_huckel()` works fine.
The UHF, ROHF, GHF, and DHF versions already use the usual `(self, mol=None)`
style, and the method's docstring only documents `mol`, so RHF seems to be
the odd one out here.

This PR drops the unused `updated_rule` parameter:

```python
-    def init_guess_by_mod_huckel(self, updated_rule, mol=None):
+    def init_guess_by_mod_huckel(self, mol=None):
```

A note on behavior, to be precise about scope:

- The common string-dispatch path (`mf.init_guess = 'mod_huckel'` /
  `get_init_guess(key='mod_huckel')`), which uses `self.mol`, returns the
  same result as before.
- The direct no-argument call, which used to raise `TypeError`, now works.
- An explicit `mol` argument now follows the documented `(mol=None)`
  convention used by the sibling methods, instead of landing in the old
  `updated_rule` slot.

I added a small regression test next to the existing huckel test, checking
that `scf.hf.RHF(mol).init_guess_by_mod_huckel()` returns the expected
density-matrix fingerprint.

While in the area I also synced a few nearby docstrings with the
implementation:

- added `'mod_huckel'` to the `init_guess` option lists where it was missing;
- added `'huckel'` and `'sap'`, which were also missing from the list in
  `pyscf/scf/__init__.py`;
- corrected the generic SCF `conv_tol` default in `pyscf/scf/__init__.py`
  from `1e-10` to `1e-9` to match the actual default in `pyscf/scf/hf.py`.

I intentionally left a couple of things alone: `'vsap'` is not added to the
generic SCF option list since it is DFT-specific, and the DHF/PBC `conv_tol`
defaults (which are `1e-8`) are untouched.

The doc changes are independent of the code fix, so I'm happy to split them
into a separate PR if you'd prefer to keep this one to just the bugfix.

Thanks again for your time and for all the work on PySCF.
