### PR TITLE
Added self-consistent dipole corrections for slab/2D systems

### DIFF
--- a/examples/pbc/49-slab_dipole_correction.py
+++ b/examples/pbc/49-slab_dipole_correction.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+#
+# Author: Ardavan Farahvash <ardf.scf@gmail.com>
+#
+'''
+Benggston-Neugebauer-Scheffler Dipole Corrections for surface calculations. 
+
+
+Removes the leading-order error of polarized surfaces caused by the spurious
+electrostatic interaction between periodic slab surface and its normal images. 
+
+'''
+
+import numpy as np
+from pyscf.pbc import gto, dft
+from pyscf.pbc.scf.addons import slab_dipole_correction
+
+# Create a highly polar HF molecule unit cell
+atom = "F 0.00 0.00 0.00; H 0.00 0.00 0.92"
+cell = gto.Cell()
+cell.atom = atom
+cell.basis = "gth-szv"
+cell.pseudo = "gth-pade"
+cell.unit = "A"
+cell.dimension = 3 
+cell.verbose = 0
+
+# Run large calculation  
+print("--------- Running Huge Vacuum ---------")
+cell.a = np.diag([10, 10, 200])
+cell.build()
+
+mf = dft.KUKS(cell, cell.make_kpts([1, 1, 1])).density_fit()
+mf.xc = "pbe"
+mf.kernel()
+e0 = mf.kernel()
+    
+# uncorrected energy
+print("--------- Running Uncorrected Calculations ---------")
+for d in np.arange(5,18,3):
+    cell.a = np.diag([10, 10, d])
+    cell.build()
+
+    mf = dft.KRKS(cell, cell.make_kpts([1, 1, 1])).density_fit()
+    mf.xc = "pbe"
+    mf.kernel()
+    e = mf.kernel()-e0
+    print(f"Uncorrected d={d}, E-E(d=200)={e:.6f} Ha")
+
+print("--------- Running Corrected Calculations ---------")
+# corrected energy
+for d in np.arange(5,18,3):
+    cell.a = np.diag([10, 10, d])
+    cell.build()
+
+    mf = dft.KRKS(cell, cell.make_kpts([1, 1, 1])).density_fit()
+    mf = slab_dipole_correction(mf, dir_idx=2)
+    mf.xc = "pbe"
+    mf.kernel()
+    e = mf.kernel()-e0
+    print(f"Corrected d={d}, E-E(d=200)={e:.6f} Ha")

--- a/pyscf/pbc/scf/addons.py
+++ b/pyscf/pbc/scf/addons.py
@@ -377,3 +377,100 @@ def mo_energy_with_exxdiv_none(mf, mo_coeff=None):
     else:
         log.error(f'Unknown SCF type {mf.__class__.__name__}')
         raise NotImplementedError
+        
+def slab_dipole_correction(mf, dir_idx=2, slab_center=None):
+    """Apply self-consistent Neugebauer-Scheffler slab dipole corrections.
+
+    doi:10.1103/PhysRevB.46.16067
+    doi:10.1103/PhysRevB.59.12301
+    
+    Removes the leading-order error in the energy of polarized surfaces
+    caused by the spurious electrostatic interaction between periodic slab
+    images. A compensating sawtooth potential is added to the KS potential,
+    so the density relaxes self-consistently; this can slow SCF convergence.
+    k-point-sampled DFT (KS) only.
+
+    Note: this is distinct from pyscf.pbc.scf.makov_payne_correction.
+    """
+    if not hasattr(mf, "_numint") or not hasattr(mf, "grids"):
+        raise NotImplementedError(
+            "Dipole correction requires a periodic DFT object with an "
+            "integration grid; got %s" % type(mf).__name__)
+    cell = mf.cell
+    lattice = cell.lattice_vectors()
+    lattice_inv = numpy.linalg.inv(lattice)  # cartesian -> fractional
+    L = lattice[dir_idx, dir_idx]
+    area = abs(numpy.linalg.det(lattice)) / L
+
+    # Automatically determine the slab center if not provided.
+    if slab_center is None:
+        charges = cell.atom_charges()
+        coords = cell.atom_coords()
+        real_atom_mask = charges > 0
+        if numpy.any(real_atom_mask):
+            real_z = coords[real_atom_mask, dir_idx]
+            slab_center = (numpy.max(real_z) + numpy.min(real_z)) / 2.0
+        else:
+            slab_center = L / 2.0
+
+    origin = numpy.zeros(3)
+    origin[dir_idx] = slab_center
+
+    def wrap_dir(r):
+        rf = (r - origin).dot(lattice_inv)
+        rf[:, dir_idx] -= numpy.round(rf[:, dir_idx])
+        return rf.dot(lattice)[:, dir_idx]
+
+    old_get_veff = mf.get_veff
+
+    def get_veff(cell=None, dm=None, dm_last=0, vhf_last=0, hermi=1,
+                 kpts=None, kpts_band=None):
+        if cell is None:
+            cell = mf.cell
+        if dm is None:
+            dm = mf.make_rdm1()
+        if kpts is None:
+            kpts = getattr(mf, "kpts", numpy.zeros((1, 3)))
+        veff = old_get_veff(cell, dm, dm_last, vhf_last, hermi,
+                            kpts, kpts_band)
+        if mf.grids.coords is None:
+            mf.grids.build()
+        coords = mf.grids.coords
+        weights = mf.grids.weights
+        # Total (k-point-traced) electron density on the grid. Collapse the
+        # spin channels for UKS before evaluating the density.
+        dm_rho = dm
+        if getattr(dm_rho, "ndim", None) == 4:  # (2, nkpts, nao, nao)
+            dm_rho = dm_rho[0] + dm_rho[1]
+        rho = mf._numint.get_rho(cell, dm_rho, mf.grids, kpts, mf.max_memory)
+        rho = numpy.atleast_2d(rho).sum(axis=0)
+        # Reference so dir_idx = 0 sits at the slab center; the sawtooth
+        # discontinuity lands in the vacuum at slab_center + L/2.
+        z_shifted = wrap_dir(coords)
+        # Electronic and ionic dipole moments per cell
+        p_elec = numpy.sum(rho * z_shifted * weights)
+        charges = cell.atom_charges()
+        ion_shifted = wrap_dir(cell.atom_coords())
+        p_ion = numpy.sum(charges * ion_shifted)
+        p_tot = p_ion - p_elec
+        # Artificial PBC field and compensating sawtooth potential.
+        e_field = 4 * numpy.pi * p_tot / (area * L)
+        v_dip_grid = -e_field * z_shifted * weights
+        # TODO: cache AO values on the grid
+        ao_kpts = cell.pbc_eval_gto("GTOval", coords, kpts=kpts)
+        v_dip_mat = numpy.asarray(
+      [lib.einsum("pi,p,pj->ij", ao.conj(), v_dip_grid, ao) for ao in ao_kpts])
+        veff_new = veff + v_dip_mat
+        exc_dip = 0.5 * e_field * p_tot
+        logger.info(mf, "Dipole correction: E = %.10g, p = %.6g",
+                    exc_dip, p_tot)
+        veff_new = lib.tag_array(
+            veff_new,
+            exc=getattr(veff, "exc", 0.0) + exc_dip,
+            ecoul=getattr(veff, "ecoul", 0.0),
+            vj=getattr(veff, "vj", None),
+            vk=getattr(veff, "vk", None),
+        )
+        return veff_new
+    mf.get_veff = get_veff
+    return mf

