### PR TITLE
use newer pyberny and numpy in ci

### DIFF
--- a/.github/workflows/ci_linux/python_deps.sh
+++ b/.github/workflows/ci_linux/python_deps.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 python -m pip install --upgrade pip
 pip install "numpy!=1.16,!=1.17" "scipy!=1.5" h5py pytest pytest-cov pytest-timer
-pip install pyberny
+pip install git+https://github.com/jhrmnn/pyberny.git@36a4be9
 pip install --no-deps pyscf-dispersion==1.3.0
+pip install geometric
 
 version=$(python -c 'import sys; version=sys.version_info[:2]; print("{0}.{1}".format(*version))')
 if [ $version != '3.12' ]; then
-    pip install geometric
     pip install spglib
 fi
 

--- a/pyscf/fci/test/test_rdm.py
+++ b/pyscf/fci/test/test_rdm.py
@@ -267,7 +267,7 @@ class KnownValues(unittest.TestCase):
         h2 = numpy.random.random((npair,npair)) * .1
         h2 = h2 + h2.T
         cis = fci.direct_spin1.FCI()
-        e, c = cis.kernel(h1, h2, norb, nelec, verbose=5)
+        e, c = cis.kernel(h1, h2, norb, nelec)
         dm1s, dm2s = cis.make_rdm12s(c, norb, nelec)
         self.assertAlmostEqual(abs(dm1s[0]).sum(), 6, 9)
         self.assertAlmostEqual(dm1s[1].trace(), 3, 9)
@@ -285,7 +285,7 @@ class KnownValues(unittest.TestCase):
         h2 = numpy.random.random((npair,npair)) * .1
         h2 = h2 + h2.T
         cis = fci.direct_spin1.FCI()
-        e, c = cis.kernel(h1, h2, norb, nelec, verbose=5)
+        e, c = cis.kernel(h1, h2, norb, nelec)
         dm1s, dm2s = cis.make_rdm12s(c, norb, nelec)
         self.assertAlmostEqual(dm1s[0].trace(), 3, 9)
         self.assertAlmostEqual(abs(dm1s[1]).sum(), 0, 9)

--- a/pyscf/gw/test/test_gw_ac.py
+++ b/pyscf/gw/test/test_gw_ac.py
@@ -8,7 +8,6 @@ from pyscf.gw.gw_ac import GWAC
 @pytest.fixture
 def h2o_pbe0():
     mol = gto.Mole()
-    mol.verbose = 5
     mol.atom = [[8, (0.0, 0.0, 0.0)], [1, (0.0, -0.7571, 0.5861)], [1, (0.0, 0.7571, 0.5861)]]
     mol.basis = 'def2-svp'
     mol.build()

--- a/pyscf/gw/test/test_ugw_ac.py
+++ b/pyscf/gw/test/test_ugw_ac.py
@@ -6,7 +6,6 @@ from pyscf.gw.ugw_ac import UGWAC
 @pytest.fixture
 def h2o_cation_uhf():
     mol = gto.Mole()
-    mol.verbose = 5
     mol.atom = [[8, (0.0, 0.0, 0.0)], [1, (0.0, -0.7571, 0.5861)], [1, (0.0, 0.7571, 0.5861)]]
     mol.basis = 'def2-svp'
     mol.charge = 1

--- a/pyscf/lib/numpy_helper.py
+++ b/pyscf/lib/numpy_helper.py
@@ -153,10 +153,16 @@ def contract(subscripts, A, B, alpha=1, beta=0, out=None, **kwargs):
     if A.size < EINSUM_MAX_SIZE or B.size < EINSUM_MAX_SIZE:
         return _numpy_einsum(idx_str, A, B, alpha=alpha, beta=beta, out=out)
 
+    C_dtype = numpy.result_type(A, B)
     if EINSUM_BACKEND == 'pytblis':
+        # pytblis cannot apply alpha/beta when it has to fall back to numpy
+        # tensordot, and it requires the output to share the IEEE type of the
+        # inputs. Route these cases through numpy instead.
+        if ((out is not None and out.dtype != C_dtype) or
+                numpy.result_type(C_dtype, alpha, beta) != C_dtype):
+            return _numpy_einsum(idx_str, A, B, alpha=alpha, beta=beta, out=out)
         return pytblis.contract(idx_str, A, B, alpha=alpha, beta=beta, out=out)
 
