### PR TITLE
Implement CABS Singles correction

### DIFF
--- a/examples/mp/13-mp2_cabs.py
+++ b/examples/mp/13-mp2_cabs.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+#
+# Author: Igor S. Gerasimov <foxtranigor@gmail.com>
+#
+
+"""
+A simple example to run MP2 calculation with CABS correction.
+"""
+
+import pyscf
+
+mol = pyscf.M(atom='H 0 0 0; F 0 0 1.1', basis='ccpvdz')
+
+mf = mol.RHF().run()
+
+mf.MP2().run()
+
+pyscf.mp.cabs.energy_singles(mf, auxbasis='ccpvdzri')

--- a/pyscf/mp/__init__.py
+++ b/pyscf/mp/__init__.py
@@ -23,6 +23,7 @@ from pyscf.mp import ump2
 from pyscf.mp import dfump2
 from pyscf.mp import gmp2
 from pyscf.mp import dfgmp2
+from pyscf.mp import cabs
 
 def MP2(mf, frozen=None, mo_coeff=None, mo_occ=None):
     if mf.istype('UHF'):

--- a/pyscf/mp/cabs.py
+++ b/pyscf/mp/cabs.py
@@ -24,7 +24,8 @@ Refs:
 import numpy
 import scipy.linalg
 
-from pyscf import gto
+from pyscf import gto, scf
+from pyscf.data import elements
 from pyscf.lib import logger
 from pyscf.scf import hf
 
@@ -73,19 +74,93 @@ def _as_cabs_auxmol(mol, auxmol_or_basis):
     return make_cabs_auxmol(mol, auxmol_or_basis)
 
 
-def _cabs_singles_from_fock(fock, cabs_coeff, mo_coeff, mo_occ, mo_energy):
-    occidx = mo_occ > 0
+def _frozen_mask(mol, mo_occ, frozen):
+    mask = numpy.zeros(mo_occ.size, dtype=bool)
+    if frozen is None:
+        return mask
+
+    if isinstance(frozen, str):
+        scheme = frozen.lower()
+        if scheme == 'chemcore':
+            frozen = elements.chemcore(mol)
+        elif scheme == 'none':
+            frozen = 0
+        else:
+            raise ValueError(f'Unsupported CABS frozen orbital scheme {frozen!r}')
+
+    if isinstance(frozen, (bool, numpy.bool_)):
+        raise TypeError('CABS frozen orbitals must be specified as an int, sequence, tuple, or named scheme')
+    if isinstance(frozen, (int, numpy.integer)):
+        mask[:frozen] = True
+    else:
+        mask[numpy.asarray(frozen, dtype=int)] = True
+    return mask
+
+
+def _active_masks(mol, mo_occ, frozen):
+    frozen_mask = _frozen_mask(mol, mo_occ, frozen)
+    occidx = (mo_occ > 0) & ~frozen_mask
+    viridx = (mo_occ == 0) & ~frozen_mask
+    return occidx, viridx
+
+
+def _spin_masks(mol, spin_occ, frozen):
+    if isinstance(frozen, (tuple, list)) and len(frozen) == 2 and not isinstance(frozen[0], (int, numpy.integer)):
+        return tuple(_active_masks(mol, occ, frz) for occ, frz in zip(spin_occ, frozen))
+    return tuple(_active_masks(mol, occ, frozen) for occ in spin_occ)
+
+
+def _embed_dm(dm, nao, nca):
+    dm = numpy.asarray(dm)
+    dm_ext = numpy.zeros(dm.shape[:-2] + (nca, nca), dtype=dm.dtype)
+    dm_ext[..., :nao, :nao] = dm
+    return dm_ext
+
+
+def _get_jk(mf, cabs_mol, dm):
+    if getattr(mf, 'with_df', None) is not None:
+        dfmf = scf.RHF(cabs_mol).density_fit(auxbasis=mf.with_df.auxbasis)
+        dfmf.with_df.max_memory = mf.with_df.max_memory
+        dfmf.with_df.stdout = mf.with_df.stdout
+        dfmf.with_df.verbose = mf.with_df.verbose
+        return dfmf.get_jk(cabs_mol, dm, hermi=1)
+    return hf.get_jk(cabs_mol, dm, hermi=1)
+
+
+def _unrestricted_focks(mf, cabs_mol, dm):
+    vj, vk = _get_jk(mf, cabs_mol, dm)
+    hcore = mf.get_hcore(cabs_mol)
+    vj_tot = vj[0] + vj[1]
+    return hcore + vj_tot - vk[0], hcore + vj_tot - vk[1]
+
+
+def _extended_projector(mo_coeff, cabs_coeff):
+    nao, nmo = mo_coeff.shape
+    nca = cabs_coeff.shape[0]
+    pcoeff = numpy.zeros((nca, nmo + cabs_coeff.shape[1]))
+    pcoeff[:nao, :nmo] = mo_coeff
+    pcoeff[:, nmo:] = cabs_coeff
+    return pcoeff
+
+
+def _cabs_singles_from_fock(fock, pcoeff, mo_occ, mo_energy, occidx, viridx):
+    nmo = mo_occ.size
     if not numpy.any(occidx):
         return 0.0
 
