### PR TITLE
MC-PDFT unittests stabilize (#3245)

### DIFF
--- a/pyscf/grad/test/test_mcpdft.py
+++ b/pyscf/grad/test/test_mcpdft.py
@@ -43,23 +43,26 @@ def auto_setup (xyz='Li 0 0 0\nH 1.5 0 0'):
     mol_sym = gto.M (atom = xyz, basis = 'sto3g', symmetry=True,
                      output = '/dev/null', verbose = 0)
     mf_nosym = scf.RHF (mol_nosym).run ()
-    mc_nosym = mcscf.CASSCF (mf_nosym, 5, 2).run ()
+    mc_nosym = mcscf.CASSCF (mf_nosym, 5, 2)#.run ()
     mf_sym = scf.RHF (mol_sym).run ()
     mc_sym = mcscf.CASSCF (mf_sym, 5, 2).run ()
+    mc_nosym.run (mo_coeff=mc_sym.mo_coeff)
     mcp_ss_nosym = mcpdft.CASSCF (mc_nosym, 'ftLDA,VWN3', 5, 2,
                                   grids_level=1).run ()
     mcp_ss_sym = mcpdft.CASSCF (mc_sym, 'ftLDA,VWN3', 5, 2,
                                 grids_level=1).run ()
-    mcp_sa_0 = mcp_ss_nosym.state_average ([1.0/5,]*5).run ()
+    mcp_sa_0 = mcp_ss_nosym.state_average ([1.0/5,]*5)#.run ()
     solver_S = fci.solver (mol_nosym, singlet=True).set (spin=0, nroots=2)
     solver_T = fci.solver (mol_nosym, singlet=False).set (spin=2, nroots=3)
     mcp_sa_1 = mcp_ss_nosym.state_average_mix (
-        [solver_S,solver_T], [1.0/5,]*5).set(ci=None).run ()
+        [solver_S,solver_T], [1.0/5,]*5).set(ci=None)#.run ()
     solver_A1 = fci.solver (mol_sym).set (wfnsym='A1', nroots=3)
     solver_E1x = fci.solver (mol_sym).set (wfnsym='E1x', nroots=1, spin=2)
     solver_E1y = fci.solver (mol_sym).set (wfnsym='E1y', nroots=1, spin=2)
     mcp_sa_2 = mcp_ss_sym.state_average_mix (
         [solver_A1,solver_E1x,solver_E1y], [1.0/5,]*5).set(ci=None).run ()
+    mcp_sa_0.run (mo_coeff=mcp_sa_2.mo_coeff)
+    mcp_sa_1.run (mo_coeff=mcp_sa_2.mo_coeff)
     mcp = [[mcp_ss_nosym, mcp_ss_sym], [mcp_sa_0, mcp_sa_1, mcp_sa_2]]
     nosym = [mol_nosym, mf_nosym, mc_nosym]
     sym = [mol_sym, mf_sym, mc_sym]

--- a/pyscf/grad/test/test_mcpdft.py
+++ b/pyscf/grad/test/test_mcpdft.py
@@ -43,7 +43,7 @@ def auto_setup (xyz='Li 0 0 0\nH 1.5 0 0'):
     mol_sym = gto.M (atom = xyz, basis = 'sto3g', symmetry=True,
                      output = '/dev/null', verbose = 0)
     mf_nosym = scf.RHF (mol_nosym).run ()
-    mc_nosym = mcscf.CASSCF (mf_nosym, 5, 2)#.run ()
+    mc_nosym = mcscf.CASSCF (mf_nosym, 5, 2)
     mf_sym = scf.RHF (mol_sym).run ()
     mc_sym = mcscf.CASSCF (mf_sym, 5, 2).run ()
     mc_nosym.run (mo_coeff=mc_sym.mo_coeff)
@@ -51,11 +51,11 @@ def auto_setup (xyz='Li 0 0 0\nH 1.5 0 0'):
                                   grids_level=1).run ()
     mcp_ss_sym = mcpdft.CASSCF (mc_sym, 'ftLDA,VWN3', 5, 2,
                                 grids_level=1).run ()
-    mcp_sa_0 = mcp_ss_nosym.state_average ([1.0/5,]*5)#.run ()
+    mcp_sa_0 = mcp_ss_nosym.state_average ([1.0/5,]*5)
     solver_S = fci.solver (mol_nosym, singlet=True).set (spin=0, nroots=2)
     solver_T = fci.solver (mol_nosym, singlet=False).set (spin=2, nroots=3)
     mcp_sa_1 = mcp_ss_nosym.state_average_mix (
-        [solver_S,solver_T], [1.0/5,]*5).set(ci=None)#.run ()
+        [solver_S,solver_T], [1.0/5,]*5).set(ci=None)
     solver_A1 = fci.solver (mol_sym).set (wfnsym='A1', nroots=3)
     solver_E1x = fci.solver (mol_sym).set (wfnsym='E1x', nroots=1, spin=2)
     solver_E1y = fci.solver (mol_sym).set (wfnsym='E1y', nroots=1, spin=2)

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -46,9 +46,12 @@ def auto_setup(xyz="Li 0 0 0\nH 1.5 0 0", fnal="tPBE"):
         atom=xyz, basis="sto3g", symmetry=True, verbose=0, output="/dev/null"
     )
     mf_nosym = scf.RHF(mol_nosym).run(conv_tol=1e-12)
