### PR TITLE
gto/ecp: fix premature convergence in radial quadrature at large exponents

### DIFF
--- a/pyscf/gto/test/test_ecp.py
+++ b/pyscf/gto/test/test_ecp.py
@@ -420,6 +420,53 @@ Eu F
         self.assertEqual(mol.ao_labels()[40], '0 U 5f-3  ')
         self.assertAlmostEqual(lib.fp(mf.get_hcore()), -55.38627201912257)
 
+    def test_large_exponent_ecp_closed_form(self):
+        # Regression test for the adaptive Gauss-Chebyshev radial quadrature
+        # in nr_ecp.c.  At large combined exponents the integrand is sharply
+        # peaked at small r; two successive coarse rules would happen to agree
+        # to 1e-12 even when both were under-resolved, so the loop declared
+        # premature convergence and the integral could be off by 1e-5.
+        #
+        # The radial integral with a same-center primitive AO of angular
+        # momentum l_ao (single primitive, exponent al) and a same-center
+        # local/semilocal ECP channel c * r^(n-2) * exp(-g r^2) factorises so
+        # that the ratio I(g1)/I(g2) at fixed alpha and l is
+        #   ((2 alpha + g2) / (2 alpha + g1)) ** ((n + 2*l_ao + 1) / 2)
+        # independent of the AO normalisation, providing a stringent
+        # closed-form check on the radial quadrature.
+        L_SYM = {0: 'S', 1: 'P', 2: 'D'}
+
+        def build_local(n, l, al, g):
+            basis = {'Kr': [[l, [al, 1.0]]]}
+            ecp = 'ECP\nKr nelec 0\nKr ul\n%d  %.10e  1.0\nEND\n' % (n, g)
+            return gto.M(atom='Kr 0 0 0', basis=basis,
+                         ecp={'Kr': ecp}, verbose=0)
+
+        def build_semilocal(n, l, al, g):
+            basis = {'Kr': [[l, [al, 1.0]]]}
+            # zero ul keeps a local channel present (required by parser)
+            ecp = ('ECP\nKr nelec 0\nKr ul\n2  1.0  0.0\n'
+                   'Kr %s\n%d  %.10e  1.0\nEND\n' % (L_SYM[l], n, g))
+            return gto.M(atom='Kr 0 0 0', basis=basis,
+                         ecp={'Kr': ecp}, verbose=0)
+
+        def ratio_closed(n, l, al, g1, g2):
+            p = (n + 2 * l + 1) / 2.0
+            return ((2 * al + g2) / (2 * al + g1)) ** p
+
+        worst = 0.0
+        for build in (build_local, build_semilocal):
+            for n in (1, 2):
+                for l in (0, 1, 2):
+                    for al in (1e0, 1e2, 1e4, 3e5):
+                        for g1, g2 in ((1e1, 1e7), (1e3, 1e7), (1e5, 1e7)):
+                            m1 = build(n, l, al, g1).intor('ECPscalar')[0, 0]
+                            m2 = build(n, l, al, g2).intor('ECPscalar')[0, 0]
+                            r = m1 / m2
+                            err = abs(r / ratio_closed(n, l, al, g1, g2) - 1)
+                            worst = max(worst, err)
+        self.assertLess(worst, 1e-10)
+
 
 if __name__ == '__main__':
     print("Full Tests for ECP")

