### PR TITLE
Loosen some tests in adc, gw and tdscf

### DIFF
--- a/.github/workflows/run_tests.sh
+++ b/.github/workflows/run_tests.sh
@@ -13,6 +13,7 @@ version=$(python -c 'import sys; print("{0}.{1}".format(*sys.version_info[:2]))'
 # pytest-cov on Python 3.12 consumes huge memory
 if [ "$RUNNER_OS" == "Linux" ] && [ $version != "3.12" ]; then
   pytest pyscf/ -s -c pytest.ini \
+    --durations=10 \
     --cov-report xml --cov-report term --cov-config .coveragerc --cov pyscf
 else
   pytest pyscf/ -s -c pytest.ini pyscf

--- a/.github/workflows/run_tests.sh
+++ b/.github/workflows/run_tests.sh
@@ -13,7 +13,7 @@ version=$(python -c 'import sys; print("{0}.{1}".format(*sys.version_info[:2]))'
 # pytest-cov on Python 3.12 consumes huge memory
 if [ "$RUNNER_OS" == "Linux" ] && [ $version != "3.12" ]; then
   pytest pyscf/ -s -c pytest.ini \
-    --durations=10 \
+    --durations=20 \
     --cov-report xml --cov-report term --cov-config .coveragerc --cov pyscf
 else
   pytest pyscf/ -s -c pytest.ini pyscf

--- a/pyscf/adc/test/test_radc/test_ee_df_N2.py
+++ b/pyscf/adc/test/test_radc/test_ee_df_N2.py
@@ -70,10 +70,10 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(p[3], 6.481812538202186e-30, 6)
 
         dm1_exc = np.array(myadc.make_rdm1())
-        self.assertAlmostEqual(rdms_test(dm1_exc[0]) - 39.97509426976306, 0, 4)
-        self.assertAlmostEqual(rdms_test(dm1_exc[1]) - 39.97509426976296, 0, 4)
-        self.assertAlmostEqual(rdms_test(dm1_exc[2]) - 40.69394840350379, 0, 4)
-        self.assertAlmostEqual(rdms_test(dm1_exc[3]) - 40.99987050864409, 0, 4)
+        self.assertAlmostEqual(rdms_test(dm1_exc[0]) - 39.97509426976306, 0, 3)
+        self.assertAlmostEqual(rdms_test(dm1_exc[1]) - 39.97509426976296, 0, 3)
+        self.assertAlmostEqual(rdms_test(dm1_exc[2]) - 40.69394840350379, 0, 3)
+        self.assertAlmostEqual(rdms_test(dm1_exc[3]) - 40.99987050864409, 0, 3)
 
 
     def test_ee_adc2x(self):

--- a/pyscf/adc/test/test_radc/test_ee_df_N2.py
+++ b/pyscf/adc/test/test_radc/test_ee_df_N2.py
@@ -20,9 +20,7 @@
 import unittest
 import numpy as np
 import math
-from pyscf import gto
-from pyscf import scf
-from pyscf import adc
+from pyscf import gto, scf, adc, lib
 
 def setUpModule():
     global mol, mf, myadc, myadc_fr
@@ -49,8 +47,8 @@ def tearDownModule():
 
 def rdms_test(dm):
     r2_int = mol.intor('int1e_r2')
-    dm_ao = np.einsum('pi,ij,qj->pq', mf.mo_coeff, dm, mf.mo_coeff.conj())
-    r2 = np.einsum('pq,pq->',r2_int,dm_ao)
+    dm_ao = lib.einsum('pi,ij,qj->pq', mf.mo_coeff, dm, mf.mo_coeff.conj())
+    r2 = lib.einsum('pq,pq->',r2_int,dm_ao)
     return r2
 
 class KnownValues(unittest.TestCase):
@@ -72,10 +70,10 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(p[3], 6.481812538202186e-30, 6)
 
         dm1_exc = np.array(myadc.make_rdm1())
-        self.assertAlmostEqual(rdms_test(dm1_exc[0]), 39.97509426976306, 4)
-        self.assertAlmostEqual(rdms_test(dm1_exc[1]), 39.97509426976296, 4)
-        self.assertAlmostEqual(rdms_test(dm1_exc[2]), 40.69394840350379, 4)
-        self.assertAlmostEqual(rdms_test(dm1_exc[3]), 40.99987050864409, 4)
+        self.assertAlmostEqual(rdms_test(dm1_exc[0]) - 39.97509426976306, 0, 4)
+        self.assertAlmostEqual(rdms_test(dm1_exc[1]) - 39.97509426976296, 0, 4)
+        self.assertAlmostEqual(rdms_test(dm1_exc[2]) - 40.69394840350379, 0, 4)
+        self.assertAlmostEqual(rdms_test(dm1_exc[3]) - 40.99987050864409, 0, 4)
 
 
     def test_ee_adc2x(self):
@@ -124,7 +122,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(rdms_test(dm1_exc[3]), 40.91091417592432, 4)
 
 
-    def test_ee_adc3(self):
+    def test_ee_adc3_high_cost(self):
         myadc.method = "adc(3)"
         e, t_amp1, t_amp2 = myadc.kernel_gs()
 

--- a/pyscf/adc/test/test_uadc/test_ee_df_F2.py
+++ b/pyscf/adc/test/test_uadc/test_ee_df_F2.py
@@ -120,7 +120,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(rdms_test(dm1_exc[0][2],dm1_exc[1][2]), 40.49491598756553, 6)
         self.assertAlmostEqual(rdms_test(dm1_exc[0][3],dm1_exc[1][3]), 40.49491598756554, 6)
 
-    def test_ee_adc3(self):
+    def test_ee_adc3_high_cost(self):
         myadc.method = "adc(3)"
 
         e,v,p,x = myadc.kernel(nroots=4)

--- a/pyscf/adc/test/test_uadc/test_ee_rohf_CN.py
+++ b/pyscf/adc/test/test_uadc/test_ee_rohf_CN.py
@@ -122,7 +122,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(rdms_test(dm1_exc[0][2],dm1_exc[1][2]), 40.27044834802643, 4)
         self.assertAlmostEqual(rdms_test(dm1_exc[0][3],dm1_exc[1][3]), 40.64183214575419, 4)
 
-    def test_ee_adc3(self):
+    def test_ee_adc3_high_cost(self):
         myadc.method = "adc(3)"
 
         e,v,p,x = myadc.kernel(nroots=4)

--- a/pyscf/grad/test/test_lpdft.py
+++ b/pyscf/grad/test/test_lpdft.py
@@ -286,7 +286,7 @@ class KnownValues(unittest.TestCase):
                 de_ref = mc_grad_ref.kernel(state=i)[1, 0]
                 self.assertAlmostEqual (de, de_ref, 6)
 
-    def test_dfrohf_sanity (self):
+    def test_dfrohf_sanity_high_cost (self):
         n_states = 3
         mc_grad = diatomic(
             "Li", "H", 1.4, "ftpbe", "6-31g", 4, 2, n_states, density_fit=True, spin=2

--- a/pyscf/gw/test/test_gw.py
+++ b/pyscf/gw/test/test_gw.py
@@ -49,7 +49,7 @@ class KnownValues(unittest.TestCase):
         gw_obj.orbs = range(nocc-3, nocc+3)
         gw_obj.kernel()
         self.assertAlmostEqual(gw_obj.mo_energy[nocc-1], -0.4129411145067107, 7)
-        self.assertAlmostEqual(gw_obj.mo_energy[nocc], 0.16568737755110896, 8)
+        self.assertAlmostEqual(gw_obj.mo_energy[nocc], 0.16568737755110896, 7)
 
         gw_obj = gw.GW(mf, freq_int='ac')
         gw_obj.frozen = np.array([0])
@@ -57,8 +57,8 @@ class KnownValues(unittest.TestCase):
         gw_obj.ac = 'pade'
         gw_obj.orbs = range(nocc-3, nocc+3)
         gw_obj.kernel()
-        self.assertAlmostEqual(gw_obj.mo_energy[nocc-1], -0.4129411145067107, 8)
-        self.assertAlmostEqual(gw_obj.mo_energy[nocc], 0.16568737755110896, 8)
+        self.assertAlmostEqual(gw_obj.mo_energy[nocc-1], -0.4129411145067107, 7)
+        self.assertAlmostEqual(gw_obj.mo_energy[nocc], 0.16568737755110896, 7)
 
     def test_gwcd(self):
         nocc = mol.nelectron//2

--- a/pyscf/pbc/dft/test/test_krkspu.py
+++ b/pyscf/pbc/dft/test/test_krkspu.py
@@ -93,7 +93,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(vxc.E_U, 0.07587726255165786, 11)
         self.assertAlmostEqual(lib.fp(vxc), 12.77643098220399, 8)
 
-    def test_KRKSpU_linear_response(self):
+    def test_KRKSpU_linear_response_high_cost(self):
         cell = pgto.Cell()
         cell.unit = 'A'
         cell.atom = 'C 0.,  0.,  0.; C 0.8917,  0.8917,  0.8917'

--- a/pyscf/pbc/gw/test/test_gw_ac.py
+++ b/pyscf/pbc/gw/test/test_gw_ac.py
@@ -42,7 +42,7 @@ def diamond_supercell_pbe():
     yield mf
 
 
-def test_gwac_pade_diamond_supercell(diamond_supercell_pbe):
+def test_gwac_pade_diamond_supercell_high_cost(diamond_supercell_pbe):
     gw = GWAC(diamond_supercell_pbe)
     gw.kernel()
 

--- a/pyscf/pbc/tdscf/test/test_uks.py
+++ b/pyscf/pbc/tdscf/test/test_uks.py
@@ -87,7 +87,7 @@ class DiamondM06(unittest.TestCase):
 
     def kernel(self, TD, ref, **kwargs):
         td = getattr(self.mf, TD)().set(nstates=self.nstates, **kwargs).run()
-        self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 5)
+        self.assertAlmostEqual(abs(td.e[:self.nstates_test] * unitev  - ref).max(), 0, 4)
         return td
 
     def test_tda(self):
@@ -103,7 +103,7 @@ class DiamondM06(unittest.TestCase):
         td = self.kernel('TDDFT', ref, conv_tol=1e-8)
         a, b = td.get_ab()
         eref = diagonalize(a, b)
-        self.assertAlmostEqual(abs(td.e[:4] - eref[:4]).max(), 0, 8)
+        self.assertAlmostEqual(abs(td.e[:4] - eref[:4]).max(), 0, 7)
 
     def check_rsh_tda(self, xc, place=6):
         cell = self.cell

--- a/pyscf/tdscf/test/test_tdrks_vv10.py
+++ b/pyscf/tdscf/test/test_tdrks_vv10.py
@@ -117,9 +117,9 @@ class KnownValues(unittest.TestCase):
         mf = make_mf(mol)
         tda = mf.TDA()
         tda.exclude_nlc = False
-        test_excitation_energy, test_state_vector = tda.kernel(nstates = 3)
+        test_excitation_energy, test_state_vector = tda.kernel(nstates = 2)
 
-        assert np.linalg.norm(test_excitation_energy - reference_excitation_energy[:3]) < excitation_energy_threshold
+        assert np.linalg.norm(test_excitation_energy - reference_excitation_energy[:2]) < excitation_energy_threshold
 
         reference_transition_dipole = np.array([
             [-0.0039, -0.0088, -0.0068],
@@ -130,14 +130,14 @@ class KnownValues(unittest.TestCase):
         ])
         test_transition_dipole = tda.transition_dipole()
 
-        for i_dipole in range(reference_transition_dipole.shape[0]):
+        for i_dipole in range(2):
             assert np.linalg.norm(test_transition_dipole[i_dipole] - reference_transition_dipole[i_dipole]) < dipole_threshold \
                 or np.linalg.norm(test_transition_dipole[i_dipole] + reference_transition_dipole[i_dipole]) < dipole_threshold
 
         reference_oscillator_strength = np.array([0.0000204074, 0.0054841178, 0.0031204297, 0.0063755735, 0.0137712931])
         test_oscillator_strength = tda.oscillator_strength()
 
-        assert np.linalg.norm(test_oscillator_strength - reference_oscillator_strength[:3]) < oscillator_strength_threshold
+        assert np.linalg.norm(test_oscillator_strength - reference_oscillator_strength[:2]) < oscillator_strength_threshold
 
     def test_wb97xv_tddft_triplet_high_cost(self):
         ### Q-Chem input

--- a/pyscf/tdscf/test/test_tdrks_vv10.py
+++ b/pyscf/tdscf/test/test_tdrks_vv10.py
@@ -117,9 +117,9 @@ class KnownValues(unittest.TestCase):
         mf = make_mf(mol)
         tda = mf.TDA()
         tda.exclude_nlc = False
-        test_excitation_energy, test_state_vector = tda.kernel(nstates = len(reference_excited_state_energy))
+        test_excitation_energy, test_state_vector = tda.kernel(nstates = 3)
 
-        assert np.linalg.norm(test_excitation_energy - reference_excitation_energy) < excitation_energy_threshold
+        assert np.linalg.norm(test_excitation_energy - reference_excitation_energy[:3]) < excitation_energy_threshold
 
         reference_transition_dipole = np.array([
             [-0.0039, -0.0088, -0.0068],
@@ -137,7 +137,7 @@ class KnownValues(unittest.TestCase):
         reference_oscillator_strength = np.array([0.0000204074, 0.0054841178, 0.0031204297, 0.0063755735, 0.0137712931])
         test_oscillator_strength = tda.oscillator_strength()
 
-        assert np.linalg.norm(test_oscillator_strength - reference_oscillator_strength) < oscillator_strength_threshold
+        assert np.linalg.norm(test_oscillator_strength - reference_oscillator_strength[:3]) < oscillator_strength_threshold
 
     def test_wb97xv_tddft_triplet_high_cost(self):
         ### Q-Chem input
@@ -232,7 +232,7 @@ class KnownValues(unittest.TestCase):
 
         assert np.linalg.norm(test_oscillator_strength - reference_oscillator_strength) < oscillator_strength_threshold
 
-    def test_wb97xv_unrestricted_tda(self):
+    def test_wb97xv_unrestricted_tda_high_cost(self):
         # Same Q-Chem input as above, Q-Chem computes both TDA and TDDFT in the same run
         reference_ground_state_energy = -150.9397884760
         reference_excited_state_energy = np.array([-150.88981193, -150.79604327, -150.75118183, -150.72292823, -150.71461300])

--- a/pyscf/tdscf/test/test_tduks.py
+++ b/pyscf/tdscf/test/test_tduks.py
@@ -147,7 +147,7 @@ class KnownValues(unittest.TestCase):
         a,b = td.get_ab()
         e_ref = diagonalize(a, b, 5)
         self.assertAlmostEqual(abs(es[:3]-e_ref[:3]).max(), 0, 5)
-        self.assertAlmostEqual(lib.fp(es[:3]*27.2114), 7.69383202636, 4)
+        self.assertAlmostEqual(lib.fp(es[:3]*27.2114) - 7.69383202636, 0, 4)
 
     def test_tda_b3lyp(self):
         td = tdscf.TDA(mf_b3lyp)

--- a/pyscf/tdscf/test/test_tduks.py
+++ b/pyscf/tdscf/test/test_tduks.py
@@ -146,7 +146,7 @@ class KnownValues(unittest.TestCase):
         es = td.kernel(nstates=4)[0]
         a,b = td.get_ab()
         e_ref = diagonalize(a, b, 5)
-        self.assertAlmostEqual(abs(es[:3]-e_ref[:3]).max(), 0, 6)
+        self.assertAlmostEqual(abs(es[:3]-e_ref[:3]).max(), 0, 5)
         self.assertAlmostEqual(lib.fp(es[:3]*27.2114), 7.69383202636, 4)
 
     def test_tda_b3lyp(self):


### PR DESCRIPTION
Resolve part of #3245 . Did not touch mcpdft and the suspicious ones in which the error is not small enough (like test_eom_gccsd.py::KnownValues::test_ipccsd, test_rks.py::Diamond::test_hse06_tda, etc.)

Also mute a few high cost tests.