-    fcabs = numpy.dot(fock, cabs_coeff)
-    e_cabs, u_cabs = scipy.linalg.eigh(numpy.dot(cabs_coeff.T, fcabs))
-    fia = numpy.dot(numpy.dot(mo_coeff[:, occidx].T, fcabs[: mo_coeff.shape[0]]), u_cabs)
+    # Diagonalize the external space formed by orbital-basis virtual MOs and CABS.
+    # The MO-virtual block is zero for canonical RHF/UHF, but gives the ROHF/non-canonical singles contribution,
+    # and MolPro separates those contributions.
+    extidx = numpy.r_[numpy.where(viridx)[0], numpy.arange(nmo, pcoeff.shape[1])]
+
+    fock_p = pcoeff.T.dot(fock).dot(pcoeff)
+    e_cabs, u_cabs = scipy.linalg.eigh(fock_p[numpy.ix_(extidx, extidx)])
+    fia = fock_p[numpy.ix_(occidx, extidx)].dot(u_cabs)
     denom = mo_energy[occidx, None] - e_cabs
     return numpy.einsum('i,ia,ia,ia->', mo_occ[occidx], fia, fia, 1.0 / denom)
 
 
-def energy_singles(mf, auxmol_or_basis, lindep=1e-8):
+def energy_singles(mf, auxmol_or_basis, frozen='chemcore', lindep=1e-8):
     r"""CABS singles correction to the Hartree-Fock reference energy.
 
     For a closed-shell reference this evaluates
@@ -94,21 +169,53 @@ def energy_singles(mf, auxmol_or_basis, lindep=1e-8):
         E_\mathrm{CABS} = 2 \sum_{iA}
             \frac{|F_{iA}|^2}{\epsilon_i - \epsilon_A}
 
-    where ``A`` denotes canonical orbitals in the complementary auxiliary
-    basis space. For UHF references the same expression is evaluated for the
-    alpha and beta Fock matrices with spin occupations as prefactors.
+    where ``A`` denotes canonical orbitals in the external space formed by
+    the virtual MOs of the orbital basis and CABS. For UHF and ROHF references
+    the same expression is evaluated for the alpha and beta Fock matrices with
+    spin occupations as prefactors.
 
     Args:
         mf : SCF object
             Converged molecular HF object.
         auxmol_or_basis : Mole, str, list, tuple, or dict
             CABS/OptRI basis as a Mole object or in the usual Mole.basis format.
-            If a normal charged Mole is supplied on the same centers as ``mf``,
-            it is converted to ghost centers to avoid doubled nuclei.
+            If a normal charged Mole is supplied on the same centers as ``mf``.
+        frozen : None, int, sequence, tuple, or str
+            Frozen orbital selection. ``'chemcore'`` (default) freezes the chemical
+            core. ``None`` or ``0`` includes all orbitals. An integer freezes
+            the lowest orbitals and a sequence freezes explicit MO indices. For
+            UHF, a flat sequence is applied to both spins; a nested two-item
+            sequence gives separate alpha and beta frozen orbitals.
         lindep : float
             Linear-dependence threshold in the CABS projection.
     """
     mol = mf.mol
