### PR TITLE
Load basis from BSE if elements are missing from .dat 

### DIFF
--- a/pyscf/gto/basis/__init__.py
+++ b/pyscf/gto/basis/__init__.py
@@ -722,6 +722,7 @@ def load(filename_or_basisname, symb, optimize=OPTIMIZE_CONTRACTION):
             mod = importlib.import_module('.'+basmod, __package__)
             b = mod.__getattribute__(symb)
     except (BasisNotFoundError, AttributeError):
+        # When basis set is recognized but its .dat file lacks required elements (e.g., lanthanides), fallback to BSE
         from pyscf.gto.basis import bse
         if bse.basis_set_exchange is None:
             warnings.warn(

--- a/pyscf/gto/basis/__init__.py
+++ b/pyscf/gto/basis/__init__.py
@@ -711,15 +711,32 @@ def load(filename_or_basisname, symb, optimize=OPTIMIZE_CONTRACTION):
 
         raise BasisNotFoundError(f'Unknown basis format or basis name for {filename_or_basisname}')
 
-    if 'dat' in basmod:
-        b = fload(join(basis_dir, basmod), symb, optimize)
-    elif isinstance(basmod, (tuple, list)) and isinstance(basmod[0], str):
-        b = []
-        for f in basmod:
-            b += fload(join(basis_dir, f), symb, optimize)
-    else:
-        mod = importlib.import_module('.'+basmod, __package__)
-        b = mod.__getattribute__(symb)
+    try:
+        if 'dat' in basmod:
+            b = fload(join(basis_dir, basmod), symb, optimize)
+        elif isinstance(basmod, (tuple, list)) and isinstance(basmod[0], str):
+            b = []
+            for f in basmod:
+                b += fload(join(basis_dir, f), symb, optimize)
+        else:
+            mod = importlib.import_module('.'+basmod, __package__)
+            b = mod.__getattribute__(symb)
+    except (BasisNotFoundError, AttributeError):
+        from pyscf.gto.basis import bse
+        if bse.basis_set_exchange is None:
+            warnings.warn(
+                'Basis may be available in basis-set-exchange. '
+                'It is recommended to install basis-set-exchange: '
+                'pip install basis-set-exchange')
+            raise BasisNotFoundError(
+                f'Basis set not found for {symb} in {filename_or_basisname}')
+        try:
+            bse_obj = bse.basis_set_exchange.api.get_basis(
+                filename_or_basisname, elements=symb)
+        except KeyError:
+            raise BasisNotFoundError(
+                f'Basis set not found for {symb} in {filename_or_basisname}')
+        b = bse._orbital_basis(bse_obj)[0][symb]
 
     if contr_scheme != 'Full':
         b = _truncate(b, contr_scheme, symb, split_name)


### PR DESCRIPTION
The BSE fallback in 'load' is only reached in the case of unknown basis names. Some basis sets (e.g., def2-svp) are recognized from the ALIAS dictionary, but their associated .dat file omits lanthanide elements, preventing the basis and ECP from loading. Added an exception to load the basis from basis set exchange if the basis is found in the ALIAS dictionary but some elements are missing. Follows the same structure as earlier BSE fallback in the case of unrecognized basis set names.