-    C_dtype = numpy.result_type(A, B)
     if EINSUM_BACKEND =='pyscf-tblis' and C_dtype == numpy.double:
         # tblis is slow for complex type
         return tblis_einsum.contract(idx_str, A, B, alpha=alpha, beta=beta, out=out)

--- a/pyscf/lib/test/test_einsum.py
+++ b/pyscf/lib/test/test_einsum.py
@@ -3,6 +3,9 @@ import numpy
 from pyscf import lib
 einsum = lib.einsum
 
+# pytblis does not support contractions between operands of different dtypes
+_pytblis = lib.numpy_helper.EINSUM_BACKEND == 'pytblis'
+
 def setUpModule():
     global bak
     lib.numpy_helper.EINSUM_MAX_SIZE, bak = 0, lib.numpy_helper.EINSUM_MAX_SIZE
@@ -92,6 +95,7 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(c0.dtype == c1.dtype)
         self.assertTrue(abs(c0-c1).max() < 1e-14)
 
+    @unittest.skipIf(_pytblis, 'pytblis does not support mixed input dtypes')
     def test_d_cslice(self):
         a = numpy.random.random((7,1,3,4))
         b = numpy.random.random((2,4,5,7)).astype(numpy.float32)
@@ -100,6 +104,7 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(c0.dtype == c1.dtype)
         self.assertTrue(abs(c0-c1).max() < 1e-14)
 
+    @unittest.skipIf(_pytblis, 'pytblis does not support mixed input dtypes')
     def test_z_cslice(self):
         a = numpy.random.random((7,1,3,4)).astype(numpy.float32) + 0j
         b = numpy.random.random((2,4,5,7))
@@ -108,6 +113,7 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(c0.dtype == c1.dtype)
         self.assertTrue(abs(c0-c1).max() < 1e-14)
 
+    @unittest.skipIf(_pytblis, 'pytblis does not support mixed input dtypes')
     def test_cslice_dslice(self):
         a = numpy.random.random((7,1,3,4)).astype(numpy.float32) + 0j
         b = numpy.random.random((2,4,5,7))

--- a/pyscf/lib/test/test_einsum.py
+++ b/pyscf/lib/test/test_einsum.py
@@ -3,7 +3,9 @@ import numpy
 from pyscf import lib
 einsum = lib.einsum
 
-# pytblis does not support contractions between operands of different dtypes
+# pytblis does not support contractions between operands of different
+# floating-point precision (e.g. float64 vs float32); real/complex mixing at
+# the same precision is fine
 _pytblis = lib.numpy_helper.EINSUM_BACKEND == 'pytblis'
 
 def setUpModule():
@@ -95,7 +97,7 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(c0.dtype == c1.dtype)
         self.assertTrue(abs(c0-c1).max() < 1e-14)
 
-    @unittest.skipIf(_pytblis, 'pytblis does not support mixed input dtypes')
+    @unittest.skipIf(_pytblis, 'pytblis does not support operands of different precision')
     def test_d_cslice(self):
         a = numpy.random.random((7,1,3,4))
         b = numpy.random.random((2,4,5,7)).astype(numpy.float32)
@@ -104,7 +106,7 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(c0.dtype == c1.dtype)
         self.assertTrue(abs(c0-c1).max() < 1e-14)
 
-    @unittest.skipIf(_pytblis, 'pytblis does not support mixed input dtypes')
+    @unittest.skipIf(_pytblis, 'pytblis does not support operands of different precision')
     def test_z_cslice(self):
         a = numpy.random.random((7,1,3,4)).astype(numpy.float32) + 0j
         b = numpy.random.random((2,4,5,7))
@@ -113,7 +115,7 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(c0.dtype == c1.dtype)
         self.assertTrue(abs(c0-c1).max() < 1e-14)
 
-    @unittest.skipIf(_pytblis, 'pytblis does not support mixed input dtypes')
+    @unittest.skipIf(_pytblis, 'pytblis does not support operands of different precision')
     def test_cslice_dslice(self):
         a = numpy.random.random((7,1,3,4)).astype(numpy.float32) + 0j
         b = numpy.random.random((2,4,5,7))