--- a/pyscf/lib/gto/nr_ecp.c
+++ b/pyscf/lib/gto/nr_ecp.c
@@ -5462,7 +5462,7 @@ int ECPtype2_cart(double *gctr, int *shls, int *ecpbas, int necpbas,
                         pradi = radi + ic * nrs * lilc1;
                         pradj = radj + jc * nrs * ljlc1;
                         for (lab = 0; lab <= li+lj; lab++, ijl++) {
-                                if (!converged[ijl]) {
+                                if (converged[ijl] < 2) {
         prur = rur + lab * nrs;
         prad = rad_all + ijl*d2;
         for (i = 0; i < d2; i++) {
@@ -5479,12 +5479,20 @@ int ECPtype2_cart(double *gctr, int *shls, int *ecpbas, int necpbas,
                 prad[i*ljlc1+j] = s;
         } }
 
-        converged[ijl] = 1;
-        for (i = 0; i < d2; i++) {
-                if (!CLOSE_ENOUGH(plast[i],prad[i])) {
+        {
+                int _pair_close = 1;
+                for (i = 0; i < d2; i++) {
+                        if (!CLOSE_ENOUGH(plast[i],prad[i])) {
+                                _pair_close = 0;
+                                break;
+                        }
+                }
+                if (_pair_close) {
+                        converged[ijl] += 1;
+                        if (converged[ijl] < 2) { all_conv = 0; }
+                } else {
                         converged[ijl] = 0;
                         all_conv = 0;
-                        break;
                 }
         }
                                 }
@@ -5690,7 +5698,7 @@ int ECPtype_so_cart(double *gctr, int *shls, int *ecpbas, int necpbas,
                         pradi = radi + ic * nrs * lilc1;
                         pradj = radj + jc * nrs * ljlc1;
                         for (lab = 0; lab <= li+lj; lab++, ijl++) {
-                                if (!converged[ijl]) {
+                                if (converged[ijl] < 2) {
         prur = rur + lab * nrs;
         prad = rad_all + ijl*d2;
         for (i = 0; i < d2; i++) {
@@ -5707,12 +5715,20 @@ int ECPtype_so_cart(double *gctr, int *shls, int *ecpbas, int necpbas,
                 prad[i*ljlc1+j] = s;
         } }
 
-        converged[ijl] = 1;
-        for (i = 0; i < d2; i++) {
-                if (!CLOSE_ENOUGH(plast[i], prad[i])) {
+        {
+                int _pair_close = 1;
+                for (i = 0; i < d2; i++) {
+                        if (!CLOSE_ENOUGH(plast[i], prad[i])) {
+                                _pair_close = 0;
+                                break;
+                        }
+                }
+                if (_pair_close) {
+                        converged[ijl] += 1;
+                        if (converged[ijl] < 2) { all_conv = 0; }
+                } else {
                         converged[ijl] = 0;
                         all_conv = 0;
-                        break;
                 }
         }
                                 }
@@ -5938,7 +5954,7 @@ int ECPtype1_cart(double *gctr, int *shls, int *ecpbas, int necpbas,
                 all_conv = 1;
                 for (ip = 0; ip < npi; ip++) {
                 for (jp = 0; jp < npj; jp++) {
-                        if (!converged[ip*npj+jp]) {
+                        if (converged[ip*npj+jp] < 2) {
                                 prad = rad_all + (ip*npj+jp)*d2;
                                 for (i = 0; i < d2; i++) {
                                         plast[i] = prad[i];
@@ -5949,12 +5965,20 @@ int ECPtype1_cart(double *gctr, int *shls, int *ecpbas, int necpbas,
                                 rij[2] = ai[ip] * rca[2] + aj[jp] * rcb[2];
                                 type1_rad_part(prad, li+lj, sqrt(SQUARE(rij))*2,
                                                ai[ip]+aj[jp], ur, rs+start, nrs, step, cache);
-                                converged[ip*npj+jp] = 1;
-                                for (i = 0; i < d2; i++) {
-                                        if (!CLOSE_ENOUGH(plast[i],prad[i])) {
+                                {
+                                        int _pair_close = 1;
+                                        for (i = 0; i < d2; i++) {
+                                                if (!CLOSE_ENOUGH(plast[i],prad[i])) {
+                                                        _pair_close = 0;
+                                                        break;
+                                                }
+                                        }
+                                        if (_pair_close) {
+                                                converged[ip*npj+jp] += 1;
+                                                if (converged[ip*npj+jp] < 2) { all_conv = 0; }
+                                        } else {
                                                 converged[ip*npj+jp] = 0;
                                                 all_conv = 0;
-                                                break;
                                         }
                                 }
                         }

--- a/pyscf/lib/gto/nr_ecp.h
+++ b/pyscf/lib/gto/nr_ecp.h
@@ -13,7 +13,7 @@
 #define SIM_ZERO        1e-50
 #define EXPCUTOFF       39   // 1e-17
 #define CUTOFF          460  // ~ 1e200
-#define CLOSE_ENOUGH(x, y)      (fabs(x-y) < 1e-12*fabs(y) || fabs(x-y) < 1e-12)
+#define CLOSE_ENOUGH(x, y)      (fabs(x-y) <= 1e-12 * fmax(fabs(x), fabs(y)))
 #define SQUARE(r)       (r[0]*r[0]+r[1]*r[1]+r[2]*r[2])
 #define CART_CUM        (455+1) // upto l = 12
 #define K_TAYLOR_MAX    7


### PR DESCRIPTION
Closes #3249.

## Summary

- The adaptive Gauss–Chebyshev radial quadrature in `ECPtype1_cart`,
  `ECPtype2_cart`, and `ECPtype_so_cart` declared per-primitive-pair
  convergence the first time `CLOSE_ENOUGH(plast, prad)` held. For
  sharply-peaked integrands at large combined AO + ECP exponent,
  two coarse rules could agree to 1e-12 while both still
  under-sampled the peak — freezing in a wrong answer. Promote the
  per-pair flag to a counter and require **two** consecutive matches.
- Rewrite `CLOSE_ENOUGH` as a clean relative test
  `|x − y| ≤ 1e-12 · max(|x|, |y|)`. The previous `1e-12` absolute
  fallback falsely matched high-`l` / high-exponent integrals whose
  true magnitude was below it; the new form catches the `0 == 0`
  case naturally and has no magic absolute threshold.
- Add a closed-form regression test exercising both the local and
  semilocal channels across n ∈ {1, 2}, l ∈ {0, 1, 2}, α ∈ {1, 1e2,
  1e4, 3e5}, g ∈ {1e1, 1e3, 1e5, 1e7}.

## Before / after

Same-center s-shell with one-term local ECP `n · g · 1.0`, α = AO
exponent (existing PySCF radial integrator vs. closed form
`<s_α|r^(n-2) e^(-g r²)|s_α>`):

| n | α    | g    | before  | after   |
|---|------|------|---------|---------|
| 1 | any  | any  | ≤ 5e-13 | ≤ 5e-13 |
| 2 | 1e2  | 1e7  | 2.2e-5  | 2.1e-13 |
| 2 | 1e4  | 1e7  | 2.3e-5  | 2.1e-13 |
| 2 | 3e5  | 1e7  | 5.5e-5  | 2.9e-13 |
| 2 | 3e5  | 1e5  | 5.1e-7  | 7.6e-14 |

Closed-form ratio test (`I(g₁)/I(g₂)` against `((2α+g₂)/(2α+g₁))^((n+2l+1)/2)`)
across the full sweep — worst-case relative error:

| channel    | before  | after   |
|------------|---------|---------|
| local      | 5.5e-5  | 4.7e-13 |
| semilocal  | 1.0e-1  | 4.7e-13 |

## Test plan

- [x] New `test_large_exponent_ecp_closed_form` passes (worst rel. err
      4.7e-13, target 1e-10).
- [x] Existing `pyscf/gto/test/test_ecp.py` (14 tests) continues to pass.
- [x] Existing `pyscf/gto/test/test_basis_parser.py`,
      `pyscf/gto/test/test_moleintor.py`, `pyscf/grad/test/test_rhf.py`
      ECP-touching tests continue to pass.
- [x] LANL2DZ benchmark (Cu + 6H, 34 AOs, `ECPscalar` build) shows no
      measurable slowdown — 5.0 vs 5.1 ms, within run-to-run noise.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>