-    mc_nosym = mcscf.CASSCF(mf_nosym, 5, 2).run(conv_tol=1e-8)
+    mc_nosym = mcscf.CASSCF(mf_nosym, 5, 2)#.run(conv_tol=1e-8)
     mf_sym = scf.RHF(mol_sym).run()
     mc_sym = mcscf.CASSCF(mf_sym, 5, 2).run(conv_tol=1e-8)
+    mc_nosym.run (mo_coeff=mc_sym.mo_coeff,
+                  ci=mc_sym.ci,
+                  conv_tol=1e-8)
     mcp_ss_nosym = mcpdft.CASSCF(mc_nosym, fnal, 5, 2).run(conv_tol=1e-8)
     mcp_ss_sym = (
         mcpdft.CASSCF(mc_sym, fnal, 5, 2)
@@ -60,7 +63,7 @@ def auto_setup(xyz="Li 0 0 0\nH 1.5 0 0", fnal="tPBE"):
             1.0 / 5,
         ]
         * 5
-    ).run(conv_tol=1e-8)
+    )#.run(conv_tol=1e-8)
     solver_S = fci.solver(mol_nosym, singlet=True).set(spin=0, nroots=2)
     solver_T = fci.solver(mol_nosym, singlet=False).set(spin=2, nroots=3)
     mcp_sa_1 = (
@@ -72,7 +75,7 @@ def auto_setup(xyz="Li 0 0 0\nH 1.5 0 0", fnal="tPBE"):
             * 5,
         )
         .set(ci=None)
-        .run(conv_tol=1e-8)
+        #.run(conv_tol=1e-8)
     )
     solver_A1 = fci.solver(mol_sym).set(wfnsym="A1", nroots=3)
     solver_E1x = fci.solver(mol_sym).set(wfnsym="E1x", nroots=1, spin=2)
@@ -88,6 +91,11 @@ def auto_setup(xyz="Li 0 0 0\nH 1.5 0 0", fnal="tPBE"):
         .set(ci=None, chkfile=lib.NamedTemporaryFile().name, chk_ci=True)
         .run(conv_tol=1e-8)
     )
+    mcp_sa_1.run (mo_coeff=mcp_sa_2.mo_coeff,
+                  conv_tol=1e-8)
+    ci = [mcp_sa_2.ci[i] for i in np.argsort (mcp_sa_2.e_mcscf, stable=True)]
+    mcp_sa_0.run (mo_coeff=mcp_sa_2.mo_coeff,
+                  conv_tol=1e-8)
     mcp = [[mcp_ss_nosym, mcp_ss_sym], [mcp_sa_0, mcp_sa_1, mcp_sa_2]]
     nosym = [mol_nosym, mf_nosym, mc_nosym]
     sym = [mol_sym, mf_sym, mc_sym]

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -46,7 +46,7 @@ def auto_setup(xyz="Li 0 0 0\nH 1.5 0 0", fnal="tPBE"):
         atom=xyz, basis="sto3g", symmetry=True, verbose=0, output="/dev/null"
     )
     mf_nosym = scf.RHF(mol_nosym).run(conv_tol=1e-12)
-    mc_nosym = mcscf.CASSCF(mf_nosym, 5, 2)#.run(conv_tol=1e-8)
+    mc_nosym = mcscf.CASSCF(mf_nosym, 5, 2)
     mf_sym = scf.RHF(mol_sym).run()
     mc_sym = mcscf.CASSCF(mf_sym, 5, 2).run(conv_tol=1e-8)
     mc_nosym.run (mo_coeff=mc_sym.mo_coeff,
@@ -63,7 +63,7 @@ def auto_setup(xyz="Li 0 0 0\nH 1.5 0 0", fnal="tPBE"):
             1.0 / 5,
         ]
         * 5
-    )#.run(conv_tol=1e-8)
+    )
     solver_S = fci.solver(mol_nosym, singlet=True).set(spin=0, nroots=2)
     solver_T = fci.solver(mol_nosym, singlet=False).set(spin=2, nroots=3)
     mcp_sa_1 = (
@@ -75,7 +75,6 @@ def auto_setup(xyz="Li 0 0 0\nH 1.5 0 0", fnal="tPBE"):
             * 5,
         )
         .set(ci=None)
-        #.run(conv_tol=1e-8)
     )
     solver_A1 = fci.solver(mol_sym).set(wfnsym="A1", nroots=3)
     solver_E1x = fci.solver(mol_sym).set(wfnsym="E1x", nroots=1, spin=2)
@@ -93,7 +92,6 @@ def auto_setup(xyz="Li 0 0 0\nH 1.5 0 0", fnal="tPBE"):
     )
     mcp_sa_1.run (mo_coeff=mcp_sa_2.mo_coeff,
                   conv_tol=1e-8)
-    ci = [mcp_sa_2.ci[i] for i in np.argsort (mcp_sa_2.e_mcscf, stable=True)]
     mcp_sa_0.run (mo_coeff=mcp_sa_2.mo_coeff,
                   conv_tol=1e-8)
     mcp = [[mcp_ss_nosym, mcp_ss_sym], [mcp_sa_0, mcp_sa_1, mcp_sa_2]]


### PR DESCRIPTION
In MC-PDFT unittests which perform a variety of calculations on LiH, SA-MCSCF calculations sometimes converge to different solutions. Try to control this by initializing all calc'ns with converged orbitals from high-symmetry version in setup.