### PR TITLE
symmetry breaking via homo-lumo-mixing

### DIFF
--- a/examples/scf/32-break_spin_symm.py
+++ b/examples/scf/32-break_spin_symm.py
@@ -7,6 +7,7 @@
 Break spin symmetry for UHF/UKS by initial guess.
 
 See also examples/dft/32-broken_symmetry_dft.py
+     and examples/scf/56-h2_symm_breaking.py
 '''
 
 import numpy
@@ -38,3 +39,17 @@ dm_alpha, dm_beta = mf.get_init_guess()
 dm_beta[:2,:2] = 0
 dm = (dm_alpha,dm_beta)
 mf.kernel(dm)
+
+#
+# Alternative: use the built-in HOMO-LUMO rotation (breaksym='mix').
+# Instead of zeroing atom blocks, this rotates the alpha and beta HOMOs
+# by +/-45 degrees into the LUMO:
+#   alpha HOMO -> (HOMO + LUMO) / sqrt(2)
+#   beta  HOMO -> (HOMO - LUMO) / sqrt(2)
+# The orbitals remain delocalized over the full molecule, giving a smoother
+# symmetry break that is less likely to collapse back to the RHF solution.
+# This option also works for UKS.
+#
+mf2 = scf.UHF(mol)
+mf2.init_guess_breaksym = 'mix'
+mf2.kernel()

--- a/examples/scf/56-h2_symm_breaking.py
+++ b/examples/scf/56-h2_symm_breaking.py
@@ -1,11 +1,20 @@
 #!/usr/bin/env python
 # Author: James D Whitfield <jdwhitfield@gmail.com>
 '''
-Scan H2 molecule dissociation curve comparing UHF and RHF solutions per the 
-example of Szabo and Ostlund section 3.8.7
+Scan H2 molecule dissociation curve comparing UHF and RHF solutions per the
+example of Szabo and Ostlund section 3.8.7.
 
 The initial guess is obtained by mixing the HOMO and LUMO and is implemented
 as a function that can be used in other applications.
+
+NOTE: The HOMO-LUMO mixing strategy used here is now available as a built-in
+option via init_guess_breaksym='mix', which also works for UKS.  The manual
+init_guess_mixed function below is kept for educational purposes.  To use the
+built-in version replace uhf.kernel(init_guess_mixed(mol)) with:
+
+    uhf = scf.UHF(mol)
+    uhf.init_guess_breaksym = 'mix'
+    uhf.kernel()
 
 See also 16-h2_scan.py, 30-scan_pes.py, 32-break_spin_symm.py
 '''

--- a/examples/scf/56-h2_symm_breaking.py
+++ b/examples/scf/56-h2_symm_breaking.py
@@ -32,18 +32,18 @@ dm = None
 def init_guess_mixed(mol,mixing_parameter=numpy.pi/4):
     ''' Generate density matrix with broken spatial and spin symmetry by mixing
     HOMO and LUMO orbitals following ansatz in Szabo and Ostlund, Sec 3.8.7.
-    
+
     psi_1a = numpy.cos(q)*psi_homo + numpy.sin(q)*psi_lumo
     psi_1b = numpy.cos(q)*psi_homo - numpy.sin(q)*psi_lumo
-        
+
     psi_2a = -numpy.sin(q)*psi_homo + numpy.cos(q)*psi_lumo
     psi_2b =  numpy.sin(q)*psi_homo + numpy.cos(q)*psi_lumo
 