+    mo_coeff = mf.mo_coeff
+    mo_occ = mf.mo_occ
+    mo_energy = mf.mo_energy
+    is_uhf = isinstance(mo_coeff, (tuple, list)) or getattr(mo_coeff, 'ndim', 0) == 3
+    is_rohf = not is_uhf and numpy.any(mo_occ == 1)
+
+    if not is_uhf:
+        valid_occ = (mo_occ == 0) | (mo_occ == 2)
+        if is_rohf:
+            valid_occ |= mo_occ == 1
+        if numpy.any(~valid_occ):
+            raise NotImplementedError('CABS singles for general fractional-occupation references is not implemented.')
+
+    if is_rohf:
+        spin_coeff = (mo_coeff, mo_coeff)
+        spin_occ = (mo_occ > 0, mo_occ == 2)
+        spin_energy = (mo_energy.mo_ea, mo_energy.mo_eb)
+        spin_masks = _spin_masks(mol, spin_occ, frozen)
+    elif is_uhf:
+        spin_coeff = mo_coeff
+        spin_occ = mo_occ
+        spin_energy = mo_energy
+        spin_masks = _spin_masks(mol, spin_occ, frozen)
+    else:
+        occidx, viridx = _active_masks(mol, mo_occ, frozen)
+
     auxmol = _as_cabs_auxmol(mol, auxmol_or_basis)
     cabs_mol, cabs_coeff = find_cabs(mol, auxmol, lindep)
     if cabs_coeff.shape[1] == 0:
@@ -117,32 +224,19 @@ def energy_singles(mf, auxmol_or_basis, lindep=1e-8):
     nao = mol.nao_nr()
     nca = cabs_mol.nao_nr()
 
-    mo_coeff = mf.mo_coeff
-    mo_occ = mf.mo_occ
-    mo_energy = mf.mo_energy
-    is_uhf = isinstance(mo_coeff, (tuple, list)) or getattr(mo_coeff, 'ndim', 0) == 3
-    if is_uhf:
-        moa, mob = mo_coeff
-        dma, dmb = mf.make_rdm1()
-        dm = numpy.zeros((2, nca, nca))
-        dm[0, :nao, :nao] = dma
-        dm[1, :nao, :nao] = dmb
-        vj, vk = hf.get_jk(cabs_mol, dm, hermi=1)
-        hcore = mf.get_hcore(cabs_mol)
-        focka = hcore + vj[0] + vj[1] - vk[0]
-        fockb = hcore + vj[0] + vj[1] - vk[1]
-        e_cabs = _cabs_singles_from_fock(focka, cabs_coeff, moa, mo_occ[0], mo_energy[0])
-        e_cabs += _cabs_singles_from_fock(fockb, cabs_coeff, mob, mo_occ[1], mo_energy[1])
+    if is_rohf or is_uhf:
+        dm = _embed_dm(mf.make_rdm1(), nao, nca)
+        focks = _unrestricted_focks(mf, cabs_mol, dm)
+        e_cabs = 0.0
+        for fock, coeff, occ, energy, (occidx, viridx) in zip(focks, spin_coeff, spin_occ, spin_energy, spin_masks):
+            pcoeff = _extended_projector(coeff, cabs_coeff)
+            e_cabs += _cabs_singles_from_fock(fock, pcoeff, occ, energy, occidx, viridx)
     else:
-        if numpy.any((mo_occ != 0) & (mo_occ != 2)):
-            raise NotImplementedError(
-                'CABS singles for ROHF/general open-shell references is not implemented. Use a UHF reference.'
-            )
-        dm = numpy.zeros((nca, nca))
-        dm[:nao, :nao] = mf.make_rdm1()
-        vj, vk = hf.get_jk(cabs_mol, dm, hermi=1)
+        pcoeff = _extended_projector(mo_coeff, cabs_coeff)
+        dm = _embed_dm(mf.make_rdm1(), nao, nca)
+        vj, vk = _get_jk(mf, cabs_mol, dm)
         fock = mf.get_hcore(cabs_mol) + vj - vk * 0.5
