### PR TITLE
High order cc improvements

### DIFF
--- a/examples/cc/61-rccsdtq.py
+++ b/examples/cc/61-rccsdtq.py
@@ -52,7 +52,7 @@ mycc2.conv_tol_normt = 1e-6
 mycc2.verbose = 5
 mycc2.incore_complete = True
 mycc2.kernel()
-print('Full-T4 RCCSDQ e_corr       % .12f    Ref % .12f    Diff % .12e' % (
+print('Full-T4 RCCSDTQ e_corr       % .12f    Ref % .12f    Diff % .12e' % (
         mycc2.e_corr, ref_e_corr, mycc2.e_corr - ref_e_corr))
 
 #

--- a/examples/cc/63-check_rccsdt_uccsdt_consistency.py
+++ b/examples/cc/63-check_rccsdt_uccsdt_consistency.py
@@ -63,7 +63,7 @@ print('RCCSDT correlation energy % .12f    Ref % .12f    Diff % .12e' % (
 
 # Restart UCCSDT using amplitudes converted from RCCSDT
 tamps_init_uhf = [t1_rhf2uhf, t2_rhf2uhf, t3_rhf2uhf]
-myucc2 = cc.UCCSDT(mf, compact_tamps=False).set(conv_tol=1e-10, conv_tol_normt=1e-8, verbose=5)
+myucc2 = cc.UCCSDT(mf_uhf, compact_tamps=False).set(conv_tol=1e-10, conv_tol_normt=1e-8, verbose=5)
 myucc2.kernel(tamps=tamps_init_uhf)
 print('UCCSDT correlation energy % .12f    Ref % .12f    Diff % .12e' % (
         myucc2.e_corr, -0.2188784727114157, myucc2.e_corr - -0.2188784727114157))

--- a/examples/cc/64-chained_rccsd_rccsdt_rccsdtq.py
+++ b/examples/cc/64-chained_rccsd_rccsdt_rccsdtq.py
@@ -11,7 +11,6 @@ This script demonstrates how to:
     - Examine the influence of DIIS acceleration on convergence.
 '''
 
-import numpy as np
 from pyscf import gto, scf, cc
 
 def run_rccsd_rccsdt_rccsdtq(do_diis=False, do_diis_max_t=False, verbose=0):

--- a/examples/cc/65-chained_uccsd_uccsdt.py
+++ b/examples/cc/65-chained_uccsd_uccsdt.py
@@ -11,7 +11,6 @@ This script demonstrates how to:
     - Understand and handle the difference in T2 amplitude conventions between UCCSD and UCCSDT implementations.
 '''
 
-import numpy as np
 from pyscf import gto, scf, cc
 
 def run_uccsd_uccsdt(do_diis=False, do_diis_max_t=False, verbose=0):
@@ -32,7 +31,7 @@ def run_uccsd_uccsdt(do_diis=False, do_diis_max_t=False, verbose=0):
     myccsd.verbose = verbose
     myccsd.diis = do_diis
     myccsd.kernel()
-    print('RCCSD   e_corr % .12f    Ref % .12f    Diff % .12e' % (
+    print('UCCSD   e_corr % .12f    Ref % .12f    Diff % .12e' % (
             myccsd.e_corr, ref_ccsd_e_corr, myccsd.e_corr - ref_ccsd_e_corr))
 
     # UCCSDT
@@ -99,7 +98,7 @@ if __name__ == "__main__":
     do_diis_max_t = False
     run_uccsd_uccsdt(do_diis=do_diis, do_diis_max_t=do_diis_max_t)
 
-    print('=== UCCSD / UCCSDT with DIIS (including T3 amplitudes) ===')
+    print('=== UCCSD -> UCCSDT with DIIS (including T3 amplitudes) ===')
     do_diis = True
     do_diis_max_t = True
     run_uccsd_uccsdt(do_diis=do_diis, do_diis_max_t=do_diis_max_t)

--- a/examples/cc/66-rccsdt_q.py
+++ b/examples/cc/66-rccsdt_q.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+#
+# Author: Yu Jin <yjin@flatironinstitute.org>
+#
+
+'''
+Examples of RCCSDT(Q) calculations.
+
+This script demonstrates:
+    - Consistency of the [Q] and (Q) energy corrections on top of RCCSDT between calculations
+        using full and compact T3 storage.
+'''
+
+from pyscf import gto, scf, cc
+
+mol = gto.M(atom='H 0 0 0; F 0 0 1.1', basis='ccpvdz')
+mf = scf.RHF(mol)
+mf.conv_tol = 1e-14
+mf.kernel()
+
+# Reference CCSDT correlation energy, and [Q] and (Q) energy correction
+ref_e_corr = -0.2188784733230733
+ref_e_q_bracket = -0.0005026220700017348
+ref_e_q_paren = -0.0005490746450078632
+
+mycc1 = cc.RCCSDT(mf, compact_tamps=True)
+mycc1.conv_tol = 1e-10
+mycc1.conv_tol_normt = 1e-8
+mycc1.verbose = 5
+# einsum_backend: numpy (default) | pyscf | pytblis (recommended)
+# pytblis can be installed via `pip install pytblis==0.05` (See https://github.com/chillenb/pytblis)
+mycc1.set_einsum_backend('pyscf')
+mycc1.incore_complete = True
+mycc1.kernel()
+e_q_bracket, e_q_paren = mycc1.ccsdt_q()
+print('Triangular RCCSDT e_corr % .12f    Ref % .12f    Diff % .12e' % (
+        mycc1.e_corr, ref_e_corr, mycc1.e_corr - ref_e_corr))
+print('Triangular RCCSDT [Q]    % .12f    Ref % .12f    Diff % .12e' % (
+        e_q_bracket, ref_e_q_bracket, e_q_bracket - ref_e_q_bracket))
+print('Triangular RCCSDT (Q)    % .12f    Ref % .12f    Diff % .12e' % (
+        e_q_paren, ref_e_q_paren, e_q_paren - ref_e_q_paren))
+
+#
+# RCCSDT with full T3 storage
+# Same as cc.rccsdt_highm.RCCSDT
+#
+mycc2 = cc.RCCSDT(mf, compact_tamps=False)
+mycc2.conv_tol = 1e-10
+mycc2.conv_tol_normt = 1e-8
+mycc2.verbose = 5
+mycc2.incore_complete = True
+mycc2.kernel()
+q_bracket2, q_paren2 = mycc2.ccsdt_q()
+print('Full-T3 RCCSDT e_corr    % .12f    Ref % .12f    Diff % .12e' % (
+        mycc2.e_corr, ref_e_corr, mycc2.e_corr - ref_e_corr))
+print('Full-T3 RCCSDT [Q]       % .12f    Ref % .12f    Diff % .12e' % (
+        q_bracket2, ref_e_q_bracket, q_bracket2 - ref_e_q_bracket))
+print('Full-T3 RCCSDT (Q)       % .12f    Ref % .12f    Diff % .12e' % (
+        q_paren2, ref_e_q_paren, q_paren2 - ref_e_q_paren))

--- a/pyscf/cc/rccsdt.py
+++ b/pyscf/cc/rccsdt.py
@@ -756,7 +756,7 @@ def compute_r3_tri(mycc, imds, t2, t3):
                 einsum('acde,dbe->abc', W_vvvv, t3[index], out=r3[index], alpha=1.0, beta=1.0)
                 einsum('bcde,ade->abc', W_vvvv, t3[index], out=r3[index], alpha=1.0, beta=1.0)
                 index += 1
-        time2 = log.timer_debug1('t3: iter: W_vvvv %3d:'%k0, *time2)
+        time2 = log.timer_debug1('t3: iter: W_vvvv %3d:'%i0, *time2)
     W_vvvv = imds.W_vvvv = None
     time1 = log.timer_debug1('t3: W_vvvv * t3', *time1)
     return r3

--- a/pyscf/cc/rccsdt.py
+++ b/pyscf/cc/rccsdt.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ from pyscf import ao2mo, lib
 from pyscf.ao2mo import _ao2mo
 from pyscf.lib import logger
 from pyscf.mp.mp2 import get_nocc, get_nmo, get_frozen_mask, get_e_hf, _mo_without_core
-from pyscf.cc import ccsd, _ccsd
+from pyscf.cc import ccsd
 from pyscf import __config__
 
 
@@ -121,23 +121,6 @@ def unpack_t3_tri2block_(t3, t3_blk, map_, mask, i0, i1, j0, j1, k0, k1, nocc, n
     )
     return t3_blk
 
-def unpack_t3_tri2single_pair_(t3, t3_blk, map_, mask, i0, j0, k0, nocc, nvir):
-    assert t3.dtype == np.float64 and t3_blk.dtype == np.float64
-    assert map_.dtype == np.int64 and mask.dtype == np.bool_
-    t3 = np.ascontiguousarray(t3)
-    t3_blk = np.ascontiguousarray(t3_blk)
-    map_ = np.ascontiguousarray(map_)
-    mask = np.ascontiguousarray(mask)
-    _libccsdt.unpack_t3_tri2single_pair_(
-        t3.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
-        t3_blk.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
-        map_.ctypes.data_as(ctypes.POINTER(ctypes.c_int64)),
-        mask.ctypes.data_as(ctypes.POINTER(ctypes.c_bool)),
-        ctypes.c_int64(i0), ctypes.c_int64(j0), ctypes.c_int64(k0),
-        ctypes.c_int64(nocc), ctypes.c_int64(nvir),
-    )
-    return t3_blk
-
 def unpack_t3_tri2block_pair_(t3, t3_blk, map_, mask, i0, i1, j0, j1, k0, k1, nocc, nvir, blk_i, blk_j, blk_k):
     assert t3.dtype == np.float64 and t3_blk.dtype == np.float64
     assert map_.dtype == np.int64 and mask.dtype == np.bool_
@@ -177,22 +160,6 @@ def accumulate_t3_block2tri_(t3, t3_blk, map_, i0, i1, j0, j1, k0, k1, nocc, nvi
     )
     return t3
 
-def accumulate_t3_single2tri_(t3, t3_blk, map_, i0, j0, k0, nocc, nvir, alpha, beta):
-    assert t3.dtype == np.float64 and t3_blk.dtype == np.float64
-    assert map_.dtype == np.int64
-    t3 = np.ascontiguousarray(t3)
-    t3_blk = np.ascontiguousarray(t3_blk)
-    map_ = np.ascontiguousarray(map_)
-    _libccsdt.accumulate_t3_single2tri_(
-        t3.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
-        t3_blk.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
-        map_.ctypes.data_as(ctypes.POINTER(ctypes.c_int64)),
-        ctypes.c_int64(i0), ctypes.c_int64(j0), ctypes.c_int64(k0),
-        ctypes.c_int64(nocc), ctypes.c_int64(nvir),
-        ctypes.c_double(alpha), ctypes.c_double(beta)
-    )
-    return t3
-
 def _unpack_t3_(mycc, t3, t3_blk, i0, i1, j0, j1, k0, k1, blksize0=None, blksize1=None, blksize2=None):
     r'''Unpack triangular-stored T3 amplitudes into the block `t3_full[i0:i1, j0:j1, k0:k1, :, :, :]`'''
     if blksize0 is None: blksize0 = mycc.blksize
@@ -202,17 +169,10 @@ def _unpack_t3_(mycc, t3, t3_blk, i0, i1, j0, j1, k0, k1, blksize0=None, blksize
                         i0, i1, j0, j1, k0, k1, mycc.nocc, mycc.nmo - mycc.nocc, blksize0, blksize1, blksize2)
     return t3_blk
 
-def _unpack_t3_s_pair_(mycc, t3, t3_blk, i0, j0, k0):
-    r'''Unpack triangular-stored T3 amplitudes into the block
-    `t3_full[i0, j0, k0, :, :, :] + t3_full[j0, i0, k0, :, :, :].transpose(1, 0, 2)`
-    '''
-    unpack_t3_tri2single_pair_(t3, t3_blk, mycc.tri2block_map, mycc.tri2block_mask,
-                                i0, j0, k0, mycc.nocc, mycc.nmo - mycc.nocc)
-    return t3_blk
-
 def _unpack_t3_pair_(mycc, t3, t3_blk, i0, i1, j0, j1, k0, k1, blksize0=None, blksize1=None, blksize2=None):
     r'''Unpack triangular-stored T3 amplitudes into the block
-    `t3_full[i0:i1, j0:j1, k0:k1, :, :, :] + t3_full[k0:k1, j0:j1, i0:i1, :, :, :].transpose(0, 1, 2, 3, 5, 4)`
+    # `t3_full[i0:i1, j0:j1, k0:k1, :, :, :] + t3_full[k0:k1, j0:j1, i0:i1, :, :, :].transpose(0, 1, 2, 3, 5, 4)`
+    `t3_full[i0:i1, j0:j1, k0:k1, :, :, :] + t3_full[i0:i1, j0:j1, k0:k1, :, :, :].transpose(0, 1, 2, 4, 5, 3)`
     '''
     if blksize0 is None: blksize0 = mycc.blksize_oovv
     if blksize1 is None: blksize1 = mycc.nocc
@@ -228,11 +188,6 @@ def _accumulate_t3_(mycc, t3, t3_blk, i0, i1, j0, j1, k0, k1,
     if blksize2 is None: blksize2 = mycc.blksize
     accumulate_t3_block2tri_(t3, t3_blk, mycc.tri2block_map, i0, i1, j0, j1, k0, k1,
                         mycc.nocc, mycc.nmo - mycc.nocc, blksize0, blksize1, blksize2, alpha=alpha, beta=beta)
-    return t3
-
-def _accumulate_t3_s_(mycc, t3, t3_blk, i0, j0, k0, alpha=1.0, beta=0.0):
-    accumulate_t3_single2tri_(t3, t3_blk, mycc.tri2block_map, i0, j0, k0,
-                                mycc.nocc, mycc.nmo - mycc.nocc, alpha=alpha, beta=beta)
     return t3
 
 def setup_tri2block_rhf(mycc):
@@ -463,12 +418,13 @@ def intermediates_t1t2(mycc, imds, t2):
     einsum('lkdc,ljcd->kj', t1_eris[:nocc, :nocc, nocc:, nocc:], t2, out=F_oo, alpha=-1.0, beta=1.0)
     W_oooo = t1_eris[:nocc, :nocc, :nocc, :nocc].copy()
     einsum('klcd,ijcd->klij', t1_eris[:nocc, :nocc, nocc:, nocc:], t2, out=W_oooo, alpha=1.0, beta=1.0)
-    W_ovvo = - t1_eris[:nocc, nocc:, nocc:, :nocc]
-    einsum('klcd,ilad->kaci', t1_eris[:nocc, :nocc, nocc:, nocc:], t2, out=W_ovvo, alpha=-1.0, beta=1.0)
-    einsum('kldc,ilad->kaci', t1_eris[:nocc, :nocc, nocc:, nocc:], t2, out=W_ovvo, alpha=0.5, beta=1.0)
-    einsum('klcd,ilda->kaci', t1_eris[:nocc, :nocc, nocc:, nocc:], t2, out=W_ovvo, alpha=0.5, beta=1.0)
-    W_ovov = - t1_eris[:nocc, nocc:, :nocc, nocc:]
-    einsum('kldc,liad->kaic', t1_eris[:nocc, :nocc, nocc:, nocc:], t2, out=W_ovov, alpha=0.5, beta=1.0)
+    c_t2 = 2.0 * t2 - t2.transpose(0, 1, 3, 2)
+    W_ovvo = 2.0 * t1_eris[:nocc, nocc:, nocc:, :nocc] - t1_eris[:nocc, nocc:, :nocc, nocc:].transpose(0, 1, 3, 2)
+    einsum('mled,miea->ladi', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t2, out=W_ovvo, alpha=1.0, beta=1.0)
+    einsum('mlde,miea->ladi', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t2, out=W_ovvo, alpha=-0.5, beta=1.0)
+    c_t2 = None
+    W_ovov = t1_eris[:nocc, nocc:, :nocc, nocc:].copy()
+    einsum('mlde,imea->laid', t1_eris[:nocc, :nocc, nocc:, nocc:], t2, out=W_ovov, alpha=-0.5, beta=1.0)
     imds.F_vv, imds.F_oo, imds.W_oooo, imds.W_ovvo, imds.W_ovov = F_vv, F_oo, W_oooo, W_ovvo, W_ovov
     return imds
 
@@ -495,12 +451,10 @@ def compute_r1r2(mycc, imds, t2):
     einsum("kj,ikab->ijab", F_oo, t2, out=r2, alpha=-1.0, beta=1.0)
     einsum("abcd,ijcd->ijab", t1_eris[nocc:, nocc:, nocc:, nocc:], t2, out=r2, alpha=0.5, beta=1.0)
     einsum("klij,klab->ijab", W_oooo, t2, out=r2, alpha=0.5, beta=1.0)
-    einsum("kajc,ikcb->ijab", W_ovov, t2, out=r2, alpha=1.0, beta=1.0)
-    einsum("kaci,kjcb->ijab", W_ovvo, t2, out=r2, alpha=-2.0, beta=1.0)
-    einsum("kaic,kjcb->ijab", W_ovov, t2, out=r2, alpha=1.0, beta=1.0)
-    einsum("kaci,jkcb->ijab", W_ovvo, t2, out=r2, alpha=1.0, beta=1.0)
-    W_ovvo = imds.W_ovvo = None
-    W_ovov = imds.W_ovov = None
+    einsum("kaci,kjcb->ijab", W_ovvo, c_t2, out=r2, alpha=0.5, beta=1.0)
+    einsum("kaic,jkcb->ijab", W_ovov, t2, out=r2, alpha=-0.5, beta=1.0)
+    einsum("kbic,jkca->ijab", W_ovov, t2, out=r2, alpha=-1.0, beta=1.0)
+    c_t2 = None
     return r1, r2
 
 def r1r2_add_t3_tri_(mycc, imds, r1, r2, t3):
@@ -523,9 +477,7 @@ def r1r2_add_t3_tri_(mycc, imds, r1, r2, t3):
                 t3_spin_summation_inplace_(t3_tmp, blksize**3, nvir, "P3_422", 1.0, 0.0)
                 einsum('jkbc,ijkabc->ia', t1_eris[j0:j1, k0:k1, nocc:, nocc:],
                     t3_tmp[:bi, :bj, :bk], out=r1[i0:i1, :], alpha=0.5, beta=1.0)
-    t3_tmp = None
 
-    t3_tmp = np.empty((blksize,) * 3 + (nvir,) * 3, dtype=t3.dtype)
     for k0, k1 in lib.prange(0, nocc, blksize):
         bk = k1 - k0
         for j0, j1 in lib.prange(0, nocc, blksize):
@@ -535,7 +487,7 @@ def r1r2_add_t3_tri_(mycc, imds, r1, r2, t3):
                 _unpack_t3_(mycc, t3, t3_tmp, k0, k1, i0, i1, j0, j1)
                 t3_spin_summation_inplace_(t3_tmp, blksize**3, nvir, "P3_201", 1.0, 0.0)
                 einsum("kc,kijcab->ijab", t1_fock[k0:k1, nocc:], t3_tmp[:bk, :bi, :bj],
-                    out=r2[i0:i1, j0:j1, :, :], alpha=0.5, beta=1.0)
+                        out=r2[i0:i1, j0:j1, :, :], alpha=0.5, beta=1.0)
                 einsum("bkcd,kijdac->ijab", t1_eris[nocc:, k0:k1, nocc:, nocc:],
                         t3_tmp[:bk, :bi, :bj], out=r2[i0:i1, j0:j1, :, :], alpha=1.0, beta=1.0)
                 einsum("jklc,kijcab->ilab", t1_eris[j0:j1, k0:k1, :nocc, nocc:],
@@ -578,14 +530,12 @@ def intermediates_t3(mycc, imds, t2):
     einsum('lbde,jlea->abdj', t1_eris[:nocc, nocc:, nocc:, nocc:], t2, out=W_vvvo, alpha=-1.0, beta=1.0)
     einsum('lmdj,lmab->abdj', t1_eris[:nocc, :nocc, nocc:, :nocc], t2, out=W_vvvo, alpha=1.0, beta=1.0)
 
-    W_ovvo = (2.0 * t1_eris[:nocc, nocc:, nocc:, :nocc] - t1_eris[:nocc, nocc:, :nocc, nocc:].transpose(0, 1, 3, 2))
-    einsum('mled,miea->ladi', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t2, out=W_ovvo, alpha=2.0, beta=1.0)
-    einsum('mlde,miea->ladi', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t2, out=W_ovvo, alpha=-1.0, beta=1.0)
+    einsum('mled,miea->ladi', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t2, out=imds.W_ovvo, alpha=1.0, beta=1.0)
+    einsum('mlde,miea->ladi', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t2, out=imds.W_ovvo, alpha=-0.5, beta=1.0)
     c_t2 = None
 
-    W_ovov = t1_eris[:nocc, nocc:, :nocc, nocc:].copy()
-    einsum('mlde,imea->laid', t1_eris[:nocc, :nocc, nocc:, nocc:], t2, out=W_ovov, alpha=-1.0, beta=1.0)
-    imds.W_vooo, imds.W_ovvo, imds.W_ovov, imds.W_vvvo, imds.W_vvvv = W_vooo, W_ovvo, W_ovov, W_vvvo, W_vvvv
+    einsum('mlde,imea->laid', t1_eris[:nocc, :nocc, nocc:, nocc:], t2, out=imds.W_ovov, alpha=-0.5, beta=1.0)
+    imds.W_vooo, imds.W_vvvo, imds.W_vvvv = W_vooo, W_vvvo, W_vvvv
     return imds
 
 def intermediates_t3_add_t3_tri(mycc, imds, t3):
@@ -673,10 +623,8 @@ def compute_r3_tri(mycc, imds, t2, t3):
 
                 _unpack_t3_(mycc, t3, t3_tmp, i0, i1, j0, j1, k0, k1)
                 einsum('ad,ijkdbc->ijkabc', F_vv, t3_tmp[:bi, :bj, :bk], out=r3_tmp[:bi, :bj, :bk], alpha=1.0, beta=1.0)
-                _unpack_t3_(mycc, t3, t3_tmp, j0, j1, i0, i1, k0, k1)
-                einsum('bd,jikdac->ijkabc', F_vv, t3_tmp[:bj, :bi, :bk], out=r3_tmp[:bi, :bj, :bk], alpha=1.0, beta=1.0)
-                _unpack_t3_(mycc, t3, t3_tmp, k0, k1, j0, j1, i0, i1)
-                einsum('cd,kjidba->ijkabc', F_vv, t3_tmp[:bk, :bj, :bi], out=r3_tmp[:bi, :bj, :bk], alpha=1.0, beta=1.0)
+                einsum('bd,ijkadc->ijkabc', F_vv, t3_tmp[:bi, :bj, :bk], out=r3_tmp[:bi, :bj, :bk], alpha=1.0, beta=1.0)
+                einsum('cd,ijkabd->ijkabc', F_vv, t3_tmp[:bi, :bj, :bk], out=r3_tmp[:bi, :bj, :bk], alpha=1.0, beta=1.0)
 
                 _accumulate_t3_(mycc, r3, r3_tmp, i0, i1, j0, j1, k0, k1, alpha=1.0, beta=1.0)
         time2 = log.timer_debug1('t3: iter: W_vvvo, W_vooo, F_vv [%3d, %3d]:'%(k0, k1), *time2)
@@ -740,8 +688,7 @@ def compute_r3_tri(mycc, imds, t2, t3):
                 _unpack_t3_(mycc, t3, t3_tmp, j0, j1, 0, nocc, k0, k1, blksize_oovv, nocc, blksize_oovv)
                 einsum('lbid,jlkdac->ijkabc', W_ovov[:, :, i0:i1, :], t3_tmp[:bj, :, :bk],
                     out=r3_tmp[:bi, :bj, :bk], alpha=-1.0, beta=0.0)
-                _unpack_t3_(mycc, t3, t3_tmp, k0, k1, 0, nocc, j0, j1, blksize_oovv, nocc, blksize_oovv)
-                einsum('lcid,kljdab->ijkabc', W_ovov[:, :, i0:i1, :], t3_tmp[:bk, :, :bj],
+                einsum('lcid,jlkbad->ijkabc', W_ovov[:, :, i0:i1, :], t3_tmp[:bj, :, :bk],
                     out=r3_tmp[:bi, :bj, :bk], alpha=-1.0, beta=1.0)
                 _unpack_t3_pair_(mycc, t3, t3_tmp, j0, j1, 0, nocc, k0, k1)
                 einsum('laid,jlkdbc->ijkabc', W_ovov[:, :, i0:i1, :], t3_tmp[:bj, :, :bk],
@@ -750,8 +697,7 @@ def compute_r3_tri(mycc, imds, t2, t3):
                 _unpack_t3_(mycc, t3, t3_tmp, i0, i1, 0, nocc, k0, k1, blksize_oovv, nocc, blksize_oovv)
                 einsum('lajd,ilkdbc->ijkabc', W_ovov[:, :, j0:j1, :], t3_tmp[:bi, :, :bk],
                     out=r3_tmp[:bi, :bj, :bk], alpha=-1.0, beta=1.0)
-                _unpack_t3_(mycc, t3, t3_tmp, k0, k1, 0, nocc, i0, i1, blksize_oovv, nocc, blksize_oovv)
-                einsum('lcjd,klidba->ijkabc', W_ovov[:, :, j0:j1, :], t3_tmp[:bk, :, :bi],
+                einsum('lcjd,ilkabd->ijkabc', W_ovov[:, :, j0:j1, :], t3_tmp[:bi, :, :bk],
                     out=r3_tmp[:bi, :bj, :bk], alpha=-1.0, beta=1.0)
                 _unpack_t3_pair_(mycc, t3, t3_tmp, i0, i1, 0, nocc, k0, k1)
                 einsum('lbjd,ilkdac->ijkabc', W_ovov[:, :, j0:j1, :], t3_tmp[:bi, :, :bk],
@@ -760,8 +706,7 @@ def compute_r3_tri(mycc, imds, t2, t3):
                 _unpack_t3_(mycc, t3, t3_tmp, i0, i1, 0, nocc, j0, j1, blksize_oovv, nocc, blksize_oovv)
                 einsum('lakd,iljdcb->ijkabc', W_ovov[:, :, k0:k1, :], t3_tmp[:bi, :, :bj],
                     out=r3_tmp[:bi, :bj, :bk], alpha=-1.0, beta=1.0)
-                _unpack_t3_(mycc, t3, t3_tmp, j0, j1, 0, nocc, i0, i1, blksize_oovv, nocc, blksize_oovv)
-                einsum('lbkd,jlidca->ijkabc', W_ovov[:, :, k0:k1, :], t3_tmp[:bj, :, :bi],
+                einsum('lbkd,iljacd->ijkabc', W_ovov[:, :, k0:k1, :], t3_tmp[:bi, :, :bj],
                     out=r3_tmp[:bi, :bj, :bk], alpha=-1.0, beta=1.0)
                 _unpack_t3_pair_(mycc, t3, t3_tmp, i0, i1, 0, nocc, j0, j1)
                 einsum('lckd,iljdab->ijkabc', W_ovov[:, :, k0:k1, :], t3_tmp[:bi, :, :bj],
@@ -803,22 +748,16 @@ def compute_r3_tri(mycc, imds, t2, t3):
     W_oooo = imds.W_oooo = None
     time1 = log.timer_debug1('t3: W_oooo * t3', *time1)
 
-    t3_tmp_s = np.empty((nvir, nvir, nvir), dtype=t3.dtype)
-    r3_tmp_s = np.empty((nvir, nvir, nvir), dtype=t3.dtype)
     time2 = logger.process_clock(), logger.perf_counter()
-    for k0 in range(nocc):
-        for j0 in range(k0 + 1):
-            for i0 in range(j0 + 1):
-                _unpack_t3_s_pair_(mycc, t3, t3_tmp_s, i0, j0, k0)
-                einsum('abde,dec->abc', W_vvvv, t3_tmp_s, out=r3_tmp_s, alpha=0.5, beta=0.0)
-                _unpack_t3_s_pair_(mycc, t3, t3_tmp_s, i0, k0, j0)
-                einsum('acde,deb->abc', W_vvvv, t3_tmp_s, out=r3_tmp_s, alpha=0.5, beta=1.0)
-                _unpack_t3_s_pair_(mycc, t3, t3_tmp_s, j0, k0, i0)
-                einsum('bcde,dea->abc', W_vvvv, t3_tmp_s, out=r3_tmp_s, alpha=0.5, beta=1.0)
-                _accumulate_t3_s_(mycc, r3, r3_tmp_s, i0, j0, k0, alpha=1.0, beta=1.0)
+    index = 0
+    for i0 in range(nocc):
+        for j0 in range(i0, nocc):
+            for k0 in range(j0, nocc):
+                einsum('abde,dec->abc', W_vvvv, t3[index], out=r3[index], alpha=1.0, beta=1.0)
+                einsum('acde,dbe->abc', W_vvvv, t3[index], out=r3[index], alpha=1.0, beta=1.0)
+                einsum('bcde,ade->abc', W_vvvv, t3[index], out=r3[index], alpha=1.0, beta=1.0)
+                index += 1
         time2 = log.timer_debug1('t3: iter: W_vvvv %3d:'%k0, *time2)
-    t3_tmp_s = None
-    r3_tmp_s = None
     W_vvvv = imds.W_vvvv = None
     time1 = log.timer_debug1('t3: W_vvvv * t3', *time1)
     return r3
@@ -869,15 +808,9 @@ def update_amps_rccsdt_tri_(mycc, tamps, eris):
     # symmetrization
     r2 += r2.transpose(1, 0, 3, 2)
     time1 = log.timer_debug1('t1t2: symmetrize r2', *time1)
-    # divide by eijkabc
+    # divide by eijab
     r1r2_divide_e_(mycc, r1, r2, mo_energy)
     time1 = log.timer_debug1('t1t2: divide r1 & r2 by eia & eijab', *time1)
-
-    res_norm = [np.linalg.norm(r1), np.linalg.norm(r2)]
-
-    t1 += r1
-    t2 += r2
-    time1 = log.timer_debug1('t1t2: update t1 & t2', *time1)
     time0 = log.timer_debug1('t1t2 total', *time0)
 
     # t3
@@ -897,11 +830,13 @@ def update_amps_rccsdt_tri_(mycc, tamps, eris):
     r3_tri_divide_e_(mycc, r3, mo_energy)
     time1 = log.timer_debug1('t3: divide r3 by eijkabc', *time1)
 
-    res_norm.append(np.linalg.norm(r3))
+    res_norm = [np.linalg.norm(r1), np.linalg.norm(r2), np.linalg.norm(r3)]
 
+    t1 += r1
+    t2 += r2
     t3 += r3
-    r3 = None
-    time1 = log.timer_debug1('t3: update t3', *time1)
+    r1, r2, r3 = None, None, None
+    time1 = log.timer_debug1('t3: update t1, t2, t3', *time1)
     time0 = log.timer_debug1('t3 total', *time0)
     return res_norm
 
@@ -1087,9 +1022,9 @@ def restore_from_diis_(mycc, diis_file, inplace=True):
     else:
         mycc.tamps[:cc_order - 1] = tamps
         if mycc.do_tri_max_t:
-            mycc.tamp[-1] = np.zeros((nx(nocc, cc_order),) + (nvir,) * cc_order, dtype=ccvec.dtype)
+            mycc.tamps[-1] = np.zeros((nx(nocc, cc_order),) + (nvir,) * cc_order, dtype=ccvec.dtype)
         else:
-            mycc.tamp[-1] = np.zeros((nocc,) * cc_order + (nvir,) * cc_order, dtype=ccvec.dtype)
+            mycc.tamps[-1] = np.zeros((nocc,) * cc_order + (nvir,) * cc_order, dtype=ccvec.dtype)
     if inplace:
         mycc.diis = adiis
     return mycc
@@ -1337,8 +1272,8 @@ iterative_damping, incore_complete, level_shift, and frozen can be configured in
 the same way as in CCSD. Additional attributes are:
 
     do_diis_max_t : bool
-        Whether to use DIIS to accelerate convergence. Note that enabling DIIS
-        will increase memory consumption.
+        Whether to use DIIS for the highest-order amplitudes to accelerate convergence.
+        Note that enabling DIIS will increase memory consumption.
     blksize, blksize_oovv, blksize_oooo :
         Batch sizes used to reduce the memory footprint during tensor contractions.
     einsum_backend : string
@@ -1359,7 +1294,7 @@ Saved results:
         T amplitudes t1[i,a], t2[i,j,a,b]  (i,j in occ, a,b in virt)
     t3 :
         An array of shape (compressed_occ, nvir, nvir, nvir) for T3 amplitudes.
-        The occupied-oribtal dimension is stored in a compressed form for the
+        The occupied-orbital dimension is stored in a compressed form for the
         i <= j <= k index combinations. The compressed tensor can be expanded to
         the full tensor by self.tamps_tri2full(t3)
     tamps :
@@ -1490,8 +1425,11 @@ Saved results:
         self._finalize()
         return self.e_corr, self.tamps
 
-    def ccsdt_q(self, tamps, eris=None):
-        raise NotImplementedError
+    def ccsdt_q(self, tamps=None, eris=None):
+        from pyscf.cc import rccsdt_q
+        if tamps is None: tamps = self.tamps
+        if eris is None: eris = self.ao2mo(self.mo_coeff)
+        return rccsdt_q.kernel(self, eris, tamps, self.verbose)
 
 class _IMDS:
 
@@ -1634,3 +1572,13 @@ if __name__ == "__main__":
     print('max(abs(t2 difference))                    % .10e' % np.max(np.abs(mycc.t2 - mycc2.t2)))
     print('max(abs(t3_tri - t3_tri_from_t3_full))     % .10e' % np.max(np.abs(t3_tri - t3_tri_from_t3_full)))
     print('max(abs(t3_full - t3_full_from_t3_tri))    % .10e' % np.max(np.abs(t3_full - t3_full_from_t3_tri)))
+
+    # ccsdt_q
+    # [Q] and (Q) energy correction
+    e_q_bracket, e_q_paren = mycc.ccsdt_q()
+    e_q_bracket2, e_q_paren2 = mycc2.ccsdt_q()
+    ref_e_q_bracket, ref_e_q_paren = -0.001412978902990858, -0.0017003938319959389
+    print('[Q] difference                      % .10e' % (e_q_bracket - e_q_bracket2))
+    print('(Q) difference                      % .10e' % (e_q_paren - e_q_paren2))
+    print('[Q] difference from reference       % .10e' % (e_q_bracket - ref_e_q_bracket))
+    print('(Q) difference from reference       % .10e' % (e_q_paren - ref_e_q_paren))

--- a/pyscf/cc/rccsdt.py
+++ b/pyscf/cc/rccsdt.py
@@ -171,7 +171,6 @@ def _unpack_t3_(mycc, t3, t3_blk, i0, i1, j0, j1, k0, k1, blksize0=None, blksize
 
 def _unpack_t3_pair_(mycc, t3, t3_blk, i0, i1, j0, j1, k0, k1, blksize0=None, blksize1=None, blksize2=None):
     r'''Unpack triangular-stored T3 amplitudes into the block
-    # `t3_full[i0:i1, j0:j1, k0:k1, :, :, :] + t3_full[k0:k1, j0:j1, i0:i1, :, :, :].transpose(0, 1, 2, 3, 5, 4)`
     `t3_full[i0:i1, j0:j1, k0:k1, :, :, :] + t3_full[i0:i1, j0:j1, k0:k1, :, :, :].transpose(0, 1, 2, 4, 5, 3)`
     '''
     if blksize0 is None: blksize0 = mycc.blksize_oovv

--- a/pyscf/cc/rccsdt_highm.py
+++ b/pyscf/cc/rccsdt_highm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,13 +27,11 @@ Chem. Phys. Lett. 228, 233 (1994); DOI:10.1016/0009-2614(94)00898-1
 '''
 
 import numpy as np
-import numpy
 import functools
 import ctypes
 from pyscf import lib
 from pyscf.lib import logger
-from pyscf.mp.mp2 import get_nocc, get_nmo, get_frozen_mask, get_e_hf, _mo_without_core
-from pyscf.cc import _ccsd, rccsdt
+from pyscf.cc import rccsdt
 from pyscf.cc.rccsdt import (_einsum, t3_spin_summation_inplace_, update_t1_fock_eris, intermediates_t1t2,
                             compute_r1r2, r1r2_divide_e_, intermediates_t3, _PhysicistsERIs, _IMDS)
 from pyscf import __config__
@@ -187,15 +185,9 @@ def update_amps_rccsdt_(mycc, tamps, eris):
     # symmetrization
     r2 += r2.transpose(1, 0, 3, 2)
     time1 = log.timer_debug1('t1t2: symmetrize r2', *time1)
-    # divide by eijkabc
+    # divide by eijab
     r1r2_divide_e_(mycc, r1, r2, mo_energy)
     time1 = log.timer_debug1('t1t2: divide r1 & r2 by eia & eijab', *time1)
-
-    res_norm = [np.linalg.norm(r1), np.linalg.norm(r2)]
-
-    t1 += r1
-    t2 += r2
-    time1 = log.timer_debug1('t1t2: update t1 & t2', *time1)
     time0 = log.timer_debug1('t1t2 total', *time0)
 
     intermediates_t3(mycc, imds, t2)
@@ -215,11 +207,13 @@ def update_amps_rccsdt_(mycc, tamps, eris):
     r3_divide_e_(mycc, r3, mo_energy)
     time1 = log.timer_debug1('t3: divide r3 by eijkabc', *time1)
 
-    res_norm.append(np.linalg.norm(r3))
+    res_norm = [np.linalg.norm(r1), np.linalg.norm(r2), np.linalg.norm(r3)]
 
+    t1 += r1
+    t2 += r2
     t3 += r3
-    r3 = None
-    time1 = log.timer_debug1('t3: update t3', *time1)
+    r1, r2, r3 = None, None, None
+    time1 = log.timer_debug1('t3: update t1, t2, t3', *time1)
     time0 = log.timer_debug1('t3 total', *time0)
     return res_norm
 

--- a/pyscf/cc/rccsdt_q.py
+++ b/pyscf/cc/rccsdt_q.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Yu Jin <yjin@flatironinstitute.org>
+#         Huanchen Zhai <hczhai.ok@gmail.com>
+#
+
+'''
+RHF-CCSDT(Q) for real integrals
+'''
+
+import sys
+import functools
+import numpy as np
+import ctypes
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf.cc.rccsdt import _einsum, _unpack_t3_, setup_tri2block_rhf
+from pyscf.cc.rccsdtq import t4_add_
+
+
+_libccsdt = lib.load_library('libccsdt')
+
+def eijkl_division_single_(A, eocc, evir, i, j, k, l, nvir):
+    assert A.dtype == np.float64 and A.flags['C_CONTIGUOUS'], "A must be a contiguous float64 array"
+    assert eocc.dtype == np.float64 and eocc.flags['C_CONTIGUOUS'], "eocc must be a contiguous float64 array"
+    assert evir.dtype == np.float64 and evir.flags['C_CONTIGUOUS'], "evir must be a contiguous float64 array"
+    _libccsdt.eijkl_division_single_(
+        A.ctypes.data_as(ctypes.c_void_p), eocc.ctypes.data_as(ctypes.c_void_p), evir.ctypes.data_as(ctypes.c_void_p),
+        ctypes.c_int64(i), ctypes.c_int64(j), ctypes.c_int64(k), ctypes.c_int64(l), ctypes.c_int64(nvir)
+    )
+    return A
+
+def t4_spin_summation_single_inplace_(A, nvir, pattern, alpha=1.0, beta=0.0):
+    assert A.dtype == np.float64 and A.flags['C_CONTIGUOUS'], "A must be a contiguous float64 array"
+    pattern_c = pattern.encode('utf-8')
+    _libccsdt.t4_spin_summation_single_inplace_(
+        A.ctypes.data_as(ctypes.c_void_p),
+        ctypes.c_int64(nvir), ctypes.c_char_p(pattern_c),
+        ctypes.c_double(alpha), ctypes.c_double(beta)
+    )
+    return A
+
+def kernel(mycc, eris=None, tamps=None, verbose=logger.NOTE):
+
+    time0 = logger.process_clock(), logger.perf_counter()
+    log = logger.new_logger(mycc, verbose)
+
+    if tamps is not None:
+        if len(tamps) != 3:
+            raise ValueError("tamps should be a list of length 3, containing T1, T2, and T3 amplitudes.")
+        if mycc.do_tri_max_t and len(tamps[2].shape) != 4:
+            raise ValueError("CC object uses compact T3 amplitudes but the input T3 is full.")
+        if not mycc.do_tri_max_t and len(tamps[2].shape) == 4:
+            raise ValueError("CC object uses full T3 amplitudes but the input T3 is compact.")
+    else:
+        tamps = mycc.tamps
+
+    if eris is None:
+        eris = mycc.ao2mo(mycc.mo_coeff)
+
+    if mycc.do_tri_max_t and (not hasattr(mycc, "tri2block_map") or mycc.tri2block_map is None):
+        mycc.tri2block_map, mycc.tri2block_mask, mycc.tri2block_tp = setup_tri2block_rhf(mycc)
+
+    name = mycc.__class__.__name__
+
+    backend = mycc.einsum_backend
+    einsum = functools.partial(_einsum, backend)
+
+    t1 = tamps[0]
+    nocc, nvir = t1.shape[0], t1.shape[1]
+
+    t2, t3 = tamps[1:3]
+    mo_energy = eris.mo_energy
+    e_occ = mo_energy[:nocc]
+    e_occ = np.ascontiguousarray(e_occ)
+    e_vir = mo_energy[nocc:]
+    e_vir = np.ascontiguousarray(e_vir)
+
+    eris_ovvv = eris.pppp[:nocc, nocc:, nocc:, nocc:].copy()
+    eris_oovo = eris.pppp[:nocc, :nocc, nocc:, :nocc].copy()
+    eris_oovv = eris.pppp[:nocc, :nocc, nocc:, nocc:].copy()
+    eris_ovvo = eris.pppp[:nocc, nocc:, nocc:, :nocc].copy()
+    eris_ovov = eris.pppp[:nocc, nocc:, :nocc, nocc:].copy()
+    eris_vvvv = eris.pppp[nocc:, nocc:, nocc:, nocc:].copy()
+    eris_oooo = eris.pppp[:nocc, :nocc, :nocc, :nocc].copy()
+
+    def get_t3_slice(t3_blk, i, j):
+        if mycc.do_tri_max_t:
+            _unpack_t3_(mycc, t3, t3_blk, i, i + 1, j, j + 1, 0, nocc, 1, 1, nocc)
+        else:
+            t3_blk[0, 0, :nocc] = t3[i, j, :nocc]
+        return t3_blk
+
+    def compute_W_vvvvoo(j, k):
+        W = np.empty((nvir, nvir, nvir, nvir), dtype=t2.dtype)
+        einsum('abef,fc->abce', eris_vvvv, t2[j, k], out=W, alpha=0.5, beta=0.0)
+        einsum('acef,fb->abce', eris_vvvv, t2[k, j], out=W, alpha=0.5, beta=1.0)
+        return W
+
+    def compute_W_vvoooo(i, j, k):
+        W = np.empty((nvir, nvir, nocc), dtype=t2.dtype)
+        einsum('eam,be->abm', eris_ovvo[i], t2[j, k], out=W, alpha=1.0, beta=0.0)
+        einsum('ebm,ae->abm', eris_ovvo[j], t2[i, k], out=W, alpha=1.0, beta=1.0)
+        einsum('ema,be->abm', eris_ovov[k], t2[j, i], out=W, alpha=1.0, beta=1.0)
+        einsum('emb,ae->abm', eris_ovov[k], t2[i, j], out=W, alpha=1.0, beta=1.0)
+        einsum('mn,nab->abm', eris_oooo[k, i], t2[:, j], out=W, alpha=-0.5, beta=1.0)
+        einsum('mn,nba->abm', eris_oooo[k, j], t2[:, i], out=W, alpha=-0.5, beta=1.0)
+        return W
+
+    time1 = logger.process_clock(), logger.perf_counter()
+    t4_blk = np.empty((nvir,) * 4, dtype=t2.dtype)
+    z4_blk = np.empty_like(t4_blk)
+    t3_blk = np.empty((1,) * 2 + (nocc,) + (nvir,) * 3, dtype=t3.dtype)
+    e_q_bracket = 0.0
+    e_q_paren = 0.0
+    for l in range(nocc):
+        for k in range(l + 1):
+            for j in range(k + 1):
+                for i in range(j + 1):
+
+                    if (i == j == k == l) or (i == j and j == k) or (j == k and k == l):
+                        continue
+                    elif i < j and j < k and k < l:
+                        factor = 24.0
+                    elif (i == j and j < k and k < l) or (i < j and j == k and k < l) or (i < j and j < k and k == l):
+                        factor = 12.0
+                    elif (i == j and j < k and k == l):
+                        factor = 6.0
+
+                    # z for (Q)
+                    get_t3_slice(t3_blk, k, l)
+                    einsum('am,mcdb->abcd', eris_oovo[i, j], t3_blk[0, 0], out=z4_blk, alpha=-1.0, beta=0.0)
+                    einsum('bm,mcda->abcd', eris_oovo[j, i], t3_blk[0, 0], out=z4_blk, alpha=-1.0, beta=1.0)
+                    einsum('eba,cde->abcd', eris_ovvv[j], t3_blk[0, 0, i], out=z4_blk, alpha=1.0, beta=1.0)
+                    einsum('eab,cde->abcd', eris_ovvv[i], t3_blk[0, 0, j], out=z4_blk, alpha=1.0, beta=1.0)
+
+                    get_t3_slice(t3_blk, j, l)
+                    einsum('am,mbdc->abcd', eris_oovo[i, k], t3_blk[0, 0], out=z4_blk, alpha=-1.0, beta=1.0)
+                    einsum('cm,mbda->abcd', eris_oovo[k, i], t3_blk[0, 0], out=z4_blk, alpha=-1.0, beta=1.0)
+                    einsum('eca,bde->abcd', eris_ovvv[k], t3_blk[0, 0, i], out=z4_blk, alpha=1.0, beta=1.0)
+                    einsum('eac,bde->abcd', eris_ovvv[i], t3_blk[0, 0, k], out=z4_blk, alpha=1.0, beta=1.0)
+
+                    get_t3_slice(t3_blk, j, k)
+                    einsum('am,mbcd->abcd', eris_oovo[i, l], t3_blk[0, 0], out=z4_blk, alpha=-1.0, beta=1.0)
+                    einsum('dm,mbca->abcd', eris_oovo[l, i], t3_blk[0, 0], out=z4_blk, alpha=-1.0, beta=1.0)
+                    einsum('eda,bce->abcd', eris_ovvv[l], t3_blk[0, 0, i], out=z4_blk, alpha=1.0, beta=1.0)
+                    einsum('ead,bce->abcd', eris_ovvv[i], t3_blk[0, 0, l], out=z4_blk, alpha=1.0, beta=1.0)
+
+                    get_t3_slice(t3_blk, i, l)
+                    einsum('bm,madc->abcd', eris_oovo[j, k], t3_blk[0, 0], out=z4_blk, alpha=-1.0, beta=1.0)
+                    einsum('cm,madb->abcd', eris_oovo[k, j], t3_blk[0, 0], out=z4_blk, alpha=-1.0, beta=1.0)
+                    einsum('ecb,ade->abcd', eris_ovvv[k], t3_blk[0, 0, j], out=z4_blk, alpha=1.0, beta=1.0)
+                    einsum('ebc,ade->abcd', eris_ovvv[j], t3_blk[0, 0, k], out=z4_blk, alpha=1.0, beta=1.0)
+
+                    get_t3_slice(t3_blk, i, k)
+                    einsum('bm,macd->abcd', eris_oovo[j, l], t3_blk[0, 0], out=z4_blk, alpha=-1.0, beta=1.0)
+                    einsum('dm,macb->abcd', eris_oovo[l, j], t3_blk[0, 0], out=z4_blk, alpha=-1.0, beta=1.0)
+                    einsum('edb,ace->abcd', eris_ovvv[l], t3_blk[0, 0, j], out=z4_blk, alpha=1.0, beta=1.0)
+                    einsum('ebd,ace->abcd', eris_ovvv[j], t3_blk[0, 0, l], out=z4_blk, alpha=1.0, beta=1.0)
+
+                    get_t3_slice(t3_blk, i, j)
+                    einsum('cm,mabd->abcd', eris_oovo[k, l], t3_blk[0, 0], out=z4_blk, alpha=-1.0, beta=1.0)
+                    einsum('dm,mabc->abcd', eris_oovo[l, k], t3_blk[0, 0], out=z4_blk, alpha=-1.0, beta=1.0)
+                    einsum('edc,abe->abcd', eris_ovvv[l], t3_blk[0, 0, k], out=z4_blk, alpha=1.0, beta=1.0)
+                    einsum('ecd,abe->abcd', eris_ovvv[k], t3_blk[0, 0, l], out=z4_blk, alpha=1.0, beta=1.0)
+
+                    # t4
+                    W_vvoooo_ijk = compute_W_vvoooo(i, j, k)
+                    W_vvoooo_ijl = compute_W_vvoooo(i, j, l)
+                    W_vvoooo_ikj = compute_W_vvoooo(i, k, j)
+                    W_vvoooo_ikl = compute_W_vvoooo(i, k, l)
+                    W_vvoooo_ilj = compute_W_vvoooo(i, l, j)
+                    W_vvoooo_ilk = compute_W_vvoooo(i, l, k)
+                    W_vvoooo_jki = compute_W_vvoooo(j, k, i)
+                    W_vvoooo_jkl = compute_W_vvoooo(j, k, l)
+                    W_vvoooo_jli = compute_W_vvoooo(j, l, i)
+                    W_vvoooo_jlk = compute_W_vvoooo(j, l, k)
+                    W_vvoooo_kli = compute_W_vvoooo(k, l, i)
+                    W_vvoooo_klj = compute_W_vvoooo(k, l, j)
+                    einsum('abm,mdc->abcd', W_vvoooo_ijk, t2[l], out=t4_blk, alpha=-1.0, beta=0.0)
+                    einsum('abm,mcd->abcd', W_vvoooo_ijl, t2[k], out=t4_blk, alpha=-1.0, beta=1.0)
+                    einsum('acm,mdb->abcd', W_vvoooo_ikj, t2[l], out=t4_blk, alpha=-1.0, beta=1.0)
+                    einsum('acm,mbd->abcd', W_vvoooo_ikl, t2[j], out=t4_blk, alpha=-1.0, beta=1.0)
+                    einsum('adm,mcb->abcd', W_vvoooo_ilj, t2[k], out=t4_blk, alpha=-1.0, beta=1.0)
+                    einsum('adm,mbc->abcd', W_vvoooo_ilk, t2[j], out=t4_blk, alpha=-1.0, beta=1.0)
+                    einsum('bcm,mda->abcd', W_vvoooo_jki, t2[l], out=t4_blk, alpha=-1.0, beta=1.0)
+                    einsum('bcm,mad->abcd', W_vvoooo_jkl, t2[i], out=t4_blk, alpha=-1.0, beta=1.0)
+                    einsum('bdm,mca->abcd', W_vvoooo_jli, t2[k], out=t4_blk, alpha=-1.0, beta=1.0)
+                    einsum('bdm,mac->abcd', W_vvoooo_jlk, t2[i], out=t4_blk, alpha=-1.0, beta=1.0)
+                    einsum('cdm,mba->abcd', W_vvoooo_kli, t2[j], out=t4_blk, alpha=-1.0, beta=1.0)
+                    einsum('cdm,mab->abcd', W_vvoooo_klj, t2[i], out=t4_blk, alpha=-1.0, beta=1.0)
+
+                    W_vvvvoo_jk = compute_W_vvvvoo(j, k)
+                    W_vvvvoo_jl = compute_W_vvvvoo(j, l)
+                    W_vvvvoo_kl = compute_W_vvvvoo(k, l)
+                    W_vvvvoo_ik = compute_W_vvvvoo(i, k)
+                    W_vvvvoo_il = compute_W_vvvvoo(i, l)
+                    W_vvvvoo_ij = compute_W_vvvvoo(i, j)
+                    einsum('abce,ed->abcd', W_vvvvoo_jk, t2[i, l], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('dbce,ea->abcd', W_vvvvoo_jk, t2[l, i], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('abde,ec->abcd', W_vvvvoo_jl, t2[i, k], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('cbde,ea->abcd', W_vvvvoo_jl, t2[k, i], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('acde,eb->abcd', W_vvvvoo_kl, t2[i, j], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('bcde,ea->abcd', W_vvvvoo_kl, t2[j, i], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('bace,ed->abcd', W_vvvvoo_ik, t2[j, l], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('dace,eb->abcd', W_vvvvoo_ik, t2[l, j], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('bade,ec->abcd', W_vvvvoo_il, t2[j, k], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('cade,eb->abcd', W_vvvvoo_il, t2[k, j], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('cabe,ed->abcd', W_vvvvoo_ij, t2[k, l], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('dabe,ec->abcd', W_vvvvoo_ij, t2[l, k], out=t4_blk, alpha=1.0, beta=1.0)
+
+                    t4_add_(t4_blk, z4_blk, 1, nvir)
+                    eijkl_division_single_(t4_blk, e_occ, e_vir, i, j, k, l, nvir)
+                    t4_spin_summation_single_inplace_(t4_blk, nvir, 'P4_444', alpha=1.0, beta=0.0)
+
+                    e_q_paren += np.dot(z4_blk.ravel(), t4_blk.ravel()) * factor
+
+                    # z for [Q]
+                    einsum('ab,cd->abcd', eris_oovv[i, j], t2[k, l], out=z4_blk, alpha=1.0, beta=0.0)
+                    einsum('ac,bd->abcd', eris_oovv[i, k], t2[j, l], out=z4_blk, alpha=1.0, beta=1.0)
+                    einsum('ad,bc->abcd', eris_oovv[i, l], t2[j, k], out=z4_blk, alpha=1.0, beta=1.0)
+                    einsum('bc,ad->abcd', eris_oovv[j, k], t2[i, l], out=z4_blk, alpha=1.0, beta=1.0)
+                    einsum('bd,ac->abcd', eris_oovv[j, l], t2[i, k], out=z4_blk, alpha=1.0, beta=1.0)
+                    einsum('cd,ab->abcd', eris_oovv[k, l], t2[i, j], out=z4_blk, alpha=1.0, beta=1.0)
+
+                    e_q_bracket += np.dot(z4_blk.ravel(), t4_blk.ravel()) * factor
+
+        time1 = log.timer_debug1('%s(Q): iter %3d:' % (name, l), *time1)
+
+    e_q_paren += e_q_bracket
+    e_q_bracket /= 12.0
+    e_q_paren /= 12.0
+
+    log.timer('%s(Q)' % name, *time0)
+    log.info("[Q] correction = % .12e    (Q) correction = % .12e" % (e_q_bracket, e_q_paren))
+    return e_q_bracket, e_q_paren
+
+
+if __name__ == '__main__':
+
+    from pyscf import gto, scf, lib
+    from pyscf.data.elements import chemcore
+    from pyscf.cc.rccsdt import RCCSDT
+    from pyscf.cc.rccsdt_highm import RCCSDT as RCCSDT_highm
+
+    atom = '''
+    O  1.416468653903   0.111264435953   0.000000000000
+    H  1.746241653903  -0.373945564047  -0.758561000000
+    H  2.102765241     -0.898304829      1.578786622
+    '''
+    basis = 'cc-pvdz'
+
+    mol = gto.M(atom=atom, basis=basis)
+    mol.verbose = 1
+    mol.max_memory = 10000
+    frozen = chemcore(mol)
+
+    mf = scf.RHF(mol).density_fit()
+    mf.conv_tol = 1e-12
+    mf.kernel()
+
+    mycc = RCCSDT(mf, frozen=frozen)
+    mycc.set_einsum_backend('numpy')
+    mycc.conv_tol = 1e-10
+    mycc.conv_tol_normt = 1e-8
+    mycc.max_cycle = 100
+    mycc.verbose = 3
+    mycc.blksize = 2
+    mycc.blksize_oovv = 2
+    mycc.blksize_oooo = 2
+    mycc.do_diis_max_t = False
+    mycc.incore_complete = True
+    ecorr, tamps = mycc.kernel()
+
+    ref_e_q_bracket = -0.001462052703
+    ref_e_q_paren = -0.001620887567
+
+    mycc.verbose = 8
+    e_q_bracket, e_q_paren = kernel(mycc)
+    print('[Q] corr: % .12f    Ref: % .12f    Diff: % .12e'%(
+        e_q_bracket, ref_e_q_bracket, e_q_bracket - ref_e_q_bracket))
+    print('(Q) corr: % .12f    Ref: % .12f    Diff: % .12e'%(
+        e_q_paren, ref_e_q_paren, e_q_paren - ref_e_q_paren))
+
+    mycc2 = RCCSDT_highm(mf, frozen=frozen)
+    mycc2.set_einsum_backend('numpy')
+    mycc2.conv_tol = 1e-10
+    mycc2.conv_tol_normt = 1e-8
+    mycc2.max_cycle = 100
+    mycc2.verbose = 3
+    mycc2.do_diis_max_t = False
+    mycc2.incore_complete = True
+    ecorr, tamps = mycc2.kernel()
+    e_q_bracket, e_q_paren = mycc2.ccsdt_q()
+    print('[Q] corr: % .12f    Ref: % .12f    Diff: % .12e'%(
+        e_q_bracket, ref_e_q_bracket, e_q_bracket - ref_e_q_bracket))
+    print('(Q) corr: % .12f    Ref: % .12f    Diff: % .12e'%(
+        e_q_paren, ref_e_q_paren, e_q_paren - ref_e_q_paren))

--- a/pyscf/cc/rccsdt_q.py
+++ b/pyscf/cc/rccsdt_q.py
@@ -97,6 +97,8 @@ def kernel(mycc, eris=None, tamps=None, verbose=logger.NOTE):
     eris_vvvv = eris.pppp[nocc:, nocc:, nocc:, nocc:].copy()
     eris_oooo = eris.pppp[:nocc, :nocc, :nocc, :nocc].copy()
 
+    eris = None
+
     def get_t3_slice(t3_blk, i, j):
         if mycc.do_tri_max_t:
             _unpack_t3_(mycc, t3, t3_blk, i, i + 1, j, j + 1, 0, nocc, 1, 1, nocc)

--- a/pyscf/cc/rccsdt_q.py
+++ b/pyscf/cc/rccsdt_q.py
@@ -21,7 +21,6 @@
 RHF-CCSDT(Q) for real integrals
 '''
 
-import sys
 import functools
 import numpy as np
 import ctypes
@@ -106,26 +105,26 @@ def kernel(mycc, eris=None, tamps=None, verbose=logger.NOTE):
             t3_blk[0, 0, :nocc] = t3[i, j, :nocc]
         return t3_blk
 
-    def compute_W_vvvvoo(j, k):
-        W = np.empty((nvir, nvir, nvir, nvir), dtype=t2.dtype)
-        einsum('abef,fc->abce', eris_vvvv, t2[j, k], out=W, alpha=0.5, beta=0.0)
-        einsum('acef,fb->abce', eris_vvvv, t2[k, j], out=W, alpha=0.5, beta=1.0)
-        return W
+    def compute_W_vvvvoo(W_vvvvoo_slice, j, k):
+        einsum('abef,fc->abce', eris_vvvv, t2[j, k], out=W_vvvvoo_slice, alpha=0.5, beta=0.0)
+        einsum('acef,fb->abce', eris_vvvv, t2[k, j], out=W_vvvvoo_slice, alpha=0.5, beta=1.0)
+        return W_vvvvoo_slice
 
-    def compute_W_vvoooo(i, j, k):
-        W = np.empty((nvir, nvir, nocc), dtype=t2.dtype)
-        einsum('eam,be->abm', eris_ovvo[i], t2[j, k], out=W, alpha=1.0, beta=0.0)
-        einsum('ebm,ae->abm', eris_ovvo[j], t2[i, k], out=W, alpha=1.0, beta=1.0)
-        einsum('ema,be->abm', eris_ovov[k], t2[j, i], out=W, alpha=1.0, beta=1.0)
-        einsum('emb,ae->abm', eris_ovov[k], t2[i, j], out=W, alpha=1.0, beta=1.0)
-        einsum('mn,nab->abm', eris_oooo[k, i], t2[:, j], out=W, alpha=-0.5, beta=1.0)
-        einsum('mn,nba->abm', eris_oooo[k, j], t2[:, i], out=W, alpha=-0.5, beta=1.0)
-        return W
+    def compute_W_vvoooo(W_vvoooo_slice, i, j, k):
+        einsum('eam,be->abm', eris_ovvo[i], t2[j, k], out=W_vvoooo_slice, alpha=1.0, beta=0.0)
+        einsum('ebm,ae->abm', eris_ovvo[j], t2[i, k], out=W_vvoooo_slice, alpha=1.0, beta=1.0)
+        einsum('ema,be->abm', eris_ovov[k], t2[j, i], out=W_vvoooo_slice, alpha=1.0, beta=1.0)
+        einsum('emb,ae->abm', eris_ovov[k], t2[i, j], out=W_vvoooo_slice, alpha=1.0, beta=1.0)
+        einsum('mn,nab->abm', eris_oooo[k, i], t2[:, j], out=W_vvoooo_slice, alpha=-0.5, beta=1.0)
+        einsum('mn,nba->abm', eris_oooo[k, j], t2[:, i], out=W_vvoooo_slice, alpha=-0.5, beta=1.0)
+        return W_vvoooo_slice
 
     time1 = logger.process_clock(), logger.perf_counter()
     t4_blk = np.empty((nvir,) * 4, dtype=t2.dtype)
     z4_blk = np.empty_like(t4_blk)
     t3_blk = np.empty((1,) * 2 + (nocc,) + (nvir,) * 3, dtype=t3.dtype)
+    W_vvoooo_slice = np.empty((nvir, nvir, nocc), dtype=t2.dtype)
+    W_vvvvoo_slice = np.empty((nvir, nvir, nvir, nvir), dtype=t2.dtype)
     e_q_bracket = 0.0
     e_q_paren = 0.0
     for l in range(nocc):
@@ -180,49 +179,49 @@ def kernel(mycc, eris=None, tamps=None, verbose=logger.NOTE):
                     einsum('ecd,abe->abcd', eris_ovvv[k], t3_blk[0, 0, l], out=z4_blk, alpha=1.0, beta=1.0)
 
                     # t4
-                    W_vvoooo_ijk = compute_W_vvoooo(i, j, k)
-                    W_vvoooo_ijl = compute_W_vvoooo(i, j, l)
-                    W_vvoooo_ikj = compute_W_vvoooo(i, k, j)
-                    W_vvoooo_ikl = compute_W_vvoooo(i, k, l)
-                    W_vvoooo_ilj = compute_W_vvoooo(i, l, j)
-                    W_vvoooo_ilk = compute_W_vvoooo(i, l, k)
-                    W_vvoooo_jki = compute_W_vvoooo(j, k, i)
-                    W_vvoooo_jkl = compute_W_vvoooo(j, k, l)
-                    W_vvoooo_jli = compute_W_vvoooo(j, l, i)
-                    W_vvoooo_jlk = compute_W_vvoooo(j, l, k)
-                    W_vvoooo_kli = compute_W_vvoooo(k, l, i)
-                    W_vvoooo_klj = compute_W_vvoooo(k, l, j)
-                    einsum('abm,mdc->abcd', W_vvoooo_ijk, t2[l], out=t4_blk, alpha=-1.0, beta=0.0)
-                    einsum('abm,mcd->abcd', W_vvoooo_ijl, t2[k], out=t4_blk, alpha=-1.0, beta=1.0)
-                    einsum('acm,mdb->abcd', W_vvoooo_ikj, t2[l], out=t4_blk, alpha=-1.0, beta=1.0)
-                    einsum('acm,mbd->abcd', W_vvoooo_ikl, t2[j], out=t4_blk, alpha=-1.0, beta=1.0)
-                    einsum('adm,mcb->abcd', W_vvoooo_ilj, t2[k], out=t4_blk, alpha=-1.0, beta=1.0)
-                    einsum('adm,mbc->abcd', W_vvoooo_ilk, t2[j], out=t4_blk, alpha=-1.0, beta=1.0)
-                    einsum('bcm,mda->abcd', W_vvoooo_jki, t2[l], out=t4_blk, alpha=-1.0, beta=1.0)
-                    einsum('bcm,mad->abcd', W_vvoooo_jkl, t2[i], out=t4_blk, alpha=-1.0, beta=1.0)
-                    einsum('bdm,mca->abcd', W_vvoooo_jli, t2[k], out=t4_blk, alpha=-1.0, beta=1.0)
-                    einsum('bdm,mac->abcd', W_vvoooo_jlk, t2[i], out=t4_blk, alpha=-1.0, beta=1.0)
-                    einsum('cdm,mba->abcd', W_vvoooo_kli, t2[j], out=t4_blk, alpha=-1.0, beta=1.0)
-                    einsum('cdm,mab->abcd', W_vvoooo_klj, t2[i], out=t4_blk, alpha=-1.0, beta=1.0)
+                    compute_W_vvoooo(W_vvoooo_slice, i, j, k)
+                    einsum('abm,mdc->abcd', W_vvoooo_slice, t2[l], out=t4_blk, alpha=-1.0, beta=0.0)
+                    compute_W_vvoooo(W_vvoooo_slice, i, j, l)
+                    einsum('abm,mcd->abcd', W_vvoooo_slice, t2[k], out=t4_blk, alpha=-1.0, beta=1.0)
+                    compute_W_vvoooo(W_vvoooo_slice, i, k, j)
+                    einsum('acm,mdb->abcd', W_vvoooo_slice, t2[l], out=t4_blk, alpha=-1.0, beta=1.0)
+                    compute_W_vvoooo(W_vvoooo_slice, i, k, l)
+                    einsum('acm,mbd->abcd', W_vvoooo_slice, t2[j], out=t4_blk, alpha=-1.0, beta=1.0)
+                    compute_W_vvoooo(W_vvoooo_slice, i, l, j)
+                    einsum('adm,mcb->abcd', W_vvoooo_slice, t2[k], out=t4_blk, alpha=-1.0, beta=1.0)
+                    compute_W_vvoooo(W_vvoooo_slice, i, l, k)
+                    einsum('adm,mbc->abcd', W_vvoooo_slice, t2[j], out=t4_blk, alpha=-1.0, beta=1.0)
+                    compute_W_vvoooo(W_vvoooo_slice, j, k, i)
+                    einsum('bcm,mda->abcd', W_vvoooo_slice, t2[l], out=t4_blk, alpha=-1.0, beta=1.0)
+                    compute_W_vvoooo(W_vvoooo_slice, j, k, l)
+                    einsum('bcm,mad->abcd', W_vvoooo_slice, t2[i], out=t4_blk, alpha=-1.0, beta=1.0)
+                    compute_W_vvoooo(W_vvoooo_slice, j, l, i)
+                    einsum('bdm,mca->abcd', W_vvoooo_slice, t2[k], out=t4_blk, alpha=-1.0, beta=1.0)
+                    compute_W_vvoooo(W_vvoooo_slice, j, l, k)
+                    einsum('bdm,mac->abcd', W_vvoooo_slice, t2[i], out=t4_blk, alpha=-1.0, beta=1.0)
+                    compute_W_vvoooo(W_vvoooo_slice, k, l, i)
+                    einsum('cdm,mba->abcd', W_vvoooo_slice, t2[j], out=t4_blk, alpha=-1.0, beta=1.0)
+                    compute_W_vvoooo(W_vvoooo_slice, k, l, j)
+                    einsum('cdm,mab->abcd', W_vvoooo_slice, t2[i], out=t4_blk, alpha=-1.0, beta=1.0)
 
-                    W_vvvvoo_jk = compute_W_vvvvoo(j, k)
-                    W_vvvvoo_jl = compute_W_vvvvoo(j, l)
-                    W_vvvvoo_kl = compute_W_vvvvoo(k, l)
-                    W_vvvvoo_ik = compute_W_vvvvoo(i, k)
-                    W_vvvvoo_il = compute_W_vvvvoo(i, l)
-                    W_vvvvoo_ij = compute_W_vvvvoo(i, j)
-                    einsum('abce,ed->abcd', W_vvvvoo_jk, t2[i, l], out=t4_blk, alpha=1.0, beta=1.0)
-                    einsum('dbce,ea->abcd', W_vvvvoo_jk, t2[l, i], out=t4_blk, alpha=1.0, beta=1.0)
-                    einsum('abde,ec->abcd', W_vvvvoo_jl, t2[i, k], out=t4_blk, alpha=1.0, beta=1.0)
-                    einsum('cbde,ea->abcd', W_vvvvoo_jl, t2[k, i], out=t4_blk, alpha=1.0, beta=1.0)
-                    einsum('acde,eb->abcd', W_vvvvoo_kl, t2[i, j], out=t4_blk, alpha=1.0, beta=1.0)
-                    einsum('bcde,ea->abcd', W_vvvvoo_kl, t2[j, i], out=t4_blk, alpha=1.0, beta=1.0)
-                    einsum('bace,ed->abcd', W_vvvvoo_ik, t2[j, l], out=t4_blk, alpha=1.0, beta=1.0)
-                    einsum('dace,eb->abcd', W_vvvvoo_ik, t2[l, j], out=t4_blk, alpha=1.0, beta=1.0)
-                    einsum('bade,ec->abcd', W_vvvvoo_il, t2[j, k], out=t4_blk, alpha=1.0, beta=1.0)
-                    einsum('cade,eb->abcd', W_vvvvoo_il, t2[k, j], out=t4_blk, alpha=1.0, beta=1.0)
-                    einsum('cabe,ed->abcd', W_vvvvoo_ij, t2[k, l], out=t4_blk, alpha=1.0, beta=1.0)
-                    einsum('dabe,ec->abcd', W_vvvvoo_ij, t2[l, k], out=t4_blk, alpha=1.0, beta=1.0)
+                    compute_W_vvvvoo(W_vvvvoo_slice, j, k)
+                    einsum('abce,ed->abcd', W_vvvvoo_slice, t2[i, l], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('dbce,ea->abcd', W_vvvvoo_slice, t2[l, i], out=t4_blk, alpha=1.0, beta=1.0)
+                    compute_W_vvvvoo(W_vvvvoo_slice, j, l)
+                    einsum('abde,ec->abcd', W_vvvvoo_slice, t2[i, k], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('cbde,ea->abcd', W_vvvvoo_slice, t2[k, i], out=t4_blk, alpha=1.0, beta=1.0)
+                    compute_W_vvvvoo(W_vvvvoo_slice, k, l)
+                    einsum('acde,eb->abcd', W_vvvvoo_slice, t2[i, j], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('bcde,ea->abcd', W_vvvvoo_slice, t2[j, i], out=t4_blk, alpha=1.0, beta=1.0)
+                    compute_W_vvvvoo(W_vvvvoo_slice, i, k)
+                    einsum('bace,ed->abcd', W_vvvvoo_slice, t2[j, l], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('dace,eb->abcd', W_vvvvoo_slice, t2[l, j], out=t4_blk, alpha=1.0, beta=1.0)
+                    compute_W_vvvvoo(W_vvvvoo_slice, i, l)
+                    einsum('bade,ec->abcd', W_vvvvoo_slice, t2[j, k], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('cade,eb->abcd', W_vvvvoo_slice, t2[k, j], out=t4_blk, alpha=1.0, beta=1.0)
+                    compute_W_vvvvoo(W_vvvvoo_slice, i, j)
+                    einsum('cabe,ed->abcd', W_vvvvoo_slice, t2[k, l], out=t4_blk, alpha=1.0, beta=1.0)
+                    einsum('dabe,ec->abcd', W_vvvvoo_slice, t2[l, k], out=t4_blk, alpha=1.0, beta=1.0)
 
                     t4_add_(t4_blk, z4_blk, 1, nvir)
                     eijkl_division_single_(t4_blk, e_occ, e_vir, i, j, k, l, nvir)

--- a/pyscf/cc/rccsdtq.py
+++ b/pyscf/cc/rccsdtq.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,13 +27,11 @@ Chem. Phys. Lett. 228, 233 (1994); DOI:10.1016/0009-2614(94)00898-1
 '''
 
 import numpy as np
-import numpy
 import functools
 import ctypes
 from pyscf import lib
 from pyscf.lib import logger
-from pyscf.mp.mp2 import get_nocc, get_nmo, get_frozen_mask, get_e_hf, _mo_without_core
-from pyscf.cc import ccsd, _ccsd, rccsdt
+from pyscf.cc import rccsdt
 from pyscf.cc.rccsdt import (_einsum, t3_spin_summation_inplace_, symmetrize_tamps_tri_, purify_tamps_tri_,
                             update_t1_fock_eris, intermediates_t1t2, compute_r1r2, r1r2_divide_e_,
                             intermediates_t3, kernel, _PhysicistsERIs, format_size)
@@ -51,6 +49,15 @@ def t4_spin_summation_inplace_(A, nocc4, nvir, pattern, alpha=1.0, beta=0.0):
         A.ctypes.data_as(ctypes.c_void_p),
         ctypes.c_int64(nocc4), ctypes.c_int64(nvir),
         ctypes.c_char_p(pattern_c),
+        ctypes.c_double(alpha), ctypes.c_double(beta)
+    )
+    return A
+
+def t4_project_1_minus_p4_p31_inplace_(A, nocc4, nvir, alpha=1.0, beta=0.0):
+    assert A.dtype == np.float64 and A.flags['C_CONTIGUOUS'], "A must be a contiguous float64 array"
+    _libccsdt.t4_project_1_minus_p4_p31_inplace_(
+        A.ctypes.data_as(ctypes.c_void_p),
+        ctypes.c_int64(nocc4), ctypes.c_int64(nvir),
         ctypes.c_double(alpha), ctypes.c_double(beta)
     )
     return A
@@ -86,6 +93,28 @@ def unpack_t4_tri2block_(t4, t4_blk, map_, mask, i0, i1, j0, j1, k0, k1, l0, l1,
     )
     return t4_blk
 
+def unpack_t4_tri2block_triples_(t4, t4_blk, map_, mask, i0, i1, j0, j1, k0, k1, l0, l1,
+                                nocc, nvir, blk_i, blk_j, blk_k, blk_l):
+    assert t4.dtype == np.float64 and t4_blk.dtype == np.float64
+    assert map_.dtype == np.int64 and mask.dtype == np.bool_
+    t4 = np.ascontiguousarray(t4)
+    t4_blk = np.ascontiguousarray(t4_blk)
+    map_ = np.ascontiguousarray(map_)
+    mask = np.ascontiguousarray(mask)
+    _libccsdt.unpack_t4_tri2block_triples_(
+        t4.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+        t4_blk.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+        map_.ctypes.data_as(ctypes.POINTER(ctypes.c_int64)),
+        mask.ctypes.data_as(ctypes.POINTER(ctypes.c_bool)),
+        ctypes.c_int64(i0), ctypes.c_int64(i1),
+        ctypes.c_int64(j0), ctypes.c_int64(j1),
+        ctypes.c_int64(k0), ctypes.c_int64(k1),
+        ctypes.c_int64(l0), ctypes.c_int64(l1),
+        ctypes.c_int64(nocc), ctypes.c_int64(nvir),
+        ctypes.c_int64(blk_i), ctypes.c_int64(blk_j), ctypes.c_int64(blk_k), ctypes.c_int64(blk_l)
+    )
+    return t4_blk
+
 def accumulate_t4_block2tri_(t4, t4_blk, map_, i0, i1, j0, j1, k0, k1, l0, l1,
                                 nocc, nvir, blk_i, blk_j, blk_k, blk_l, alpha, beta):
     assert t4.dtype == np.float64 and t4_blk.dtype == np.float64
@@ -107,6 +136,18 @@ def accumulate_t4_block2tri_(t4, t4_blk, map_, i0, i1, j0, j1, k0, k1, l0, l1,
     )
     return t4
 
+def r4_tri_divide_e_(mycc, r4, mo_energy):
+    nocc, nmo = mycc.nocc, mycc.nmo
+    nvir = nmo - nocc
+    assert r4.dtype == np.float64 and r4.flags['C_CONTIGUOUS'], "r4 must be a contiguous float64 array"
+    eia = np.ascontiguousarray(mo_energy[:nocc, None] - mo_energy[None, nocc:] - mycc.level_shift, dtype=np.float64)
+    _libccsdt.r4_tri_divide_e_(
+        r4.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+        eia.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+        ctypes.c_int64(nocc), ctypes.c_int64(nvir)
+    )
+    return r4
+
 def _unpack_t4_(mycc, t4, t4_blk, i0, i1, j0, j1, k0, k1, l0, l1,
                     blksize0=None, blksize1=None, blksize2=None, blksize3=None):
     if blksize0 is None: blksize0 = mycc.blksize
@@ -114,6 +155,16 @@ def _unpack_t4_(mycc, t4, t4_blk, i0, i1, j0, j1, k0, k1, l0, l1,
     if blksize2 is None: blksize2 = mycc.blksize
     if blksize3 is None: blksize3 = mycc.blksize
     unpack_t4_tri2block_(t4, t4_blk, mycc.tri2block_map, mycc.tri2block_mask, i0, i1, j0, j1, k0, k1, l0, l1,
+                        mycc.nocc, mycc.nmo - mycc.nocc, blksize0, blksize1, blksize2, blksize3)
+    return t4_blk
+
+def _unpack_t4_triples_(mycc, t4, t4_blk, i0, i1, j0, j1, k0, k1, l0, l1,
+                        blksize0=None, blksize1=None, blksize2=None, blksize3=None):
+    if blksize0 is None: blksize0 = mycc.blksize
+    if blksize1 is None: blksize1 = mycc.blksize
+    if blksize2 is None: blksize2 = mycc.blksize
+    if blksize3 is None: blksize3 = mycc.blksize
+    unpack_t4_tri2block_triples_(t4, t4_blk, mycc.tri2block_map, mycc.tri2block_mask, i0, i1, j0, j1, k0, k1, l0, l1,
                         mycc.nocc, mycc.nmo - mycc.nocc, blksize0, blksize1, blksize2, blksize3)
     return t4_blk
 
@@ -198,26 +249,26 @@ def intermediates_t4_tri(mycc, imds, t2, t3, t4):
 
     einsum('me,mjab->abej', t1_fock[:nocc, nocc:], t2, out=W_vvvo, alpha=-1.0, beta=1.0)
 
-    W_ovvvoo = np.empty((nocc,) + (nvir,) * 3 + (nocc,) * 2)
-    einsum('maef,jibf->mabeij', t1_eris[:nocc, nocc:, nocc:, nocc:], t2, out=W_ovvvoo, alpha=2.0, beta=0.0)
-    einsum('mafe,jibf->mabeij', t1_eris[:nocc, nocc:, nocc:, nocc:], t2, out=W_ovvvoo, alpha=-1.0, beta=1.0)
-    einsum('mnei,njab->mabeij', t1_eris[:nocc, :nocc, nocc:, :nocc], t2, out=W_ovvvoo, alpha=-2.0, beta=1.0)
-    einsum('nmei,njab->mabeij', t1_eris[:nocc, :nocc, nocc:, :nocc], t2, out=W_ovvvoo, alpha=1.0, beta=1.0)
+    W_oovvvo = np.empty((nocc,) * 2 + (nvir,) * 3 + (nocc,))
+    einsum('maef,jibf->ijeabm', t1_eris[:nocc, nocc:, nocc:, nocc:], t2, out=W_oovvvo, alpha=2.0, beta=0.0)
+    einsum('mafe,jibf->ijeabm', t1_eris[:nocc, nocc:, nocc:, nocc:], t2, out=W_oovvvo, alpha=-1.0, beta=1.0)
+    einsum('mnei,njab->ijeabm', t1_eris[:nocc, :nocc, nocc:, :nocc], t2, out=W_oovvvo, alpha=-2.0, beta=1.0)
+    einsum('nmei,njab->ijeabm', t1_eris[:nocc, :nocc, nocc:, :nocc], t2, out=W_oovvvo, alpha=1.0, beta=1.0)
     c_t3 = np.empty_like(t3)
     t3_spin_summation(t3, c_t3, nocc**3, nvir, "P3_201", 1.0, 0.0)
-    einsum('nmfe,nijfab->mabeij', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t3, out=W_ovvvoo, alpha=0.5, beta=1.0)
-    einsum('mnfe,nijfab->mabeij', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t3, out=W_ovvvoo, alpha=-0.25, beta=1.0)
+    einsum('nmfe,nijfab->ijeabm', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t3, out=W_oovvvo, alpha=0.5, beta=1.0)
+    einsum('mnfe,nijfab->ijeabm', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t3, out=W_oovvvo, alpha=-0.25, beta=1.0)
     c_t3 = None
 
-    W_ovvovo = np.empty((nocc, nvir, nvir, nocc, nvir, nocc))
-    einsum('mafe,jibf->mabiej', t1_eris[:nocc, nocc:, nocc:, nocc:], t2, out=W_ovvovo, alpha=1.0, beta=0.0)
-    einsum('mnie,njab->mabiej', t1_eris[:nocc, :nocc, :nocc, nocc:], t2, out=W_ovvovo, alpha=-1.0, beta=1.0)
-    einsum('nmef,injfab->mabiej', t1_eris[:nocc, :nocc, nocc:, nocc:], t3, out=W_ovvovo, alpha=-0.5, beta=1.0)
+    W_ovovvo = np.empty((nocc, nvir, nocc, nvir, nvir, nocc))
+    einsum('mafe,jibf->iejabm', t1_eris[:nocc, nocc:, nocc:, nocc:], t2, out=W_ovovvo, alpha=1.0, beta=0.0)
+    einsum('mnie,njab->iejabm', t1_eris[:nocc, :nocc, :nocc, nocc:], t2, out=W_ovovvo, alpha=-1.0, beta=1.0)
+    einsum('nmef,injfab->iejabm', t1_eris[:nocc, :nocc, nocc:, nocc:], t3, out=W_ovovvo, alpha=-0.5, beta=1.0)
 
-    W_vooooo = np.empty((nvir,) + (nocc,) * 5)
-    einsum('mnek,ijae->amnijk', t1_eris[:nocc, :nocc, nocc:, :nocc], t2, out=W_vooooo, alpha=1.0, beta=0.0)
-    einsum('mnef,ijkaef->amnijk', t1_eris[:nocc, :nocc, nocc:, nocc:], t3, out=W_vooooo, alpha=0.5, beta=1.0)
-    W_vooooo += W_vooooo.transpose(0, 2, 1, 3, 5, 4)
+    W_ooooov = np.empty((nocc,) * 5 + (nvir,))
+    einsum('mnek,ijae->kjinma', t1_eris[:nocc, :nocc, nocc:, :nocc], t2, out=W_ooooov, alpha=1.0, beta=0.0)
+    einsum('mnef,ijkaef->kjinma', t1_eris[:nocc, :nocc, nocc:, nocc:], t3, out=W_ooooov, alpha=0.5, beta=1.0)
+    W_ooooov += W_ooooov.transpose(1, 0, 2, 4, 3, 5)
 
     W_vvoooo = np.empty((nvir,) * 2 + (nocc,) * 4)
     einsum('amef,ijkebf->abmijk', t1_eris[nocc:, :nocc, nocc:, nocc:], t3, out=W_vvoooo, alpha=1.0, beta=0.0)
@@ -252,10 +303,10 @@ def intermediates_t4_tri(mycc, imds, t2, t3, t4):
                         t4_tmp[:bn, :bi, :bj, :bk], out=W_vvvvoo[..., j0:j1, k0:k1], alpha=-0.5, beta=1.0)
     t4_tmp = None
 
-    W_ovvvoo += W_ovvvoo.transpose(0, 2, 1, 3, 5, 4)
+    W_oovvvo += W_oovvvo.transpose(1, 0, 2, 4, 3, 5)
     W_vvoooo += W_vvoooo.transpose(1, 0, 2, 4, 3, 5)
     W_vvvvoo += W_vvvvoo.transpose(0, 2, 1, 3, 5, 4)
-    imds.W_ovvvoo, imds.W_ovvovo, imds.W_vooooo = W_ovvvoo, W_ovvovo, W_vooooo
+    imds.W_oovvvo, imds.W_ovovvo, imds.W_ooooov = W_oovvvo, W_ovovvo, W_ooooov
     imds.W_vvoooo, imds.W_vvvvoo = W_vvoooo, W_vvvvoo
     return imds
 
@@ -274,17 +325,17 @@ def compute_r4_tri(mycc, imds, t2, t3, t4):
     F_oo, F_vv = imds.F_oo, imds.F_vv
     W_oooo, W_ovvo, W_ovov = imds.W_oooo, imds.W_ovvo, imds.W_ovov
     W_vvvo, W_vooo, W_vvvv = imds.W_vvvo, imds.W_vooo, imds.W_vvvv
-    W_ovvvoo, W_ovvovo, W_vooooo = imds.W_ovvvoo, imds.W_ovvovo, imds.W_vooooo
+    W_oovvvo, W_ovovvo, W_ooooov = imds.W_oovvvo, imds.W_ovovvo, imds.W_ooooov
     W_vvoooo, W_vvvvoo = imds.W_vvoooo, imds.W_vvvvoo
+
+    W_voov = np.ascontiguousarray(W_ovvo.transpose(1, 0, 3, 2))
 
     c_t3 = np.empty_like(t3)
     t3_spin_summation(t3, c_t3, nocc**3, nvir, "P3_201", 1.0, 0.0)
 
     # r4 = np.empty_like(t4)
     r4 = np.zeros_like(t4)
-
     time2 = logger.process_clock(), logger.perf_counter()
-    t4_tmp = np.empty((blksize,) * 4 + (nvir,) * 4, dtype=t4.dtype)
     r4_tmp = np.empty((blksize,) * 4 + (nvir,) * 4, dtype=t4.dtype)
     for l0, l1 in lib.prange(0, nocc, blksize):
         bl = l1 - l0
@@ -345,152 +396,128 @@ def compute_r4_tri(mycc, imds, t2, t3, t4):
                     einsum("dmlk,mijcab->ijklabcd", W_vooo[:, :, l0:l1, k0:k1],
                         t3[:, i0:i1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
 
-                    einsum("mabeij,mklecd->ijklabcd", W_ovvvoo[..., i0:i1, j0:j1],
-                        c_t3[:, k0:k1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.25, beta=1.0)
-                    einsum("maceik,mjlebd->ijklabcd", W_ovvvoo[..., i0:i1, k0:k1],
-                        c_t3[:, j0:j1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.25, beta=1.0)
-                    einsum("madeil,mjkebc->ijklabcd", W_ovvvoo[..., i0:i1, l0:l1],
-                        c_t3[:, j0:j1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.25, beta=1.0)
-                    einsum("mbaeji,mklecd->ijklabcd", W_ovvvoo[..., j0:j1, i0:i1],
-                        c_t3[:, k0:k1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.25, beta=1.0)
-                    einsum("mcaeki,mjlebd->ijklabcd", W_ovvvoo[..., k0:k1, i0:i1],
-                        c_t3[:, j0:j1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.25, beta=1.0)
-                    einsum("mdaeli,mjkebc->ijklabcd", W_ovvvoo[..., l0:l1, i0:i1],
-                        c_t3[:, j0:j1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.25, beta=1.0)
-                    einsum("mbcejk,milead->ijklabcd", W_ovvvoo[..., j0:j1, k0:k1],
-                        c_t3[:, i0:i1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.25, beta=1.0)
-                    einsum("mbdejl,mikeac->ijklabcd", W_ovvvoo[..., j0:j1, l0:l1],
-                        c_t3[:, i0:i1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.25, beta=1.0)
-                    einsum("mcbekj,milead->ijklabcd", W_ovvvoo[..., k0:k1, j0:j1],
-                        c_t3[:, i0:i1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.25, beta=1.0)
-                    einsum("mdbelj,mikeac->ijklabcd", W_ovvvoo[..., l0:l1, j0:j1],
-                        c_t3[:, i0:i1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.25, beta=1.0)
-                    einsum("mcdekl,mijeab->ijklabcd", W_ovvvoo[..., k0:k1, l0:l1],
-                        c_t3[:, i0:i1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.25, beta=1.0)
-                    einsum("mdcelk,mijeab->ijklabcd", W_ovvvoo[..., l0:l1, k0:k1],
-                        c_t3[:, i0:i1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.25, beta=1.0)
+                    einsum("ijeabm,mklecd->ijklabcd", W_oovvvo[i0:i1, j0:j1],
+                        c_t3[:, k0:k1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
+                    einsum("ikeacm,mjlebd->ijklabcd", W_oovvvo[i0:i1, k0:k1],
+                        c_t3[:, j0:j1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
+                    einsum("ileadm,mjkebc->ijklabcd", W_oovvvo[i0:i1, l0:l1],
+                        c_t3[:, j0:j1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
+                    einsum("jkebcm,milead->ijklabcd", W_oovvvo[j0:j1, k0:k1],
+                        c_t3[:, i0:i1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
+                    einsum("jlebdm,mikeac->ijklabcd", W_oovvvo[j0:j1, l0:l1],
+                        c_t3[:, i0:i1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
+                    einsum("klecdm,mijeab->ijklabcd", W_oovvvo[k0:k1, l0:l1],
+                        c_t3[:, i0:i1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
 
-                    einsum("mabiej,mklced->ijklabcd", W_ovvovo[..., i0:i1, :, j0:j1],
-                        t3[:, k0:k1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mabiej,mlkdec->ijklabcd", W_ovvovo[..., i0:i1, :, j0:j1],
-                        t3[:, l0:l1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("maciek,mjlbed->ijklabcd", W_ovvovo[..., i0:i1, :, k0:k1],
-                        t3[:, j0:j1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("madiel,mjkbec->ijklabcd", W_ovvovo[..., i0:i1, :, l0:l1],
-                        t3[:, j0:j1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("maciek,mljdeb->ijklabcd", W_ovvovo[..., i0:i1, :, k0:k1],
-                        t3[:, l0:l1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("madiel,mkjceb->ijklabcd", W_ovvovo[..., i0:i1, :, l0:l1],
-                        t3[:, k0:k1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mbajei,mklced->ijklabcd", W_ovvovo[..., j0:j1, :, i0:i1],
-                        t3[:, k0:k1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mbajei,mlkdec->ijklabcd", W_ovvovo[..., j0:j1, :, i0:i1],
-                        t3[:, l0:l1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mcakei,mjlbed->ijklabcd", W_ovvovo[..., k0:k1, :, i0:i1],
-                        t3[:, j0:j1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mdalei,mjkbec->ijklabcd", W_ovvovo[..., l0:l1, :, i0:i1],
-                        t3[:, j0:j1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mcakei,mljdeb->ijklabcd", W_ovvovo[..., k0:k1, :, i0:i1],
-                        t3[:, l0:l1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mdalei,mkjceb->ijklabcd", W_ovvovo[..., l0:l1, :, i0:i1],
-                        t3[:, k0:k1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mbcjek,milaed->ijklabcd", W_ovvovo[..., j0:j1, :, k0:k1],
-                        t3[:, i0:i1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mbdjel,mikaec->ijklabcd", W_ovvovo[..., j0:j1, :, l0:l1],
-                        t3[:, i0:i1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mcbkej,milaed->ijklabcd", W_ovvovo[..., k0:k1, :, j0:j1],
-                        t3[:, i0:i1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mdblej,mikaec->ijklabcd", W_ovvovo[..., l0:l1, :, j0:j1],
-                        t3[:, i0:i1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mcdkel,mijaeb->ijklabcd", W_ovvovo[..., k0:k1, :, l0:l1],
-                        t3[:, i0:i1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mdclek,mijaeb->ijklabcd", W_ovvovo[..., l0:l1, :, k0:k1],
-                        t3[:, i0:i1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mbcjek,mlidea->ijklabcd", W_ovvovo[..., j0:j1, :, k0:k1],
-                        t3[:, l0:l1, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mbdjel,mkicea->ijklabcd", W_ovvovo[..., j0:j1, :, l0:l1],
-                        t3[:, k0:k1, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mcbkej,mlidea->ijklabcd", W_ovvovo[..., k0:k1, :, j0:j1],
-                        t3[:, l0:l1, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mdblej,mkicea->ijklabcd", W_ovvovo[..., l0:l1, :, j0:j1],
-                        t3[:, k0:k1, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mcdkel,mjibea->ijklabcd", W_ovvovo[..., k0:k1, :, l0:l1],
-                        t3[:, j0:j1, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                    einsum("mdclek,mjibea->ijklabcd", W_ovvovo[..., l0:l1, :, k0:k1],
-                        t3[:, j0:j1, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-
-                    einsum("mcbiej,mklaed->ijklabcd", W_ovvovo[..., i0:i1, :, j0:j1],
+                    einsum("iejcbm,mklaed->ijklabcd", W_ovovvo[i0:i1, :, j0:j1],
                         t3[:, k0:k1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mdbiej,mlkaec->ijklabcd", W_ovvovo[..., i0:i1, :, j0:j1],
+                    einsum("iejdbm,mlkaec->ijklabcd", W_ovovvo[i0:i1, :, j0:j1],
                         t3[:, l0:l1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mbciek,mjlaed->ijklabcd", W_ovvovo[..., i0:i1, :, k0:k1],
+                    einsum("iekbcm,mjlaed->ijklabcd", W_ovovvo[i0:i1, :, k0:k1],
                         t3[:, j0:j1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mbdiel,mjkaec->ijklabcd", W_ovvovo[..., i0:i1, :, l0:l1],
+                    einsum("ielbdm,mjkaec->ijklabcd", W_ovovvo[i0:i1, :, l0:l1],
                         t3[:, j0:j1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mdciek,mljaeb->ijklabcd", W_ovvovo[..., i0:i1, :, k0:k1],
+                    einsum("iekdcm,mljaeb->ijklabcd", W_ovovvo[i0:i1, :, k0:k1],
                         t3[:, l0:l1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mcdiel,mkjaeb->ijklabcd", W_ovvovo[..., i0:i1, :, l0:l1],
+                    einsum("ielcdm,mkjaeb->ijklabcd", W_ovovvo[i0:i1, :, l0:l1],
                         t3[:, k0:k1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mcajei,mklbed->ijklabcd", W_ovvovo[..., j0:j1, :, i0:i1],
+                    einsum("jeicam,mklbed->ijklabcd", W_ovovvo[j0:j1, :, i0:i1],
                         t3[:, k0:k1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mdajei,mlkbec->ijklabcd", W_ovvovo[..., j0:j1, :, i0:i1],
+                    einsum("jeidam,mlkbec->ijklabcd", W_ovovvo[j0:j1, :, i0:i1],
                         t3[:, l0:l1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mbakei,mjlced->ijklabcd", W_ovvovo[..., k0:k1, :, i0:i1],
+                    einsum("keibam,mjlced->ijklabcd", W_ovovvo[k0:k1, :, i0:i1],
                         t3[:, j0:j1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mbalei,mjkdec->ijklabcd", W_ovvovo[..., l0:l1, :, i0:i1],
+                    einsum("leibam,mjkdec->ijklabcd", W_ovovvo[l0:l1, :, i0:i1],
                         t3[:, j0:j1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mdakei,mljceb->ijklabcd", W_ovvovo[..., k0:k1, :, i0:i1],
+                    einsum("keidam,mljceb->ijklabcd", W_ovovvo[k0:k1, :, i0:i1],
                         t3[:, l0:l1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mcalei,mkjdeb->ijklabcd", W_ovvovo[..., l0:l1, :, i0:i1],
+                    einsum("leicam,mkjdeb->ijklabcd", W_ovovvo[l0:l1, :, i0:i1],
                         t3[:, k0:k1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("macjek,milbed->ijklabcd", W_ovvovo[..., j0:j1, :, k0:k1],
+                    einsum("jekacm,milbed->ijklabcd", W_ovovvo[j0:j1, :, k0:k1],
                         t3[:, i0:i1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("madjel,mikbec->ijklabcd", W_ovvovo[..., j0:j1, :, l0:l1],
+                    einsum("jeladm,mikbec->ijklabcd", W_ovovvo[j0:j1, :, l0:l1],
                         t3[:, i0:i1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mabkej,milced->ijklabcd", W_ovvovo[..., k0:k1, :, j0:j1],
+                    einsum("kejabm,milced->ijklabcd", W_ovovvo[k0:k1, :, j0:j1],
                         t3[:, i0:i1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mablej,mikdec->ijklabcd", W_ovvovo[..., l0:l1, :, j0:j1],
+                    einsum("lejabm,mikdec->ijklabcd", W_ovovvo[l0:l1, :, j0:j1],
                         t3[:, i0:i1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("madkel,mijceb->ijklabcd", W_ovvovo[..., k0:k1, :, l0:l1],
+                    einsum("keladm,mijceb->ijklabcd", W_ovovvo[k0:k1, :, l0:l1],
                         t3[:, i0:i1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("maclek,mijdeb->ijklabcd", W_ovvovo[..., l0:l1, :, k0:k1],
+                    einsum("lekacm,mijdeb->ijklabcd", W_ovovvo[l0:l1, :, k0:k1],
                         t3[:, i0:i1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mdcjek,mlibea->ijklabcd", W_ovvovo[..., j0:j1, :, k0:k1],
+                    einsum("jekdcm,mlibea->ijklabcd", W_ovovvo[j0:j1, :, k0:k1],
                         t3[:, l0:l1, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mcdjel,mkibea->ijklabcd", W_ovvovo[..., j0:j1, :, l0:l1],
+                    einsum("jelcdm,mkibea->ijklabcd", W_ovovvo[j0:j1, :, l0:l1],
                         t3[:, k0:k1, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mdbkej,mlicea->ijklabcd", W_ovvovo[..., k0:k1, :, j0:j1],
+                    einsum("kejdbm,mlicea->ijklabcd", W_ovovvo[k0:k1, :, j0:j1],
                         t3[:, l0:l1, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mcblej,mkidea->ijklabcd", W_ovvovo[..., l0:l1, :, j0:j1],
+                    einsum("lejcbm,mkidea->ijklabcd", W_ovovvo[l0:l1, :, j0:j1],
                         t3[:, k0:k1, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mbdkel,mjicea->ijklabcd", W_ovvovo[..., k0:k1, :, l0:l1],
+                    einsum("kelbdm,mjicea->ijklabcd", W_ovovvo[k0:k1, :, l0:l1],
                         t3[:, j0:j1, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                    einsum("mbclek,mjidea->ijklabcd", W_ovvovo[..., l0:l1, :, k0:k1],
+                    einsum("lekbcm,mjidea->ijklabcd", W_ovovvo[l0:l1, :, k0:k1],
                         t3[:, j0:j1, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
 
-                    einsum("amnijk,mnlbcd->ijklabcd", W_vooooo[..., i0:i1, j0:j1, k0:k1],
+                    _accumulate_t4_(mycc, r4, r4_tmp, i0, i1, j0, j1, k0, k1, l0, l1)
+        time2 = log.timer_debug1('t4: iter: W_vvvo * t3, W_vooo * t3, W_oovvvo * t3, W_ovovvo * t3'
+                                 ' [%3d, %3d]:' % (l0, l1), *time2)
+    r4_tmp = None
+    c_t3 = None
+    W_vvvo = imds.W_vvvo = None
+    W_vooo = imds.W_vooo = None
+    W_oovvvo = imds.W_oovvvo = None
+    time1 = log.timer_debug1('t4: W_vvvo * t3, W_vooo * t3, W_oovvvo * t3, W_ovovvo * t3', *time1)
+
+    c_t3 = t3 + t3.transpose(0, 1, 2, 4, 5, 3)
+    W_ovovvo += W_ovovvo.transpose(2, 1, 0, 4, 3, 5)
+    time2 = logger.process_clock(), logger.perf_counter()
+    t4_tmp = np.empty((blksize,) * 4 + (nvir,) * 4, dtype=t4.dtype)
+    r4_tmp = np.empty((blksize,) * 4 + (nvir,) * 4, dtype=t4.dtype)
+    for l0, l1 in lib.prange(0, nocc, blksize):
+        bl = l1 - l0
+        for k0, k1 in lib.prange(0, l1, blksize):
+            bk = k1 - k0
+            for j0, j1 in lib.prange(0, k1, blksize):
+                bj = j1 - j0
+                for i0, i1 in lib.prange(0, j1, blksize):
+                    bi = i1 - i0
+
+                    einsum("iejabm,mklced->ijklabcd", W_ovovvo[i0:i1, :, j0:j1],
+                        c_t3[:, k0:k1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=0.0)
+                    einsum("iekacm,mjlbed->ijklabcd", W_ovovvo[i0:i1, :, k0:k1],
+                        c_t3[:, j0:j1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
+                    einsum("ieladm,mjkbec->ijklabcd", W_ovovvo[i0:i1, :, l0:l1],
+                        c_t3[:, j0:j1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
+                    einsum("jekbcm,milaed->ijklabcd", W_ovovvo[j0:j1, :, k0:k1],
+                        c_t3[:, i0:i1, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
+                    einsum("jelbdm,mikaec->ijklabcd", W_ovovvo[j0:j1, :, l0:l1],
+                        c_t3[:, i0:i1, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
+                    einsum("kelcdm,mijaeb->ijklabcd", W_ovovvo[k0:k1, :, l0:l1],
+                        c_t3[:, i0:i1, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
+
+                    einsum("kjinma,mnlbcd->ijklabcd", W_ooooov[k0:k1, j0:j1, i0:i1],
                         t3[:, :, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    einsum("amnijl,mnkbdc->ijklabcd", W_vooooo[..., i0:i1, j0:j1, l0:l1],
+                    einsum("ljinma,mnkbdc->ijklabcd", W_ooooov[l0:l1, j0:j1, i0:i1],
                         t3[:, :, k0:k1,], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    einsum("amnikl,mnjcdb->ijklabcd", W_vooooo[..., i0:i1, k0:k1, l0:l1],
+                    einsum("lkinma,mnjcdb->ijklabcd", W_ooooov[l0:l1, k0:k1, i0:i1],
                         t3[:, :, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    einsum("bmnjik,mnlacd->ijklabcd", W_vooooo[..., j0:j1, i0:i1, k0:k1],
+                    einsum("kijnmb,mnlacd->ijklabcd", W_ooooov[k0:k1, i0:i1, j0:j1],
                         t3[:, :, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    einsum("bmnjil,mnkadc->ijklabcd", W_vooooo[..., j0:j1, i0:i1, l0:l1],
+                    einsum("lijnmb,mnkadc->ijklabcd", W_ooooov[l0:l1, i0:i1, j0:j1],
                         t3[:, :, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    einsum("bmnjkl,mnicda->ijklabcd", W_vooooo[..., j0:j1, k0:k1, l0:l1],
+                    einsum("lkjnmb,mnicda->ijklabcd", W_ooooov[l0:l1, k0:k1, j0:j1],
                         t3[:, :, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    einsum("cmnkij,mnlabd->ijklabcd", W_vooooo[..., k0:k1, i0:i1, j0:j1],
+                    einsum("jiknmc,mnlabd->ijklabcd", W_ooooov[j0:j1, i0:i1, k0:k1],
                         t3[:, :, l0:l1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    einsum("cmnkil,mnjadb->ijklabcd", W_vooooo[..., k0:k1, i0:i1, l0:l1],
+                    einsum("liknmc,mnjadb->ijklabcd", W_ooooov[l0:l1, i0:i1, k0:k1],
                         t3[:, :, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    einsum("cmnkjl,mnibda->ijklabcd", W_vooooo[..., k0:k1, j0:j1, l0:l1],
+                    einsum("ljknmc,mnibda->ijklabcd", W_ooooov[l0:l1, j0:j1, k0:k1],
                         t3[:, :, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    einsum("dmnlij,mnkabc->ijklabcd", W_vooooo[..., l0:l1, i0:i1, j0:j1],
+                    einsum("jilnmd,mnkabc->ijklabcd", W_ooooov[j0:j1, i0:i1, l0:l1],
                         t3[:, :, k0:k1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    einsum("dmnlik,mnjacb->ijklabcd", W_vooooo[..., l0:l1, i0:i1, k0:k1],
+                    einsum("kilnmd,mnjacb->ijklabcd", W_ooooov[k0:k1, i0:i1, l0:l1],
                         t3[:, :, j0:j1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    einsum("dmnljk,mnibca->ijklabcd", W_vooooo[..., l0:l1, j0:j1, k0:k1],
+                    einsum("kjlnmd,mnibca->ijklabcd", W_ooooov[k0:k1, j0:j1, l0:l1],
                         t3[:, :, i0:i1], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
 
                     einsum("mlcd,abmijk->ijklabcd", t2[:, l0:l1], W_vvoooo[..., i0:i1, j0:j1, k0:k1],
@@ -546,57 +573,44 @@ def compute_r4_tri(mycc, imds, t2, t3, t4):
                     _unpack_t4_(mycc, t4, t4_tmp, i0, i1, j0, j1, k0, k1, l0, l1)
                     einsum("ae,ijklebcd->ijklabcd", F_vv, t4_tmp[:bi, :bj, :bk, :bl],
                         out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    _unpack_t4_(mycc, t4, t4_tmp, j0, j1, i0, i1, k0, k1, l0, l1)
-                    einsum("be,jikleacd->ijklabcd", F_vv, t4_tmp[:bj, :bi, :bk, :bl],
+                    einsum("be,ijklaecd->ijklabcd", F_vv, t4_tmp[:bi, :bj, :bk, :bl],
                         out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    _unpack_t4_(mycc, t4, t4_tmp, k0, k1, i0, i1, j0, j1, l0, l1)
-                    einsum("ce,kijleabd->ijklabcd", F_vv, t4_tmp[:bk, :bi, :bj, :bl],
+                    einsum("ce,ijklabed->ijklabcd", F_vv, t4_tmp[:bi, :bj, :bk, :bl],
                         out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    _unpack_t4_(mycc, t4, t4_tmp, l0, l1, i0, i1, j0, j1, k0, k1)
-                    einsum("de,lijkeabc->ijklabcd", F_vv, t4_tmp[:bl, :bi, :bj, :bk],
+                    einsum("de,ijklabce->ijklabcd", F_vv, t4_tmp[:bi, :bj, :bk, :bl],
                         out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
 
-                    _unpack_t4_(mycc, t4, t4_tmp, i0, i1, j0, j1, k0, k1, l0, l1)
                     einsum("abef,ijklefcd->ijklabcd", W_vvvv, t4_tmp[:bi, :bj, :bk, :bl],
                         out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    _unpack_t4_(mycc, t4, t4_tmp, i0, i1, k0, k1, j0, j1, l0, l1)
-                    einsum("acef,ikjlefbd->ijklabcd", W_vvvv, t4_tmp[:bi, :bk, :bj, :bl],
+                    einsum("acef,ijklebfd->ijklabcd", W_vvvv, t4_tmp[:bi, :bj, :bk, :bl],
                         out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    _unpack_t4_(mycc, t4, t4_tmp, i0, i1, l0, l1, j0, j1, k0, k1)
-                    einsum("adef,iljkefbc->ijklabcd", W_vvvv, t4_tmp[:bi, :bl, :bj, :bk],
+                    einsum("adef,ijklebcf->ijklabcd", W_vvvv, t4_tmp[:bi, :bj, :bk, :bl],
                         out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    _unpack_t4_(mycc, t4, t4_tmp, j0, j1, k0, k1, i0, i1, l0, l1)
-                    einsum("bcef,jkilefad->ijklabcd", W_vvvv, t4_tmp[:bj, :bk, :bi, :bl],
+                    einsum("bcef,ijklaefd->ijklabcd", W_vvvv, t4_tmp[:bi, :bj, :bk, :bl],
                         out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    _unpack_t4_(mycc, t4, t4_tmp, j0, j1, l0, l1, i0, i1, k0, k1)
-                    einsum("bdef,jlikefac->ijklabcd", W_vvvv, t4_tmp[:bj, :bl, :bi, :bk],
+                    einsum("bdef,ijklaecf->ijklabcd", W_vvvv, t4_tmp[:bi, :bj, :bk, :bl],
                         out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                    _unpack_t4_(mycc, t4, t4_tmp, k0, k1, l0, l1, i0, i1, j0, j1)
-                    einsum("cdef,klijefab->ijklabcd", W_vvvv, t4_tmp[:bk, :bl, :bi, :bj],
+                    einsum("cdef,ijklabef->ijklabcd", W_vvvv, t4_tmp[:bi, :bj, :bk, :bl],
                         out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
 
-                    _accumulate_t4_(mycc, r4, r4_tmp, i0, i1, j0, j1, k0, k1, l0, l1)
-        time2 = log.timer_debug1('t4: iter: W_vvoooo * t2, W_vvvvoo * t2,\n'
-            '                           W_vvvo * t3, W_vooo * t3, W_ovvvoo * t3, W_ovvovo * t3, W_vooooo * t3,\n'
+                    _accumulate_t4_(mycc, r4, r4_tmp, i0, i1, j0, j1, k0, k1, l0, l1, beta=1.0)
+        time2 = log.timer_debug1('t4: iter: W_vvoooo * t2, W_vvvvoo * t2, W_ovovvo * t3, W_ooooov * t3,\n'
             '                           F_vv * t4, W_vvvv * t4 [%3d, %3d]:' % (l0, l1), *time2)
     t4_tmp = None
     r4_tmp = None
     c_t3 = None
     F_vv = imds.F_vv = None
-    W_vvvo = imds.W_vvvo = None
-    W_vooo = imds.W_vooo = None
     W_vvvv = imds.W_vvvv = None
-    W_ovvvoo = imds.W_ovvvoo = None
-    W_ovvovo = imds.W_ovvovo = None
-    W_vooooo = imds.W_vooooo = None
+    W_ovovvo = imds.W_ovovvo = None
+    W_ooooov = imds.W_ooooov = None
     W_vvoooo = imds.W_vvoooo = None
     W_vvvvoo = imds.W_vvvvoo = None
 
-    time1 = log.timer_debug1('t4: W_vvoooo * t2, W_vvvvoo * t2, W_vvvo * t3, W_vooo * t3, W_ovvvoo * t3,\n'
-                        '                     W_ovvovo * t3, W_vooooo * t3, F_vv * t4, W_vvvv * t4', *time1)
+    time1 = log.timer_debug1('t4: W_vvoooo * t2, W_vvvvoo * t2, W_ovovvo * t3, W_ooooov * t3, F_vv * t4, W_vvvv * t4',
+                             *time1)
 
     time2 = logger.process_clock(), logger.perf_counter()
-    t4_tmp = np.empty((blksize,) * 4 + (nvir,) * 4, dtype=t4.dtype)
+    t4_tmp = np.empty((nocc,) + (blksize,) * 3 + (nvir,) * 4, dtype=t4.dtype)
     r4_tmp = np.empty((blksize,) * 4 + (nvir,) * 4, dtype=t4.dtype)
     for l0, l1 in lib.prange(0, nocc, blksize):
         bl = l1 - l0
@@ -607,95 +621,74 @@ def compute_r4_tri(mycc, imds, t2, t3, t4):
                 for i0, i1 in lib.prange(0, j1, blksize):
                     bi = i1 - i0
 
-                    r4_tmp[:] = 0.0
-                    for m0, m1 in lib.prange(0, nocc, blksize):
-                        bm = m1 - m0
+                    _unpack_t4_(mycc, t4, t4_tmp, 0, nocc, j0, j1, k0, k1, l0, l1, nocc, blksize, blksize, blksize)
+                    einsum("mi,mjklabcd->ijklabcd", F_oo[:, i0:i1], t4_tmp[:, :bj, :bk, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=0.0)
+                    einsum("mbie,mjklaecd->ijklabcd", W_ovov[:, :, i0:i1, :], t4_tmp[:, :bj, :bk, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    einsum("mcie,mjklabed->ijklabcd", W_ovov[:, :, i0:i1, :], t4_tmp[:, :bj, :bk, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    einsum("mdie,mjklabce->ijklabcd", W_ovov[:, :, i0:i1, :], t4_tmp[:, :bj, :bk, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    t4_spin_summation_inplace_(t4_tmp, nocc * blksize**3, nvir, "P4_201", 1.0, 0.0)
+                    einsum("amie,mjklebcd->ijklabcd", W_voov[:, :, i0:i1, :], t4_tmp[:, :bj, :bk, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
 
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, j0, j1, k0, k1, l0, l1)
-                        einsum("mi,mjklabcd->ijklabcd", F_oo[m0:m1, i0:i1], t4_tmp[:bm, :bj, :bk, :bl],
-                            out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        t4_spin_summation_inplace_(t4_tmp, blksize**4, nvir, "P4_201", 1.0, 0.0)
-                        einsum("maei,mjklebcd->ijklabcd", W_ovvo[m0:m1, :, :, i0:i1],
-                            t4_tmp[:bm, :bj, :bk, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, i0, i1, k0, k1, l0, l1)
-                        einsum("mj,miklbacd->ijklabcd", F_oo[m0:m1, j0:j1], t4_tmp[:bm, :bi, :bk, :bl],
-                            out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        t4_spin_summation_inplace_(t4_tmp, blksize**4, nvir, "P4_201", 1.0, 0.0)
-                        einsum("mbej,mikleacd->ijklabcd", W_ovvo[m0:m1, :, :, j0:j1],
-                            t4_tmp[:bm, :bi, :bk, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, i0, i1, j0, j1, l0, l1)
-                        einsum("mk,mijlcabd->ijklabcd", F_oo[m0:m1, k0:k1], t4_tmp[:bm, :bi, :bj, :bl],
-                            out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        t4_spin_summation_inplace_(t4_tmp, blksize**4, nvir, "P4_201", 1.0, 0.0)
-                        einsum("mcek,mijleabd->ijklabcd", W_ovvo[m0:m1, :, :, k0:k1],
-                            t4_tmp[:bm, :bi, :bj, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, i0, i1, j0, j1, k0, k1)
-                        einsum("ml,mijkdabc->ijklabcd", F_oo[m0:m1, l0:l1], t4_tmp[:bm, :bi, :bj, :bk],
-                            out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        t4_spin_summation_inplace_(t4_tmp, blksize**4, nvir, "P4_201", 1.0, 0.0)
-                        einsum("mdel,mijkeabc->ijklabcd", W_ovvo[m0:m1, :, :, l0:l1],
-                            t4_tmp[:bm, :bi, :bj, :bk], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
+                    _unpack_t4_(mycc, t4, t4_tmp, 0, nocc, i0, i1, k0, k1, l0, l1, nocc, blksize, blksize, blksize)
+                    einsum("mj,miklbacd->ijklabcd", F_oo[:, j0:j1], t4_tmp[:, :bi, :bk, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    einsum("maje,miklbecd->ijklabcd", W_ovov[:, :, j0:j1, :], t4_tmp[:, :bi, :bk, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    einsum("mcje,miklbaed->ijklabcd", W_ovov[:, :, j0:j1, :], t4_tmp[:, :bi, :bk, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    einsum("mdje,miklbace->ijklabcd", W_ovov[:, :, j0:j1, :], t4_tmp[:, :bi, :bk, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    t4_spin_summation_inplace_(t4_tmp, nocc * blksize**3, nvir, "P4_201", 1.0, 0.0)
+                    einsum("bmje,mikleacd->ijklabcd", W_voov[:, :, j0:j1, :], t4_tmp[:, :bi, :bk, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
 
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, j0, j1, k0, k1, l0, l1)
-                        einsum("maie,mjklbecd->ijklabcd", W_ovov[m0:m1, :, i0:i1, :],
-                            t4_tmp[:bm, :bj, :bk, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                        einsum("mbie,mjklaecd->ijklabcd", W_ovov[m0:m1, :, i0:i1, :],
-                            t4_tmp[:bm, :bj, :bk, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, k0, k1, j0, j1, l0, l1)
-                        einsum("maie,mkjlcebd->ijklabcd", W_ovov[m0:m1, :, i0:i1, :],
-                            t4_tmp[:bm, :bk, :bj, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                        einsum("mcie,mkjlaebd->ijklabcd", W_ovov[m0:m1, :, i0:i1, :],
-                            t4_tmp[:bm, :bk, :bj, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, l0, l1, j0, j1, k0, k1)
-                        einsum("maie,mljkdebc->ijklabcd", W_ovov[m0:m1, :, i0:i1, :],
-                            t4_tmp[:bm, :bl, :bj, :bk], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                        einsum("mdie,mljkaebc->ijklabcd", W_ovov[m0:m1, :, i0:i1, :],
-                            t4_tmp[:bm, :bl, :bj, :bk], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, i0, i1, k0, k1, l0, l1)
-                        einsum("mbje,miklaecd->ijklabcd", W_ovov[m0:m1, :, j0:j1, :],
-                            t4_tmp[:bm, :bi, :bk, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                        einsum("maje,miklbecd->ijklabcd", W_ovov[m0:m1, :, j0:j1, :],
-                            t4_tmp[:bm, :bi, :bk, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, i0, i1, j0, j1, l0, l1)
-                        einsum("mcke,mijlaebd->ijklabcd", W_ovov[m0:m1, :, k0:k1, :],
-                            t4_tmp[:bm, :bi, :bj, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                        einsum("make,mijlcebd->ijklabcd", W_ovov[m0:m1, :, k0:k1, :],
-                            t4_tmp[:bm, :bi, :bj, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, i0, i1, j0, j1, k0, k1)
-                        einsum("mdle,mijkaebc->ijklabcd", W_ovov[m0:m1, :, l0:l1, :],
-                            t4_tmp[:bm, :bi, :bj, :bk], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                        einsum("male,mijkdebc->ijklabcd", W_ovov[m0:m1, :, l0:l1, :],
-                            t4_tmp[:bm, :bi, :bj, :bk], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, k0, k1, i0, i1, l0, l1)
-                        einsum("mbje,mkilcead->ijklabcd", W_ovov[m0:m1, :, j0:j1, :],
-                            t4_tmp[:bm, :bk, :bi, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                        einsum("mcje,mkilbead->ijklabcd", W_ovov[m0:m1, :, j0:j1, :],
-                            t4_tmp[:bm, :bk, :bi, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, l0, l1, i0, i1, k0, k1)
-                        einsum("mbje,mlikdeac->ijklabcd", W_ovov[m0:m1, :, j0:j1, :],
-                            t4_tmp[:bm, :bl, :bi, :bk], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                        einsum("mdje,mlikbeac->ijklabcd", W_ovov[m0:m1, :, j0:j1, :],
-                            t4_tmp[:bm, :bl, :bi, :bk], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, j0, j1, i0, i1, l0, l1)
-                        einsum("mcke,mjilbead->ijklabcd", W_ovov[m0:m1, :, k0:k1, :],
-                            t4_tmp[:bm, :bj, :bi, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                        einsum("mbke,mjilcead->ijklabcd", W_ovov[m0:m1, :, k0:k1, :],
-                            t4_tmp[:bm, :bj, :bi, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, j0, j1, i0, i1, k0, k1)
-                        einsum("mdle,mjikbeac->ijklabcd", W_ovov[m0:m1, :, l0:l1, :],
-                            t4_tmp[:bm, :bj, :bi, :bk], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                        einsum("mble,mjikdeac->ijklabcd", W_ovov[m0:m1, :, l0:l1, :],
-                            t4_tmp[:bm, :bj, :bi, :bk], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, l0, l1, i0, i1, j0, j1)
-                        einsum("mcke,mlijdeab->ijklabcd", W_ovov[m0:m1, :, k0:k1, :],
-                            t4_tmp[:bm, :bl, :bi, :bj], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                        einsum("mdke,mlijceab->ijklabcd", W_ovov[m0:m1, :, k0:k1, :],
-                            t4_tmp[:bm, :bl, :bi, :bj], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
-                        _unpack_t4_(mycc, t4, t4_tmp, m0, m1, k0, k1, i0, i1, j0, j1)
-                        einsum("mdle,mkijceab->ijklabcd", W_ovov[m0:m1, :, l0:l1, :],
-                            t4_tmp[:bm, :bk, :bi, :bj], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
-                        einsum("mcle,mkijdeab->ijklabcd", W_ovov[m0:m1, :, l0:l1, :],
-                            t4_tmp[:bm, :bk, :bi, :bj], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    _unpack_t4_(mycc, t4, t4_tmp, 0, nocc, i0, i1, j0, j1, l0, l1, nocc, blksize, blksize, blksize)
+                    einsum("mk,mijlcabd->ijklabcd", F_oo[:, k0:k1], t4_tmp[:, :bi, :bj, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    einsum("make,mijlcebd->ijklabcd", W_ovov[:, :, k0:k1, :], t4_tmp[:, :bi, :bj, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    einsum("mbke,mijlcaed->ijklabcd", W_ovov[:, :, k0:k1, :], t4_tmp[:, :bi, :bj, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    einsum("mdke,mijlcabe->ijklabcd", W_ovov[:, :, k0:k1, :], t4_tmp[:, :bi, :bj, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    t4_spin_summation_inplace_(t4_tmp, nocc * blksize**3, nvir, "P4_201", 1.0, 0.0)
+                    einsum("cmke,mijleabd->ijklabcd", W_voov[:, :, k0:k1, :], t4_tmp[:, :bi, :bj, :bl],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
+
+                    _unpack_t4_(mycc, t4, t4_tmp, 0, nocc, i0, i1, j0, j1, k0, k1, nocc, blksize, blksize, blksize)
+                    einsum("ml,mijkdabc->ijklabcd", F_oo[:, l0:l1], t4_tmp[:, :bi, :bj, :bk],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    einsum("male,mijkdebc->ijklabcd", W_ovov[:, :, l0:l1, :], t4_tmp[:, :bi, :bj, :bk],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    einsum("mble,mijkdaec->ijklabcd", W_ovov[:, :, l0:l1, :], t4_tmp[:, :bi, :bj, :bk],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    einsum("mcle,mijkdabe->ijklabcd", W_ovov[:, :, l0:l1, :], t4_tmp[:, :bi, :bj, :bk],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-1.0, beta=1.0)
+                    t4_spin_summation_inplace_(t4_tmp, nocc * blksize**3, nvir, "P4_201", 1.0, 0.0)
+                    einsum("dmle,mijkeabc->ijklabcd", W_voov[:, :, l0:l1, :], t4_tmp[:, :bi, :bj, :bk],
+                        out=r4_tmp[:bi, :bj, :bk, :bl], alpha=0.5, beta=1.0)
+
+                    _unpack_t4_triples_(mycc, t4, t4_tmp, 0, nocc, j0, j1, k0, k1, l0, l1,
+                                        nocc, blksize, blksize, blksize)
+                    einsum("maie,mjklbecd->ijklabcd", W_ovov[:, :, i0:i1, :],
+                        t4_tmp[:, :bj, :bk, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
+                    _unpack_t4_triples_(mycc, t4, t4_tmp, 0, nocc, i0, i1, k0, k1, l0, l1,
+                                        nocc, blksize, blksize, blksize)
+                    einsum("mbje,miklaecd->ijklabcd", W_ovov[:, :, j0:j1, :],
+                        t4_tmp[:, :bi, :bk, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
+                    _unpack_t4_triples_(mycc, t4, t4_tmp, 0, nocc, i0, i1, j0, j1, l0, l1,
+                                        nocc, blksize, blksize, blksize)
+                    einsum("mcke,mijlaebd->ijklabcd", W_ovov[:, :, k0:k1, :],
+                        t4_tmp[:, :bi, :bj, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
+                    _unpack_t4_triples_(mycc, t4, t4_tmp, 0, nocc, i0, i1, j0, j1, k0, k1,
+                                        nocc, blksize, blksize, blksize)
+                    einsum("mdle,mijkaebc->ijklabcd", W_ovov[:, :, l0:l1, :],
+                        t4_tmp[:, :bi, :bj, :bk], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=-0.5, beta=1.0)
 
                     _accumulate_t4_(mycc, r4, r4_tmp, i0, i1, j0, j1, k0, k1, l0, l1, beta=1.0)
         time2 = log.timer_debug1('t4: iter: F_oo * t4, W_ovvo * t4, W_ovov * t4 [%3d, %3d]:'%(l0, l1), *time2)
@@ -703,11 +696,11 @@ def compute_r4_tri(mycc, imds, t2, t3, t4):
     r4_tmp = None
     F_oo = imds.F_oo = None
     W_ovvo = imds.W_ovvo = None
-    W_ovov = imds.V_ovov = None
+    W_ovov = imds.W_ovov = None
     time1 = log.timer_debug1('t4: F_oo * t4, W_ovvo * t4, W_ovov * t4', *time1)
 
     time2 = logger.process_clock(), logger.perf_counter()
-    t4_tmp = np.empty((blksize,) * 4 + (nvir,) * 4, dtype=t4.dtype)
+    t4_tmp = np.empty((blksize,) * 3 + (nocc,) + (nvir,) * 4, dtype=t4.dtype)
     r4_tmp = np.empty((blksize,) * 4 + (nvir,) * 4, dtype=t4.dtype)
     for l0, l1 in lib.prange(0, nocc, blksize):
         bl = l1 - l0
@@ -717,33 +710,30 @@ def compute_r4_tri(mycc, imds, t2, t3, t4):
                 bj = j1 - j0
                 for i0, i1 in lib.prange(0, j1, blksize):
                     bi = i1 - i0
-
-                    r4_tmp[:] = 0.0
                     for m0, m1 in lib.prange(0, nocc, blksize):
                         bm = m1 - m0
-                        for n0, n1 in lib.prange(0, nocc, blksize):
-                            bn = n1 - n0
 
-                            _unpack_t4_(mycc, t4, t4_tmp, m0, m1, n0, n1, k0, k1, l0, l1)
-                            einsum("mnij,mnklabcd->ijklabcd", W_oooo[m0:m1, n0:n1, i0:i1, j0:j1],
-                                t4_tmp[:bm, :bn, :bk, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                            _unpack_t4_(mycc, t4, t4_tmp, m0, m1, n0, n1, j0, j1, l0, l1)
-                            einsum("mnik,mnjlacbd->ijklabcd", W_oooo[m0:m1, n0:n1, i0:i1, k0:k1],
-                                t4_tmp[:bm, :bn, :bj, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                            _unpack_t4_(mycc, t4, t4_tmp, m0, m1, n0, n1, j0, j1, k0, k1)
-                            einsum("mnil,mnjkadbc->ijklabcd", W_oooo[m0:m1, n0:n1, i0:i1, l0:l1],
-                                t4_tmp[:bm, :bn, :bj, :bk], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                            _unpack_t4_(mycc, t4, t4_tmp, m0, m1, n0, n1, i0, i1, l0, l1)
-                            einsum("mnjk,mnilbcad->ijklabcd", W_oooo[m0:m1, n0:n1, j0:j1, k0:k1],
-                                t4_tmp[:bm, :bn, :bi, :bl], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                            _unpack_t4_(mycc, t4, t4_tmp, m0, m1, n0, n1, i0, i1, k0, k1)
-                            einsum("mnjl,mnikbdac->ijklabcd", W_oooo[m0:m1, n0:n1, j0:j1, l0:l1],
-                                t4_tmp[:bm, :bn, :bi, :bk], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
-                            _unpack_t4_(mycc, t4, t4_tmp, m0, m1, n0, n1, i0, i1, j0, j1)
-                            einsum("mnkl,mnijcdab->ijklabcd", W_oooo[m0:m1, n0:n1, k0:k1, l0:l1],
-                                t4_tmp[:bm, :bn, :bi, :bj], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
+                        _unpack_t4_(mycc, t4, t4_tmp, k0, k1, l0, l1,  m0, m1, 0, nocc, blksize, blksize, blksize, nocc)
+                        einsum("mnij,klmncdab->ijklabcd", W_oooo[m0:m1, :, i0:i1, j0:j1],
+                            t4_tmp[:bk, :bl, :bm], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=0.0)
+                        _unpack_t4_(mycc, t4, t4_tmp, j0, j1, l0, l1, m0, m1, 0, nocc, blksize, blksize, blksize, nocc)
+                        einsum("mnik,jlmnbdac->ijklabcd", W_oooo[m0:m1, :, i0:i1, k0:k1],
+                            t4_tmp[:bj, :bl, :bm], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
+                        _unpack_t4_(mycc, t4, t4_tmp, j0, j1, k0, k1, m0, m1, 0, nocc, blksize, blksize, blksize, nocc)
+                        einsum("mnil,jkmnbcad->ijklabcd", W_oooo[m0:m1, :, i0:i1, l0:l1],
+                            t4_tmp[:bj, :bk, :bm], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
+                        _unpack_t4_(mycc, t4, t4_tmp, i0, i1, l0, l1, m0, m1, 0, nocc, blksize, blksize, blksize, nocc)
+                        einsum("mnjk,ilmnadbc->ijklabcd", W_oooo[m0:m1, :, j0:j1, k0:k1],
+                            t4_tmp[:bi, :bl, :bm], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
+                        _unpack_t4_(mycc, t4, t4_tmp, i0, i1, k0, k1, m0, m1, 0, nocc, blksize, blksize, blksize, nocc)
+                        einsum("mnjl,ikmnacbd->ijklabcd", W_oooo[m0:m1, :, j0:j1, l0:l1],
+                            t4_tmp[:bi, :bk, :bm], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
+                        _unpack_t4_(mycc, t4, t4_tmp, i0, i1, j0, j1, m0, m1, 0, nocc, blksize, blksize, blksize, nocc)
+                        einsum("mnkl,ijmnabcd->ijklabcd", W_oooo[m0:m1, :, k0:k1, l0:l1],
+                            t4_tmp[:bi, :bj, :bm], out=r4_tmp[:bi, :bj, :bk, :bl], alpha=1.0, beta=1.0)
 
-                    _accumulate_t4_(mycc, r4, r4_tmp, i0, i1, j0, j1, k0, k1, l0, l1, beta=1.0)
+                        _accumulate_t4_(mycc, r4, r4_tmp, i0, i1, j0, j1, k0, k1, l0, l1, beta=1.0)
+
         time2 = log.timer_debug1('t4: iter: W_oooo * t4 [%3d, %3d]:'%(l0, l1), *time2)
     t4_tmp = None
     r4_tmp = None
@@ -751,7 +741,8 @@ def compute_r4_tri(mycc, imds, t2, t3, t4):
     time1 = log.timer_debug1('t4: W_oooo * t4', *time1)
     return r4
 
-def r4_tri_divide_e_(mycc, r4, mo_energy):
+def r4_tri_divide_e_py_(mycc, r4, mo_energy):
+    # NOTE: For reference, not used in the actual code.
     nocc, nmo = mycc.nocc, mycc.nmo
     nvir = nmo - nocc
     blksize = mycc.blksize
@@ -804,15 +795,9 @@ def update_amps_rccsdtq_tri_(mycc, tamps, eris):
     # symmetrization
     r2 += r2.transpose(1, 0, 3, 2)
     time1 = log.timer_debug1('t1t2: symmetrize r2', *time1)
-    # divide by eijkabc
+    # divide by eijab
     r1r2_divide_e_(mycc, r1, r2, mo_energy)
     time1 = log.timer_debug1('t1t2: divide r1 & r2 by eia & eijab', *time1)
-
-    res_norm = [np.linalg.norm(r1), np.linalg.norm(r2)]
-
-    t1 += r1
-    t2 += r2
-    time1 = log.timer_debug1('t1t2: update t1 & t2', *time1)
     time0 = log.timer_debug1('t1t2 total', *time0)
 
     # t3
@@ -830,12 +815,6 @@ def update_amps_rccsdtq_tri_(mycc, tamps, eris):
     # divide by eijkabc
     r3_divide_e_(mycc, r3, mo_energy)
     time1 = log.timer_debug1('t3: divide r3 by eijkabc', *time1)
-
-    res_norm.append(np.linalg.norm(r3))
-
-    t3 += r3
-    r3 = None
-    time1 = log.timer_debug1('t3: update t3', *time1)
     time0 = log.timer_debug1('t3 total', *time0)
 
     # t4
@@ -847,19 +826,22 @@ def update_amps_rccsdtq_tri_(mycc, tamps, eris):
     time1 = log.timer_debug1('t4: compute r4', *time1)
     # symmetrization
     symmetrize_tamps_tri_(r4, nocc)
-    t4_spin_summation_inplace_(r4, nocc4, nvir, "P4_full", -1.0 / 24.0, 1.0)
+    t4_project_1_minus_p4_p31_inplace_(r4, nocc4, nvir)
     purify_tamps_tri_(r4, nocc)
     time1 = log.timer_debug1('t4: symmetrize r4', *time1)
     # divide by eijkabc
     r4_tri_divide_e_(mycc, r4, mo_energy)
     time1 = log.timer_debug1('t4: divide r4 by eijklabcd', *time1)
 
-    res_norm.append(np.linalg.norm(r4))
+    res_norm = [np.linalg.norm(r1), np.linalg.norm(r2), np.linalg.norm(r3), np.linalg.norm(r4)]
 
-    # t4 += r4
+    t1 += r1
+    t2 += r2
+    t3 += r3
+    # C implementation of t4 += r4
     t4_add_(t4, r4, nocc4, nvir)
-    r4 = None
-    time1 = log.timer_debug1('t4: update t4', *time1)
+    r1, r2, r3, r4 = None, None, None, None
+    time1 = log.timer_debug1('t4: update t1, t2, t3, t4', *time1)
     time0 = log.timer_debug1('t4 total', *time0)
     return res_norm
 
@@ -956,6 +938,7 @@ def dump_chk(mycc, tamps=None, frozen=None, mo_coeff=None, mo_occ=None):
         lib.chkfile.save(mycc.chkfile, 'rccsdtq', cc_chk)
     else:
         lib.chkfile.save(mycc.chkfile, 'rccsdtq_highm', cc_chk)
+    return mycc
 
 
 class RCCSDTQ(rccsdt.RCCSDT):
@@ -987,7 +970,7 @@ Saved results:
         T amplitudes t1[i,a], t2[i,j,a,b], t3[i,j,k,a,b,c]
     t4 :
         An array of shape (compressed_occ, nvir, nvir, nvir, nvir) for T4 amplitudes.
-        The occupied-oribtal dimension is stored in a compressed form for the
+        The occupied-orbital dimension is stored in a compressed form for the
         i <= j <= k <= l index combinations. The compressed tensor can be expanded to
         the full tensor by self.tamps_tri2full(t4)
     tamps :
@@ -1071,9 +1054,9 @@ class _IMDS:
         self.W_vooo = None
         self.W_vvvo = None
         self.W_vvvv = None
-        self.W_ovvvoo = None
-        self.W_ovvovo = None
-        self.W_vooooo = None
+        self.W_oovvvo = None
+        self.W_ovovvo = None
+        self.W_ooooov = None
         self.W_vvoooo = None
         self.W_vvvvoo = None
 

--- a/pyscf/cc/rccsdtq_highm.py
+++ b/pyscf/cc/rccsdtq_highm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,18 +27,16 @@ Chem. Phys. Lett. 228, 233 (1994); DOI:10.1016/0009-2614(94)00898-1
 '''
 
 import numpy as np
-import numpy
 import functools
 import ctypes
 from pyscf import lib
 from pyscf.lib import logger
-from pyscf.mp.mp2 import get_nocc, get_nmo, get_frozen_mask, get_e_hf, _mo_without_core
-from pyscf.cc import _ccsd, rccsdtq
+from pyscf.cc import rccsdtq
 from pyscf.cc.rccsdt import (_einsum, t3_spin_summation_inplace_, update_t1_fock_eris, intermediates_t1t2,
                             compute_r1r2, r1r2_divide_e_, intermediates_t3, _PhysicistsERIs)
 from pyscf.cc.rccsdt_highm import (t3_spin_summation, t3_perm_symmetrize_inplace_, purify_tamps_, r1r2_add_t3_,
                                     intermediates_t3_add_t3, compute_r3, r3_divide_e_)
-from pyscf.cc.rccsdtq import t4_spin_summation_inplace_, t4_add_, _IMDS
+from pyscf.cc.rccsdtq import t4_project_1_minus_p4_p31_inplace_, t4_add_, _IMDS
 from pyscf import __config__
 
 
@@ -119,26 +117,26 @@ def intermediates_t4(mycc, imds, t2, t3, t4):
 
     einsum('me,mjab->abej', t1_fock[:nocc, nocc:], t2, out=W_vvvo, alpha=-1.0, beta=1.0)
 
-    W_ovvvoo = np.empty((nocc,) + (nvir,) * 3 + (nocc,) * 2, dtype=t2.dtype)
-    einsum('maef,jibf->mabeij', t1_eris[:nocc, nocc:, nocc:, nocc:], t2, out=W_ovvvoo, alpha=2.0, beta=0.0)
-    einsum('mafe,jibf->mabeij', t1_eris[:nocc, nocc:, nocc:, nocc:], t2, out=W_ovvvoo, alpha=-1.0, beta=1.0)
-    einsum('mnei,njab->mabeij', t1_eris[:nocc, :nocc, nocc:, :nocc], t2, out=W_ovvvoo, alpha=-2.0, beta=1.0)
-    einsum('nmei,njab->mabeij', t1_eris[:nocc, :nocc, nocc:, :nocc], t2, out=W_ovvvoo, alpha=1.0, beta=1.0)
+    W_oovvvo = np.empty((nocc,) * 2 + (nvir,) * 3 + (nocc,), dtype=t2.dtype)
+    einsum('maef,jibf->ijeabm', t1_eris[:nocc, nocc:, nocc:, nocc:], t2, out=W_oovvvo, alpha=2.0, beta=0.0)
+    einsum('mafe,jibf->ijeabm', t1_eris[:nocc, nocc:, nocc:, nocc:], t2, out=W_oovvvo, alpha=-1.0, beta=1.0)
+    einsum('mnei,njab->ijeabm', t1_eris[:nocc, :nocc, nocc:, :nocc], t2, out=W_oovvvo, alpha=-2.0, beta=1.0)
+    einsum('nmei,njab->ijeabm', t1_eris[:nocc, :nocc, nocc:, :nocc], t2, out=W_oovvvo, alpha=1.0, beta=1.0)
     c_t3 = np.empty_like(t3)
     t3_spin_summation(t3, c_t3, nocc**3, nvir, "P3_201", 1.0, 0.0)
-    einsum('nmfe,nijfab->mabeij', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t3, out=W_ovvvoo, alpha=0.5, beta=1.0)
-    einsum('mnfe,nijfab->mabeij', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t3, out=W_ovvvoo, alpha=-0.25, beta=1.0)
+    einsum('nmfe,nijfab->ijeabm', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t3, out=W_oovvvo, alpha=0.5, beta=1.0)
+    einsum('mnfe,nijfab->ijeabm', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t3, out=W_oovvvo, alpha=-0.25, beta=1.0)
     c_t3 = None
 
-    W_ovvovo = np.empty((nocc,) + (nvir,) * 2 + (nocc, nvir, nocc), dtype=t2.dtype)
-    einsum('mafe,jibf->mabiej', t1_eris[:nocc, nocc:, nocc:, nocc:], t2, out=W_ovvovo, alpha=1.0, beta=0.0)
-    einsum('mnie,njab->mabiej', t1_eris[:nocc, :nocc, :nocc, nocc:], t2, out=W_ovvovo, alpha=-1.0, beta=1.0)
-    einsum('nmef,injfab->mabiej', t1_eris[:nocc, :nocc, nocc:, nocc:], t3, out=W_ovvovo, alpha=-0.5, beta=1.0)
+    W_ovovvo = np.empty((nocc,) + (nvir,) + (nocc, nvir, nvir, nocc), dtype=t2.dtype)
+    einsum('mafe,jibf->iejabm', t1_eris[:nocc, nocc:, nocc:, nocc:], t2, out=W_ovovvo, alpha=1.0, beta=0.0)
+    einsum('mnie,njab->iejabm', t1_eris[:nocc, :nocc, :nocc, nocc:], t2, out=W_ovovvo, alpha=-1.0, beta=1.0)
+    einsum('nmef,injfab->iejabm', t1_eris[:nocc, :nocc, nocc:, nocc:], t3, out=W_ovovvo, alpha=-0.5, beta=1.0)
 
-    W_vooooo = np.empty((nvir,) + (nocc,) * 5, dtype=t2.dtype)
-    einsum('mnek,ijae->amnijk', t1_eris[:nocc, :nocc, nocc:, :nocc], t2, out=W_vooooo, alpha=1.0, beta=0.0)
-    einsum('mnef,ijkaef->amnijk', t1_eris[:nocc, :nocc, nocc:, nocc:], t3, out=W_vooooo, alpha=0.5, beta=1.0)
-    W_vooooo += W_vooooo.transpose(0, 2, 1, 3, 5, 4)
+    W_ooooov = np.empty((nocc,) * 5 + (nvir,), dtype=t2.dtype)
+    einsum('mnek,ijae->kjinma', t1_eris[:nocc, :nocc, nocc:, :nocc], t2, out=W_ooooov, alpha=1.0, beta=0.0)
+    einsum('mnef,ijkaef->kjinma', t1_eris[:nocc, :nocc, nocc:, nocc:], t3, out=W_ooooov, alpha=0.5, beta=1.0)
+    W_ooooov += W_ooooov.transpose(1, 0, 2, 4, 3, 5)
 
     W_vvoooo = np.empty((nvir,) * 2 + (nocc,) * 4, dtype=t2.dtype)
     einsum('amef,ijkebf->abmijk', t1_eris[nocc:, :nocc, nocc:, nocc:], t3, out=W_vvoooo, alpha=1.0, beta=0.0)
@@ -161,10 +159,10 @@ def intermediates_t4(mycc, imds, t2, t3, t4):
     einsum('mnef,nmjkfabc->abcejk', t1_eris[:nocc, :nocc, nocc:, nocc:], c_t4, out=W_vvvvoo, alpha=-0.5, beta=1.0)
     c_t4 = None
 
-    W_ovvvoo += W_ovvvoo.transpose(0, 2, 1, 3, 5, 4)
+    W_oovvvo += W_oovvvo.transpose(1, 0, 2, 4, 3, 5)
     W_vvoooo += W_vvoooo.transpose(1, 0, 2, 4, 3, 5)
     W_vvvvoo += W_vvvvoo.transpose(0, 2, 1, 3, 5, 4)
-    imds.W_ovvvoo, imds.W_ovvovo, imds.W_vooooo = W_ovvvoo, W_ovvovo, W_vooooo
+    imds.W_oovvvo, imds.W_ovovvo, imds.W_ooooov = W_oovvvo, W_ovovvo, W_ooooov
     imds.W_vvoooo, imds.W_vvvvoo = W_vvoooo, W_vvvvoo
     return imds
 
@@ -183,7 +181,7 @@ def compute_r4(mycc, imds, t2, t3, t4):
     F_oo, F_vv = imds.F_oo, imds.F_vv
     W_oooo, W_ovvo, W_ovov = imds.W_oooo, imds.W_ovvo, imds.W_ovov
     W_vvvo, W_vooo, W_vvvv = imds.W_vvvo, imds.W_vooo, imds.W_vvvv
-    W_ovvvoo, W_ovvovo, W_vooooo = imds.W_ovvvoo, imds.W_ovvovo, imds.W_vooooo
+    W_oovvvo, W_ovovvo, W_ooooov = imds.W_oovvvo, imds.W_ovovvo, imds.W_ooooov
     W_vvoooo, W_vvvvoo = imds.W_vvoooo, imds.W_vvvvoo
 
     r4 = np.empty_like(t4)
@@ -225,19 +223,19 @@ def compute_r4(mycc, imds, t2, t3, t4):
 
     c_t3 = np.empty_like(t3)
     t3_spin_summation(t3, c_t3, nocc**3, nvir, "P3_201", 1.0, 0.0)
-    einsum('mabeij,mklecd->ijklabcd', W_ovvvoo, c_t3, out=r4, alpha=0.125, beta=1.0)
-    W_ovvvoo = imds.W_ovvvoo = None
+    einsum('ijeabm,mklecd->ijklabcd', W_oovvvo, c_t3, out=r4, alpha=0.125, beta=1.0)
+    W_oovvvo = imds.W_oovvvo = None
     c_t3 = None
-    time1 = log.timer_debug1('t4: W_ovvvoo * c_t3', *time1)
+    time1 = log.timer_debug1('t4: W_oovvvo * c_t3', *time1)
 
-    einsum('mabiej,kmlecd->ijklabcd', W_ovvovo, t3, out=r4, alpha=-0.5, beta=1.0)
-    einsum('mcbiej,kmlead->ijklabcd', W_ovvovo, t3, out=r4, alpha=-1.0, beta=1.0)
-    W_ovvovo = imds.W_ovvovo = None
-    time1 = log.timer_debug1('t4: W_ovvovo * t3', *time1)
+    einsum('iejabm,kmlecd->ijklabcd', W_ovovvo, t3, out=r4, alpha=-0.5, beta=1.0)
+    einsum('iejcbm,kmlead->ijklabcd', W_ovovvo, t3, out=r4, alpha=-1.0, beta=1.0)
+    W_ovovvo = imds.W_ovovvo = None
+    time1 = log.timer_debug1('t4: W_ovovvo * t3', *time1)
 
-    einsum('amnijk,mnlbcd->ijklabcd', W_vooooo, t3, out=r4, alpha=0.5, beta=1.0)
-    W_vooooo = imds.W_vooooo = None
-    time1 = log.timer_debug1('t4: W_vooooo * t3', *time1)
+    einsum('kjinma,mnlbcd->ijklabcd', W_ooooov, t3, out=r4, alpha=0.5, beta=1.0)
+    W_ooooov = imds.W_ooooov = None
+    time1 = log.timer_debug1('t4: W_ooooov * t3', *time1)
 
     einsum('abmijk,mlcd->ijklabcd', W_vvoooo, t2, out=r4, alpha=-0.5, beta=1.0)
     W_vvoooo = imds.W_vvoooo = None
@@ -266,7 +264,7 @@ def update_amps_rccsdtq_(mycc, tamps, eris):
     t1, t2, t3, t4 = tamps
     mo_energy = eris.mo_energy
 
-    imds = _IMDS
+    imds = _IMDS()
 
     # t1, t2
     update_t1_fock_eris(mycc, imds, t1, eris)
@@ -280,15 +278,9 @@ def update_amps_rccsdtq_(mycc, tamps, eris):
     # symmetrization
     r2 += r2.transpose(1, 0, 3, 2)
     time1 = log.timer_debug1('t1t2: symmetrize r2', *time1)
-    # divide by eijkabc
+    # divide by eijab
     r1r2_divide_e_(mycc, r1, r2, mo_energy)
     time1 = log.timer_debug1('t1t2: divide r1 & r2 by eia & eijab', *time1)
-
-    res_norm = [np.linalg.norm(r1), np.linalg.norm(r2)]
-
-    t1 += r1
-    t2 += r2
-    time1 = log.timer_debug1('t1t2: update t1 & t2', *time1)
     time0 = log.timer_debug1('t1t2 total', *time0)
 
     # t3
@@ -306,12 +298,6 @@ def update_amps_rccsdtq_(mycc, tamps, eris):
     # divide by eijkabc
     r3_divide_e_(mycc, r3, mo_energy)
     time1 = log.timer_debug1('t3: divide r3 by eijkabc', *time1)
-
-    res_norm.append(np.linalg.norm(r3))
-
-    t3 += r3
-    r3 = None
-    time1 = log.timer_debug1('t3: update t3', *time1)
     time0 = log.timer_debug1('t3 total', *time0)
 
     # t4
@@ -323,18 +309,22 @@ def update_amps_rccsdtq_(mycc, tamps, eris):
     time1 = log.timer_debug1('t4: compute r4', *time1)
     # symmetrization
     t4_perm_symmetrize_inplace_(r4, nocc, nvir, 1.0, 0.0)
-    t4_spin_summation_inplace_(r4, nocc**4, nvir, "P4_full", -1.0 / 24.0, 1.0)
+    t4_project_1_minus_p4_p31_inplace_(r4, nocc**4, nvir)
     purify_tamps_(r4)
     time1 = log.timer_debug1('t4: symmetrize r4', *time1)
     # divide by eijkabc
     r4_divide_e_(mycc, r4, mo_energy)
     time1 = log.timer_debug1('t4: divide r4 by eijklabcd', *time1)
 
-    res_norm.append(np.linalg.norm(r4))
+    res_norm = [np.linalg.norm(r1), np.linalg.norm(r2), np.linalg.norm(r3), np.linalg.norm(r4)]
 
+    t1 += r1
+    t2 += r2
+    t3 += r3
+    # C implementation of t4 += r4
     t4_add_(t4, r4, nocc**4, nvir)
-    r4 = None
-    time1 = log.timer_debug1('t4: update t4', *time1)
+    r1, r2, r3, r4 = None, None, None, None
+    time1 = log.timer_debug1('t4: update t1, t2, t3, t4', *time1)
     time0 = log.timer_debug1('t4 total', *time0)
     return res_norm
 

--- a/pyscf/cc/test/test_rccsdt.py
+++ b/pyscf/cc/test/test_rccsdt.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -134,7 +134,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = False
         cc1.max_cycle = 4
         cc1.kernel()
-        self.assertAlmostEqual(cc1.e_corr, -0.1362172678103062, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.13620561873465928, 7)
 
     def test_restart(self):
         ftmp = lib.NamedTemporaryFile()
@@ -148,7 +148,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = adiis
         cc1.max_cycle = 3
         cc1.kernel(tamps=None)
-        self.assertAlmostEqual(cc1.e_corr, -0.13618790413398396, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.13601543222004697, 7)
 
         tamps = cc1.vector_to_amplitudes(adiis.extrapolate())
         self.assertAlmostEqual(abs(tamps[0] - cc1.t1).max(), 0, 9)
@@ -159,7 +159,7 @@ class KnownValues(unittest.TestCase):
         import copy
         tmp_tamps = copy.deepcopy(tamps)
         cc1.kernel(tmp_tamps)
-        self.assertAlmostEqual(cc1.e_corr, -0.13636637468987364, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.13632994594327189, 7)
 
         cc1.diis = adiis
         cc1.max_cycle = 2

--- a/pyscf/cc/test/test_rccsdt_highm.py
+++ b/pyscf/cc/test/test_rccsdt_highm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = False
         cc1.max_cycle = 4
         cc1.kernel()
-        self.assertAlmostEqual(cc1.e_corr, -0.1362172678103062, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.13620561873465487, 7)
 
     def test_restart(self):
         ftmp = lib.NamedTemporaryFile()
@@ -105,7 +105,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = adiis
         cc1.max_cycle = 3
         cc1.kernel(tamps=None)
-        self.assertAlmostEqual(cc1.e_corr, -0.13618790413398396, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.13601543222004753, 7)
 
         tamps = cc1.vector_to_amplitudes(adiis.extrapolate())
         self.assertAlmostEqual(abs(tamps[0] - cc1.t1).max(), 0, 9)
@@ -116,7 +116,7 @@ class KnownValues(unittest.TestCase):
         import copy
         tmp_tamps = copy.deepcopy(tamps)
         cc1.kernel(tmp_tamps)
-        self.assertAlmostEqual(cc1.e_corr, -0.13636637468987364, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.1363299459432733, 7)
 
         cc1.diis = adiis
         cc1.max_cycle = 2

--- a/pyscf/cc/test/test_rccsdt_q.py
+++ b/pyscf/cc/test/test_rccsdt_q.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy
+from functools import reduce
+
+from pyscf import gto, scf, lib, symm
+from pyscf import cc
+from pyscf import ao2mo
+from pyscf.cc import rccsdt_q
+
+
+def setUpModule():
+    global mol, rhf, mcc, mcc2
+    mol = gto.Mole()
+    mol.atom = [
+        [8 , (0. , 0.     , 0.)],
+        [1 , (0. , -.757 , .487)],
+        [1 , (0. ,  .757 , .687)]]
+    mol.symmetry = True
+    mol.verbose = 7
+    mol.output = '/dev/null'
+    mol.basis = 'ccpvdz'
+    mol.build()
+    rhf = scf.RHF(mol)
+    rhf.conv_tol = 1e-14
+    rhf.scf()
+
+    mcc = cc.CCSDT(rhf, compact_tamps=True)
+    mcc.conv_tol = 1e-10
+    mcc.blksize = 2
+    mcc.blksize_oooo = 2
+    mcc.blksize_oovv = 2
+    mcc.ccsdt()
+
+    mcc2 = cc.CCSDT(rhf, compact_tamps=False)
+    mcc2.conv_tol = 1e-10
+    mcc2.ccsdt()
+
+def tearDownModule():
+    global mol, rhf, mcc, mcc2
+    mol.stdout.close()
+    del mol, rhf, mcc, mcc2
+
+class KnownValues(unittest.TestCase):
+    def test_rccsdt_q(self):
+        e_q_bracket, e_q_paren  = mcc.ccsdt_q()
+        self.assertAlmostEqual(e_q_bracket, -0.00044374834015582527, 9)
+        self.assertAlmostEqual(e_q_paren, -0.0004917163848923114, 9)
+        e_q_bracket2, e_q_paren2 = mcc2.ccsdt_q()
+        self.assertAlmostEqual(e_q_bracket2, -0.00044374834015582527, 9)
+        self.assertAlmostEqual(e_q_paren2, -0.0004917163848923114, 9)
+
+    def test_random(self):
+        mol = gto.M()
+        numpy.random.seed(42)
+        nocc, nvir = 5, 9
+        nmo = nocc + nvir
+
+        eris = cc.rccsdt._PhysicistsERIs()
+        eri1 = numpy.random.random((nmo, nmo, nmo, nmo)) - .5
+        eri1 = eri1 + eri1.transpose(2, 1, 0, 3)
+        eri1 = eri1 + eri1.transpose(0, 3, 2, 1)
+        eri1 = eri1 + eri1.transpose(1, 0, 3, 2)
+        eri1 *= .1
+        eris.pppp = eri1
+        f = numpy.random.random((nmo, nmo)) * .1
+        eris.fock = f + f.T + numpy.diag(numpy.arange(nmo))
+        eris.mo_energy = eris.fock.diagonal()
+
+        t1 = numpy.random.random((nocc, nvir)) * .1
+        t2 = numpy.random.random((nocc, nocc, nvir, nvir)) * .1
+        t2 = t2 + t2.transpose(1, 0, 3, 2)
+        t3_full = numpy.random.random((nocc, nocc, nocc, nvir, nvir, nvir)) * .1
+        t3_full = t3_full + t3_full.transpose(1, 0, 2, 4, 3, 5) + t3_full.transpose(2, 1, 0, 5, 4, 3)
+        t3_full = t3_full + t3_full.transpose(0, 2, 1, 3, 5, 4)
+        mf = scf.RHF(mol)
+        mycc = cc.CCSDT(mf, compact_tamps=False)
+        mycc.incore_complete = True
+        mycc.mo_energy = mycc._scf.mo_energy = numpy.arange(0., nocc + nvir)
+        e_q_bracket, e_q_paren = rccsdt_q.kernel(mycc, eris, (t1, t2, t3_full))
+        self.assertAlmostEqual(e_q_bracket, -1.1359579193293403, 9)
+        self.assertAlmostEqual(e_q_paren, -256.1325101409764, 9)
+
+        idx_i, idx_j, idx_k = numpy.meshgrid(numpy.arange(nocc), numpy.arange(nocc), numpy.arange(nocc), indexing='ij')
+        t3_tri = t3_full[(idx_i <= idx_j) & (idx_j <= idx_k)].reshape(-1, nvir, nvir, nvir)
+        mycc2 = cc.CCSDT(mf, compact_tamps=True)
+        mycc2.incore_complete = True
+        mycc2.mo_energy = mycc2._scf.mo_energy = numpy.arange(0., nocc + nvir)
+        mycc2.nocc, mycc2.nmo = nocc, nmo
+        e_q_bracket2, e_q_paren2 = rccsdt_q.kernel(mycc2, eris, (t1, t2, t3_tri))
+        self.assertAlmostEqual(e_q_bracket2, -1.1359579193293403, 9)
+        self.assertAlmostEqual(e_q_paren2, -256.1325101409764, 9)
+
+if __name__ == "__main__":
+    print("Full Tests for RCCSDT(Q)")
+    unittest.main()

--- a/pyscf/cc/test/test_rccsdtq.py
+++ b/pyscf/cc/test/test_rccsdtq.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -119,7 +119,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = False
         cc1.max_cycle = 4
         cc1.kernel()
-        self.assertAlmostEqual(cc1.e_corr, -0.04931187059105583, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.049309044956853954, 7)
 
     def test_restart(self):
         ftmp = lib.NamedTemporaryFile()
@@ -133,7 +133,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = adiis
         cc1.max_cycle = 3
         cc1.kernel(tamps=None)
-        self.assertAlmostEqual(cc1.e_corr, -0.04958018529884438, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.04957847496659795, 7)
 
         tamps = cc1.vector_to_amplitudes(adiis.extrapolate())
         self.assertAlmostEqual(abs(tamps[0] - cc1.t1).max(), 0, 9)
@@ -145,7 +145,7 @@ class KnownValues(unittest.TestCase):
         import copy
         tmp_tamps = copy.deepcopy(tamps)
         cc1.kernel(tmp_tamps)
-        self.assertAlmostEqual(cc1.e_corr, -0.04956154962282544, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.04956142543268752, 7)
 
         cc1.diis = adiis
         cc1.max_cycle = 2

--- a/pyscf/cc/test/test_rccsdtq_highm.py
+++ b/pyscf/cc/test/test_rccsdtq_highm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = False
         cc1.max_cycle = 4
         cc1.kernel()
-        self.assertAlmostEqual(cc1.e_corr, -0.04931187059105583, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.04930904495685323, 7)
 
     def test_restart(self):
         ftmp = lib.NamedTemporaryFile()
@@ -101,7 +101,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = adiis
         cc1.max_cycle = 3
         cc1.kernel(tamps=None)
-        self.assertAlmostEqual(cc1.e_corr, -0.04958018529884438, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.04957847496659781, 7)
 
         tamps = cc1.vector_to_amplitudes(adiis.extrapolate())
         self.assertAlmostEqual(abs(tamps[0] - cc1.t1).max(), 0, 9)
@@ -113,7 +113,7 @@ class KnownValues(unittest.TestCase):
         import copy
         tmp_tamps = copy.deepcopy(tamps)
         cc1.kernel(tmp_tamps)
-        self.assertAlmostEqual(cc1.e_corr, -0.04956154962282544, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.04956142543268758, 7)
 
         cc1.diis = adiis
         cc1.max_cycle = 2

--- a/pyscf/cc/test/test_uccsdt.py
+++ b/pyscf/cc/test/test_uccsdt.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -195,7 +195,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = adiis
         cc1.max_cycle = 3
         cc1.kernel(tamps=None)
-        self.assertAlmostEqual(cc1.e_corr, -0.13617537767875998, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.13598921953216506, 7)
 
         tamps = cc1.vector_to_amplitudes(adiis.extrapolate())
         self.assertAlmostEqual(abs(tamps[0][0] - cc1.t1[0]).max(), 0, 9)
@@ -212,7 +212,7 @@ class KnownValues(unittest.TestCase):
         import copy
         tmp_tamps = copy.deepcopy(tamps)
         cc1.kernel(tmp_tamps)
-        self.assertAlmostEqual(cc1.e_corr, -0.13636112399459543, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.13631662652255083, 7)
 
         cc1.diis = adiis
         cc1.max_cycle = 2
@@ -243,7 +243,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = adiis
         cc1.max_cycle = 3
         cc1.kernel(tamps=None)
-        self.assertAlmostEqual(cc1.e_corr, -0.10899528342067309, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.10890900976962495, 7)
 
         tamps = cc1.vector_to_amplitudes(adiis.extrapolate())
         self.assertAlmostEqual(abs(tamps[0][0] - cc1.t1[0]).max(), 0, 9)
@@ -260,7 +260,7 @@ class KnownValues(unittest.TestCase):
         import copy
         tmp_tamps = copy.deepcopy(tamps)
         cc1.kernel(tmp_tamps)
-        self.assertAlmostEqual(cc1.e_corr, -0.10909663534556953, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.10908025852894825, 7)
 
         cc1.diis = adiis
         cc1.max_cycle = 2
@@ -292,7 +292,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = adiis
         cc1.max_cycle = 3
         cc1.kernel(tamps=None)
-        self.assertAlmostEqual(cc1.e_corr, -0.10900065442286336, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.10890253107679486, 7)
 
         tamps = cc1.vector_to_amplitudes(adiis.extrapolate())
         tamps.append(cc1.tamps[2])
@@ -306,7 +306,7 @@ class KnownValues(unittest.TestCase):
         import copy
         tmp_tamps = copy.deepcopy(tamps)
         cc1.kernel(tmp_tamps)
-        self.assertAlmostEqual(cc1.e_corr, -0.10907414414270558, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.10903201331931782, 7)
 
         cc1.diis = adiis
         cc1.max_cycle = 2

--- a/pyscf/cc/test/test_uccsdt_highm.py
+++ b/pyscf/cc/test/test_uccsdt_highm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = adiis
         cc1.max_cycle = 3
         cc1.kernel(tamps=None)
-        self.assertAlmostEqual(cc1.e_corr, -0.13617537767875998, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.13598921953216658, 7)
 
         tamps = cc1.vector_to_amplitudes(adiis.extrapolate())
         self.assertAlmostEqual(abs(tamps[0][0] - cc1.t1[0]).max(), 0, 9)
@@ -120,7 +120,7 @@ class KnownValues(unittest.TestCase):
         import copy
         tmp_tamps = copy.deepcopy(tamps)
         cc1.kernel(tmp_tamps)
-        self.assertAlmostEqual(cc1.e_corr, -0.13636112399459543, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.1363166265225506, 7)
 
         cc1.diis = adiis
         cc1.max_cycle = 2
@@ -151,7 +151,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = adiis
         cc1.max_cycle = 3
         cc1.kernel(tamps=None)
-        self.assertAlmostEqual(cc1.e_corr, -0.10899528342067309, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.10890900976962473, 7)
 
         tamps = cc1.vector_to_amplitudes(adiis.extrapolate())
         self.assertAlmostEqual(abs(tamps[0][0] - cc1.t1[0]).max(), 0, 9)
@@ -168,7 +168,7 @@ class KnownValues(unittest.TestCase):
         import copy
         tmp_tamps = copy.deepcopy(tamps)
         cc1.kernel(tmp_tamps)
-        self.assertAlmostEqual(cc1.e_corr, -0.10909663534556953, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.10908025852894809, 7)
 
         cc1.diis = adiis
         cc1.max_cycle = 2
@@ -200,7 +200,7 @@ class KnownValues(unittest.TestCase):
         cc1.diis = adiis
         cc1.max_cycle = 3
         cc1.kernel(tamps=None)
-        self.assertAlmostEqual(cc1.e_corr, -0.10900065442286336, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.10890253107679505, 7)
 
         tamps = cc1.vector_to_amplitudes(adiis.extrapolate())
         tamps.append(cc1.tamps[2])
@@ -214,7 +214,7 @@ class KnownValues(unittest.TestCase):
         import copy
         tmp_tamps = copy.deepcopy(tamps)
         cc1.kernel(tmp_tamps)
-        self.assertAlmostEqual(cc1.e_corr, -0.10907414414270558, 7)
+        self.assertAlmostEqual(cc1.e_corr, -0.10903201331931785, 7)
 
         cc1.diis = adiis
         cc1.max_cycle = 2

--- a/pyscf/cc/uccsdt.py
+++ b/pyscf/cc/uccsdt.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -450,7 +450,7 @@ def energy_uhf(mycc, tamps, eris=None):
     eos +=       lib.einsum('ia,JB,iJaB', t1a, t1b, eris.pPpP[:nocca, :noccb, nocca:, noccb:])
 
     if abs((ess + eos).imag) > 1e-4:
-        logger.warn(mycc, 'Non-zero imaginary part found in %s energy %s', mycc.__class__.name, ess + eos)
+        logger.warn(mycc, 'Non-zero imaginary part found in %s energy %s', mycc.__class__.__name__, ess + eos)
 
     mycc.e_corr = lib.tag_array((ess + eos).real, e_corr_ss=ess.real, e_corr_os=eos.real)
     return mycc.e_corr.real
@@ -553,12 +553,12 @@ def intermediates_t1t2_uhf(mycc, imds, t2):
     einsum('kldc,jdlc->kj', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=F_oo, alpha=1.0, beta=1.0)
     W_oooo = t1_erisaa[:nocca, :nocca, :nocca, :nocca].copy()
     einsum('klcd,ijcd->klij', t1_erisaa[:nocca, :nocca, nocca:, nocca:], t2aa, out=W_oooo, alpha=0.5, beta=1.0)
-    W_ovvo = t1_erisaa[:nocca, nocca:, nocca:, :nocca].copy()
-    einsum('klcd,jlbd->kbcj', t1_erisaa[:nocca, :nocca, nocca:, nocca:], t2aa, out=W_ovvo, alpha=0.5, beta=1.0)
-    einsum('klcd,jbld->kbcj', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_ovvo, alpha=0.5, beta=1.0)
-    W_OvVo = t1_erisab[nocca:, :noccb, :nocca, noccb:].transpose(1, 0, 3, 2).copy()
-    einsum('klcd,jbld->kbcj', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2ab, out=W_OvVo, alpha=0.5, beta=1.0)
-    einsum('lkdc,jlbd->kbcj', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2aa, out=W_OvVo, alpha=0.5, beta=1.0)
+    W_voov = t1_erisaa[nocca:, :nocca, :nocca, nocca:].copy()
+    einsum('klcd,jlbd->bkjc', t1_erisaa[:nocca, :nocca, nocca:, nocca:], t2aa, out=W_voov, alpha=0.5, beta=1.0)
+    einsum('klcd,jbld->bkjc', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_voov, alpha=0.5, beta=1.0)
+    W_vOoV = t1_erisab[nocca:, :noccb, :nocca, noccb:].copy()
+    einsum('klcd,jbld->bkjc', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2ab, out=W_vOoV, alpha=0.5, beta=1.0)
+    einsum('lkdc,jlbd->bkjc', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2aa, out=W_vOoV, alpha=0.5, beta=1.0)
 
     F_VV = t1_fockb[noccb:, noccb:].copy()
     einsum('klcd,klbd->bc', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2bb, out=F_VV, alpha=-0.5, beta=1.0)
@@ -568,36 +568,31 @@ def intermediates_t1t2_uhf(mycc, imds, t2):
     einsum('lkcd,lcjd->kj', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=F_OO, alpha=1.0, beta=1.0)
     W_OOOO = t1_erisbb[:noccb, :noccb, :noccb, :noccb].copy()
     einsum('klcd,ijcd->klij', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2bb, out=W_OOOO, alpha=0.5, beta=1.0)
-    W_OVVO = t1_erisbb[:noccb, noccb:, noccb:, :noccb].copy()
-    einsum('klcd,jlbd->kbcj', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2bb, out=W_OVVO, alpha=0.5, beta=1.0)
-    einsum('lkdc,ldjb->kbcj', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_OVVO, alpha=0.5, beta=1.0)
+    W_VOOV = t1_erisbb[noccb:, :noccb, :noccb, noccb:].copy()
+    einsum('klcd,jlbd->bkjc', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2bb, out=W_VOOV, alpha=0.5, beta=1.0)
+    einsum('lkdc,ldjb->bkjc', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_VOOV, alpha=0.5, beta=1.0)
+
     W_oVvO = t1_erisab[:nocca, noccb:, nocca:, :noccb].copy()
     einsum('klcd,ldjb->kbcj', t1_erisaa[:nocca, :nocca, nocca:, nocca:], t2ab, out=W_oVvO, alpha=0.5, beta=1.0)
     einsum('klcd,jlbd->kbcj', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2bb, out=W_oVvO, alpha=0.5, beta=1.0)
-
     W_oOoO = t1_erisab[:nocca, :noccb, :nocca, :noccb].copy()
     einsum('klcd,icjd->klij', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_oOoO, alpha=1.0, beta=1.0)
-    W_vOvO = - t1_erisab[nocca:, :noccb, nocca:, :noccb]
-    einsum('lkcd,lajd->akcj', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_vOvO, alpha=0.5, beta=1.0)
-    W_VoVo = - t1_erisab[:nocca, noccb:, :nocca, noccb:].transpose(1, 0, 3, 2)
-    einsum('kldc,idlb->bkci', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_VoVo, alpha=0.5, beta=1.0)
-    W_vovo = - t1_erisaa[nocca:, :nocca, nocca:, :nocca]
-    einsum('klcd,lida->akci', t1_erisaa[:nocca, :nocca, nocca:, nocca:], t2aa, out=W_vovo, alpha=0.5, beta=1.0)
-    einsum('klcd,iald->akci', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_vovo, alpha=0.5, beta=1.0)
-    W_VOVO = - t1_erisbb[noccb:, :noccb, noccb:, :noccb]
-    einsum('klcd,ljdb->bkcj', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2bb, out=W_VOVO, alpha=0.5, beta=1.0)
-    einsum('lkdc,ldjb->bkcj', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_VOVO, alpha=0.5, beta=1.0)
-    W_vOVo = t1_erisab[nocca:, :noccb, :nocca, noccb:].transpose(0, 1, 3, 2).copy()
-    einsum('lkdc,ilad->akci', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2aa, out=W_vOVo, alpha=0.5, beta=1.0)
-    einsum('lkdc,iald->akci', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2ab, out=W_vOVo, alpha=0.5, beta=1.0)
-    W_VovO = t1_erisab[:nocca, noccb:, nocca:, :noccb].transpose(1, 0, 2, 3).copy()
-    einsum('klcd,ljdb->bkcj', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2bb, out=W_VovO, alpha=0.5, beta=1.0)
-    einsum('lkdc,ldjb->bkcj', t1_erisaa[:nocca, :nocca, nocca:, nocca:], t2ab, out=W_VovO, alpha=0.5, beta=1.0)
+    W_vOvO = t1_erisab[nocca:, :noccb, nocca:, :noccb].copy()
+    einsum('lkcd,lajd->akcj', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_vOvO, alpha=-0.5, beta=1.0)
+    W_oVoV = t1_erisab[:nocca, noccb:, :nocca, noccb:].copy()
+    einsum('kldc,idlb->kbic', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_oVoV, alpha=-0.5, beta=1.0)
+    W_vovo = t1_erisaa[nocca:, :nocca, nocca:, :nocca].copy()
+    einsum('klcd,lida->akci', t1_erisaa[:nocca, :nocca, nocca:, nocca:], t2aa, out=W_vovo, alpha=-0.5, beta=1.0)
+    einsum('klcd,iald->akci', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_vovo, alpha=-0.5, beta=1.0)
+    W_VOVO = t1_erisbb[noccb:, :noccb, noccb:, :noccb].copy()
+    einsum('klcd,ljdb->bkcj', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2bb, out=W_VOVO, alpha=-0.5, beta=1.0)
+    einsum('lkdc,ldjb->bkcj', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_VOVO, alpha=-0.5, beta=1.0)
+
     imds.F_oo, imds.F_OO, imds.F_vv, imds.F_VV = F_oo, F_OO, F_vv, F_VV
     imds.W_oooo, imds.W_oOoO, imds.W_OOOO = W_oooo, W_oOoO, W_OOOO
-    imds.W_ovvo, imds.W_oVvO, imds.W_OvVo, imds.W_OVVO = W_ovvo, W_oVvO, W_OvVo, W_OVVO,
-    imds.W_vovo, imds.W_vOvO, imds.W_vOVo = W_vovo, W_vOvO, W_vOVo
-    imds.W_VovO, imds.W_VoVo, imds.W_VOVO = W_VovO, W_VoVo, W_VOVO
+    imds.W_voov, imds.W_oVvO, imds.W_VOOV = W_voov, W_oVvO, W_VOOV
+    imds.W_vovo, imds.W_vOvO, imds.W_vOoV = W_vovo, W_vOvO, W_vOoV
+    imds.W_oVoV, imds.W_VOVO = W_oVoV, W_VOVO
     return imds
 
 def compute_r1r2_uhf(mycc, imds, t2):
@@ -613,9 +608,9 @@ def compute_r1r2_uhf(mycc, imds, t2):
 
     F_oo, F_OO, F_vv, F_VV = imds.F_oo, imds.F_OO, imds.F_vv, imds.F_VV
     W_oooo, W_oOoO, W_OOOO = imds.W_oooo, imds.W_oOoO, imds.W_OOOO
-    W_ovvo, W_oVvO, W_OvVo, W_OVVO = imds.W_ovvo, imds.W_oVvO, imds.W_OvVo, imds.W_OVVO
-    W_vovo, W_vOvO, W_vOVo = imds.W_vovo, imds.W_vOvO, imds.W_vOVo
-    W_VovO, W_VoVo, W_VOVO = imds.W_VovO, imds.W_VoVo, imds.W_VOVO
+    W_voov, W_oVvO, W_VOOV = imds.W_voov, imds.W_oVvO, imds.W_VOOV
+    W_vovo, W_vOvO, W_vOoV = imds.W_vovo, imds.W_vOvO, imds.W_vOoV
+    W_oVoV, W_VOVO = imds.W_oVoV, imds.W_VOVO
 
     r1a = t1_focka[nocca:, :nocca].T.copy()
     einsum('kc,ikac->ia', t1_focka[:nocca, nocca:], t2aa, out=r1a, alpha=1.0, beta=1.0)
@@ -638,10 +633,8 @@ def compute_r1r2_uhf(mycc, imds, t2):
     einsum("kj,ikab->ijab", F_oo, t2aa, out=r2aa, alpha=-0.5, beta=1.0)
     einsum("abcd,ijcd->ijab", t1_erisaa[nocca:, nocca:, nocca:, nocca:], t2aa, out=r2aa, alpha=0.125, beta=1.0)
     einsum("klij,klab->ijab", W_oooo, t2aa, out=r2aa, alpha=0.125, beta=1.0)
-    einsum("kbcj,ikac->ijab", W_ovvo, t2aa, out=r2aa, alpha=1.0, beta=1.0)
-    einsum("kbcj,iakc->ijab", W_OvVo, t2ab, out=r2aa, alpha=1.0, beta=1.0)
-    W_ovvo = imds.W_ovvo = None
-    W_OvVo = imds.W_OvVo = None
+    einsum("bkjc,ikac->ijab", W_voov, t2aa, out=r2aa, alpha=1.0, beta=1.0)
+    einsum("bkjc,iakc->ijab", W_vOoV, t2ab, out=r2aa, alpha=1.0, beta=1.0)
 
     r2ab = t1_erisab[nocca:, noccb:, :nocca, :noccb].transpose(2, 3, 0, 1).copy()
     r2ab = r2ab.transpose(0, 2, 1, 3)
@@ -651,17 +644,13 @@ def compute_r1r2_uhf(mycc, imds, t2):
     einsum("ki,kajb->iajb", F_oo, t2ab, out=r2ab, alpha=-1.0, beta=1.0)
     einsum("abcd,icjd->iajb", t1_erisab[nocca:, noccb:, nocca:, noccb:], t2ab, out=r2ab, alpha=1.0, beta=1.0)
     einsum("klij,kalb->iajb", W_oOoO, t2ab, out=r2ab, alpha=1.0, beta=1.0)
-    einsum("akcj,ickb->iajb", W_vOvO, t2ab, out=r2ab, alpha=1.0, beta=1.0)
-    einsum("akci,kcjb->iajb", W_vovo, t2ab, out=r2ab, alpha=1.0, beta=1.0)
-    einsum("akci,kjcb->iajb", W_vOVo, t2bb, out=r2ab, alpha=1.0, beta=1.0)
-    einsum("bkcj,ikac->iajb", W_VovO, t2aa, out=r2ab, alpha=1.0, beta=1.0)
-    einsum("bkcj,iakc->iajb", W_VOVO, t2ab, out=r2ab, alpha=1.0, beta=1.0)
-    einsum("bkci,kajc->iajb", W_VoVo, t2ab, out=r2ab, alpha=1.0, beta=1.0)
+    einsum("akcj,ickb->iajb", W_vOvO, t2ab, out=r2ab, alpha=-1.0, beta=1.0)
+    einsum("akci,kcjb->iajb", W_vovo, t2ab, out=r2ab, alpha=-1.0, beta=1.0)
+    einsum("akic,kjcb->iajb", W_vOoV, t2bb, out=r2ab, alpha=1.0, beta=1.0)
+    einsum("kbcj,ikac->iajb", W_oVvO, t2aa, out=r2ab, alpha=1.0, beta=1.0)
+    einsum("bkcj,iakc->iajb", W_VOVO, t2ab, out=r2ab, alpha=-1.0, beta=1.0)
+    einsum("kbic,kajc->iajb", W_oVoV, t2ab, out=r2ab, alpha=-1.0, beta=1.0)
     W_vovo = imds.W_vovo = None
-    W_vOvO = imds.W_vOvO = None
-    W_vOVo = imds.W_vOVo = None
-    W_VovO = imds.W_VovO = None
-    W_VoVo = imds.W_VoVo = None
     W_VOVO = imds.W_VOVO = None
 
     r2bb = 0.25 * t1_erisbb[noccb:, noccb:, :noccb, :noccb].T
@@ -669,10 +658,8 @@ def compute_r1r2_uhf(mycc, imds, t2):
     einsum("kj,ikab->ijab", F_OO, t2bb, out=r2bb, alpha=-0.5, beta=1.0)
     einsum("abcd,ijcd->ijab", t1_erisbb[noccb:, noccb:, noccb:, noccb:], t2bb, out=r2bb, alpha=0.125, beta=1.0)
     einsum("klij,klab->ijab", W_OOOO, t2bb, out=r2bb, alpha=0.125, beta=1.0)
-    einsum("kbcj,ikac->ijab", W_OVVO, t2bb, out=r2bb, alpha=1.0, beta=1.0)
+    einsum("bkjc,ikac->ijab", W_VOOV, t2bb, out=r2bb, alpha=1.0, beta=1.0)
     einsum("kbcj,kcia->ijab", W_oVvO, t2ab, out=r2bb, alpha=1.0, beta=1.0)
-    W_oVvO = imds.W_oVvO = None
-    W_OVVO = imds.W_OVVO = None
     return [r1a, r1b], [r2aa, r2ab, r2bb]
 
 def r1r2_add_t3_tri_uhf_(mycc, imds, r1, r2, t3):
@@ -855,12 +842,6 @@ def intermediates_t3_uhf(mycc, imds, t2):
 
     W_vvvv = t1_erisaa[nocca:, nocca:, nocca:, nocca:].copy()
     einsum('lmde,lmab->abde', t1_erisaa[:nocca, :nocca, nocca:, nocca:], t2aa, out=W_vvvv, alpha=0.5, beta=1.0)
-    W_voov = t1_erisaa[nocca:, :nocca, :nocca, nocca:].copy()
-    einsum('mled,imae->alid', t1_erisaa[:nocca, :nocca, nocca:, nocca:], t2aa, out=W_voov, alpha=1.0, beta=1.0)
-    einsum('lmde,iame->alid', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_voov, alpha=1.0, beta=1.0)
-    W_vOoV = t1_erisab[nocca:, :noccb, :nocca, noccb:].copy()
-    einsum('mled,imae->alid', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2aa, out=W_vOoV, alpha=1.0, beta=1.0)
-    einsum('mled,iame->alid', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2ab, out=W_vOoV, alpha=1.0, beta=1.0)
     W_vvvo = t1_erisaa[nocca:, nocca:, nocca:, :nocca].copy()
     einsum('lbed,klce->bcdk', t1_erisaa[:nocca, nocca:, nocca:, nocca:], t2aa, out=W_vvvo, alpha=2.0, beta=1.0)
     einsum('blde,kcle->bcdk', t1_erisab[nocca:, :noccb, nocca:, noccb:], t2ab, out=W_vvvo, alpha=2.0, beta=1.0)
@@ -870,15 +851,8 @@ def intermediates_t3_uhf(mycc, imds, t2):
     einsum('mldj,kmcd->lcjk', t1_erisaa[:nocca, :nocca, nocca:, :nocca], t2aa, out=W_ovoo, alpha=2.0, beta=1.0)
     einsum('lmjd,kcmd->lcjk', t1_erisab[:nocca, :noccb, :nocca, noccb:], t2ab, out=W_ovoo, alpha=2.0, beta=1.0)
     einsum('lcde,jkde->lcjk', t1_erisaa[:nocca, nocca:, nocca:, nocca:], t2aa, out=W_ovoo, alpha=0.5, beta=1.0)
-
     W_VVVV = t1_erisbb[noccb:, noccb:, noccb:, noccb:].copy()
     einsum('lmde,lmab->abde', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2bb, out=W_VVVV, alpha=0.5, beta=1.0)
-    W_VOOV = t1_erisbb[noccb:, :noccb, :noccb, noccb:].copy()
-    einsum('mled,imae->alid', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2bb, out=W_VOOV, alpha=1.0, beta=1.0)
-    einsum('mled,meia->alid', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_VOOV, alpha=1.0, beta=1.0)
-    W_VoOv = t1_erisab[:nocca, noccb:, nocca:, :noccb].transpose(1, 0, 3, 2).copy()
-    einsum('lmde,imae->alid', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2bb, out=W_VoOv, alpha=1.0, beta=1.0)
-    einsum('mled,meia->alid', t1_erisaa[:nocca, :nocca, nocca:, nocca:], t2ab, out=W_VoOv, alpha=1.0, beta=1.0)
     W_VVVO = t1_erisbb[noccb:, noccb:, noccb:, :noccb].copy()
     einsum('lbed,klce->bcdk', t1_erisbb[:noccb, noccb:, noccb:, noccb:], t2bb, out=W_VVVO, alpha=2.0, beta=1.0)
     einsum('lbed,lekc->bcdk', t1_erisab[:nocca, noccb:, nocca:, noccb:], t2ab, out=W_VVVO, alpha=2.0, beta=1.0)
@@ -888,13 +862,8 @@ def intermediates_t3_uhf(mycc, imds, t2):
     einsum('mldj,kmcd->lcjk', t1_erisbb[:noccb, :noccb, noccb:, :noccb], t2bb, out=W_OVOO, alpha=2.0, beta=1.0)
     einsum('mldj,mdkc->lcjk', t1_erisab[:nocca, :noccb, nocca:, :noccb], t2ab, out=W_OVOO, alpha=2.0, beta=1.0)
     einsum('lcde,jkde->lcjk', t1_erisbb[:noccb, noccb:, noccb:, noccb:], t2bb, out=W_OVOO, alpha=0.5, beta=1.0)
-
     W_vVvV = t1_erisab[nocca:, noccb:, nocca:, noccb:].copy()
     einsum('lmed,lbmc->bced', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_vVvV, alpha=1.0, beta=1.0)
-    W_oVoV = t1_erisab[:nocca, noccb:, :nocca, noccb:].copy()
-    einsum('lmed,iemc->lcid', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_oVoV, alpha=-1.0, beta=1.0)
-    W_vOvO = t1_erisab[nocca:, :noccb, nocca:, :noccb].copy()
-    einsum('mlde,make->aldk', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=W_vOvO, alpha=-1.0, beta=1.0)
     W_vVvO = t1_erisab[nocca:, noccb:, nocca:, :noccb].copy()
     einsum('lbed,lekc->bcdk', t1_erisaa[:nocca, nocca:, nocca:, nocca:], t2ab, out=W_vVvO, alpha=1.0, beta=1.0)
     einsum('blde,lkec->bcdk', t1_erisab[nocca:, :noccb, nocca:, noccb:], t2bb, out=W_vVvO, alpha=1.0, beta=1.0)
@@ -919,10 +888,19 @@ def intermediates_t3_uhf(mycc, imds, t2):
     einsum('alde,jdke->aljk', t1_erisab[nocca:, :noccb, nocca:, noccb:], t2ab, out=W_vOoO, alpha=1.0, beta=1.0)
     imds.W_ovoo, imds.W_oVoO, imds.W_OVOO = W_ovoo, W_oVoO, W_OVOO
     imds.W_vOoO, imds.W_vVoV = W_vOoO, W_vVoV
-    imds.W_voov, imds.W_vOoV, imds.W_VoOv, imds.W_VOOV = W_voov, W_vOoV, W_VoOv, W_VOOV
-    imds.W_oVoV, imds.W_vOvO = W_oVoV, W_vOvO
     imds.W_vvvo, imds.W_vVvO, imds.W_VVVO = W_vvvo, W_vVvO, W_VVVO
     imds.W_vvvv, imds.W_vVvV, imds.W_VVVV = W_vvvv, W_vVvV, W_VVVV
+
+    einsum('mled,imae->alid', t1_erisaa[:nocca, :nocca, nocca:, nocca:], t2aa, out=imds.W_voov, alpha=0.5, beta=1.0)
+    einsum('lmde,iame->alid', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=imds.W_voov, alpha=0.5, beta=1.0)
+    einsum('mled,imae->alid', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2aa, out=imds.W_vOoV, alpha=0.5, beta=1.0)
+    einsum('mled,iame->alid', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2ab, out=imds.W_vOoV, alpha=0.5, beta=1.0)
+    einsum('mled,imae->alid', t1_erisbb[:noccb, :noccb, noccb:, noccb:], t2bb, out=imds.W_VOOV, alpha=0.5, beta=1.0)
+    einsum('mled,meia->alid', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=imds.W_VOOV, alpha=0.5, beta=1.0)
+    einsum('lmde,imae->ladi', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2bb, out=imds.W_oVvO, alpha=0.5, beta=1.0)
+    einsum('mled,meia->ladi', t1_erisaa[:nocca, :nocca, nocca:, nocca:], t2ab, out=imds.W_oVvO, alpha=0.5, beta=1.0)
+    einsum('lmed,iemc->lcid', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=imds.W_oVoV, alpha=-0.5, beta=1.0)
+    einsum('mlde,make->aldk', t1_erisab[:nocca, :noccb, nocca:, noccb:], t2ab, out=imds.W_vOvO, alpha=-0.5, beta=1.0)
     return imds
 
 def intermediates_t3_add_t3_tri_uhf(mycc, imds, t3):
@@ -1289,7 +1267,7 @@ def compute_r3bbb_tri_uhf(mycc, imds, t2, t3):
 
     F_OO, F_VV = imds.F_OO, imds.F_VV
     W_OOOO, W_OVOO, W_VVVO, W_VVVV = imds.W_OOOO, imds.W_OVOO, imds.W_VVVO, imds.W_VVVV
-    W_VoOv, W_VOOV = imds.W_VoOv, imds.W_VOOV
+    W_oVvO, W_VOOV = imds.W_oVvO, imds.W_VOOV
 
     r3bbb = np.zeros_like(t3bbb)
 
@@ -1465,39 +1443,39 @@ def compute_r3bbb_tri_uhf(mycc, imds, t2, t3):
 
                             _unp_bba_(mycc, t3bba, t3_tmp_2, j0, j1, k0, k1, b0, b1, c0, c1,
                                 blk_i=blksize_o_aaa, blk_j=blksize_o_aaa, blk_a=blksize_v_aaa, blk_b=blksize_v_aaa)
-                            einsum("alid,jkbcld->ijkabc", W_VoOv[a0:a1, :, i0:i1, :],
+                            einsum("ladi,jkbcld->ijkabc", W_oVvO[:, a0:a1, :, i0:i1],
                                 t3_tmp_2[:bj, :bk, :bb, :bc], out=r3_tmp[bijkabc], alpha=1.0, beta=1.0)
                             _unp_bba_(mycc, t3bba, t3_tmp_2, j0, j1, k0, k1, a0, a1, c0, c1,
                                 blk_i=blksize_o_aaa, blk_j=blksize_o_aaa, blk_a=blksize_v_aaa, blk_b=blksize_v_aaa)
-                            einsum("blid,jkacld->ijkabc", W_VoOv[b0:b1, :, i0:i1, :],
+                            einsum("lbdi,jkacld->ijkabc", W_oVvO[:, b0:b1, :, i0:i1],
                                 t3_tmp_2[:bj, :bk, :ba, :bc], out=r3_tmp[bijkabc], alpha=-1.0, beta=1.0)
                             _unp_bba_(mycc, t3bba, t3_tmp_2, j0, j1, k0, k1, a0, a1, b0, b1,
                                 blk_i=blksize_o_aaa, blk_j=blksize_o_aaa, blk_a=blksize_v_aaa, blk_b=blksize_v_aaa)
-                            einsum("clid,jkabld->ijkabc", W_VoOv[c0:c1, :, i0:i1, :],
+                            einsum("lcdi,jkabld->ijkabc", W_oVvO[:, c0:c1, :, i0:i1],
                                 t3_tmp_2[:bj, :bk, :ba, :bb], out=r3_tmp[bijkabc], alpha=1.0, beta=1.0)
                             _unp_bba_(mycc, t3bba, t3_tmp_2, i0, i1, k0, k1, b0, b1, c0, c1,
                                 blk_i=blksize_o_aaa, blk_j=blksize_o_aaa, blk_a=blksize_v_aaa, blk_b=blksize_v_aaa)
-                            einsum("aljd,ikbcld->ijkabc", W_VoOv[a0:a1, :, j0:j1, :],
+                            einsum("ladj,ikbcld->ijkabc", W_oVvO[:, a0:a1, :, j0:j1],
                                 t3_tmp_2[:bi, :bk, :bb, :bc], out=r3_tmp[bijkabc], alpha=-1.0, beta=1.0)
                             _unp_bba_(mycc, t3bba, t3_tmp_2, i0, i1, k0, k1, a0, a1, c0, c1,
                                 blk_i=blksize_o_aaa, blk_j=blksize_o_aaa, blk_a=blksize_v_aaa, blk_b=blksize_v_aaa)
-                            einsum("bljd,ikacld->ijkabc", W_VoOv[b0:b1, :, j0:j1, :],
+                            einsum("lbdj,ikacld->ijkabc", W_oVvO[:, b0:b1, :, j0:j1],
                                 t3_tmp_2[:bi, :bk, :ba, :bc], out=r3_tmp[bijkabc], alpha=1.0, beta=1.0)
                             _unp_bba_(mycc, t3bba, t3_tmp_2, i0, i1, k0, k1, a0, a1, b0, b1,
                                 blk_i=blksize_o_aaa, blk_j=blksize_o_aaa, blk_a=blksize_v_aaa, blk_b=blksize_v_aaa)
-                            einsum("cljd,ikabld->ijkabc", W_VoOv[c0:c1, :, j0:j1, :],
+                            einsum("lcdj,ikabld->ijkabc", W_oVvO[:, c0:c1, :, j0:j1],
                                 t3_tmp_2[:bi, :bk, :ba, :bb], out=r3_tmp[bijkabc], alpha=-1.0, beta=1.0)
                             _unp_bba_(mycc, t3bba, t3_tmp_2, i0, i1, j0, j1, b0, b1, c0, c1,
                                 blk_i=blksize_o_aaa, blk_j=blksize_o_aaa, blk_a=blksize_v_aaa, blk_b=blksize_v_aaa)
-                            einsum("alkd,ijbcld->ijkabc", W_VoOv[a0:a1, :, k0:k1, :],
+                            einsum("ladk,ijbcld->ijkabc", W_oVvO[:, a0:a1, :, k0:k1],
                                 t3_tmp_2[:bi, :bj, :bb, :bc], out=r3_tmp[bijkabc], alpha=1.0, beta=1.0)
                             _unp_bba_(mycc, t3bba, t3_tmp_2, i0, i1, j0, j1, a0, a1, c0, c1,
                                 blk_i=blksize_o_aaa, blk_j=blksize_o_aaa, blk_a=blksize_v_aaa, blk_b=blksize_v_aaa)
-                            einsum("blkd,ijacld->ijkabc", W_VoOv[b0:b1, :, k0:k1, :],
+                            einsum("lbdk,ijacld->ijkabc", W_oVvO[:, b0:b1, :, k0:k1],
                                 t3_tmp_2[:bi, :bj, :ba, :bc], out=r3_tmp[bijkabc], alpha=-1.0, beta=1.0)
                             _unp_bba_(mycc, t3bba, t3_tmp_2, i0, i1, j0, j1, a0, a1, b0, b1,
                                 blk_i=blksize_o_aaa, blk_j=blksize_o_aaa, blk_a=blksize_v_aaa, blk_b=blksize_v_aaa)
-                            einsum("clkd,ijabld->ijkabc", W_VoOv[c0:c1, :, k0:k1, :],
+                            einsum("lcdk,ijabld->ijkabc", W_oVvO[:, c0:c1, :, k0:k1],
                                 t3_tmp_2[:bi, :bj, :ba, :bb], out=r3_tmp[bijkabc], alpha=1.0, beta=1.0)
 
                             _update_packed_bbb_(mycc, r3bbb, r3_tmp, i0, i1, j0, j1, k0, k1,
@@ -1525,7 +1503,7 @@ def compute_r3aab_tri_uhf(mycc, imds, t2, t3):
     F_oo, F_vv, F_OO, F_VV = imds.F_oo, imds.F_vv, imds.F_OO, imds.F_VV
     W_oooo, W_oOoO, W_ovoo, W_oVoO = imds.W_oooo, imds.W_oOoO, imds.W_ovoo, imds.W_oVoO
     W_vOoO, W_oVoV, W_vOvO, W_vVoV = imds.W_vOoO, imds.W_oVoV, imds.W_vOvO, imds.W_vVoV
-    W_voov, W_vOoV, W_VoOv, W_VOOV = imds.W_voov, imds.W_vOoV, imds.W_VoOv, imds.W_VOOV
+    W_voov, W_vOoV, W_oVvO, W_VOOV = imds.W_voov, imds.W_vOoV, imds.W_oVvO, imds.W_VOOV
     W_vvvo, W_vVvO, W_vvvv, W_vVvV = imds.W_vvvo, imds.W_vVvO, imds.W_vvvv, imds.W_vVvV
 
     r3aab = np.zeros_like(t3aab)
@@ -1688,7 +1666,7 @@ def compute_r3aab_tri_uhf(mycc, imds, t2, t3):
                     _unp_aaa_(mycc, t3aaa, t3_tmp_3, i0, i1, j0, j1, 0, nocca, a0, a1, b0, b1, 0, nvira,
                             blk_i=blksize_o_aab, blk_j=blksize_o_aab, blk_k=nocca,
                             blk_a=blksize_v_aab, blk_b=blksize_v_aab, blk_c=nvira)
-                    einsum("clkd,ijlabd->ijabkc", W_VoOv, t3_tmp_3[:bi, :bj, :, :ba, :bb, :],
+                    einsum("lcdk,ijlabd->ijabkc", W_oVvO, t3_tmp_3[:bi, :bj, :, :ba, :bb, :],
                         out=r3_tmp[:bi, :bj, :ba, :bb], alpha=1.0, beta=1.0)
 
                     _update_packed_aab_(mycc, r3aab, r3_tmp, i0, i1, j0, j1, a0, a1, b0, b1)
@@ -1720,7 +1698,7 @@ def compute_r3bba_tri_uhf(mycc, imds, t2, t3):
     F_oo, F_vv, F_OO, F_VV = imds.F_oo, imds.F_vv, imds.F_OO, imds.F_VV
     W_oOoO, W_OOOO, W_oVoO, W_OVOO = imds.W_oOoO, imds.W_OOOO, imds.W_oVoO, imds.W_OVOO
     W_vOoO, W_oVoV, W_vOvO, W_vVoV = imds.W_vOoO, imds.W_oVoV, imds.W_vOvO, imds.W_vVoV
-    W_voov, W_vOoV, W_VoOv, W_VOOV = imds.W_voov, imds.W_vOoV, imds.W_VoOv, imds.W_VOOV
+    W_voov, W_vOoV, W_oVvO, W_VOOV = imds.W_voov, imds.W_vOoV, imds.W_oVvO, imds.W_VOOV
     W_vVvO, W_VVVO, W_vVvV, W_VVVV = imds.W_vVvO, imds.W_VVVO, imds.W_vVvV, imds.W_VVVV
 
     r3bba = np.zeros_like(t3bba)
@@ -1867,16 +1845,16 @@ def compute_r3bba_tri_uhf(mycc, imds, t2, t3):
                             bd = d1 - d0
                             _unp_aab_(mycc, t3aab, t3_tmp_2, l0, l1, 0, nocca,
                                     d0, d1, 0, nvira, blk_j=nocca, blk_b=nvira)
-                            einsum("alid,lkdcjb->ijabkc", W_VoOv[a0:a1, l0:l1, i0:i1, d0:d1],
+                            einsum("ladi,lkdcjb->ijabkc", W_oVvO[l0:l1, a0:a1, d0:d1, i0:i1],
                                 t3_tmp_2[:bl, :, :bd, :, j0:j1, b0:b1],
                                 out=r3_tmp[:bi, :bj, :ba, :bb], alpha=1.0, beta=1.0)
-                            einsum("blid,lkdcja->ijabkc", W_VoOv[b0:b1, l0:l1, i0:i1, d0:d1],
+                            einsum("lbdi,lkdcja->ijabkc", W_oVvO[l0:l1, b0:b1, d0:d1, i0:i1],
                                 t3_tmp_2[:bl, :, :bd, :, j0:j1, a0:a1],
                                 out=r3_tmp[:bi, :bj, :ba, :bb], alpha=-1.0, beta=1.0)
-                            einsum("aljd,lkdcib->ijabkc", W_VoOv[a0:a1, l0:l1, j0:j1, d0:d1],
+                            einsum("ladj,lkdcib->ijabkc", W_oVvO[l0:l1, a0:a1, d0:d1, j0:j1],
                                 t3_tmp_2[:bl, :, :bd, :, i0:i1, b0:b1],
                                 out=r3_tmp[:bi, :bj, :ba, :bb], alpha=-1.0, beta=1.0)
-                            einsum("bljd,lkdcia->ijabkc", W_VoOv[b0:b1, l0:l1, j0:j1, d0:d1],
+                            einsum("lbdj,lkdcia->ijabkc", W_oVvO[l0:l1, b0:b1, d0:d1, j0:j1],
                                 t3_tmp_2[:bl, :, :bd, :, i0:i1, a0:a1],
                                 out=r3_tmp[:bi, :bj, :ba, :bb], alpha=1.0, beta=1.0)
 
@@ -1905,7 +1883,7 @@ def compute_r3bba_tri_uhf(mycc, imds, t2, t3):
     W_oOoO = imds.W_oOoO = None
     W_oVoV = imds.W_oVoV = None
     W_vOvO = imds.W_vOvO = None
-    W_VoOv = imds.W_VoOv = None
+    W_oVvO = imds.W_oVvO = None
     W_VOOV = imds.W_VOOV = None
     W_VVVV = imds.W_VVVV = None
     W_VVVO = imds.W_VVVO = None
@@ -2045,20 +2023,10 @@ def update_amps_uccsdt_tri_(mycc, tamps, eris):
     # antisymmetrization
     antisymmetrize_r2_uhf_(r2)
     time1 = log.timer_debug1('t1t2: antisymmetrize r2', *time1)
-    # divide by eijkabc
+    # divide by eijab
     r1r2_divide_e_uhf_(mycc, r1, r2, mo_energy)
     (r1a, r1b), (r2aa, r2ab, r2bb) = r1, r2
     time1 = log.timer_debug1('t1t2: divide r1 & r2 by eia & eijab', *time1)
-
-    res_norm = [np.linalg.norm(r1a), np.linalg.norm(r1b),
-                np.linalg.norm(r2aa), np.linalg.norm(r2ab), np.linalg.norm(r2bb)]
-
-    t1a += r1a
-    t1b += r1b
-    t2aa += r2aa
-    t2ab += r2ab
-    t2bb += r2bb
-    time1 = log.timer_debug1('t1t2: update t1 & t2', *time1)
     time0 = log.timer_debug1('t1t2 total', *time0)
 
     # t3
@@ -2074,8 +2042,16 @@ def update_amps_uccsdt_tri_(mycc, tamps, eris):
     r3aaa, r3aab, r3bba, r3bbb = r3
     time1 = log.timer_debug1('t3: divide r3 by eijkabc', *time1)
 
-    res_norm += [np.linalg.norm(r3aaa), np.linalg.norm(r3aab), np.linalg.norm(r3bba), np.linalg.norm(r3bbb)]
+    res_norm = [np.linalg.norm(r1a), np.linalg.norm(r1b),
+                np.linalg.norm(r2aa), np.linalg.norm(r2ab), np.linalg.norm(r2bb),
+                np.linalg.norm(r3aaa), np.linalg.norm(r3aab), np.linalg.norm(r3bba), np.linalg.norm(r3bbb)]
 
+    t1a += r1a
+    t1b += r1b
+    t2aa += r2aa
+    t2ab += r2ab
+    t2bb += r2bb
+    r1a, r1b, r2aa, r2ab, r2bb = None, None, None, None, None
     t3aaa += r3aaa
     r3aaa = None
     t3bbb += r3bbb
@@ -2085,7 +2061,7 @@ def update_amps_uccsdt_tri_(mycc, tamps, eris):
     t3bba += r3bba
     r3bba = None
     t3 = [t3aaa, t3aab, t3bba, t3bbb]
-    time1 = log.timer_debug1('t3: update t3', *time1)
+    time1 = log.timer_debug1('t3: update t1, t2, t3', *time1)
     time0 = log.timer_debug1('t3 total', *time0)
 
     tamps = [t1, t2, t3]
@@ -2280,7 +2256,7 @@ def restore_from_diis_(mycc, diis_file, inplace=True):
             else:
                 n1, nocc1, nvir1, n2, nocc2, nvir2 = nb, noccb, nvirb, na, nocca, nvira
             if mycc.do_tri_max_t:
-                if n2 >= 0:
+                if n2 > 0:
                     shape = (nx(nocc1, n1),) + (nx(nvir1, n1),) + (nx(nocc2, n2),) + (nx(nvir2, n2),)
                 else:
                     shape = (nx(nocc1, n1),) + (nx(nvir1, n1),)
@@ -2471,6 +2447,7 @@ def dump_chk(mycc, tamps=None, frozen=None, mo_coeff=None, mo_occ=None):
         lib.chkfile.save(mycc.chkfile, 'uccsdt', cc_chk)
     else:
         lib.chkfile.save(mycc.chkfile, 'uccsdt_highm', cc_chk)
+    return mycc
 
 def tamps_tri2full_uhf(mycc, tamps_tri):
     '''Convert triangular-stored T amplitudes to their full tensor form (UHF case).'''
@@ -2912,11 +2889,11 @@ class _IMDS:
         self.F_oo, self.F_OO = None, None
         self.F_vv, self.F_VV = None, None
         self.W_oooo, self.W_oOoO, self.W_OOOO = None, None, None
-        self.W_ovoo, self.W_oVoO, self.W_OVOO = None, None, None
-        self.W_vOoO, self.W_oVoV, self.W_vOvO, self.W_vVoV = None, None, None, None
-        self.W_voov, self.W_vOoV, self.W_VoOv, self.W_VOOV = None, None, None, None
-        self.W_vvvo, self.W_vVvO, self.W_VVVO = None, None, None
+        self.W_voov, self.W_vOoV, self.W_oVvO, self.W_VOOV = None, None, None, None
+        self.W_vovo, self.W_vOvO, self.W_oVoV, self.W_VOVO = None, None, None, None
         self.W_vvvv, self.W_vVvV, self.W_VVVV = None, None, None
+        self.W_vvvo, self.W_vVvO, self.W_vVoV, self.W_VVVO = None, None, None, None
+        self.W_ovoo, self.W_oVoO, self.W_vOoO, self.W_OVOO = None, None, None, None
 
 
 if __name__ == "__main__":

--- a/pyscf/cc/uccsdt_highm.py
+++ b/pyscf/cc/uccsdt_highm.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,14 +28,10 @@ MBPT and Coupled-Cluster Theory, Cambridge University Press (2009). DOI: 10.1017
 '''
 
 import numpy as np
-import numpy
 import functools
-from pyscf import lib
 from pyscf.lib import logger
-from pyscf.mp.mp2 import get_e_hf
-from pyscf.mp.ump2 import get_nocc, get_nmo, get_frozen_mask
 from pyscf.cc import uccsdt
-from pyscf.cc.rccsdt import _einsum, run_diis, _finalize
+from pyscf.cc.rccsdt import _einsum
 from pyscf.cc.uccsdt import (update_t1_fock_eris_uhf, intermediates_t1t2_uhf, compute_r1r2_uhf,
                             antisymmetrize_r2_uhf_, r1r2_divide_e_uhf_, intermediates_t3_uhf, _PhysicistsERIs, _IMDS)
 from pyscf import __config__
@@ -132,7 +128,7 @@ def compute_r3_uhf(mycc, imds, t2, t3):
     W_oooo, W_oOoO, W_OOOO = imds.W_oooo, imds.W_oOoO, imds.W_OOOO
     W_ovoo, W_oVoO, W_OVOO = imds.W_ovoo, imds.W_oVoO, imds.W_OVOO
     W_vOoO, W_oVoV, W_vOvO, W_vVoV = imds.W_vOoO, imds.W_oVoV, imds.W_vOvO, imds.W_vVoV
-    W_voov, W_vOoV, W_VoOv, W_VOOV = imds.W_voov, imds.W_vOoV, imds.W_VoOv, imds.W_VOOV
+    W_voov, W_vOoV, W_oVvO, W_VOOV = imds.W_voov, imds.W_vOoV, imds.W_oVvO, imds.W_VOOV
     W_vvvo, W_vVvO, W_VVVO = imds.W_vvvo, imds.W_vVvO, imds.W_VVVO
     W_vvvv, W_vVvV, W_VVVV = imds.W_vvvv, imds.W_vVvV, imds.W_VVVV
 
@@ -155,7 +151,7 @@ def compute_r3_uhf(mycc, imds, t2, t3):
     einsum("abde,ijkdec->ijkabc", W_VVVV, t3bbb, out=r3bbb, alpha=1.0 / 24.0, beta=1.0)
     einsum("lmij,lmkabc->ijkabc", W_OOOO, t3bbb, out=r3bbb, alpha=1.0 / 24.0, beta=1.0)
     einsum("alid,ljkdbc->ijkabc", W_VOOV, t3bbb, out=r3bbb, alpha=0.25, beta=1.0)
-    einsum("alid,jkbcld->ijkabc", W_VoOv, t3bba, out=r3bbb, alpha=0.25, beta=1.0)
+    einsum("ladi,jkbcld->ijkabc", W_oVvO, t3bba, out=r3bbb, alpha=0.25, beta=1.0)
     time1 = log.timer_debug1('t3: r3bbb', *time1)
 
     r3aab = np.empty_like(t3aab)
@@ -177,7 +173,7 @@ def compute_r3_uhf(mycc, imds, t2, t3):
     einsum("alid,lkdcjb->ijabkc", W_vOoV, t3bba, out=r3aab, alpha=1.0, beta=1.0)
     einsum("lcid,ljabkd->ijabkc", W_oVoV, t3aab, out=r3aab, alpha=-0.5, beta=1.0)
     einsum("aldk,ijdblc->ijabkc", W_vOvO, t3aab, out=r3aab, alpha=-0.5, beta=1.0)
-    einsum("clkd,ijlabd->ijabkc", W_VoOv, t3aaa, out=r3aab, alpha=0.25, beta=1.0)
+    einsum("lcdk,ijlabd->ijabkc", W_oVvO, t3aaa, out=r3aab, alpha=0.25, beta=1.0)
     einsum("clkd,ijabld->ijabkc", W_VOOV, t3aab, out=r3aab, alpha=0.25, beta=1.0)
     W_vvvo = imds.W_vvvo = None
     W_ovoo = imds.W_ovoo = None
@@ -201,7 +197,7 @@ def compute_r3_uhf(mycc, imds, t2, t3):
     einsum("lmij,lmabkc->ijabkc", W_OOOO, t3bba, out=r3bba, alpha=0.125, beta=1.0)
     einsum("mlki,ljabmc->ijabkc", W_oOoO, t3bba, out=r3bba, alpha=0.5, beta=1.0)
     einsum("alid,ljdbkc->ijabkc", W_VOOV, t3bba, out=r3bba, alpha=1.0, beta=1.0)
-    einsum("alid,lkdcjb->ijabkc", W_VoOv, t3aab, out=r3bba, alpha=1.0, beta=1.0)
+    einsum("ladi,lkdcjb->ijabkc", W_oVvO, t3aab, out=r3bba, alpha=1.0, beta=1.0)
     einsum("cldi,ljabkd->ijabkc", W_vOvO, t3bba, out=r3bba, alpha=-0.5, beta=1.0)
     einsum("lakd,ijdblc->ijabkc", W_oVoV, t3bba, out=r3bba, alpha=-0.5, beta=1.0)
     einsum("clkd,ijlabd->ijabkc", W_vOoV, t3bbb, out=r3bba, alpha=0.25, beta=1.0)
@@ -220,7 +216,7 @@ def compute_r3_uhf(mycc, imds, t2, t3):
     W_oOoO = imds.W_oOoO = None
     W_oVoV = imds.W_oVoV = None
     W_vOvO = imds.W_vOvO = None
-    W_VoOv = imds.W_VoOv = None
+    W_oVvO = imds.W_oVvO = None
     W_VOOV = imds.W_VOOV = None
     W_VVVV = imds.W_VVVV = None
     W_VVVO = imds.W_VVVO = None
@@ -292,20 +288,10 @@ def update_amps_uccsdt_(mycc, tamps, eris):
     # antisymmetrization
     antisymmetrize_r2_uhf_(r2)
     time1 = log.timer_debug1('t1t2: antisymmetrize r2', *time1)
-    # divide by eijkabc
+    # divide by eijab
     r1r2_divide_e_uhf_(mycc, r1, r2, mo_energy)
     (r1a, r1b), (r2aa, r2ab, r2bb) = r1, r2
     time1 = log.timer_debug1('t1t2: divide r1 & r2 by eia & eijab', *time1)
-
-    res_norm = [np.linalg.norm(r1a), np.linalg.norm(r1b),
-                np.linalg.norm(r2aa), np.linalg.norm(r2ab), np.linalg.norm(r2bb)]
-
-    t1a += r1a
-    t1b += r1b
-    t2aa += r2aa
-    t2ab += r2ab
-    t2bb += r2bb
-    time1 = log.timer_debug1('t1t2: update t1 & t2', *time1)
     time0 = log.timer_debug1('t1t2 total', *time0)
 
     # t3
@@ -324,8 +310,16 @@ def update_amps_uccsdt_(mycc, tamps, eris):
     r3aaa, r3aab, r3bba, r3bbb = r3
     time1 = log.timer_debug1('t3: divide r3 by eijkabc', *time1)
 
-    res_norm += [np.linalg.norm(r3aaa), np.linalg.norm(r3aab), np.linalg.norm(r3bba), np.linalg.norm(r3bbb)]
+    res_norm = [np.linalg.norm(r1a), np.linalg.norm(r1b),
+                np.linalg.norm(r2aa), np.linalg.norm(r2ab), np.linalg.norm(r2bb),
+                np.linalg.norm(r3aaa), np.linalg.norm(r3aab), np.linalg.norm(r3bba), np.linalg.norm(r3bbb)]
 
+    t1a += r1a
+    t1b += r1b
+    t2aa += r2aa
+    t2ab += r2ab
+    t2bb += r2bb
+    r1a, r1b, r2aa, r2ab, r2bb = None, None, None, None, None
     t3aaa += r3aaa
     r3aaa = None
     t3bbb += r3bbb
@@ -335,7 +329,7 @@ def update_amps_uccsdt_(mycc, tamps, eris):
     t3bba += r3bba
     r3bba = None
     t3 = (t3aaa, t3aab, t3bba, t3bbb)
-    time1 = log.timer_debug1('t3: update t3', *time1)
+    time1 = log.timer_debug1('t3: update t1, t2, t3', *time1)
     time0 = log.timer_debug1('t3 total', *time0)
 
     tamps = [t1, t2, t3]

--- a/pyscf/lib/ccsdt/rccsdt.c
+++ b/pyscf/lib/ccsdt/rccsdt.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+/* Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -496,6 +496,17 @@ const int64_t tp_t3[6][3] = {
     {2, 1, 0}, // reverse
 };
 
+static inline int64_t src_idx_from_full3(const int64_t *restrict perm, int64_t v0, int64_t v1, int64_t v2, int64_t nvir)
+{
+    int64_t src_abc[3];
+
+    src_abc[perm[0]] = v0;
+    src_abc[perm[1]] = v1;
+    src_abc[perm[2]] = v2;
+
+    return ((src_abc[0] * nvir + src_abc[1]) * nvir + src_abc[2]);
+}
+
 // Unpack triangular-stored T3 amplitudes into a full T3 block.
 //
 // This kernel reconstructs the full permutation-expanded T3 tensor block from the compressed triangular
@@ -521,6 +532,7 @@ void unpack_t3_tri2block_(const double *restrict t3_tri,
 {
 #define MAP(sym, x, y, z) map[(((sym) * nocc + (x)) * nocc + (y)) * nocc + (z)]
 #define MASK(sym, x, y, z) mask[(((sym) * nocc + (x)) * nocc + (y)) * nocc + (z)]
+#define VIDX(a, b, c) (((a) * nvir + (b)) * nvir + (c))
 
 #pragma omp parallel for collapse(4) schedule(dynamic)
     for (int64_t sym = 0; sym < 6; ++sym)
@@ -549,15 +561,10 @@ void unpack_t3_tri2block_(const double *restrict t3_tri,
                         {
                             for (int64_t c = 0; c < nvir; ++c)
                             {
-                                int64_t abc[3] = {a, b, c};
-                                int64_t aa = abc[perm[0]];
-                                int64_t bb = abc[perm[1]];
-                                int64_t cc = abc[perm[2]];
+                                int64_t src = src_base + src_idx_from_full3(perm, a, b, c, nvir);
+                                int64_t dest = dest_base + VIDX(a, b, c);
 
-                                int64_t src_idx = src_base + (a * nvir + b) * nvir + c;
-                                int64_t dest_idx = dest_base + (aa * nvir + bb) * nvir + cc;
-
-                                t3_blk[dest_idx] = t3_tri[src_idx];
+                                t3_blk[dest] = t3_tri[src];
                             }
                         }
                     }
@@ -569,112 +576,11 @@ void unpack_t3_tri2block_(const double *restrict t3_tri,
 #undef MASK
 }
 
-// Unpack a triangular-stored T3 (i, j, k) element into its 6-fold
-// permutation representation for a single occupied triplet.
+
+// Unpack triangular-stored T3 amplitudes directly into the final block:
 //
-// This routine identifies the symmetry representative of (i0, j0, k0) in the triangular (i <= j <= k) index domain,
-// applies the corresponding (a, b, c) permutation, and scatters the resulting amplitudes into `t3_blk`.
-// In addition, a second symmetry partner (selected via `tmp_indices`) is accumulated to complete the required
-// two-term contribution.  Conceptually, this corresponds to reconstructing:
+//   t3_tmp + t3_tmp.transpose(0, 1, 2, 4, 5, 3)
 //
-//     t3_full[i0, j0, k0, :, :, :] + t3_full[j0, i0, k0, :, :, :].transpose(1, 0, 2)
-//
-// Input
-//   t3_tri     : triangular-stored T3 amplitudes
-//   t3_blk     : output buffer [nvir**3]
-//   map        : mapping (sym, i, j, k) -> tri index
-//   mask       : triangular-domain mask for valid (i, j, k)
-//   i0, j0, k0 : occupied indices for this element
-//   nocc       : number of occupied orbitals
-//   nvir       : number of virtual orbitals
-void unpack_t3_tri2single_pair_(const double *restrict t3_tri,
-                                double *restrict t3_blk,
-                                const int64_t *restrict map,
-                                const bool *restrict mask,
-                                int64_t i0, int64_t j0, int64_t k0,
-                                int64_t nocc, int64_t nvir)
-{
-
-#define MAP(sym, x, y, z) map[(((sym) * nocc + (x)) * nocc + (y)) * nocc + (z)]
-#define MASK(sym, x, y, z) mask[(((sym) * nocc + (x)) * nocc + (y)) * nocc + (z)]
-
-    int64_t sym;
-    for (sym = 0; sym < 6; ++sym)
-    {
-        if (MASK(sym, i0, j0, k0))
-            break;
-    }
-
-    const int64_t *perm = tp_t3[sym];
-    int64_t idx = MAP(sym, i0, j0, k0);
-
-#pragma omp parallel for collapse(3) schedule(static)
-    for (int64_t a = 0; a < nvir; ++a)
-    {
-        for (int64_t b = 0; b < nvir; ++b)
-        {
-            for (int64_t c = 0; c < nvir; ++c)
-            {
-                int64_t abc[3] = {a, b, c};
-                int64_t aa = abc[perm[0]];
-                int64_t bb = abc[perm[1]];
-                int64_t cc = abc[perm[2]];
-
-                int64_t src_idx = ((idx * nvir + a) * nvir + b) * nvir + c;
-                int64_t dest_idx = (aa * nvir + bb) * nvir + cc;
-
-                t3_blk[dest_idx] = t3_tri[src_idx];
-            }
-        }
-    }
-
-    const int64_t tmp_indices[6] = {2, 4, 0, 5, 1, 3};
-
-    for (sym = 0; sym < 6; ++sym)
-    {
-        if (MASK(tmp_indices[sym], i0, j0, k0))
-            break;
-    }
-
-    const int64_t *perm2 = tp_t3[tmp_indices[sym]];
-    idx = MAP(tmp_indices[sym], i0, j0, k0);
-
-#pragma omp parallel for collapse(3) schedule(static)
-    for (int64_t a = 0; a < nvir; ++a)
-    {
-        for (int64_t b = 0; b < nvir; ++b)
-        {
-            for (int64_t c = 0; c < nvir; ++c)
-            {
-                int64_t abc[3] = {a, b, c};
-                int64_t aa = abc[perm2[0]];
-                int64_t bb = abc[perm2[1]];
-                int64_t cc = abc[perm2[2]];
-
-                int64_t src_idx = ((idx * nvir + a) * nvir + b) * nvir + c;
-                int64_t dest_idx = (aa * nvir + bb) * nvir + cc;
-
-                t3_blk[dest_idx] += t3_tri[src_idx];
-            }
-        }
-    }
-#undef MAP
-#undef MASK
-}
-
-// Unpack triangular-stored T3 amplitudes into a full T3 block.
-//
-// This kernel reconstructs the full permutation-expanded T3 tensor block from the compressed triangular
-// representation without forming the full tensor in memory.
-//
-// Input:
-//   t3_tri                    : triangular-stored T3 amplitudes
-//   t3_blk                    : output buffer [blk_i * blk_j * blk_k * nvir**3]
-//   map                       : mapping index table for (i, j, k) -> tri index
-//   mask                      : mask indicating which (i, j, k) indices are stored (triangular domain)
-//   [i0:i1), [j0:j1), [k0:k1) : occupied index block ranges
-//   nocc, nvir                : number of occupied / virtual orbitals
-//   blk_i, blk_j, blk_k       : block sizes for the destination tensor
 void unpack_t3_tri2block_pair_(const double *restrict t3_tri,
                                double *restrict t3_blk,
                                const int64_t *restrict map,
@@ -688,9 +594,7 @@ void unpack_t3_tri2block_pair_(const double *restrict t3_tri,
 
 #define MAP(sym, x, y, z) map[(((sym) * nocc + (x)) * nocc + (y)) * nocc + (z)]
 #define MASK(sym, x, y, z) mask[(((sym) * nocc + (x)) * nocc + (y)) * nocc + (z)]
-
-    const int64_t tmp_indices[6] = {5, 3, 4, 1, 2, 0};
-    const int64_t trans_indices[6] = {1, 0, 3, 2, 5, 4};
+#define VIDX(a, b, c) (((a) * nvir + (b)) * nvir + (c))
 
 #pragma omp parallel for collapse(4) schedule(dynamic)
     for (int64_t sym = 0; sym < 6; ++sym)
@@ -719,59 +623,11 @@ void unpack_t3_tri2block_pair_(const double *restrict t3_tri,
                         {
                             for (int64_t c = 0; c < nvir; ++c)
                             {
-                                int64_t abc[3] = {a, b, c};
-                                int64_t aa = abc[perm[0]];
-                                int64_t bb = abc[perm[1]];
-                                int64_t cc = abc[perm[2]];
+                                const int64_t src0 = src_base + src_idx_from_full3(perm, a, b, c, nvir);
+                                const int64_t src1 = src_base + src_idx_from_full3(perm, b, c, a, nvir);
+                                const int64_t dest = dest_base + VIDX(a, b, c);
 
-                                int64_t src_idx = src_base + (a * nvir + b) * nvir + c;
-                                int64_t dest_idx = dest_base + (aa * nvir + bb) * nvir + cc;
-
-                                t3_blk[dest_idx] = t3_tri[src_idx];
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-#pragma omp parallel for collapse(4) schedule(dynamic)
-    for (int64_t sym = 0; sym < 6; ++sym)
-    {
-        for (int64_t i = i0; i < i1; ++i)
-        {
-            for (int64_t j = j0; j < j1; ++j)
-            {
-                for (int64_t k = k0; k < k1; ++k)
-                {
-                    if (!MASK(tmp_indices[sym], i, j, k))
-                        continue;
-
-                    const int64_t *perm2 = tp_t3[trans_indices[sym]];
-
-                    int64_t loc_i = i - i0;
-                    int64_t loc_j = j - j0;
-                    int64_t loc_k = k - k0;
-
-                    int64_t src_base = MAP(tmp_indices[sym], i, j, k) * nvir * nvir * nvir;
-                    int64_t dest_base = ((loc_i * blk_j + loc_j) * blk_k + loc_k) * nvir * nvir * nvir;
-
-                    for (int64_t a = 0; a < nvir; ++a)
-                    {
-                        for (int64_t b = 0; b < nvir; ++b)
-                        {
-                            for (int64_t c = 0; c < nvir; ++c)
-                            {
-                                int64_t abc[3] = {a, b, c};
-                                int64_t aa = abc[perm2[0]];
-                                int64_t bb = abc[perm2[1]];
-                                int64_t cc = abc[perm2[2]];
-
-                                int64_t src_idx = src_base + (a * nvir + b) * nvir + c;
-                                int64_t dest_idx = dest_base + (aa * nvir + bb) * nvir + cc;
-
-                                t3_blk[dest_idx] += t3_tri[src_idx];
+                                t3_blk[dest] = t3_tri[src0] + t3_tri[src1];
                             }
                         }
                     }
@@ -846,43 +702,6 @@ void accumulate_t3_block2tri_(double *restrict t3_tri,
                         }
                     }
                 }
-            }
-        }
-    }
-#undef MAP
-}
-
-// Accumulate a single (i0, j0, k0) full T3 slice into the triangular 6-fold compressed T3 storage.
-//
-// Inputs
-//   t3_tri      : triangular-stored T3 amplitudes
-//   t3_blk      : full T3 slice [nvir**3] for (i0, j0, k0)
-//   map         : mapping (sym, i, j, k) -> triangular index (sym = 0 used here)
-//   i0, j0, k0  : occupied indices
-//   nocc        : number of occupied orbitals
-//   nvir        : number of virtual orbitals
-//   alpha, beta : scaling coefficients for accumulation
-void accumulate_t3_single2tri_(double *restrict t3_tri,
-                               const double *restrict t3_blk,
-                               const int64_t *restrict map,
-                               int64_t i0, int64_t j0, int64_t k0,
-                               int64_t nocc, int64_t nvir,
-                               double alpha, double beta)
-{
-#define MAP(sym, x, y, z) map[(((sym) * nocc + (x)) * nocc + (y)) * nocc + (z)]
-
-    int64_t p = MAP(0, i0, j0, k0);
-    int64_t tri_base = p * nvir * nvir * nvir;
-
-#pragma omp parallel for collapse(3) schedule(static)
-    for (int64_t a = 0; a < nvir; ++a)
-    {
-        for (int64_t b = 0; b < nvir; ++b)
-        {
-            for (int64_t c = 0; c < nvir; ++c)
-            {
-                int64_t idx = ((a * nvir + b) * nvir + c);
-                t3_tri[tri_base + idx] = beta * t3_tri[tri_base + idx] + alpha * t3_blk[idx];
             }
         }
     }

--- a/pyscf/lib/ccsdt/rccsdtq.c
+++ b/pyscf/lib/ccsdt/rccsdtq.c
@@ -1,4 +1,4 @@
-/* Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+/* Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
 
    Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -27,8 +27,9 @@
 // Apply spin summation projection to T4 amplitudes in place.
 // A: pointer to T4 tensor (size nocc4 * nvir**4)
 // pattern: "P4_full" : P(A) = (1 + P_c^d) (1 + P_b^c + P_b^d) (1 + P_a^b + P_a^c + P_a^d) A
-//          "P4_422"  : P(A) = (1 + 0 * P_c^d) (1 + 0 * P_b^c + 0 * P_b^d) (2 - P_a^b - P_a^c - P_a^d) A
-//          "P4_201"  : P(A) = (1 + 0 * P_c^d) (2 - P_b^c - P_b^d) (2 - P_a^b - P_a^c - P_a^d) A
+//         "P4_444"  : P(A) = (2 - P_c^d) (2 - P_b^c - P_b^d) (2 - P_a^b - P_a^c - P_a^d) A
+//          "P4_422"  : P(A) = (1 + 0 * P_c^d) (2 - P_b^c - P_b^d) (2 - P_a^b - P_a^c - P_a^d) A
+//          "P4_201"  : P(A) = (1 + 0 * P_c^d) (1 + 0 * P_b^c + 0 * P_b^d) (2 - P_a^b - P_a^c - P_a^d) A
 // alpha, beta: A = beta * A + alpha * P(A)
 void t4_spin_summation_inplace_(double *A, int64_t nocc4, int64_t nvir, char *pattern, double alpha, double beta)
 {
@@ -68,6 +69,18 @@ void t4_spin_summation_inplace_(double *A, int64_t nocc4, int64_t nvir, char *pa
         p[6] = -1.0;
         p[7] = 1.0;
         p[8] = 0.0;
+    }
+    else if (strcmp(pattern, "P4_444") == 0)
+    {
+        p[0] = 2.0;
+        p[1] = -1.0;
+        p[2] = -1.0;
+        p[3] = -1.0;
+        p[4] = 2.0;
+        p[5] = -1.0;
+        p[6] = -1.0;
+        p[7] = 2.0;
+        p[8] = -1.0;
     }
     else
     {
@@ -530,6 +543,18 @@ void t4_spin_summation(const double *A, double *B, int64_t nocc4, int64_t nvir,
         p[7] = 1.0;
         p[8] = 0.0;
     }
+    else if (strcmp(pattern, "P4_444") == 0)
+    {
+        p[0] = 2.0;
+        p[1] = -1.0;
+        p[2] = -1.0;
+        p[3] = -1.0;
+        p[4] = 2.0;
+        p[5] = -1.0;
+        p[6] = -1.0;
+        p[7] = 2.0;
+        p[8] = -1.0;
+    }
     else
     {
         fprintf(stderr, "Error: unrecognized pattern \"%s\"\n", pattern);
@@ -947,6 +972,491 @@ void t4_spin_summation(const double *A, double *B, int64_t nocc4, int64_t nvir,
     }
 }
 
+void t4_spin_summation_single_inplace_(double *A, int64_t nvir, char *pattern, double alpha, double beta)
+{
+    int64_t nvv = nvir * nvir;
+    int64_t nvvv = nvir * nvv;
+
+    double p[9];
+
+    if (strcmp(pattern, "P4_full") == 0)
+    {
+        for (int i = 0; i < 9; i++)
+            p[i] = 1.0;
+    }
+    else if (strcmp(pattern, "P4_201") == 0)
+    {
+        p[0] = 2.0;
+        p[1] = -1.0;
+        p[2] = -1.0;
+        p[3] = -1.0;
+        p[4] = 1.0;
+        p[5] = 0.0;
+        p[6] = 0.0;
+        p[7] = 1.0;
+        p[8] = 0.0;
+    }
+    else if (strcmp(pattern, "P4_442") == 0)
+    {
+        p[0] = 2.0;
+        p[1] = -1.0;
+        p[2] = -1.0;
+        p[3] = -1.0;
+        p[4] = 2.0;
+        p[5] = -1.0;
+        p[6] = -1.0;
+        p[7] = 1.0;
+        p[8] = 0.0;
+    }
+    else if (strcmp(pattern, "P4_444") == 0)
+    {
+        p[0] = 2.0;
+        p[1] = -1.0;
+        p[2] = -1.0;
+        p[3] = -1.0;
+        p[4] = 2.0;
+        p[5] = -1.0;
+        p[6] = -1.0;
+        p[7] = 2.0;
+        p[8] = -1.0;
+    }
+    else
+    {
+        fprintf(stderr, "Error: unrecognized pattern \"%s\"\n", pattern);
+        return;
+    }
+
+    int64_t total_combinations = (nvir * (nvir + 1) * (nvir + 2) * (nvir + 3)) / 24;
+
+#pragma omp parallel for schedule(static)
+    for (int64_t idx_linear = 0; idx_linear < total_combinations; idx_linear++)
+    {
+        int64_t a, b, c, d;
+        int64_t remaining = idx_linear;
+
+        a = 0;
+        while (a < nvir)
+        {
+            int64_t count_with_a = ((a + 1) * (a + 2) * (a + 3)) / 6;
+            if (remaining < count_with_a)
+            {
+                break;
+            }
+            remaining -= count_with_a;
+            a++;
+        }
+
+        b = 0;
+        while (b <= a)
+        {
+            int64_t count_with_b = ((b + 1) * (b + 2)) / 2;
+            if (remaining < count_with_b)
+            {
+                break;
+            }
+            remaining -= count_with_b;
+            b++;
+        }
+
+        c = 0;
+        while (c <= b)
+        {
+            int64_t count_with_c = c + 1;
+            if (remaining < count_with_c)
+            {
+                break;
+            }
+            remaining -= count_with_c;
+            c++;
+        }
+
+        d = remaining;
+
+        int64_t nvvv = nvir * nvir * nvir;
+        int64_t nvv = nvir * nvir;
+        if (a > b && b > c && c > d)
+        {
+            double T1_local[24];
+            double T2_local[24];
+
+            int64_t indices[24];
+            indices[0] = a * nvvv + b * nvv + c * nvir + d;
+            indices[1] = a * nvvv + b * nvv + d * nvir + c;
+            indices[2] = a * nvvv + c * nvv + b * nvir + d;
+            indices[3] = a * nvvv + c * nvv + d * nvir + b;
+            indices[4] = a * nvvv + d * nvv + b * nvir + c;
+            indices[5] = a * nvvv + d * nvv + c * nvir + b;
+            indices[6] = b * nvvv + a * nvv + c * nvir + d;
+            indices[7] = b * nvvv + a * nvv + d * nvir + c;
+            indices[8] = b * nvvv + c * nvv + a * nvir + d;
+            indices[9] = b * nvvv + c * nvv + d * nvir + a;
+            indices[10] = b * nvvv + d * nvv + a * nvir + c;
+            indices[11] = b * nvvv + d * nvv + c * nvir + a;
+            indices[12] = c * nvvv + a * nvv + b * nvir + d;
+            indices[13] = c * nvvv + a * nvv + d * nvir + b;
+            indices[14] = c * nvvv + b * nvv + a * nvir + d;
+            indices[15] = c * nvvv + b * nvv + d * nvir + a;
+            indices[16] = c * nvvv + d * nvv + a * nvir + b;
+            indices[17] = c * nvvv + d * nvv + b * nvir + a;
+            indices[18] = d * nvvv + a * nvv + b * nvir + c;
+            indices[19] = d * nvvv + a * nvv + c * nvir + b;
+            indices[20] = d * nvvv + b * nvv + a * nvir + c;
+            indices[21] = d * nvvv + b * nvv + c * nvir + a;
+            indices[22] = d * nvvv + c * nvv + a * nvir + b;
+            indices[23] = d * nvvv + c * nvv + b * nvir + a;
+
+            T1_local[0] = p[0] * A[indices[0]] + p[1] * A[indices[6]] + p[2] * A[indices[14]] + p[3] * A[indices[21]];
+            T1_local[1] = p[0] * A[indices[1]] + p[1] * A[indices[7]] + p[2] * A[indices[20]] + p[3] * A[indices[15]];
+            T1_local[2] = p[0] * A[indices[2]] + p[1] * A[indices[12]] + p[2] * A[indices[8]] + p[3] * A[indices[23]];
+            T1_local[3] = p[0] * A[indices[3]] + p[1] * A[indices[13]] + p[2] * A[indices[22]] + p[3] * A[indices[9]];
+            T1_local[4] = p[0] * A[indices[4]] + p[1] * A[indices[18]] + p[2] * A[indices[10]] + p[3] * A[indices[17]];
+            T1_local[5] = p[0] * A[indices[5]] + p[1] * A[indices[19]] + p[2] * A[indices[16]] + p[3] * A[indices[11]];
+            T1_local[6] = p[0] * A[indices[6]] + p[1] * A[indices[0]] + p[2] * A[indices[12]] + p[3] * A[indices[19]];
+            T1_local[7] = p[0] * A[indices[7]] + p[1] * A[indices[1]] + p[2] * A[indices[18]] + p[3] * A[indices[13]];
+            T1_local[8] = p[0] * A[indices[8]] + p[1] * A[indices[14]] + p[2] * A[indices[2]] + p[3] * A[indices[22]];
+            T1_local[9] = p[0] * A[indices[9]] + p[1] * A[indices[15]] + p[2] * A[indices[23]] + p[3] * A[indices[3]];
+            T1_local[10] = p[0] * A[indices[10]] + p[1] * A[indices[20]] + p[2] * A[indices[4]] + p[3] * A[indices[16]];
+            T1_local[11] = p[0] * A[indices[11]] + p[1] * A[indices[21]] + p[2] * A[indices[17]] + p[3] * A[indices[5]];
+            T1_local[12] = p[0] * A[indices[12]] + p[1] * A[indices[2]] + p[2] * A[indices[6]] + p[3] * A[indices[18]];
+            T1_local[13] = p[0] * A[indices[13]] + p[1] * A[indices[3]] + p[2] * A[indices[19]] + p[3] * A[indices[7]];
+            T1_local[14] = p[0] * A[indices[14]] + p[1] * A[indices[8]] + p[2] * A[indices[0]] + p[3] * A[indices[20]];
+            T1_local[15] = p[0] * A[indices[15]] + p[1] * A[indices[9]] + p[2] * A[indices[21]] + p[3] * A[indices[1]];
+            T1_local[16] = p[0] * A[indices[16]] + p[1] * A[indices[22]] + p[2] * A[indices[5]] + p[3] * A[indices[10]];
+            T1_local[17] = p[0] * A[indices[17]] + p[1] * A[indices[23]] + p[2] * A[indices[11]] + p[3] * A[indices[4]];
+            T1_local[18] = p[0] * A[indices[18]] + p[1] * A[indices[4]] + p[2] * A[indices[7]] + p[3] * A[indices[12]];
+            T1_local[19] = p[0] * A[indices[19]] + p[1] * A[indices[5]] + p[2] * A[indices[13]] + p[3] * A[indices[6]];
+            T1_local[20] = p[0] * A[indices[20]] + p[1] * A[indices[10]] + p[2] * A[indices[1]] + p[3] * A[indices[14]];
+            T1_local[21] = p[0] * A[indices[21]] + p[1] * A[indices[11]] + p[2] * A[indices[15]] + p[3] * A[indices[0]];
+            T1_local[22] = p[0] * A[indices[22]] + p[1] * A[indices[16]] + p[2] * A[indices[3]] + p[3] * A[indices[8]];
+            T1_local[23] = p[0] * A[indices[23]] + p[1] * A[indices[17]] + p[2] * A[indices[9]] + p[3] * A[indices[2]];
+
+            T2_local[0] = p[4] * T1_local[0] + p[5] * T1_local[2] + p[6] * T1_local[5];
+            T2_local[1] = p[4] * T1_local[1] + p[5] * T1_local[4] + p[6] * T1_local[3];
+            T2_local[2] = p[4] * T1_local[2] + p[5] * T1_local[0] + p[6] * T1_local[4];
+            T2_local[3] = p[4] * T1_local[3] + p[5] * T1_local[5] + p[6] * T1_local[1];
+            T2_local[4] = p[4] * T1_local[4] + p[5] * T1_local[1] + p[6] * T1_local[2];
+            T2_local[5] = p[4] * T1_local[5] + p[5] * T1_local[3] + p[6] * T1_local[0];
+            T2_local[6] = p[4] * T1_local[6] + p[5] * T1_local[8] + p[6] * T1_local[11];
+            T2_local[7] = p[4] * T1_local[7] + p[5] * T1_local[10] + p[6] * T1_local[9];
+            T2_local[8] = p[4] * T1_local[8] + p[5] * T1_local[6] + p[6] * T1_local[10];
+            T2_local[9] = p[4] * T1_local[9] + p[5] * T1_local[11] + p[6] * T1_local[7];
+            T2_local[10] = p[4] * T1_local[10] + p[5] * T1_local[7] + p[6] * T1_local[8];
+            T2_local[11] = p[4] * T1_local[11] + p[5] * T1_local[9] + p[6] * T1_local[6];
+            T2_local[12] = p[4] * T1_local[12] + p[5] * T1_local[14] + p[6] * T1_local[17];
+            T2_local[13] = p[4] * T1_local[13] + p[5] * T1_local[16] + p[6] * T1_local[15];
+            T2_local[14] = p[4] * T1_local[14] + p[5] * T1_local[12] + p[6] * T1_local[16];
+            T2_local[15] = p[4] * T1_local[15] + p[5] * T1_local[17] + p[6] * T1_local[13];
+            T2_local[16] = p[4] * T1_local[16] + p[5] * T1_local[13] + p[6] * T1_local[14];
+            T2_local[17] = p[4] * T1_local[17] + p[5] * T1_local[15] + p[6] * T1_local[12];
+            T2_local[18] = p[4] * T1_local[18] + p[5] * T1_local[20] + p[6] * T1_local[23];
+            T2_local[19] = p[4] * T1_local[19] + p[5] * T1_local[22] + p[6] * T1_local[21];
+            T2_local[20] = p[4] * T1_local[20] + p[5] * T1_local[18] + p[6] * T1_local[22];
+            T2_local[21] = p[4] * T1_local[21] + p[5] * T1_local[23] + p[6] * T1_local[19];
+            T2_local[22] = p[4] * T1_local[22] + p[5] * T1_local[19] + p[6] * T1_local[20];
+            T2_local[23] = p[4] * T1_local[23] + p[5] * T1_local[21] + p[6] * T1_local[18];
+
+            A[indices[0]] = alpha * (p[7] * T2_local[0] + p[8] * T2_local[1]) + beta * A[indices[0]];
+            A[indices[1]] = alpha * (p[7] * T2_local[1] + p[8] * T2_local[0]) + beta * A[indices[1]];
+            A[indices[2]] = alpha * (p[7] * T2_local[2] + p[8] * T2_local[3]) + beta * A[indices[2]];
+            A[indices[3]] = alpha * (p[7] * T2_local[3] + p[8] * T2_local[2]) + beta * A[indices[3]];
+            A[indices[4]] = alpha * (p[7] * T2_local[4] + p[8] * T2_local[5]) + beta * A[indices[4]];
+            A[indices[5]] = alpha * (p[7] * T2_local[5] + p[8] * T2_local[4]) + beta * A[indices[5]];
+            A[indices[6]] = alpha * (p[7] * T2_local[6] + p[8] * T2_local[7]) + beta * A[indices[6]];
+            A[indices[7]] = alpha * (p[7] * T2_local[7] + p[8] * T2_local[6]) + beta * A[indices[7]];
+            A[indices[8]] = alpha * (p[7] * T2_local[8] + p[8] * T2_local[9]) + beta * A[indices[8]];
+            A[indices[9]] = alpha * (p[7] * T2_local[9] + p[8] * T2_local[8]) + beta * A[indices[9]];
+            A[indices[10]] = alpha * (p[7] * T2_local[10] + p[8] * T2_local[11]) + beta * A[indices[10]];
+            A[indices[11]] = alpha * (p[7] * T2_local[11] + p[8] * T2_local[10]) + beta * A[indices[11]];
+            A[indices[12]] = alpha * (p[7] * T2_local[12] + p[8] * T2_local[13]) + beta * A[indices[12]];
+            A[indices[13]] = alpha * (p[7] * T2_local[13] + p[8] * T2_local[12]) + beta * A[indices[13]];
+            A[indices[14]] = alpha * (p[7] * T2_local[14] + p[8] * T2_local[15]) + beta * A[indices[14]];
+            A[indices[15]] = alpha * (p[7] * T2_local[15] + p[8] * T2_local[14]) + beta * A[indices[15]];
+            A[indices[16]] = alpha * (p[7] * T2_local[16] + p[8] * T2_local[17]) + beta * A[indices[16]];
+            A[indices[17]] = alpha * (p[7] * T2_local[17] + p[8] * T2_local[16]) + beta * A[indices[17]];
+            A[indices[18]] = alpha * (p[7] * T2_local[18] + p[8] * T2_local[19]) + beta * A[indices[18]];
+            A[indices[19]] = alpha * (p[7] * T2_local[19] + p[8] * T2_local[18]) + beta * A[indices[19]];
+            A[indices[20]] = alpha * (p[7] * T2_local[20] + p[8] * T2_local[21]) + beta * A[indices[20]];
+            A[indices[21]] = alpha * (p[7] * T2_local[21] + p[8] * T2_local[20]) + beta * A[indices[21]];
+            A[indices[22]] = alpha * (p[7] * T2_local[22] + p[8] * T2_local[23]) + beta * A[indices[22]];
+            A[indices[23]] = alpha * (p[7] * T2_local[23] + p[8] * T2_local[22]) + beta * A[indices[23]];
+        }
+        else if (a > b && b > c && c == d)
+        {
+            double T1_local[12];
+            double T2_local[12];
+
+            int64_t indices[12];
+            indices[0] = a * nvvv + b * nvv + c * nvir + c;
+            indices[1] = a * nvvv + c * nvv + b * nvir + c;
+            indices[2] = a * nvvv + c * nvv + c * nvir + b;
+            indices[3] = b * nvvv + a * nvv + c * nvir + c;
+            indices[4] = b * nvvv + c * nvv + a * nvir + c;
+            indices[5] = b * nvvv + c * nvv + c * nvir + a;
+            indices[6] = c * nvvv + a * nvv + b * nvir + c;
+            indices[7] = c * nvvv + a * nvv + c * nvir + b;
+            indices[8] = c * nvvv + b * nvv + a * nvir + c;
+            indices[9] = c * nvvv + b * nvv + c * nvir + a;
+            indices[10] = c * nvvv + c * nvv + a * nvir + b;
+            indices[11] = c * nvvv + c * nvv + b * nvir + a;
+
+            T1_local[0] = p[0] * A[indices[0]] + p[1] * A[indices[3]] + p[2] * A[indices[8]] + p[3] * A[indices[9]];
+            T1_local[1] = p[0] * A[indices[1]] + p[1] * A[indices[6]] + p[2] * A[indices[4]] + p[3] * A[indices[11]];
+            T1_local[2] = p[0] * A[indices[2]] + p[1] * A[indices[7]] + p[2] * A[indices[10]] + p[3] * A[indices[5]];
+            T1_local[3] = p[0] * A[indices[3]] + p[1] * A[indices[0]] + p[2] * A[indices[6]] + p[3] * A[indices[7]];
+            T1_local[4] = p[0] * A[indices[4]] + p[1] * A[indices[8]] + p[2] * A[indices[1]] + p[3] * A[indices[10]];
+            T1_local[5] = p[0] * A[indices[5]] + p[1] * A[indices[9]] + p[2] * A[indices[11]] + p[3] * A[indices[2]];
+            T1_local[6] = p[0] * A[indices[6]] + p[1] * A[indices[1]] + p[2] * A[indices[3]] + p[3] * A[indices[6]];
+            T1_local[7] = p[0] * A[indices[7]] + p[1] * A[indices[2]] + p[2] * A[indices[7]] + p[3] * A[indices[3]];
+            T1_local[8] = p[0] * A[indices[8]] + p[1] * A[indices[4]] + p[2] * A[indices[0]] + p[3] * A[indices[8]];
+            T1_local[9] = p[0] * A[indices[9]] + p[1] * A[indices[5]] + p[2] * A[indices[9]] + p[3] * A[indices[0]];
+            T1_local[10] = p[0] * A[indices[10]] + p[1] * A[indices[10]] + p[2] * A[indices[2]] + p[3] * A[indices[4]];
+            T1_local[11] = p[0] * A[indices[11]] + p[1] * A[indices[11]] + p[2] * A[indices[5]] + p[3] * A[indices[1]];
+
+            T2_local[0] = p[4] * T1_local[0] + p[5] * T1_local[1] + p[6] * T1_local[2];
+            T2_local[1] = p[4] * T1_local[1] + p[5] * T1_local[0] + p[6] * T1_local[1];
+            T2_local[2] = p[4] * T1_local[2] + p[5] * T1_local[2] + p[6] * T1_local[0];
+            T2_local[3] = p[4] * T1_local[3] + p[5] * T1_local[4] + p[6] * T1_local[5];
+            T2_local[4] = p[4] * T1_local[4] + p[5] * T1_local[3] + p[6] * T1_local[4];
+            T2_local[5] = p[4] * T1_local[5] + p[5] * T1_local[5] + p[6] * T1_local[3];
+            T2_local[6] = p[4] * T1_local[6] + p[5] * T1_local[8] + p[6] * T1_local[11];
+            T2_local[7] = p[4] * T1_local[7] + p[5] * T1_local[10] + p[6] * T1_local[9];
+            T2_local[8] = p[4] * T1_local[8] + p[5] * T1_local[6] + p[6] * T1_local[10];
+            T2_local[9] = p[4] * T1_local[9] + p[5] * T1_local[11] + p[6] * T1_local[7];
+            T2_local[10] = p[4] * T1_local[10] + p[5] * T1_local[7] + p[6] * T1_local[8];
+            T2_local[11] = p[4] * T1_local[11] + p[5] * T1_local[9] + p[6] * T1_local[6];
+
+            A[indices[0]] = alpha * (p[7] * T2_local[0] + p[8] * T2_local[0]) + beta * A[indices[0]];
+            A[indices[1]] = alpha * (p[7] * T2_local[1] + p[8] * T2_local[2]) + beta * A[indices[1]];
+            A[indices[2]] = alpha * (p[7] * T2_local[2] + p[8] * T2_local[1]) + beta * A[indices[2]];
+            A[indices[3]] = alpha * (p[7] * T2_local[3] + p[8] * T2_local[3]) + beta * A[indices[3]];
+            A[indices[4]] = alpha * (p[7] * T2_local[4] + p[8] * T2_local[5]) + beta * A[indices[4]];
+            A[indices[5]] = alpha * (p[7] * T2_local[5] + p[8] * T2_local[4]) + beta * A[indices[5]];
+            A[indices[6]] = alpha * (p[7] * T2_local[6] + p[8] * T2_local[7]) + beta * A[indices[6]];
+            A[indices[7]] = alpha * (p[7] * T2_local[7] + p[8] * T2_local[6]) + beta * A[indices[7]];
+            A[indices[8]] = alpha * (p[7] * T2_local[8] + p[8] * T2_local[9]) + beta * A[indices[8]];
+            A[indices[9]] = alpha * (p[7] * T2_local[9] + p[8] * T2_local[8]) + beta * A[indices[9]];
+            A[indices[10]] = alpha * (p[7] * T2_local[10] + p[8] * T2_local[11]) + beta * A[indices[10]];
+            A[indices[11]] = alpha * (p[7] * T2_local[11] + p[8] * T2_local[10]) + beta * A[indices[11]];
+        }
+        else if (a > b && b == c && c > d)
+        {
+            double T1_local[12];
+            double T2_local[12];
+
+            int64_t indices[12];
+            indices[0] = a * nvvv + b * nvv + b * nvir + d;
+            indices[1] = a * nvvv + b * nvv + d * nvir + b;
+            indices[2] = a * nvvv + d * nvv + b * nvir + b;
+            indices[3] = b * nvvv + a * nvv + b * nvir + d;
+            indices[4] = b * nvvv + a * nvv + d * nvir + b;
+            indices[5] = b * nvvv + b * nvv + a * nvir + d;
+            indices[6] = b * nvvv + b * nvv + d * nvir + a;
+            indices[7] = b * nvvv + d * nvv + a * nvir + b;
+            indices[8] = b * nvvv + d * nvv + b * nvir + a;
+            indices[9] = d * nvvv + a * nvv + b * nvir + b;
+            indices[10] = d * nvvv + b * nvv + a * nvir + b;
+            indices[11] = d * nvvv + b * nvv + b * nvir + a;
+
+            T1_local[0] = p[0] * A[indices[0]] + p[1] * A[indices[3]] + p[2] * A[indices[5]] + p[3] * A[indices[11]];
+            T1_local[1] = p[0] * A[indices[1]] + p[1] * A[indices[4]] + p[2] * A[indices[10]] + p[3] * A[indices[6]];
+            T1_local[2] = p[0] * A[indices[2]] + p[1] * A[indices[9]] + p[2] * A[indices[7]] + p[3] * A[indices[8]];
+            T1_local[3] = p[0] * A[indices[3]] + p[1] * A[indices[0]] + p[2] * A[indices[3]] + p[3] * A[indices[9]];
+            T1_local[4] = p[0] * A[indices[4]] + p[1] * A[indices[1]] + p[2] * A[indices[9]] + p[3] * A[indices[4]];
+            T1_local[5] = p[0] * A[indices[5]] + p[1] * A[indices[5]] + p[2] * A[indices[0]] + p[3] * A[indices[10]];
+            T1_local[6] = p[0] * A[indices[6]] + p[1] * A[indices[6]] + p[2] * A[indices[11]] + p[3] * A[indices[1]];
+            T1_local[7] = p[0] * A[indices[7]] + p[1] * A[indices[10]] + p[2] * A[indices[2]] + p[3] * A[indices[7]];
+            T1_local[8] = p[0] * A[indices[8]] + p[1] * A[indices[11]] + p[2] * A[indices[8]] + p[3] * A[indices[2]];
+            T1_local[9] = p[0] * A[indices[9]] + p[1] * A[indices[2]] + p[2] * A[indices[4]] + p[3] * A[indices[3]];
+            T1_local[10] = p[0] * A[indices[10]] + p[1] * A[indices[7]] + p[2] * A[indices[1]] + p[3] * A[indices[5]];
+            T1_local[11] = p[0] * A[indices[11]] + p[1] * A[indices[8]] + p[2] * A[indices[6]] + p[3] * A[indices[0]];
+
+            T2_local[0] = p[4] * T1_local[0] + p[5] * T1_local[0] + p[6] * T1_local[2];
+            T2_local[1] = p[4] * T1_local[1] + p[5] * T1_local[2] + p[6] * T1_local[1];
+            T2_local[2] = p[4] * T1_local[2] + p[5] * T1_local[1] + p[6] * T1_local[0];
+            T2_local[3] = p[4] * T1_local[3] + p[5] * T1_local[5] + p[6] * T1_local[8];
+            T2_local[4] = p[4] * T1_local[4] + p[5] * T1_local[7] + p[6] * T1_local[6];
+            T2_local[5] = p[4] * T1_local[5] + p[5] * T1_local[3] + p[6] * T1_local[7];
+            T2_local[6] = p[4] * T1_local[6] + p[5] * T1_local[8] + p[6] * T1_local[4];
+            T2_local[7] = p[4] * T1_local[7] + p[5] * T1_local[4] + p[6] * T1_local[5];
+            T2_local[8] = p[4] * T1_local[8] + p[5] * T1_local[6] + p[6] * T1_local[3];
+            T2_local[9] = p[4] * T1_local[9] + p[5] * T1_local[10] + p[6] * T1_local[11];
+            T2_local[10] = p[4] * T1_local[10] + p[5] * T1_local[9] + p[6] * T1_local[10];
+            T2_local[11] = p[4] * T1_local[11] + p[5] * T1_local[11] + p[6] * T1_local[9];
+
+            A[indices[0]] = alpha * (p[7] * T2_local[0] + p[8] * T2_local[1]) + beta * A[indices[0]];
+            A[indices[1]] = alpha * (p[7] * T2_local[1] + p[8] * T2_local[0]) + beta * A[indices[1]];
+            A[indices[2]] = alpha * (p[7] * T2_local[2] + p[8] * T2_local[2]) + beta * A[indices[2]];
+            A[indices[3]] = alpha * (p[7] * T2_local[3] + p[8] * T2_local[4]) + beta * A[indices[3]];
+            A[indices[4]] = alpha * (p[7] * T2_local[4] + p[8] * T2_local[3]) + beta * A[indices[4]];
+            A[indices[5]] = alpha * (p[7] * T2_local[5] + p[8] * T2_local[6]) + beta * A[indices[5]];
+            A[indices[6]] = alpha * (p[7] * T2_local[6] + p[8] * T2_local[5]) + beta * A[indices[6]];
+            A[indices[7]] = alpha * (p[7] * T2_local[7] + p[8] * T2_local[8]) + beta * A[indices[7]];
+            A[indices[8]] = alpha * (p[7] * T2_local[8] + p[8] * T2_local[7]) + beta * A[indices[8]];
+            A[indices[9]] = alpha * (p[7] * T2_local[9] + p[8] * T2_local[9]) + beta * A[indices[9]];
+            A[indices[10]] = alpha * (p[7] * T2_local[10] + p[8] * T2_local[11]) + beta * A[indices[10]];
+            A[indices[11]] = alpha * (p[7] * T2_local[11] + p[8] * T2_local[10]) + beta * A[indices[11]];
+        }
+        else if (a == b && b > c && c > d)
+        {
+            double T1_local[12];
+            double T2_local[12];
+
+            int64_t indices[12];
+            indices[0] = a * nvvv + a * nvv + c * nvir + d;
+            indices[1] = a * nvvv + a * nvv + d * nvir + c;
+            indices[2] = a * nvvv + c * nvv + a * nvir + d;
+            indices[3] = a * nvvv + c * nvv + d * nvir + a;
+            indices[4] = a * nvvv + d * nvv + a * nvir + c;
+            indices[5] = a * nvvv + d * nvv + c * nvir + a;
+            indices[6] = c * nvvv + a * nvv + a * nvir + d;
+            indices[7] = c * nvvv + a * nvv + d * nvir + a;
+            indices[8] = c * nvvv + d * nvv + a * nvir + a;
+            indices[9] = d * nvvv + a * nvv + a * nvir + c;
+            indices[10] = d * nvvv + a * nvv + c * nvir + a;
+            indices[11] = d * nvvv + c * nvv + a * nvir + a;
+
+            T1_local[0] = p[0] * A[indices[0]] + p[1] * A[indices[0]] + p[2] * A[indices[6]] + p[3] * A[indices[10]];
+            T1_local[1] = p[0] * A[indices[1]] + p[1] * A[indices[1]] + p[2] * A[indices[9]] + p[3] * A[indices[7]];
+            T1_local[2] = p[0] * A[indices[2]] + p[1] * A[indices[6]] + p[2] * A[indices[2]] + p[3] * A[indices[11]];
+            T1_local[3] = p[0] * A[indices[3]] + p[1] * A[indices[7]] + p[2] * A[indices[11]] + p[3] * A[indices[3]];
+            T1_local[4] = p[0] * A[indices[4]] + p[1] * A[indices[9]] + p[2] * A[indices[4]] + p[3] * A[indices[8]];
+            T1_local[5] = p[0] * A[indices[5]] + p[1] * A[indices[10]] + p[2] * A[indices[8]] + p[3] * A[indices[5]];
+            T1_local[6] = p[0] * A[indices[6]] + p[1] * A[indices[2]] + p[2] * A[indices[0]] + p[3] * A[indices[9]];
+            T1_local[7] = p[0] * A[indices[7]] + p[1] * A[indices[3]] + p[2] * A[indices[10]] + p[3] * A[indices[1]];
+            T1_local[8] = p[0] * A[indices[8]] + p[1] * A[indices[11]] + p[2] * A[indices[5]] + p[3] * A[indices[4]];
+            T1_local[9] = p[0] * A[indices[9]] + p[1] * A[indices[4]] + p[2] * A[indices[1]] + p[3] * A[indices[6]];
+            T1_local[10] = p[0] * A[indices[10]] + p[1] * A[indices[5]] + p[2] * A[indices[7]] + p[3] * A[indices[0]];
+            T1_local[11] = p[0] * A[indices[11]] + p[1] * A[indices[8]] + p[2] * A[indices[3]] + p[3] * A[indices[2]];
+
+            T2_local[0] = p[4] * T1_local[0] + p[5] * T1_local[2] + p[6] * T1_local[5];
+            T2_local[1] = p[4] * T1_local[1] + p[5] * T1_local[4] + p[6] * T1_local[3];
+            T2_local[2] = p[4] * T1_local[2] + p[5] * T1_local[0] + p[6] * T1_local[4];
+            T2_local[3] = p[4] * T1_local[3] + p[5] * T1_local[5] + p[6] * T1_local[1];
+            T2_local[4] = p[4] * T1_local[4] + p[5] * T1_local[1] + p[6] * T1_local[2];
+            T2_local[5] = p[4] * T1_local[5] + p[5] * T1_local[3] + p[6] * T1_local[0];
+            T2_local[6] = p[4] * T1_local[6] + p[5] * T1_local[6] + p[6] * T1_local[8];
+            T2_local[7] = p[4] * T1_local[7] + p[5] * T1_local[8] + p[6] * T1_local[7];
+            T2_local[8] = p[4] * T1_local[8] + p[5] * T1_local[7] + p[6] * T1_local[6];
+            T2_local[9] = p[4] * T1_local[9] + p[5] * T1_local[9] + p[6] * T1_local[11];
+            T2_local[10] = p[4] * T1_local[10] + p[5] * T1_local[11] + p[6] * T1_local[10];
+            T2_local[11] = p[4] * T1_local[11] + p[5] * T1_local[10] + p[6] * T1_local[9];
+
+            A[indices[0]] = alpha * (p[7] * T2_local[0] + p[8] * T2_local[1]) + beta * A[indices[0]];
+            A[indices[1]] = alpha * (p[7] * T2_local[1] + p[8] * T2_local[0]) + beta * A[indices[1]];
+            A[indices[2]] = alpha * (p[7] * T2_local[2] + p[8] * T2_local[3]) + beta * A[indices[2]];
+            A[indices[3]] = alpha * (p[7] * T2_local[3] + p[8] * T2_local[2]) + beta * A[indices[3]];
+            A[indices[4]] = alpha * (p[7] * T2_local[4] + p[8] * T2_local[5]) + beta * A[indices[4]];
+            A[indices[5]] = alpha * (p[7] * T2_local[5] + p[8] * T2_local[4]) + beta * A[indices[5]];
+            A[indices[6]] = alpha * (p[7] * T2_local[6] + p[8] * T2_local[7]) + beta * A[indices[6]];
+            A[indices[7]] = alpha * (p[7] * T2_local[7] + p[8] * T2_local[6]) + beta * A[indices[7]];
+            A[indices[8]] = alpha * (p[7] * T2_local[8] + p[8] * T2_local[8]) + beta * A[indices[8]];
+            A[indices[9]] = alpha * (p[7] * T2_local[9] + p[8] * T2_local[10]) + beta * A[indices[9]];
+            A[indices[10]] = alpha * (p[7] * T2_local[10] + p[8] * T2_local[9]) + beta * A[indices[10]];
+            A[indices[11]] = alpha * (p[7] * T2_local[11] + p[8] * T2_local[11]) + beta * A[indices[11]];
+        }
+        else if (a > b && b == c && c == d)
+        {
+            double T1_local[4];
+            double T2_local[4];
+
+            int64_t indices[4];
+            indices[0] = a * nvvv + b * nvv + b * nvir + b;
+            indices[1] = b * nvvv + a * nvv + b * nvir + b;
+            indices[2] = b * nvvv + b * nvv + a * nvir + b;
+            indices[3] = b * nvvv + b * nvv + b * nvir + a;
+
+            T1_local[0] = p[0] * A[indices[0]] + p[1] * A[indices[1]] + p[2] * A[indices[2]] + p[3] * A[indices[3]];
+            T1_local[1] = p[0] * A[indices[1]] + p[1] * A[indices[0]] + p[2] * A[indices[1]] + p[3] * A[indices[1]];
+            T1_local[2] = p[0] * A[indices[2]] + p[1] * A[indices[2]] + p[2] * A[indices[0]] + p[3] * A[indices[2]];
+            T1_local[3] = p[0] * A[indices[3]] + p[1] * A[indices[3]] + p[2] * A[indices[3]] + p[3] * A[indices[0]];
+
+            T2_local[0] = p[4] * T1_local[0] + p[5] * T1_local[0] + p[6] * T1_local[0];
+            T2_local[1] = p[4] * T1_local[1] + p[5] * T1_local[2] + p[6] * T1_local[3];
+            T2_local[2] = p[4] * T1_local[2] + p[5] * T1_local[1] + p[6] * T1_local[2];
+            T2_local[3] = p[4] * T1_local[3] + p[5] * T1_local[3] + p[6] * T1_local[1];
+
+            A[indices[0]] = alpha * (p[7] * T2_local[0] + p[8] * T2_local[0]) + beta * A[indices[0]];
+            A[indices[1]] = alpha * (p[7] * T2_local[1] + p[8] * T2_local[1]) + beta * A[indices[1]];
+            A[indices[2]] = alpha * (p[7] * T2_local[2] + p[8] * T2_local[3]) + beta * A[indices[2]];
+            A[indices[3]] = alpha * (p[7] * T2_local[3] + p[8] * T2_local[2]) + beta * A[indices[3]];
+        }
+        else if (a == b && b == c && c > d)
+        {
+            double T1_local[4];
+            double T2_local[4];
+
+            int64_t indices[4];
+            indices[0] = a * nvvv + a * nvv + a * nvir + d;
+            indices[1] = a * nvvv + a * nvv + d * nvir + a;
+            indices[2] = a * nvvv + d * nvv + a * nvir + a;
+            indices[3] = d * nvvv + a * nvv + a * nvir + a;
+
+            T1_local[0] = p[0] * A[indices[0]] + p[1] * A[indices[0]] + p[2] * A[indices[0]] + p[3] * A[indices[3]];
+            T1_local[1] = p[0] * A[indices[1]] + p[1] * A[indices[1]] + p[2] * A[indices[3]] + p[3] * A[indices[1]];
+            T1_local[2] = p[0] * A[indices[2]] + p[1] * A[indices[3]] + p[2] * A[indices[2]] + p[3] * A[indices[2]];
+            T1_local[3] = p[0] * A[indices[3]] + p[1] * A[indices[2]] + p[2] * A[indices[1]] + p[3] * A[indices[0]];
+
+            T2_local[0] = p[4] * T1_local[0] + p[5] * T1_local[0] + p[6] * T1_local[2];
+            T2_local[1] = p[4] * T1_local[1] + p[5] * T1_local[2] + p[6] * T1_local[1];
+            T2_local[2] = p[4] * T1_local[2] + p[5] * T1_local[1] + p[6] * T1_local[0];
+            T2_local[3] = p[4] * T1_local[3] + p[5] * T1_local[3] + p[6] * T1_local[3];
+
+            A[indices[0]] = alpha * (p[7] * T2_local[0] + p[8] * T2_local[1]) + beta * A[indices[0]];
+            A[indices[1]] = alpha * (p[7] * T2_local[1] + p[8] * T2_local[0]) + beta * A[indices[1]];
+            A[indices[2]] = alpha * (p[7] * T2_local[2] + p[8] * T2_local[2]) + beta * A[indices[2]];
+            A[indices[3]] = alpha * (p[7] * T2_local[3] + p[8] * T2_local[3]) + beta * A[indices[3]];
+        }
+        else if (a == b && b > c && c == d)
+        {
+            double T1_local[6];
+            double T2_local[6];
+
+            int64_t indices[6];
+            indices[0] = b * nvvv + b * nvv + c * nvir + c;
+            indices[1] = b * nvvv + c * nvv + b * nvir + c;
+            indices[2] = b * nvvv + c * nvv + c * nvir + b;
+            indices[3] = c * nvvv + b * nvv + b * nvir + c;
+            indices[4] = c * nvvv + b * nvv + c * nvir + b;
+            indices[5] = c * nvvv + c * nvv + b * nvir + b;
+
+            T1_local[0] = p[0] * A[indices[0]] + p[1] * A[indices[0]] + p[2] * A[indices[3]] + p[3] * A[indices[4]];
+            T1_local[1] = p[0] * A[indices[1]] + p[1] * A[indices[3]] + p[2] * A[indices[1]] + p[3] * A[indices[5]];
+            T1_local[2] = p[0] * A[indices[2]] + p[1] * A[indices[4]] + p[2] * A[indices[5]] + p[3] * A[indices[2]];
+            T1_local[3] = p[0] * A[indices[3]] + p[1] * A[indices[1]] + p[2] * A[indices[0]] + p[3] * A[indices[3]];
+            T1_local[4] = p[0] * A[indices[4]] + p[1] * A[indices[2]] + p[2] * A[indices[4]] + p[3] * A[indices[0]];
+            T1_local[5] = p[0] * A[indices[5]] + p[1] * A[indices[5]] + p[2] * A[indices[2]] + p[3] * A[indices[1]];
+
+            T2_local[0] = p[4] * T1_local[0] + p[5] * T1_local[1] + p[6] * T1_local[2];
+            T2_local[1] = p[4] * T1_local[1] + p[5] * T1_local[0] + p[6] * T1_local[1];
+            T2_local[2] = p[4] * T1_local[2] + p[5] * T1_local[2] + p[6] * T1_local[0];
+            T2_local[3] = p[4] * T1_local[3] + p[5] * T1_local[3] + p[6] * T1_local[5];
+            T2_local[4] = p[4] * T1_local[4] + p[5] * T1_local[5] + p[6] * T1_local[4];
+            T2_local[5] = p[4] * T1_local[5] + p[5] * T1_local[4] + p[6] * T1_local[3];
+
+            A[indices[0]] = alpha * (p[7] * T2_local[0] + p[8] * T2_local[0]) + beta * A[indices[0]];
+            A[indices[1]] = alpha * (p[7] * T2_local[1] + p[8] * T2_local[2]) + beta * A[indices[1]];
+            A[indices[2]] = alpha * (p[7] * T2_local[2] + p[8] * T2_local[1]) + beta * A[indices[2]];
+            A[indices[3]] = alpha * (p[7] * T2_local[3] + p[8] * T2_local[4]) + beta * A[indices[3]];
+            A[indices[4]] = alpha * (p[7] * T2_local[4] + p[8] * T2_local[3]) + beta * A[indices[4]];
+            A[indices[5]] = alpha * (p[7] * T2_local[5] + p[8] * T2_local[5]) + beta * A[indices[5]];
+        }
+        else if (a == b && b == c && c == d)
+        {
+            double T1_local[1];
+            double T2_local[1];
+
+            int64_t indices[1];
+            indices[0] = a * nvvv + a * nvv + a * nvir + a;
+
+            T1_local[0] = p[0] * A[indices[0]] + p[1] * A[indices[0]] + p[2] * A[indices[0]] + p[3] * A[indices[0]];
+
+            T2_local[0] = p[4] * T1_local[0] + p[5] * T1_local[0] + p[6] * T1_local[0];
+
+            A[indices[0]] = alpha * (p[7] * T2_local[0] + p[8] * T2_local[0]) + beta * A[indices[0]];
+        }
+    }
+}
+
 // Apply permutation-symmetry projection to T4 amplitudes in place.
 // A = beta * A + alpha * P(A)
 // where P(A) ijklabcd = ijklabcd + ijlkabdc + ...
@@ -1256,6 +1766,38 @@ void eijkl_division_(double *r4, const double *eia, const int64_t nocc, const in
     }
 }
 
+void eijkl_division_single_(double *r4, const double *e_occ, const double *e_vir,
+                            const int64_t i, const int64_t j, const int64_t k, const int64_t l, const int64_t nvir)
+{
+    double eijkl = e_occ[i] + e_occ[j] + e_occ[k] + e_occ[l];
+
+#pragma omp parallel for collapse(4) schedule(static)
+    for (int64_t a = 0; a < nvir; a++)
+    {
+        for (int64_t b = 0; b < nvir; b++)
+        {
+            for (int64_t c = 0; c < nvir; c++)
+            {
+                for (int64_t d = 0; d < nvir; d++)
+                {
+                    int64_t r4_idx = ((a * nvir + b) * nvir + c) * nvir + d;
+
+                    double eijklabcd = eijkl - e_vir[a] - e_vir[b] - e_vir[c] - e_vir[d];
+
+                    if (fabs(eijklabcd) > 1e-15)
+                    {
+                        r4[r4_idx] /= eijklabcd;
+                    }
+                    else
+                    {
+                        r4[r4_idx] = 0.0;
+                    }
+                }
+            }
+        }
+    }
+}
+
 void t4_add_(double *t4, const double *r4, const int64_t nocc4, const int64_t nvir)
 {
     const int64_t total_size = nocc4 * nvir * nvir * nvir * nvir;
@@ -1294,6 +1836,18 @@ const int64_t tp_t4[24][4] = {
     {3, 2, 1, 0},
 };
 
+static inline int64_t src_idx_from_full4(const int64_t *restrict perm, int64_t v0, int64_t v1, int64_t v2, int64_t v3, int64_t nvir)
+{
+    int64_t src_abcd[4];
+
+    src_abcd[perm[0]] = v0;
+    src_abcd[perm[1]] = v1;
+    src_abcd[perm[2]] = v2;
+    src_abcd[perm[3]] = v3;
+
+    return (((src_abcd[0] * nvir + src_abcd[1]) * nvir + src_abcd[2]) * nvir + src_abcd[3]);
+}
+
 // Unpack triangular-stored T4 amplitudes into a full T4 block.
 //
 // This kernel reconstructs the full permutation-expanded T4 tensor block from the compressed triangular
@@ -1320,6 +1874,7 @@ void unpack_t4_tri2block_(const double *restrict t4_tri,
 {
 #define MAP(sym, w, x, y, z) map[((((sym) * nocc + (w)) * nocc + (x)) * nocc + (y)) * nocc + (z)]
 #define MASK(sym, w, x, y, z) mask[((((sym) * nocc + (w)) * nocc + (x)) * nocc + (y)) * nocc + (z)]
+#define VIDX(a, b, c, d) ((((a) * nvir + (b)) * nvir + (c)) * nvir + (d))
 
 #pragma omp parallel for collapse(5) schedule(dynamic)
     for (int64_t sym = 0; sym < 24; ++sym)
@@ -1353,16 +1908,10 @@ void unpack_t4_tri2block_(const double *restrict t4_tri,
                                 {
                                     for (int64_t d = 0; d < nvir; ++d)
                                     {
-                                        int64_t abcd[4] = {a, b, c, d};
-                                        int64_t aa = abcd[perm[0]];
-                                        int64_t bb = abcd[perm[1]];
-                                        int64_t cc = abcd[perm[2]];
-                                        int64_t dd = abcd[perm[3]];
+                                        int64_t src = src_base + src_idx_from_full4(perm, a, b, c, d, nvir);
+                                        int64_t dest = dest_base + VIDX(a, b, c, d);
 
-                                        int64_t src_idx = src_base + ((a * nvir + b) * nvir + c) * nvir + d;
-                                        int64_t dest_idx = dest_base + ((aa * nvir + bb) * nvir + cc) * nvir + dd;
-
-                                        t4_blk[dest_idx] = t4_tri[src_idx];
+                                        t4_blk[dest] = t4_tri[src];
                                     }
                                 }
                             }
@@ -1372,6 +1921,79 @@ void unpack_t4_tri2block_(const double *restrict t4_tri,
             }
         }
     }
+#undef MAP
+#undef MASK
+}
+
+// Unpack triangular-stored T4 amplitudes directly into the final block:
+//
+//   t4_tmp + t4_tmp.transpose(0, 1, 2, 3, 5, 6, 4, 7) + t4_tmp.transpose(0, 1, 2, 3, 5, 7, 6, 4)
+//
+void unpack_t4_tri2block_triples_(const double *restrict t4_tri,
+                                  double *restrict t4_blk,
+                                  const int64_t *restrict map,
+                                  const bool *restrict mask,
+                                  int64_t i0, int64_t i1,
+                                  int64_t j0, int64_t j1,
+                                  int64_t k0, int64_t k1,
+                                  int64_t l0, int64_t l1,
+                                  int64_t nocc, int64_t nvir,
+                                  int64_t blk_i, int64_t blk_j, int64_t blk_k, int64_t blk_l)
+{
+#define MAP(sym, w, x, y, z) map[((((sym) * nocc + (w)) * nocc + (x)) * nocc + (y)) * nocc + (z)]
+#define MASK(sym, w, x, y, z) mask[((((sym) * nocc + (w)) * nocc + (x)) * nocc + (y)) * nocc + (z)]
+#define VIDX(a, b, c, d) ((((a) * nvir + (b)) * nvir + (c)) * nvir + (d))
+
+    const int64_t nvir4 = nvir * nvir * nvir * nvir;
+
+#pragma omp parallel for collapse(5) schedule(dynamic)
+    for (int64_t sym = 0; sym < 24; ++sym)
+    {
+        for (int64_t i = i0; i < i1; ++i)
+        {
+            for (int64_t j = j0; j < j1; ++j)
+            {
+                for (int64_t k = k0; k < k1; ++k)
+                {
+                    for (int64_t l = l0; l < l1; ++l)
+                    {
+                        if (!MASK(sym, i, j, k, l))
+                            continue;
+
+                        const int64_t *perm = tp_t4[sym];
+
+                        const int64_t loc_i = i - i0;
+                        const int64_t loc_j = j - j0;
+                        const int64_t loc_k = k - k0;
+                        const int64_t loc_l = l - l0;
+
+                        const int64_t src_base = MAP(sym, i, j, k, l) * nvir4;
+
+                        const int64_t dest_base = (((loc_i * blk_j + loc_j) * blk_k + loc_k) * blk_l + loc_l) * nvir4;
+
+                        for (int64_t a = 0; a < nvir; ++a)
+                        {
+                            for (int64_t b = 0; b < nvir; ++b)
+                            {
+                                for (int64_t c = 0; c < nvir; ++c)
+                                {
+                                    for (int64_t d = 0; d < nvir; ++d)
+                                    {
+                                        const int64_t src0 = src_base + src_idx_from_full4(perm, a, b, c, d, nvir);
+                                        const int64_t src1 = src_base + src_idx_from_full4(perm, c, a, b, d, nvir);
+                                        const int64_t src2 = src_base + src_idx_from_full4(perm, d, a, c, b, nvir);
+                                        const int64_t dest = dest_base + VIDX(a, b, c, d);
+                                        t4_blk[dest] = t4_tri[src0] + t4_tri[src1] + t4_tri[src2];
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+#undef VIDX
 #undef MAP
 #undef MASK
 }
@@ -1451,4 +2073,325 @@ void accumulate_t4_block2tri_(double *restrict t4_tri,
         }
     }
 #undef MAP
+}
+
+const int64_t swap_pairs[6][2] = {
+    {0, 1}, // ab
+    {0, 2}, // ac
+    {0, 3}, // ad
+    {1, 2}, // bc
+    {1, 3}, // bd
+    {2, 3}  // cd
+};
+
+static inline int64_t idx4(int64_t a, int64_t b, int64_t c, int64_t d, int64_t nvir, int64_t nvv, int64_t nvvv)
+{
+    return a * nvvv + b * nvv + c * nvir + d;
+}
+
+static inline void swap4(int64_t in[4], int p, int q, int64_t out[4])
+{
+    out[0] = in[0];
+    out[1] = in[1];
+    out[2] = in[2];
+    out[3] = in[3];
+
+    int64_t tmp = out[p];
+    out[p] = out[q];
+    out[q] = tmp;
+}
+
+static inline int same_tuple4(int64_t x[4], int64_t y[4])
+{
+    return x[0] == y[0] && x[1] == y[1] && x[2] == y[2] && x[3] == y[3];
+}
+
+static int find_tuple4(int64_t tuples[24][4], int ntuples, int64_t target[4])
+{
+    for (int i = 0; i < ntuples; i++)
+    {
+        if (same_tuple4(tuples[i], target))
+            return i;
+    }
+
+    fprintf(stderr, "Error: tuple not found in orbit.\n");
+    return -1;
+}
+
+static void apply_omega_local(double *y, const double *x, int64_t tuples[24][4], int ntuples)
+{
+    for (int i = 0; i < ntuples; i++)
+    {
+        y[i] = 0.0;
+
+        for (int s = 0; s < 6; s++)
+        {
+            int64_t target[4];
+            swap4(tuples[i], swap_pairs[s][0], swap_pairs[s][1], target);
+
+            int j = find_tuple4(tuples, ntuples, target);
+            y[i] += x[j];
+        }
+    }
+}
+
+static int build_unique_orbit(int64_t a, int64_t b, int64_t c, int64_t d, int64_t tuples[24][4])
+{
+    int64_t base[4] = {a, b, c, d};
+    int ntuples = 0;
+
+    for (int p = 0; p < 24; p++)
+    {
+        int64_t cand[4] = {base[tp_t4[p][0]], base[tp_t4[p][1]], base[tp_t4[p][2]], base[tp_t4[p][3]]};
+
+        int duplicate = 0;
+        for (int q = 0; q < ntuples; q++)
+        {
+            if (same_tuple4(tuples[q], cand))
+            {
+                duplicate = 1;
+                break;
+            }
+        }
+
+        if (!duplicate)
+        {
+            tuples[ntuples][0] = cand[0];
+            tuples[ntuples][1] = cand[1];
+            tuples[ntuples][2] = cand[2];
+            tuples[ntuples][3] = cand[3];
+            ntuples++;
+        }
+    }
+    return ntuples;
+}
+
+static int s_omega_action_24[24][6];
+static int s_omega_action_24_ready = 0;
+
+static void init_omega_action_24(void)
+{
+    if (s_omega_action_24_ready)
+        return;
+
+    int rev[4][4][4][4];
+    for (int p = 0; p < 24; p++)
+        rev[tp_t4[p][0]][tp_t4[p][1]][tp_t4[p][2]][tp_t4[p][3]] = p;
+
+    for (int p = 0; p < 24; p++)
+        for (int s = 0; s < 6; s++)
+        {
+            int t[4] = {tp_t4[p][0], tp_t4[p][1], tp_t4[p][2], tp_t4[p][3]};
+            int i = swap_pairs[s][0], j = swap_pairs[s][1];
+            int tmp = t[i];
+            t[i] = t[j];
+            t[j] = tmp;
+            s_omega_action_24[p][s] = rev[t[0]][t[1]][t[2]][t[3]];
+        }
+    s_omega_action_24_ready = 1;
+}
+
+static inline void apply_omega_24(double *restrict y, const double *restrict x)
+{
+    for (int p = 0; p < 24; p++)
+        y[p] = x[s_omega_action_24[p][0]] + x[s_omega_action_24[p][1]] + x[s_omega_action_24[p][2]] + x[s_omega_action_24[p][3]] + x[s_omega_action_24[p][4]] + x[s_omega_action_24[p][5]];
+}
+
+static inline void project_orbit_(double *restrict A, int64_t h, int64_t a, int64_t b, int64_t c, int64_t d,
+                                  int64_t nvir, int64_t nvv, int64_t nvvv, double alpha, double beta)
+{
+    if (a > b && b > c && c > d)
+    {
+        int64_t idx[24];
+        idx[0] = a * nvvv + b * nvv + c * nvir + d;
+        idx[1] = a * nvvv + b * nvv + d * nvir + c;
+        idx[2] = a * nvvv + c * nvv + b * nvir + d;
+        idx[3] = a * nvvv + c * nvv + d * nvir + b;
+        idx[4] = a * nvvv + d * nvv + b * nvir + c;
+        idx[5] = a * nvvv + d * nvv + c * nvir + b;
+        idx[6] = b * nvvv + a * nvv + c * nvir + d;
+        idx[7] = b * nvvv + a * nvv + d * nvir + c;
+        idx[8] = b * nvvv + c * nvv + a * nvir + d;
+        idx[9] = b * nvvv + c * nvv + d * nvir + a;
+        idx[10] = b * nvvv + d * nvv + a * nvir + c;
+        idx[11] = b * nvvv + d * nvv + c * nvir + a;
+        idx[12] = c * nvvv + a * nvv + b * nvir + d;
+        idx[13] = c * nvvv + a * nvv + d * nvir + b;
+        idx[14] = c * nvvv + b * nvv + a * nvir + d;
+        idx[15] = c * nvvv + b * nvv + d * nvir + a;
+        idx[16] = c * nvvv + d * nvv + a * nvir + b;
+        idx[17] = c * nvvv + d * nvv + b * nvir + a;
+        idx[18] = d * nvvv + a * nvv + b * nvir + c;
+        idx[19] = d * nvvv + a * nvv + c * nvir + b;
+        idx[20] = d * nvvv + b * nvv + a * nvir + c;
+        idx[21] = d * nvvv + b * nvv + c * nvir + a;
+        idx[22] = d * nvvv + c * nvv + a * nvir + b;
+        idx[23] = d * nvvv + c * nvv + b * nvir + a;
+
+        double x[24], x1[24], x2[24], x3[24], x4[24], y[24];
+        for (int p = 0; p < 24; p++)
+            x[p] = A[h + idx[p]];
+
+        apply_omega_24(x1, x);
+        for (int p = 0; p < 24; p++)
+            x1[p] -= 6.0 * x[p];
+
+        apply_omega_24(x2, x1);
+        for (int p = 0; p < 24; p++)
+            x2[p] -= 2.0 * x1[p];
+
+        apply_omega_24(x3, x2);
+        apply_omega_24(x4, x3);
+
+        for (int p = 0; p < 24; p++)
+            y[p] = (2.0 * x4[p] + 19.0 * x3[p] + 48.0 * x2[p]) / 576.0;
+
+        for (int p = 0; p < 24; p++)
+            A[h + idx[p]] = beta * x[p] + alpha * y[p];
+    }
+    else
+    {
+        int64_t tuples[24][4];
+        int64_t indices[24];
+        int perm_map[24][6];
+        double x[24], x1[24], x2[24], x3[24], x4[24], y[24];
+        static const int swaps[6][2] = {{0, 1}, {0, 2}, {0, 3}, {1, 2}, {1, 3}, {2, 3}};
+
+        int ntuples = build_unique_orbit(a, b, c, d, tuples);
+
+        for (int p = 0; p < ntuples; p++)
+            for (int s = 0; s < 6; s++)
+            {
+                int64_t target[4];
+                swap4(tuples[p], swaps[s][0], swaps[s][1], target);
+                perm_map[p][s] = find_tuple4(tuples, ntuples, target);
+            }
+        for (int p = 0; p < ntuples; p++)
+        {
+            indices[p] = idx4(tuples[p][0], tuples[p][1], tuples[p][2], tuples[p][3], nvir, nvv, nvvv);
+            x[p] = A[h + indices[p]];
+        }
+        for (int p = 0; p < ntuples; p++)
+        {
+            double om = 0.0;
+            for (int s = 0; s < 6; s++)
+                om += x[perm_map[p][s]];
+            x1[p] = om - 6.0 * x[p];
+        }
+        for (int p = 0; p < ntuples; p++)
+        {
+            double om = 0.0;
+            for (int s = 0; s < 6; s++)
+                om += x1[perm_map[p][s]];
+            x2[p] = om - 2.0 * x1[p];
+        }
+        for (int p = 0; p < ntuples; p++)
+        {
+            double om = 0.0;
+            for (int s = 0; s < 6; s++)
+                om += x2[perm_map[p][s]];
+            x3[p] = om;
+        }
+        for (int p = 0; p < ntuples; p++)
+        {
+            double om = 0.0;
+            for (int s = 0; s < 6; s++)
+                om += x3[perm_map[p][s]];
+            x4[p] = om;
+        }
+        for (int p = 0; p < ntuples; p++)
+            y[p] = (2.0 * x4[p] + 19.0 * x3[p] + 48.0 * x2[p]) / 576.0;
+        for (int p = 0; p < ntuples; p++)
+            A[h + indices[p]] = beta * x[p] + alpha * y[p];
+    }
+}
+
+void t4_project_1_minus_p4_p31_inplace_(double *A, int64_t nocc4, int64_t nvir, double alpha, double beta)
+{
+    init_omega_action_24();
+    int64_t nvv = nvir * nvir;
+    int64_t nvvv = nvir * nvv;
+    int64_t nvvvv = nvir * nvvv;
+    const int64_t bl = 8;
+
+#pragma omp parallel for schedule(static)
+    for (int64_t ijkl = 0; ijkl < nocc4; ijkl++)
+    {
+        int64_t h = ijkl * nvvvv;
+        for (int64_t a0 = 0; a0 < nvir; a0 += bl)
+            for (int64_t b0 = 0; b0 <= a0; b0 += bl)
+                for (int64_t c0 = 0; c0 <= b0; c0 += bl)
+                    for (int64_t d0 = 0; d0 <= c0; d0 += bl)
+                        for (int64_t a = a0; a < a0 + bl && a < nvir; a++)
+                            for (int64_t b = b0; b < b0 + bl && b <= a; b++)
+                                for (int64_t c = c0; c < c0 + bl && c <= b; c++)
+                                    for (int64_t d = d0; d < d0 + bl && d <= c; d++)
+                                        project_orbit_(A, h, a, b, c, d, nvir, nvv, nvvv, alpha, beta);
+    }
+}
+
+void r4_tri_divide_e_(double *restrict r4_tri, const double *restrict eia, int64_t nocc, int64_t nvir)
+{
+    const int64_t nvir2 = nvir * nvir;
+    const int64_t nvir3 = nvir2 * nvir;
+    const int64_t nvir4 = nvir3 * nvir;
+
+    int64_t *i_start = (int64_t *)malloc((size_t)(nocc + 1) * sizeof(int64_t));
+    if (!i_start)
+    {
+        fprintf(stderr, "r4_tri_divide_e_: malloc failed\n");
+        return;
+    }
+    i_start[0] = 0;
+    for (int64_t i = 1; i <= nocc; i++)
+    {
+        int64_t m = nocc - i + 1;
+        i_start[i] = i_start[i - 1] + m * (m + 1) * (m + 2) / 6;
+    }
+
+#pragma omp parallel for schedule(dynamic)
+    for (int64_t i = 0; i < nocc; i++)
+    {
+        int64_t idx = i_start[i];
+        const double *eia_i = eia + i * nvir;
+        for (int64_t j = i; j < nocc; j++)
+        {
+            const double *eia_j = eia + j * nvir;
+            for (int64_t k = j; k < nocc; k++)
+            {
+                const double *eia_k = eia + k * nvir;
+                for (int64_t l = k; l < nocc; l++, idx++)
+                {
+                    const double *eia_l = eia + l * nvir;
+                    double *blk = r4_tri + idx * nvir4;
+                    for (int64_t a = 0; a < nvir; a++)
+                    {
+                        double eia_ia = eia_i[a];
+                        for (int64_t b = 0; b < nvir; b++)
+                        {
+                            double eijab = eia_ia + eia_j[b];
+                            for (int64_t c = 0; c < nvir; c++)
+                            {
+                                double eijkabc = eijab + eia_k[c];
+                                double *ptr = blk + a * nvir3 + b * nvir2 + c * nvir;
+                                for (int64_t d = 0; d < nvir; d++)
+                                {
+                                    if (fabs(eijkabc + eia_l[d]) > 1e-15)
+                                    {
+                                        ptr[d] /= eijkabc + eia_l[d];
+                                    }
+                                    else
+                                    {
+                                        ptr[d] = 0.0;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    free(i_start);
 }

--- a/pyscf/lib/ccsdt/rccsdtq.c
+++ b/pyscf/lib/ccsdt/rccsdtq.c
@@ -27,7 +27,7 @@
 // Apply spin summation projection to T4 amplitudes in place.
 // A: pointer to T4 tensor (size nocc4 * nvir**4)
 // pattern: "P4_full" : P(A) = (1 + P_c^d) (1 + P_b^c + P_b^d) (1 + P_a^b + P_a^c + P_a^d) A
-//         "P4_444"  : P(A) = (2 - P_c^d) (2 - P_b^c - P_b^d) (2 - P_a^b - P_a^c - P_a^d) A
+//          "P4_444"  : P(A) = (2 - P_c^d) (2 - P_b^c - P_b^d) (2 - P_a^b - P_a^c - P_a^d) A
 //          "P4_422"  : P(A) = (1 + 0 * P_c^d) (2 - P_b^c - P_b^d) (2 - P_a^b - P_a^c - P_a^d) A
 //          "P4_201"  : P(A) = (1 + 0 * P_c^d) (1 + 0 * P_b^c + 0 * P_b^d) (2 - P_a^b - P_a^c - P_a^d) A
 // alpha, beta: A = beta * A + alpha * P(A)


### PR DESCRIPTION
Dear PySCF developers,

This PR improves the high-order coupled-cluster implementations and adds new perturbative quadruples corrections, RCCSDT[Q] and RCCSDT(Q), on top of RCCSDT.

New feature:

- Add [Q]/(Q) correction implementations in `rccsdt_q.py`, with the relevant C functions added in `rccsdtq.c`, together with unit tests and examples. The implementation follows the framework of [J. Chem. Phys. 142, 064108 (2015)], and can be used with both the compact T3 implementation in `rccsdt.py` and the full T3 implementation in `rccsdt_highm.py`.

Improvements:

- Unify intermediate construction for low- and high-order amplitude updates in RCCSDT, RCCSDTQ, and UCCSDT. For example, the `W_ovvo` intermediate is now reused in `rccsdt.py` for both T2 and T3 updates.
- Refactor the code to reduce redundant unpacking operations and tensor contractions, which slightly improves the performance.
- Replace the previous partial projector for T4 amplitudes in RCCSDTQ with a complete orthogonalization projector to remove linearly dependent components, which improves convergence robustness in difficult cases.
- Update all amplitudes synchronously at the end of each iteration. This change does not affect converged energies, but it can change early-iteration energy values and the number of iterations required for convergence. As a result, the reference values in affected iteration-specific tests have been updated accordingly.
- Fix typos and minor code/documentation issues.