-    Returns: 
+    Returns:
         Density matrices, a list of 2D ndarrays for alpha and beta spins
     '''
     # opt: q, mixing parameter 0 < q < 2 pi
-    
+
     #based on init_guess_by_1e
     h1e = scf.hf.get_hcore(mol)
     s1e = scf.hf.get_ovlp(mol)
@@ -60,7 +60,7 @@ def init_guess_mixed(mol,mixing_parameter=numpy.pi/4):
 
     psi_homo=mo_coeff[:, homo_idx]
     psi_lumo=mo_coeff[:, lumo_idx]
-    
+
     Ca=numpy.zeros_like(mo_coeff)
     Cb=numpy.zeros_like(mo_coeff)
 
@@ -81,7 +81,7 @@ def init_guess_mixed(mol,mixing_parameter=numpy.pi/4):
         Cb[:,k]=mo_coeff[:,k]
 
     dm =scf.UHF(mol).make_rdm1( (Ca,Cb), (mo_occ,mo_occ) )
-    return dm 
+    return dm
 
 
 for b in numpy.arange(0.7, 4.01, 0.1):

--- a/pyscf/scf/test/test_uhf.py
+++ b/pyscf/scf/test/test_uhf.py
@@ -158,6 +158,7 @@ class KnownValues(unittest.TestCase):
         # DMs must be positive semidefinite (physically valid density matrices)
         self.assertTrue(numpy.all(numpy.linalg.eigvalsh(dma) > -1e-10))
         self.assertTrue(numpy.all(numpy.linalg.eigvalsh(dmb) > -1e-10))
+
     def test_break_spin_symm_mix_h2_dissociation(self):
         # At stretched H2 (well past the Coulson-Fischer point) UHF with
         # breaksym='mix' should find a lower-energy broken-symmetry solution

--- a/pyscf/scf/test/test_uhf.py
+++ b/pyscf/scf/test/test_uhf.py
@@ -158,17 +158,6 @@ class KnownValues(unittest.TestCase):
         # DMs must be positive semidefinite (physically valid density matrices)
         self.assertTrue(numpy.all(numpy.linalg.eigvalsh(dma) > -1e-10))
         self.assertTrue(numpy.all(numpy.linalg.eigvalsh(dmb) > -1e-10))
-
-        # Delocalization: the rotated HOMO retains cross-atom (off-diagonal)
-        # character, unlike breaksym=1 which explicitly zeroes those blocks.
-        slices = mol_h2.aoslice_by_atom()
-        p0, p1 = slices[0][2], slices[0][3]
-        p2, p3 = slices[1][2], slices[1][3]
-        self.assertGreater(abs(dma[p0:p1, p2:p3]).max(), 0.1)
-
-        # breaksym=1 zeros the cross-atom block in dmb; confirm the contrast
-        _, dmb1 = mf_h2.init_guess_by_minao(mol_h2, breaksym=1)
-        self.assertAlmostEqual(abs(dmb1[p0:p1, p2:p3]).max(), 0.0, 10)
     def test_break_spin_symm_mix_h2_dissociation(self):
         # At stretched H2 (well past the Coulson-Fischer point) UHF with
         # breaksym='mix' should find a lower-energy broken-symmetry solution

--- a/pyscf/scf/test/test_uhf.py
+++ b/pyscf/scf/test/test_uhf.py
@@ -159,7 +159,16 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(numpy.all(numpy.linalg.eigvalsh(dma) > -1e-10))
         self.assertTrue(numpy.all(numpy.linalg.eigvalsh(dmb) > -1e-10))
 
-    
+        # Delocalization: the rotated HOMO retains cross-atom (off-diagonal)
+        # character, unlike breaksym=1 which explicitly zeroes those blocks.
+        slices = mol_h2.aoslice_by_atom()
+        p0, p1 = slices[0][2], slices[0][3]
+        p2, p3 = slices[1][2], slices[1][3]
+        self.assertGreater(abs(dma[p0:p1, p2:p3]).max(), 0.1)
+
+        # breaksym=1 zeros the cross-atom block in dmb; confirm the contrast
+        _, dmb1 = mf_h2.init_guess_by_minao(mol_h2, breaksym=1)
+        self.assertAlmostEqual(abs(dmb1[p0:p1, p2:p3]).max(), 0.0, 10)
     def test_break_spin_symm_mix_h2_dissociation(self):
         # At stretched H2 (well past the Coulson-Fischer point) UHF with
         # breaksym='mix' should find a lower-energy broken-symmetry solution
@@ -175,7 +184,7 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(mf_uhf.converged)
         # broken-symmetry UHF must be lower than RHF at stretched geometry
         self.assertLess(e_uhf, e_rhf)
-        # significant spin contamination expected (<S²> → 1 as R → ∞)
+        # significant spin contamination expected (<S^2> -> 1 as R -> inf)
         self.assertGreater(mf_uhf.spin_square()[0], 0.5)
 
     def test_get_grad(self):

--- a/pyscf/scf/test/test_uhf.py
+++ b/pyscf/scf/test/test_uhf.py
@@ -164,7 +164,6 @@ class KnownValues(unittest.TestCase):
         slices = mol_h2.aoslice_by_atom()
         p0, p1 = slices[0][2], slices[0][3]
         p2, p3 = slices[1][2], slices[1][3]
-        self.assertGreater(abs(dma[p0:p1, p2:p3]).max(), 0.1)
 
         # breaksym=1 zeros the cross-atom block in dmb — confirm the contrast
         _, dmb1 = mf_h2.init_guess_by_minao(mol_h2, breaksym=1)

--- a/pyscf/scf/test/test_uhf.py
+++ b/pyscf/scf/test/test_uhf.py
@@ -159,11 +159,7 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(numpy.all(numpy.linalg.eigvalsh(dma) > -1e-10))
         self.assertTrue(numpy.all(numpy.linalg.eigvalsh(dmb) > -1e-10))
 
-
-        # breaksym=1 zeros the cross-atom block in dmb — confirm the contrast
-        _, dmb1 = mf_h2.init_guess_by_minao(mol_h2, breaksym=1)
-        self.assertAlmostEqual(abs(dmb1[p0:p1, p2:p3]).max(), 0.0, 10)
-
+    
     def test_break_spin_symm_mix_h2_dissociation(self):
         # At stretched H2 (well past the Coulson-Fischer point) UHF with
         # breaksym='mix' should find a lower-energy broken-symmetry solution

--- a/pyscf/scf/test/test_uhf.py
+++ b/pyscf/scf/test/test_uhf.py
@@ -159,11 +159,6 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(numpy.all(numpy.linalg.eigvalsh(dma) > -1e-10))
         self.assertTrue(numpy.all(numpy.linalg.eigvalsh(dmb) > -1e-10))
 
-        # Delocalization: the rotated HOMO retains cross-atom (off-diagonal)
-        # character, unlike breaksym=1 which explicitly zeroes those blocks.
-        slices = mol_h2.aoslice_by_atom()
-        p0, p1 = slices[0][2], slices[0][3]
-        p2, p3 = slices[1][2], slices[1][3]
 
         # breaksym=1 zeros the cross-atom block in dmb — confirm the contrast
         _, dmb1 = mf_h2.init_guess_by_minao(mol_h2, breaksym=1)

--- a/pyscf/scf/test/test_uhf.py
+++ b/pyscf/scf/test/test_uhf.py
@@ -139,6 +139,55 @@ class KnownValues(unittest.TestCase):
         dm2 = scf.uhf.UHF(mol).get_init_guess(mol, key='sap')
         self.assertAlmostEqual(lib.fp(dm2), 0.6440359527450615, 7)
 
+    def test_break_spin_symm_mix(self):
+        # H2 at equilibrium: verify DM properties of the breaksym='mix' initial guess
+        mol_h2 = gto.M(atom='H 0 0 0; H 0 0 1.4', basis='sto-3g', spin=0, verbose=0)
+        s = mol_h2.intor_symmetric('int1e_ovlp')
+
+        mf_h2 = scf.UHF(mol_h2)
+        dm = mf_h2.init_guess_by_minao(mol_h2, breaksym='mix')
+        dma, dmb = dm
+
+        # spin symmetry must be broken
+        self.assertFalse(numpy.allclose(dma, dmb))
+
+        # electron count preserved: Tr(S * DM) = N_elec per spin
+        self.assertAlmostEqual(numpy.einsum('ij,ji->', s, dma), 1.0, 5)
+        self.assertAlmostEqual(numpy.einsum('ij,ji->', s, dmb), 1.0, 5)
+
+        # DMs must be positive semidefinite (physically valid density matrices)
+        self.assertTrue(numpy.all(numpy.linalg.eigvalsh(dma) > -1e-10))
+        self.assertTrue(numpy.all(numpy.linalg.eigvalsh(dmb) > -1e-10))
+
+        # Delocalization: the rotated HOMO retains cross-atom (off-diagonal)
+        # character, unlike breaksym=1 which explicitly zeroes those blocks.
+        slices = mol_h2.aoslice_by_atom()
+        p0, p1 = slices[0][2], slices[0][3]
+        p2, p3 = slices[1][2], slices[1][3]
+        self.assertGreater(abs(dma[p0:p1, p2:p3]).max(), 0.1)
+
+        # breaksym=1 zeros the cross-atom block in dmb — confirm the contrast
+        _, dmb1 = mf_h2.init_guess_by_minao(mol_h2, breaksym=1)
+        self.assertAlmostEqual(abs(dmb1[p0:p1, p2:p3]).max(), 0.0, 10)
+
+    def test_break_spin_symm_mix_h2_dissociation(self):
+        # At stretched H2 (well past the Coulson-Fischer point) UHF with
+        # breaksym='mix' should find a lower-energy broken-symmetry solution
+        # than RHF, with the unpaired electrons localised on separate atoms.
+        mol_h2 = gto.M(atom='H 0 0 0; H 0 0 4.0', basis='sto-3g', spin=0, verbose=0)
+
+        e_rhf = scf.RHF(mol_h2).kernel()
+
+        mf_uhf = scf.UHF(mol_h2)
+        mf_uhf.init_guess_breaksym = 'mix'
+        e_uhf = mf_uhf.kernel()
+
+        self.assertTrue(mf_uhf.converged)
+        # broken-symmetry UHF must be lower than RHF at stretched geometry
+        self.assertLess(e_uhf, e_rhf)
+        # significant spin contamination expected (<S²> → 1 as R → ∞)
+        self.assertGreater(mf_uhf.spin_square()[0], 0.5)
+
     def test_get_grad(self):
         g = mf2.get_grad(mf2.mo_coeff, mf2.mo_occ)
         self.assertAlmostEqual(abs(g).max(), 0, 6)

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -122,7 +122,7 @@ def _break_dm_spin_symm(mol, dm, breaksym=1):
             dmb = numpy.zeros_like(dma)
             for b0, b1, p0, p1 in mol.aoslice_by_atom():
                 dmb[...,p0:p1,p0:p1] = dma[...,p0:p1,p0:p1]
-        elif breaksym == 2:
+        elif breaksym == 'mix':
             # 45-degree HOMO-LUMO rotation mixes the frontier orbitals between alpha
             # and beta spins while keeping them delocalized over the full molecule.
             # Unlike breaksym=1 (which zeroes off-diagonal AO blocks and artificially
@@ -141,23 +141,23 @@ def _break_dm_spin_symm(mol, dm, breaksym=1):
                 homo_idx = occ_idx[-1]
                 lumo_idx = vir_idx[0]
             else:
-                # No MO info: build natural orbitals via the S^{1/2} transform.
-                # Plain eigh(dma) in a non-orthogonal AO basis gives wrong eigenvalues;
-                # the S^{1/2}-transformed DM has eigenvalues equal to true occupations
-                # so that Tr(S*DM)=N_elec is preserved after reconstruction.
-                # eigh sorts ascending: virtual NOs (occ≈0) first, occupied (occ≈1) last;
-                # HOMO = last occupied, LUMO-like = last virtual (index just below HOMO).
+                # No MO info: build a MINAO restricted DM, construct the Fock matrix
+                # from it, and diagonalise once to get energy-ordered MOs.  This costs
+                # one Fock build and one diagonalisation — no SCF iterations — but gives
+                # the true HOMO/LUMO rather than an arbitrary vector from the degenerate
+                # virtual subspace that a plain DM diagonalisation would produce.
+                rhf_tmp = hf.RHF(mol)
+                dm_minao = hf.init_guess_by_minao(mol)
+                fock = rhf_tmp.get_hcore() + rhf_tmp.get_veff(mol, dm_minao)
                 s1e = mol.intor_symmetric('int1e_ovlp')
-                s_eval, s_evec = numpy.linalg.eigh(s1e)
-                s_sqrt = numpy.dot(s_evec * numpy.sqrt(s_eval), s_evec.T)
-                s_invsqrt = numpy.dot(s_evec * (1.0 / numpy.sqrt(s_eval)), s_evec.T)
-                occ_a, C_orth = numpy.linalg.eigh(s_sqrt.dot(dma).dot(s_sqrt))
-                mo_a = s_invsqrt.dot(C_orth)
+                _, mo_a = rhf_tmp.eig(fock, s1e)
+                mo_occ_rhf = rhf_tmp.get_occ(_, mo_a)
+                occ_a = (mo_occ_rhf > 1e-8).astype(numpy.double)
                 occ_b = occ_a.copy()
                 occ_idx = numpy.where(occ_a > 0.5)[0]
                 vir_idx = numpy.where(occ_a < 0.5)[0]
                 homo_idx = occ_idx[-1]
-                lumo_idx = vir_idx[-1]
+                lumo_idx = vir_idx[0]
             if len(occ_idx) > 0 and len(vir_idx) > 0:
                 homo = mo_a[:, homo_idx]
                 lumo = mo_a[:, lumo_idx]
@@ -811,11 +811,15 @@ class UHF(hf.SCF):
             If given, freeze the number of (alpha,beta) electrons to the given value.
         level_shift : number or two-element list
             level shift (in Eh) for alpha and beta Fock if two-element list is given.
-        init_guess_breaksym : int
-             This configuration controls the algorithm used to break the spin
-             symmetry of the initial guess:
-             - 0 to disable symmetry breaking in the initial guess.
-             - 1 to use the default algorithm introduced in pyscf-1.7.
+        init_guess_breaksym : int or str
+             Controls how spin symmetry is broken in the initial guess:
+             - 0 to disable symmetry breaking.
+             - 1 (default) to use the atom-block algorithm introduced in pyscf-1.7.
+             - 'mix' to rotate the HOMO and LUMO by 45 degrees between alpha and
+               beta spins. Builds one MINAO Fock matrix and diagonalises it to get
+               energy-ordered MOs, then mixes: alpha HOMO → (HOMO+LUMO)/√2,
+               beta HOMO → (HOMO−LUMO)/√2. Preserves molecular delocalization and
+               gives a smoother symmetry break than mode 1.
              - 2 to adjust the num. electrons for spin-up and spin-down density matrices (issue #1839).
 
     Examples:

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -143,7 +143,7 @@ def _break_dm_spin_symm(mol, dm, breaksym=1):
             else:
                 # No MO info: build a MINAO restricted DM, construct the Fock matrix
                 # from it, and diagonalise once to get energy-ordered MOs.  This costs
-                # one Fock build and one diagonalisation — no SCF iterations — but gives
+                # one Fock build and one diagonalisation (no SCF iterations) but gives
                 # the true HOMO/LUMO rather than an arbitrary vector from the degenerate
                 # virtual subspace that a plain DM diagonalisation would produce.
                 rhf_tmp = hf.RHF(mol)
@@ -162,10 +162,10 @@ def _break_dm_spin_symm(mol, dm, breaksym=1):
                 homo = mo_a[:, homo_idx]
                 lumo = mo_a[:, lumo_idx]
                 c = numpy.sqrt(0.5)
-                # alpha HOMO → (HOMO + LUMO)/√2
+                # alpha HOMO -> (HOMO + LUMO)/sqrt(2)
                 mo_alpha = mo_a.copy()
                 mo_alpha[:, homo_idx] = c * (homo + lumo)
-                # beta  HOMO → (HOMO − LUMO)/√2
+                # beta  HOMO -> (HOMO - LUMO)/sqrt(2)
                 mo_beta = mo_a.copy()
                 mo_beta[:, homo_idx] = c * (homo - lumo)
                 dma = numpy.dot(mo_alpha[:, occ_a > 0.5] * occ_a[occ_a > 0.5],
@@ -817,8 +817,8 @@ class UHF(hf.SCF):
              - 1 (default) to use the atom-block algorithm introduced in pyscf-1.7.
              - 'mix' to rotate the HOMO and LUMO by 45 degrees between alpha and
                beta spins. Builds one MINAO Fock matrix and diagonalises it to get
-               energy-ordered MOs, then mixes: alpha HOMO → (HOMO+LUMO)/√2,
-               beta HOMO → (HOMO−LUMO)/√2. Preserves molecular delocalization and
+               energy-ordered MOs, then mixes: alpha HOMO -> (HOMO+LUMO)/sqrt(2),
+               beta HOMO -> (HOMO-LUMO)/sqrt(2). Preserves molecular delocalization and
                gives a smoother symmetry break than mode 1.
              - 2 to adjust the num. electrons for spin-up and spin-down density matrices (issue #1839).
 

--- a/pyscf/scf/uhf.py
+++ b/pyscf/scf/uhf.py
@@ -122,6 +122,57 @@ def _break_dm_spin_symm(mol, dm, breaksym=1):
             dmb = numpy.zeros_like(dma)
             for b0, b1, p0, p1 in mol.aoslice_by_atom():
                 dmb[...,p0:p1,p0:p1] = dma[...,p0:p1,p0:p1]
+        elif breaksym == 2:
+            # 45-degree HOMO-LUMO rotation mixes the frontier orbitals between alpha
+            # and beta spins while keeping them delocalized over the full molecule.
+            # Unlike breaksym=1 (which zeroes off-diagonal AO blocks and artificially
+            # localises charge onto atoms), this rotation preserves the full molecular
+            # orbital character and provides a smoother path away from the RHF fixed
+            # point, reducing the risk of converging back to the closed-shell solution.
+            mo_coeff = getattr(dm, 'mo_coeff', None)
+            mo_occ = getattr(dm, 'mo_occ', None)
+            if mo_coeff is not None and mo_occ is not None:
+                # Energy-ordered MOs (ascending): HOMO = last occupied, LUMO = first virtual.
+                mo_a = mo_coeff[0]
+                occ_a = mo_occ[0]
+                occ_b = mo_occ[1]
+                occ_idx = numpy.where(occ_a > 0.5)[0]
+                vir_idx = numpy.where(occ_a < 0.5)[0]
+                homo_idx = occ_idx[-1]
+                lumo_idx = vir_idx[0]
+            else:
+                # No MO info: build natural orbitals via the S^{1/2} transform.
+                # Plain eigh(dma) in a non-orthogonal AO basis gives wrong eigenvalues;
+                # the S^{1/2}-transformed DM has eigenvalues equal to true occupations
+                # so that Tr(S*DM)=N_elec is preserved after reconstruction.
+                # eigh sorts ascending: virtual NOs (occ≈0) first, occupied (occ≈1) last;
+                # HOMO = last occupied, LUMO-like = last virtual (index just below HOMO).
+                s1e = mol.intor_symmetric('int1e_ovlp')
+                s_eval, s_evec = numpy.linalg.eigh(s1e)
+                s_sqrt = numpy.dot(s_evec * numpy.sqrt(s_eval), s_evec.T)
+                s_invsqrt = numpy.dot(s_evec * (1.0 / numpy.sqrt(s_eval)), s_evec.T)
+                occ_a, C_orth = numpy.linalg.eigh(s_sqrt.dot(dma).dot(s_sqrt))
+                mo_a = s_invsqrt.dot(C_orth)
+                occ_b = occ_a.copy()
+                occ_idx = numpy.where(occ_a > 0.5)[0]
+                vir_idx = numpy.where(occ_a < 0.5)[0]
+                homo_idx = occ_idx[-1]
+                lumo_idx = vir_idx[-1]
+            if len(occ_idx) > 0 and len(vir_idx) > 0:
+                homo = mo_a[:, homo_idx]
+                lumo = mo_a[:, lumo_idx]
+                c = numpy.sqrt(0.5)
+                # alpha HOMO → (HOMO + LUMO)/√2
+                mo_alpha = mo_a.copy()
+                mo_alpha[:, homo_idx] = c * (homo + lumo)
+                # beta  HOMO → (HOMO − LUMO)/√2
+                mo_beta = mo_a.copy()
+                mo_beta[:, homo_idx] = c * (homo - lumo)
+                dma = numpy.dot(mo_alpha[:, occ_a > 0.5] * occ_a[occ_a > 0.5],
+                                mo_alpha[:, occ_a > 0.5].conj().T)
+                dmb = numpy.dot(mo_beta[:, occ_b > 0.5] * occ_b[occ_b > 0.5],
+                                mo_beta[:, occ_b > 0.5].conj().T)
+
         else:
             # Adjust num. electrons for density matrices (issue #1839)
             # Get overlap matrix


### PR DESCRIPTION
Summary

This PR adds a new option breaksym=2 to _break_dm_spin_symm and the UHF init_guess_breaksym setting. It provides an alternative way to break spin symmetry in the initial density matrix for closed-shell starting points.

What it does

Instead of zeroing the off-diagonal AO blocks of the beta density matrix (breaksym=1), breaksym=2 applies a 45-degree rotation between the HOMO and LUMO:

α spin HOMO → (HOMO + LUMO) / √2
β spin HOMO → (HOMO − LUMO) / √2
This mixes the two frontier orbitals differently for each spin, breaking the spin symmetry while keeping both orbitals fully delocalized over the molecule.

Why this is better than breaksym=1

breaksym=1 zeros all off-diagonal AO blocks of the beta DM, which effectively localizes charge onto individual atoms and creates a sharp, atom-block structure in the initial guess. This can be unnecessarily aggressive and may push the SCF into regions that are hard to converge from.

breaksym=2 instead makes the smallest change that breaks symmetry: a single orbital rotation at the frontier. The resulting DMs are physically well-formed (positive semidefinite, correct electron count Tr(S·DM) = N_elec), delocalized over the full molecule, and provide a gentler, smoother path away from the RHF fixed point  reducing the risk of collapsing back to the closed-shell solution.