-        e_cabs = _cabs_singles_from_fock(fock, cabs_coeff, mo_coeff, mo_occ, mo_energy)
+        e_cabs = _cabs_singles_from_fock(fock, pcoeff, mo_occ, mo_energy, occidx, viridx)
 
     logger.info(mf, 'CABS singles correction = %.15g', e_cabs)
     return e_cabs

--- a/pyscf/mp/cabs.py
+++ b/pyscf/mp/cabs.py
@@ -179,7 +179,8 @@ def energy_singles(mf, auxbasis, *, frozen='chemcore', lindep=1e-8):
             Converged molecular HF object.
         auxbasis : Mole, str, list, tuple, or dict
             CABS/OptRI basis as a Mole object or in the usual Mole.basis format.
-            If a normal charged Mole is supplied on the same centers as ``mf``.
+            If a normal charged Mole is supplied on the same centers as ``mf``,
+            only its basis is used; its nuclear charges and ECPs must be discarded.
         frozen : None, int, sequence, tuple, or str
             Frozen orbital selection. ``'chemcore'`` (default) freezes the chemical
             core. ``None`` or ``0`` includes all orbitals. An integer freezes

--- a/pyscf/mp/cabs.py
+++ b/pyscf/mp/cabs.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+# Copyright 2026 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Complementary auxiliary basis set (CABS).
+
+Refs:
+* JCC 127, 221106 (2007); DOI:10.1063/1.2817618
+* JCP 128, 154103 (2008); DOI:10.1063/1.2889388
+"""
+
+import numpy
+import scipy.linalg
+
+from pyscf import gto
+from pyscf.lib import logger
+from pyscf.scf import hf
+
+
+def find_cabs(mol, auxmol, lindep=1e-8):
+    """Project an auxiliary basis to the complement of the orbital basis."""
+    cabs_mol = gto.conc_mol(mol, auxmol)
+    nao = mol.nao_nr()
+    s = cabs_mol.intor_symmetric('int1e_ovlp')
+
+    ls12 = scipy.linalg.solve(s[:nao, :nao], s[:nao, nao:], assume_a='pos')
+    s[nao:, nao:] -= s[nao:, :nao].dot(ls12)
+    w, v = scipy.linalg.eigh(s[nao:, nao:])
+    c2 = v[:, w > lindep] / numpy.sqrt(w[w > lindep])
+    c1 = ls12.dot(c2)
+    return cabs_mol, numpy.vstack((-c1, c2))
+
+
+def make_cabs_auxmol(mol, auxbasis):
+    """Build a basis-only Mole object for the CABS basis.
+
+    The auxiliary functions must sit on the molecular centers, but they should
+    not add another copy of the nuclear attraction operator when the OBS and
+    CABS spaces are concatenated for one-electron matrix elements.
+    """
+    auxmol = mol.copy()
+    auxmol.basis = auxbasis
+    auxmol.build(False, False)
+    auxmol._atm[:, gto.CHARGE_OF] = 0
+    auxmol._ecpbas = auxmol._ecpbas[:0]
+    return auxmol
+
+
+def _as_cabs_auxmol(mol, auxmol_or_basis):
+    if isinstance(auxmol_or_basis, gto.MoleBase):
+        auxmol = auxmol_or_basis
+        if not auxmol._built:
+            auxmol.build(False, False)
+        if (
+            auxmol.natm == mol.natm
+            and numpy.linalg.norm(auxmol.atom_coords() - mol.atom_coords()) < 1e-10
+            and numpy.linalg.norm(auxmol.atom_charges()) > 1e-12
+        ):
+            return make_cabs_auxmol(mol, auxmol._basis)
+        return auxmol
+    return make_cabs_auxmol(mol, auxmol_or_basis)
+
+
+def _cabs_singles_from_fock(fock, cabs_coeff, mo_coeff, mo_occ, mo_energy):
+    occidx = mo_occ > 0
+    if not numpy.any(occidx):
+        return 0.0
+
+    fcabs = numpy.dot(fock, cabs_coeff)
+    e_cabs, u_cabs = scipy.linalg.eigh(numpy.dot(cabs_coeff.T, fcabs))
+    fia = numpy.dot(numpy.dot(mo_coeff[:, occidx].T, fcabs[: mo_coeff.shape[0]]), u_cabs)
+    denom = mo_energy[occidx, None] - e_cabs
+    return numpy.einsum('i,ia,ia,ia->', mo_occ[occidx], fia, fia, 1.0 / denom)
+
+
+def energy_singles(mf, auxmol_or_basis, lindep=1e-8):
+    r"""CABS singles correction to the Hartree-Fock reference energy.
+
+    For a closed-shell reference this evaluates
+
+    .. math::
+        E_\mathrm{CABS} = 2 \sum_{iA}
+            \frac{|F_{iA}|^2}{\epsilon_i - \epsilon_A}
+
+    where ``A`` denotes canonical orbitals in the complementary auxiliary
+    basis space. For UHF references the same expression is evaluated for the
+    alpha and beta Fock matrices with spin occupations as prefactors.
+
+    Args:
+        mf : SCF object
+            Converged molecular HF object.
+        auxmol_or_basis : Mole, str, list, tuple, or dict
+            CABS/OptRI basis as a Mole object or in the usual Mole.basis format.
+            If a normal charged Mole is supplied on the same centers as ``mf``,
+            it is converted to ghost centers to avoid doubled nuclei.
+        lindep : float
+            Linear-dependence threshold in the CABS projection.
+    """
+    mol = mf.mol
+    auxmol = _as_cabs_auxmol(mol, auxmol_or_basis)
+    cabs_mol, cabs_coeff = find_cabs(mol, auxmol, lindep)
+    if cabs_coeff.shape[1] == 0:
+        logger.info(mf, 'CABS singles correction = 0')
+        return 0.0
+    nao = mol.nao_nr()
+    nca = cabs_mol.nao_nr()
+
+    mo_coeff = mf.mo_coeff
+    mo_occ = mf.mo_occ
+    mo_energy = mf.mo_energy
+    is_uhf = isinstance(mo_coeff, (tuple, list)) or getattr(mo_coeff, 'ndim', 0) == 3
+    if is_uhf:
+        moa, mob = mo_coeff
+        dma, dmb = mf.make_rdm1()
+        dm = numpy.zeros((2, nca, nca))
+        dm[0, :nao, :nao] = dma
+        dm[1, :nao, :nao] = dmb
+        vj, vk = hf.get_jk(cabs_mol, dm, hermi=1)
+        hcore = mf.get_hcore(cabs_mol)
+        focka = hcore + vj[0] + vj[1] - vk[0]
+        fockb = hcore + vj[0] + vj[1] - vk[1]
+        e_cabs = _cabs_singles_from_fock(focka, cabs_coeff, moa, mo_occ[0], mo_energy[0])
+        e_cabs += _cabs_singles_from_fock(fockb, cabs_coeff, mob, mo_occ[1], mo_energy[1])
+    else:
+        if numpy.any((mo_occ != 0) & (mo_occ != 2)):
+            raise NotImplementedError(
+                'CABS singles for ROHF/general open-shell references is not implemented. Use a UHF reference.'
+            )
+        dm = numpy.zeros((nca, nca))
+        dm[:nao, :nao] = mf.make_rdm1()
+        vj, vk = hf.get_jk(cabs_mol, dm, hermi=1)
+        fock = mf.get_hcore(cabs_mol) + vj - vk * 0.5
+        e_cabs = _cabs_singles_from_fock(fock, cabs_coeff, mo_coeff, mo_occ, mo_energy)
+
+    logger.info(mf, 'CABS singles correction = %.15g', e_cabs)
+    return e_cabs
+
+
+energy_cabs_singles = energy_singles

--- a/pyscf/mp/cabs.py
+++ b/pyscf/mp/cabs.py
@@ -160,7 +160,7 @@ def _cabs_singles_from_fock(fock, pcoeff, mo_occ, mo_energy, occidx, viridx):
     return numpy.einsum('i,ia,ia,ia->', mo_occ[occidx], fia, fia, 1.0 / denom)
 
 
-def energy_singles(mf, auxmol_or_basis, *, frozen='chemcore', lindep=1e-8):
+def energy_singles(mf, auxbasis, *, frozen='chemcore', lindep=1e-8):
     r"""CABS singles correction to the Hartree-Fock reference energy.
 
     For a closed-shell reference this evaluates