--- a/pyscf/mp/dfmp2.py
+++ b/pyscf/mp/dfmp2.py
@@ -445,7 +445,7 @@ def _init_mp_df_eris_direct(with_df, occ_coeff, vir_coeff, max_memory, h5obj=Non
     # precompute for fitting
     j2c = fill_2c2e(mol, auxmol)
     try:
-        m2c = scipy.linalg.cholesky(j2c, lower=True)
+        m2c = np.asfortranarray(scipy.linalg.cholesky(j2c, lower=True))
         tag = 'cd'
     except scipy.linalg.LinAlgError:
         e, u = np.linalg.eigh(j2c)

--- a/pyscf/mp/dfump2.py
+++ b/pyscf/mp/dfump2.py
@@ -468,7 +468,7 @@ def _init_mp_df_eris_direct(with_df, occ_coeff, vir_coeff, max_memory, h5obj=Non
     # precompute for fitting
     j2c = fill_2c2e(mol, auxmol)
     try:
-        m2c = scipy.linalg.cholesky(j2c, lower=True)
+        m2c = np.asfortranarray(scipy.linalg.cholesky(j2c, lower=True))
         tag = 'cd'
     except scipy.linalg.LinAlgError:
         e, u = np.linalg.eigh(j2c)

--- a/pyscf/qmmm/pbc/itrf.py
+++ b/pyscf/qmmm/pbc/itrf.py
@@ -805,8 +805,7 @@ class QMMMGrad:
         TGGsinGvRqm = lib.einsum("iab,ga,gb,ig->g", qm_quads, Gv, Gv, sinGvRqm)
 
         DGqm = lib.einsum('ia,ga->ig', qm_dipoles, Gv)
-        GvGv = lib.einsum('ga,gb->gab', Gv, Gv)
-        TGGqm = lib.einsum('iab,gab->ig', qm_quads, GvGv)
+        TGGqm = lib.einsum('iab,ga,gb->ig', qm_quads, Gv, Gv)
 
         qm_ewg_grad = np.zeros_like(qm_coords)
         if with_mm:

--- a/pyscf/qmmm/pbc/itrf.py
+++ b/pyscf/qmmm/pbc/itrf.py
@@ -804,60 +804,49 @@ class QMMMGrad:
         TGGcosGvRqm = lib.einsum("iab,ga,gb,ig->g", qm_quads, Gv, Gv, cosGvRqm)
         TGGsinGvRqm = lib.einsum("iab,ga,gb,ig->g", qm_quads, Gv, Gv, sinGvRqm)
 
+        DGqm = lib.einsum('ia,ga->ig', qm_dipoles, Gv)
+        GvGv = lib.einsum('ga,gb->gab', Gv, Gv)
+        TGGqm = lib.einsum('iab,gab->ig', qm_quads, GvGv)
+
         qm_ewg_grad = np.zeros_like(qm_coords)
         if with_mm:
             mm_ewg_grad = np.zeros_like(mm_coords)
 
         # qm pc - mm pc
-        p = ['einsum_path', (3, 4), (1, 3), (1, 2), (0, 1)]
-        qm_ewg_grad -= lib.einsum('i,gx,ig,g,g->ix', qm_charges, Gv, sinGvRqm, zcosGvRmm, Gpref, optimize=p)
-        qm_ewg_grad += lib.einsum('i,gx,ig,g,g->ix', qm_charges, Gv, cosGvRqm, zsinGvRmm, Gpref, optimize=p)
+        qm_ewg_grad -= qm_charges[:,None] * lib.einsum('ig,gx->ix', sinGvRqm, Gv*(zcosGvRmm*Gpref)[:,None])
+        qm_ewg_grad += qm_charges[:,None] * lib.einsum('ig,gx->ix', cosGvRqm, Gv*(zsinGvRmm*Gpref)[:,None])
         if with_mm:
-            p = ['einsum_path', (0, 2), (1, 2), (0, 2), (0, 1)]
-            mm_ewg_grad -= lib.einsum('i,gx,ig,g,g->ix', mm_charges, Gv, sinGvRmm, zcosGvRqm, Gpref, optimize=p)
-            mm_ewg_grad += lib.einsum('i,gx,ig,g,g->ix', mm_charges, Gv, cosGvRmm, zsinGvRqm, Gpref, optimize=p)
+            mm_ewg_grad -= mm_charges[:,None] * lib.einsum('ig,gx->ix', sinGvRmm, Gv*(zcosGvRqm*Gpref)[:,None])
+            mm_ewg_grad += mm_charges[:,None] * lib.einsum('ig,gx->ix', cosGvRmm, Gv*(zsinGvRqm*Gpref)[:,None])
         # qm dip - mm pc
-        p = ['einsum_path', (4, 5), (1, 4), (0, 1), (0, 2), (0, 1)]
-        qm_ewg_grad -= lib.einsum('ia,gx,ga,ig,g,g->ix', qm_dipoles, Gv, Gv, sinGvRqm, zsinGvRmm, Gpref, optimize=p)
-        qm_ewg_grad -= lib.einsum('ia,gx,ga,ig,g,g->ix', qm_dipoles, Gv, Gv, cosGvRqm, zcosGvRmm, Gpref, optimize=p)
+        qm_ewg_grad -= lib.einsum('ig,gx->ix', DGqm*sinGvRqm, Gv*(zsinGvRmm*Gpref)[:,None])
+        qm_ewg_grad -= lib.einsum('ig,gx->ix', DGqm*cosGvRqm, Gv*(zcosGvRmm*Gpref)[:,None])
         if with_mm:
-            p = ['einsum_path', (1, 3), (0, 2), (0, 2), (0, 1)]
-            mm_ewg_grad += lib.einsum('g,j,gx,jg,g->jx', DGcosGvRqm, mm_charges, Gv, cosGvRmm, Gpref, optimize=p)
-            mm_ewg_grad += lib.einsum('g,j,gx,jg,g->jx', DGsinGvRqm, mm_charges, Gv, sinGvRmm, Gpref, optimize=p)
+            mm_ewg_grad += mm_charges[:,None] * lib.einsum('ig,gx->ix', cosGvRmm, Gv*(DGcosGvRqm*Gpref)[:,None])
+            mm_ewg_grad += mm_charges[:,None] * lib.einsum('ig,gx->ix', sinGvRmm, Gv*(DGsinGvRqm*Gpref)[:,None])
         # qm quad - mm pc
-        p = ['einsum_path', (5, 6), (0, 5), (0, 2), (2, 3), (1, 2), (0, 1)]
-        qm_ewg_grad += lib.einsum('ga,gb,iab,gx,ig,g,g->ix', Gv, Gv, qm_quads,
-                                  Gv, sinGvRqm, zcosGvRmm, Gpref, optimize=p) / 3
-        qm_ewg_grad -= lib.einsum('ga,gb,iab,gx,ig,g,g->ix', Gv, Gv, qm_quads,
-                                  Gv, cosGvRqm, zsinGvRmm, Gpref, optimize=p) / 3
+        qm_ewg_grad += lib.einsum('ig,gx->ix', TGGqm*sinGvRqm, Gv*(zcosGvRmm*Gpref)[:,None]) / 3
+        qm_ewg_grad -= lib.einsum('ig,gx->ix', TGGqm*cosGvRqm, Gv*(zsinGvRmm*Gpref)[:,None]) / 3
         if with_mm:
-            p = ['einsum_path', (1, 3), (0, 2), (0, 2), (0, 1)]
-            mm_ewg_grad += lib.einsum('g,j,gx,jg,g->jx', TGGcosGvRqm, mm_charges, Gv, sinGvRmm, Gpref, optimize=p) / 3
-            mm_ewg_grad -= lib.einsum('g,j,gx,jg,g->jx', TGGsinGvRqm, mm_charges, Gv, cosGvRmm, Gpref, optimize=p) / 3
+            mm_ewg_grad += mm_charges[:,None] * lib.einsum('ig,gx->ix', sinGvRmm, Gv*(TGGcosGvRqm*Gpref)[:,None]) / 3
+            mm_ewg_grad -= mm_charges[:,None] * lib.einsum('ig,gx->ix', cosGvRmm, Gv*(TGGsinGvRqm*Gpref)[:,None]) / 3
 
         # qm pc - qm pc
-        p = ['einsum_path', (3, 4), (1, 3), (1, 2), (0, 1)]
-        qm_ewg_grad -= lib.einsum('i,gx,ig,g,g->ix', qm_charges, Gv, sinGvRqm, zcosGvRqm, Gpref, optimize=p)
-        qm_ewg_grad += lib.einsum('i,gx,ig,g,g->ix', qm_charges, Gv, cosGvRqm, zsinGvRqm, Gpref, optimize=p)
+        qm_ewg_grad -= qm_charges[:,None] * lib.einsum('ig,gx->ix', sinGvRqm, Gv*(zcosGvRqm*Gpref)[:,None])
+        qm_ewg_grad += qm_charges[:,None] * lib.einsum('ig,gx->ix', cosGvRqm, Gv*(zsinGvRqm*Gpref)[:,None])
         # qm pc - qm dip
-        qm_ewg_grad += lib.einsum('i,gx,ig,g,g->ix', qm_charges, Gv, cosGvRqm, DGcosGvRqm, Gpref, optimize=p)
-        qm_ewg_grad += lib.einsum('i,gx,ig,g,g->ix', qm_charges, Gv, sinGvRqm, DGsinGvRqm, Gpref, optimize=p)
-        p = ['einsum_path', (3, 5), (1, 4), (1, 3), (1, 2), (0, 1)]
-        qm_ewg_grad -= lib.einsum('ja,ga,gx,g,jg,g->jx', qm_dipoles, Gv, Gv, zsinGvRqm, sinGvRqm, Gpref, optimize=p)
-        qm_ewg_grad -= lib.einsum('ja,ga,gx,g,jg,g->jx', qm_dipoles, Gv, Gv, zcosGvRqm, cosGvRqm, Gpref, optimize=p)
+        qm_ewg_grad += qm_charges[:,None] * lib.einsum('ig,gx->ix', cosGvRqm, Gv*(DGcosGvRqm*Gpref)[:,None])
+        qm_ewg_grad += qm_charges[:,None] * lib.einsum('ig,gx->ix', sinGvRqm, Gv*(DGsinGvRqm*Gpref)[:,None])
+        qm_ewg_grad -= lib.einsum('ig,gx->ix', DGqm*sinGvRqm, Gv*(zsinGvRqm*Gpref)[:,None])
+        qm_ewg_grad -= lib.einsum('ig,gx->ix', DGqm*cosGvRqm, Gv*(zcosGvRqm*Gpref)[:,None])
         # qm dip - qm dip
-        p = ['einsum_path', (4, 5), (1, 4), (1, 3), (1, 2), (0, 1)]
-        qm_ewg_grad -= lib.einsum('ia,ga,gx,ig,g,g->ix', qm_dipoles, Gv, Gv, sinGvRqm, DGcosGvRqm, Gpref, optimize=p)
-        qm_ewg_grad += lib.einsum('ia,ga,gx,ig,g,g->ix', qm_dipoles, Gv, Gv, cosGvRqm, DGsinGvRqm, Gpref, optimize=p)
+        qm_ewg_grad -= lib.einsum('ig,gx->ix', DGqm*sinGvRqm, Gv*(DGcosGvRqm*Gpref)[:,None])
+        qm_ewg_grad += lib.einsum('ig,gx->ix', DGqm*cosGvRqm, Gv*(DGsinGvRqm*Gpref)[:,None])
         # qm pc - qm quad
-        p = ['einsum_path', (3, 4), (1, 3), (1, 2), (0, 1)]
-        qm_ewg_grad += lib.einsum('i,gx,ig,g,g->ix', qm_charges, Gv, sinGvRqm, TGGcosGvRqm, Gpref, optimize=p) / 3
-        qm_ewg_grad -= lib.einsum('i,gx,ig,g,g->ix', qm_charges, Gv, cosGvRqm, TGGsinGvRqm, Gpref, optimize=p) / 3
-        p = ['einsum_path', (4, 6), (1, 5), (1, 2), (2, 3), (1, 2), (0, 1)]
-        qm_ewg_grad += lib.einsum('jab,ga,gb,gx,g,jg,g->jx', qm_quads, Gv, Gv,
-                                  Gv, zcosGvRqm, sinGvRqm, Gpref, optimize=p) / 3
-        qm_ewg_grad -= lib.einsum('jab,ga,gb,gx,g,jg,g->jx', qm_quads, Gv, Gv,
-                                  Gv, zsinGvRqm, cosGvRqm, Gpref, optimize=p) / 3
+        qm_ewg_grad += qm_charges[:,None] * lib.einsum('ig,gx->ix', sinGvRqm, Gv*(TGGcosGvRqm*Gpref)[:,None]) / 3
+        qm_ewg_grad -= qm_charges[:,None] * lib.einsum('ig,gx->ix', cosGvRqm, Gv*(TGGsinGvRqm*Gpref)[:,None]) / 3
+        qm_ewg_grad += lib.einsum('ig,gx->ix', TGGqm*sinGvRqm, Gv*(zcosGvRqm*Gpref)[:,None]) / 3
+        qm_ewg_grad -= lib.einsum('ig,gx->ix', TGGqm*cosGvRqm, Gv*(zsinGvRqm*Gpref)[:,None]) / 3
 
         logger.timer(self, 'grad_ewald k-space', *cput2)
         logger.timer(self, 'grad_ewald', *cput0)

--- a/pyscf/qmmm/pbc/mm_mole.py
+++ b/pyscf/qmmm/pbc/mm_mole.py
@@ -305,13 +305,12 @@ class Cell(qmmm.mm_mole.Mole, pbc.gto.Cell):
             ewg0  = lib.einsum('ig,g,g->i', cosGvR1, zcosGvR2, Gpref)
             ewg0 += lib.einsum('ig,g,g->i', sinGvR1, zsinGvR2, Gpref)
             # qm dip - mm pc
-            p = ['einsum_path', (2, 3), (0, 2), (0, 1)]
-            ewg1  = lib.einsum('gx,ig,g,g->ix', Gv, cosGvR1, zsinGvR2, Gpref, optimize=p)
-            ewg1 -= lib.einsum('gx,ig,g,g->ix', Gv, sinGvR1, zcosGvR2, Gpref, optimize=p)
+            ewg1  = lib.einsum('gx,ig->ix', Gv*(zsinGvR2*Gpref)[:,None], cosGvR1)
+            ewg1 -= lib.einsum('gx,ig->ix', Gv*(zcosGvR2*Gpref)[:,None], sinGvR1)
             # qm quad - mm pc
-            p = ['einsum_path', (3, 4), (0, 3), (0, 2), (0, 1)]
-            ewg2  = -lib.einsum('gx,gy,ig,g,g->ixy', Gv, Gv, cosGvR1, zcosGvR2, Gpref, optimize=p)
-            ewg2 += -lib.einsum('gx,gy,ig,g,g->ixy', Gv, Gv, sinGvR1, zsinGvR2, Gpref, optimize=p)
+            GvGv = lib.einsum('gx,gy->gxy', Gv, Gv)
+            ewg2  = -lib.einsum('ig,gxy->ixy', cosGvR1*(zcosGvR2*Gpref)[None,:], GvGv)
+            ewg2 += -lib.einsum('ig,gxy->ixy', sinGvR1*(zsinGvR2*Gpref)[None,:], GvGv)
             ewg2 /= 3
         else:
             # qm pc - qm pc

--- a/pyscf/qmmm/pbc/mm_mole.py
+++ b/pyscf/qmmm/pbc/mm_mole.py
@@ -308,9 +308,8 @@ class Cell(qmmm.mm_mole.Mole, pbc.gto.Cell):
             ewg1  = lib.einsum('gx,ig->ix', Gv*(zsinGvR2*Gpref)[:,None], cosGvR1)
             ewg1 -= lib.einsum('gx,ig->ix', Gv*(zcosGvR2*Gpref)[:,None], sinGvR1)
             # qm quad - mm pc
-            GvGv = lib.einsum('gx,gy->gxy', Gv, Gv)
-            ewg2  = -lib.einsum('ig,gxy->ixy', cosGvR1*(zcosGvR2*Gpref)[None,:], GvGv)
-            ewg2 += -lib.einsum('ig,gxy->ixy', sinGvR1*(zsinGvR2*Gpref)[None,:], GvGv)
+            ewg2  = -lib.einsum('ig,gx,gy->ixy', cosGvR1*(zcosGvR2*Gpref)[None,:], Gv, Gv)
+            ewg2 += -lib.einsum('ig,gx,gy->ixy', sinGvR1*(zsinGvR2*Gpref)[None,:], Gv, Gv)
             ewg2 /= 3
         else:
             # qm pc - qm pc

--- a/pyscf/tools/test/test_finite_diff.py
+++ b/pyscf/tools/test/test_finite_diff.py
@@ -62,7 +62,6 @@ class KnownValues(unittest.TestCase):
 
     def test_convergence_failed(self):
         mol = pyscf.M(atom='H 0 0 0; H 0 0 1')
-        mol.verbose = 4
         geom_ref = mol.atom_coords()
         mf = mol.RHF().run()
         ref = mf.Gradients().kernel()


### PR DESCRIPTION
Install pyberny from git temporarily, which supports numpy v2, before their new release. 

However, in py312 test the numpy comes to 2.4, and there's quite a few errors now. Some of them are related to scipy update, and has been fixed by using f-contig array. The rest ones may be related to pytblis. (can reproduce locally)