--- a/pyscf/pbc/scf/addons.py
+++ b/pyscf/pbc/scf/addons.py
@@ -377,13 +377,13 @@ def mo_energy_with_exxdiv_none(mf, mo_coeff=None):
     else:
         log.error(f'Unknown SCF type {mf.__class__.__name__}')
         raise NotImplementedError
-        
+
 def slab_dipole_correction(mf, dir_idx=2, slab_center=None):
     """Apply self-consistent Neugebauer-Scheffler slab dipole corrections.
 
     doi:10.1103/PhysRevB.46.16067
     doi:10.1103/PhysRevB.59.12301
-    
+
     Removes the leading-order error in the energy of polarized surfaces
     caused by the spurious electrostatic interaction between periodic slab
     images. A compensating sawtooth potential is added to the KS potential,
@@ -459,7 +459,7 @@ def slab_dipole_correction(mf, dir_idx=2, slab_center=None):
         # TODO: cache AO values on the grid
         ao_kpts = cell.pbc_eval_gto("GTOval", coords, kpts=kpts)
         v_dip_mat = numpy.asarray(
-      [lib.einsum("pi,p,pj->ij", ao.conj(), v_dip_grid, ao) for ao in ao_kpts])
+            [lib.einsum("pi,p,pj->ij", ao.conj(), v_dip_grid, ao) for ao in ao_kpts])
         veff_new = veff + v_dip_mat
         exc_dip = 0.5 * e_field * p_tot
         logger.info(mf, "Dipole correction: E = %.10g, p = %.6g",

--- a/pyscf/pbc/scf/test/test_slabdipole.py
+++ b/pyscf/pbc/scf/test/test_slabdipole.py
@@ -1,0 +1,58 @@
+import unittest
+import numpy as np
+from pyscf.pbc import gto, dft
+from pyscf.pbc.scf.addons import slab_dipole_correction
+
+
+def build_cell(polar):
+    a, c = 4.0, 12.0
+    if polar:
+        atom = f"F {a/2} {a/2} 5.00; H {a/2} {a/2} 5.92"
+    else:
+        atom = f"H {a/2} {a/2} 5.60; H {a/2} {a/2} 6.40"
+    cell = gto.Cell()
+    cell.atom = atom
+    cell.a = np.diag([a, a, c])
+    cell.basis = "gth-szv"
+    cell.pseudo = "gth-pade"
+    cell.unit = "A"
+    cell.dimension = 3
+    cell.verbose = 0
+    cell.build()
+    return cell
+
+def run(cell, corrected):
+    mf = dft.KRKS(cell, cell.make_kpts([1, 1, 1])).density_fit()
+    mf.xc = "pbe"
+    mf.conv_tol = 1e-8
+    mf.max_cycle = 80
+    if corrected:
+        slab_dipole_correction(mf, dir_idx=2)
+    e = mf.kernel()
+    return mf, e
+
+
+class SlabDipoleCorrectionTest(unittest.TestCase):
+    def _run_pair(self, polar):
+        cell = build_cell(polar)
+        mf0, e0 = run(cell, corrected=False)
+        mf1, e1 = run(cell, corrected=True)
+        self.assertTrue(mf0.converged, "uncorrected SCF did not converge")
+        self.assertTrue(mf1.converged, "corrected SCF did not converge")
+        return e1 - e0
+
+    def test_polar_slab(self):
+        """A polar slab has a sizeable dipole and the correction shifts E."""
+        de = self._run_pair(polar=True)
+        self.assertGreater(abs(de), 1e-5,
+                           "correction had no effect on a polar slab")
+
+    def test_nonpolar_slab(self):
+        """A symmetric slab has ~zero dipole and the correction is ~zero."""
+        de = self._run_pair(polar=False)
+        self.assertLess(abs(de), 1e-4,
+                        "correction should be ~zero for a non-polar slab")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds self-consistent dipole corrections for slab/2D systems. Effectively implementing the equivalent of LDIPOL/IDIPOL in VASP. I included a unit test and an example for completeness. 