@@ -177,7 +177,7 @@ def energy_singles(mf, auxmol_or_basis, *, frozen='chemcore', lindep=1e-8):
     Args:
         mf : SCF object
             Converged molecular HF object.
-        auxmol_or_basis : Mole, str, list, tuple, or dict
+        auxbasis : Mole, str, list, tuple, or dict
             CABS/OptRI basis as a Mole object or in the usual Mole.basis format.
             If a normal charged Mole is supplied on the same centers as ``mf``.
         frozen : None, int, sequence, tuple, or str
@@ -216,7 +216,7 @@ def energy_singles(mf, auxmol_or_basis, *, frozen='chemcore', lindep=1e-8):
     else:
         occidx, viridx = _active_masks(mol, mo_occ, frozen)
 
-    auxmol = _as_cabs_auxmol(mol, auxmol_or_basis)
+    auxmol = _as_cabs_auxmol(mol, auxbasis)
     cabs_mol, cabs_coeff = find_cabs(mol, auxmol, lindep)
     if cabs_coeff.shape[1] == 0:
         logger.note(mf, 'CABS singles correction = 0.0')

--- a/pyscf/mp/cabs.py
+++ b/pyscf/mp/cabs.py
@@ -160,7 +160,7 @@ def _cabs_singles_from_fock(fock, pcoeff, mo_occ, mo_energy, occidx, viridx):
     return numpy.einsum('i,ia,ia,ia->', mo_occ[occidx], fia, fia, 1.0 / denom)
 
 
-def energy_singles(mf, auxmol_or_basis, frozen='chemcore', lindep=1e-8):
+def energy_singles(mf, auxmol_or_basis, *, frozen='chemcore', lindep=1e-8):
     r"""CABS singles correction to the Hartree-Fock reference energy.
 
     For a closed-shell reference this evaluates
@@ -219,7 +219,7 @@ def energy_singles(mf, auxmol_or_basis, frozen='chemcore', lindep=1e-8):
     auxmol = _as_cabs_auxmol(mol, auxmol_or_basis)
     cabs_mol, cabs_coeff = find_cabs(mol, auxmol, lindep)
     if cabs_coeff.shape[1] == 0:
-        logger.info(mf, 'CABS singles correction = 0')
+        logger.note(mf, 'CABS singles correction = 0.0')
         return 0.0
     nao = mol.nao_nr()
     nca = cabs_mol.nao_nr()
@@ -238,7 +238,7 @@ def energy_singles(mf, auxmol_or_basis, frozen='chemcore', lindep=1e-8):
         fock = mf.get_hcore(cabs_mol) + vj - vk * 0.5
         e_cabs = _cabs_singles_from_fock(fock, pcoeff, mo_occ, mo_energy, occidx, viridx)
 
-    logger.info(mf, 'CABS singles correction = %.15g', e_cabs)
+    logger.note(mf, 'CABS singles correction = %.15g', e_cabs)
     return e_cabs
 
 

--- a/pyscf/mp/mp2f12_slow.py
+++ b/pyscf/mp/mp2f12_slow.py
@@ -26,29 +26,18 @@ With strong orthogonalization ansatz 2
 import warnings
 from functools import reduce
 import numpy
-import scipy.linalg
 from pyscf import lib
 from pyscf.lib import logger
 from pyscf import gto
-from pyscf import ao2mo
-from pyscf.scf import jk
 from pyscf.mp import mp2
+from pyscf.mp import cabs
 
 warnings.warn('Module MP2-F12 is under testing')
 
 
 # The cabs space, the complimentary space to the OBS.
 def find_cabs(mol, auxmol, lindep=1e-8):
-    cabs_mol = gto.conc_mol(mol, auxmol)
-    nao = mol.nao_nr()
-    s = cabs_mol.intor_symmetric('int1e_ovlp')
-
-    ls12 = scipy.linalg.solve(s[:nao,:nao], s[:nao,nao:], assume_a='pos')
-    s[nao:,nao:] -= s[nao:,:nao].dot(ls12)
-    w, v = scipy.linalg.eigh(s[nao:,nao:])
-    c2 = v[:,w>lindep]/numpy.sqrt(w[w>lindep])
-    c1 = ls12.dot(c2)
-    return cabs_mol, numpy.vstack((-c1,c2))
+    return cabs.find_cabs(mol, auxmol, lindep)
 
 def trans(eri, mos):
     naoi, nmoi = mos[0].shape

--- a/pyscf/mp/test/test_cabs.py
+++ b/pyscf/mp/test/test_cabs.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# Copyright 2026 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from functools import reduce
+import os
+import numpy
+from pyscf import gto
+from pyscf import lo
+from pyscf import scf
+from pyscf.mp import cabs
+
+
+def setUpModule():
+    global mol, mf, mf1
+    mol = gto.Mole()
+    mol.verbose = 7
+    mol.output = '/dev/null'
+    mol.atom = [
+        [8 , (0. , 0.     , 0.)],
+        [1 , (0. , -0.757 , 0.587)],
+        [1 , (0. , 0.757  , 0.587)]]
+
+    mol.basis = {'H': 'cc-pvdz',
+                 'O': 'cc-pvdz',}
+    mol.build()
+    mf = scf.RHF(mol)
+    mf.conv_tol = 1e-12
+    mf.scf()
+
+def tearDownModule():
+    global mol, mf
+    mol.stdout.close()
+    del mol, mf
+
+
+class KnownValues(unittest.TestCase):
+    def test_find_cabs(self):
+        auxmol = mol.copy()
+        auxmol.basis = 'def2-tzvp'
+        auxmol.build(False, False)
+        cabs_mol, cabs_coeff = cabs.find_cabs(mol, auxmol)
+        nao = mol.nao_nr()
+        nca = cabs_coeff.shape[0]
+        c1 = numpy.zeros((nca,nao))
+        c1[:nao,:nao] = lo.orth.lowdin(mol.intor('int1e_ovlp_sph'))
+        c = numpy.hstack((c1,cabs_coeff))
+        s = reduce(numpy.dot, (c.T, cabs_mol.intor('int1e_ovlp_sph'), c))
+        self.assertAlmostEqual(numpy.linalg.norm(s-numpy.eye(c.shape[1])), 0, 8)
+
+    def test_rhf_cabs_singles(self):
+        mol = gto.Mole(atom='''
+            H   0.000000000   0.000000000   0.457870600
+            F   0.000000000   0.000000000  -0.457870600
+        ''', basis='cc-pvdz', verbose=0)
+        mol.build()
+        mf = scf.RHF(mol).density_fit(auxbasis='cc-pvdz-jkfit').run()
+        e = cabs.energy_singles(mf, 'cc-pvdz-jkfit')
+        self.assertAlmostEqual(e, -0.03330486489465237, 9)
+
+    def test_uhf_cabs_singles(self):
+        mol = gto.Mole(atom='''
+            H   0.000000000   0.000000000   0.457870600
+            O   0.000000000   0.000000000  -0.457870600
+        ''', basis='cc-pvdz', spin=1, verbose=0)
+        mol.build()
+        mf = scf.UHF(mol).density_fit(auxbasis='cc-pvdz-jkfit').run()
+        e = cabs.energy_singles(mf, 'cc-pvdz-jkfit')
+        self.assertAlmostEqual(e, -0.02277698312272855, 9)
+
+
+if __name__ == "__main__":
+    print("Full Tests for CABS")
+    unittest.main()

--- a/pyscf/mp/test/test_cabs.py
+++ b/pyscf/mp/test/test_cabs.py
@@ -68,7 +68,13 @@ class KnownValues(unittest.TestCase):
         mol.build()
         mf = scf.RHF(mol).density_fit(auxbasis='cc-pvdz-jkfit').run()
         e = cabs.energy_singles(mf, 'cc-pvdz-jkfit')
-        self.assertAlmostEqual(e, -0.03330486489465237, 9)
+        # MolPro: -0.033551214
+        self.assertAlmostEqual(e, -0.033551214448, 9)
+        e = cabs.energy_singles(mf, 'cc-pvdz-jkfit', frozen=[0])
+        self.assertAlmostEqual(e, -0.033551214448, 9)
+        e = cabs.energy_singles(mf, 'cc-pvdz-jkfit', frozen=0)
+        # MRCC:   -0.033749160781
+        self.assertAlmostEqual(e, -0.033749161358, 9)
 
     def test_uhf_cabs_singles(self):
         mol = gto.Mole(atom='''
@@ -78,7 +84,41 @@ class KnownValues(unittest.TestCase):
         mol.build()
         mf = scf.UHF(mol).density_fit(auxbasis='cc-pvdz-jkfit').run()
         e = cabs.energy_singles(mf, 'cc-pvdz-jkfit')
-        self.assertAlmostEqual(e, -0.02277698312272855, 9)
+        # no MolPro, it has only ROHF-MP2
+        self.assertAlmostEqual(e, -0.022958881659, 9)
+        e = cabs.energy_singles(mf, 'cc-pvdz-jkfit', frozen=([0], [0]))
+        self.assertAlmostEqual(e, -0.022958881659, 9)
+        e = cabs.energy_singles(mf, 'cc-pvdz-jkfit', frozen=0)
+        # MRCC:   -0.023166900284
+        self.assertAlmostEqual(e, -0.023166901553, 9)
+
+    def test_rohf_cabs_singles(self):
+        mol = gto.Mole(atom='''
+            H   0.000000000   0.000000000   0.457870600
+            O   0.000000000   0.000000000  -0.457870600
+        ''', basis='cc-pvdz', spin=1, verbose=0)
+        mol.build()
+        mf = scf.ROHF(mol).density_fit(auxbasis='cc-pvdz-jkfit').run()
+        e = cabs.energy_singles(mf, 'cc-pvdz-jkfit')
+        # MolPro:
+        #                                       TOTAL          ALPHA          BETA
+        # Singles Contributions MO        -0.002681874   -0.001339551   -0.001342323
+        # Singles Contributions CABS      -0.022664571   -0.013326055   -0.009338516
+        # Pure DF-RHF relaxation          -0.022020485
+        #
+        # One has to sum MO + CABS contributions:
+        # -0.002681874 + -0.022664571 = -0.025346445
+        self.assertAlmostEqual(e, -0.025343529823, 9)
+        e = cabs.energy_singles(mf, 'cc-pvdz-jkfit', frozen=([0], [0]))
+        self.assertAlmostEqual(e, -0.025343529823, 9)
+        e = cabs.energy_singles(mf, 'cc-pvdz-jkfit', frozen=0)
+        # MolPro:
+        #                                       TOTAL          ALPHA          BETA
+        # Singles Contributions MO        -0.002709569   -0.001352954   -0.001356615
+        # Singles Contributions CABS      -0.022873615   -0.013438077   -0.009435538
+        # Pure DF-RHF relaxation          -0.022198754
+        # Sum: -0.025583184
+        self.assertAlmostEqual(e, -0.025580122540, 9)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch adds CABS Singles correction according to https://www.molpro.net/manual/doku.php?id=explicitly_correlated_methods#cabs_singles_correction

Tests were verified by comparing values from MRCC & MolPro. See basis setup & numbers in tests.

Refs:
- JCC 127, 221106 (2007); DOI:10.1063/1.2817618
- JCP 128, 154103 (2008); DOI:10.1063/1.2889388
- JCC 45, 1247-1253 (2024); DOI:10.1002/jcc.27325

Related to #3264 
