### PR TITLE
Fix unit tests when XCFun not enabled.

### DIFF
--- a/pyscf/dft/test/test_he.py
+++ b/pyscf/dft/test/test_he.py
@@ -114,6 +114,8 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(mf.e_tot, -1.9931564410562266, 9)
 
     def test_xcfun_nr_blyp(self):
+        if not hasattr(dft, 'xcfun'):
+            raise unittest.SkipTest('PySCF was not built with XCFun.')
         m = mol.RKS()
         m._numint.libxc = dft.xcfun
         m.xc = 'b88,lyp'

--- a/pyscf/dft/test/test_xc_deriv.py
+++ b/pyscf/dft/test/test_xc_deriv.py
@@ -521,8 +521,12 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(xc1.sum(), 19.977512805950784, 9)
         self.assertAlmostEqual(abs(ref[1] - xc1).max(), 0, 9)
 
-    @unittest.skipIf(not (hasattr(dft, 'xcfun') and dft.xcfun.MAX_DERIV_ORDER > 3), 'xcfun order')
     def test_xcfun_gga_deriv4(self):
+        if not hasattr(dft, 'xcfun'):
+            raise unittest.SkipTest('XCFun not available.')
+        if dft.xcfun.MAX_DERIV_ORDER <= 3:
+            raise unittest.SkipTest('XCFun MAX_DERIV_ORDER <= 3.')
+
         rho1 = rho[:,:4].copy()
         xc1 = dft.xcfun.eval_xc_eff('PBE', rho1, deriv=4)
         self.assertAlmostEqual(xc1.sum(), -1141.356286780069, 9)
@@ -531,8 +535,12 @@ class KnownValues(unittest.TestCase):
         xc1 = dft.xcfun.eval_xc_eff('PBE', rho1, deriv=4)
         self.assertAlmostEqual(xc1.sum(), -615.116081052867, 9)
 
-    @unittest.skipIf(not (hasattr(dft, 'xcfun') and dft.xcfun.MAX_DERIV_ORDER > 3), 'xcfun order')
     def test_xcfun_gga_deriv4_finite_diff(self):
+        if not hasattr(dft, 'xcfun'):
+            raise unittest.SkipTest('XCFun not available.')
+        if dft.xcfun.MAX_DERIV_ORDER <= 3:
+            raise unittest.SkipTest('XCFun MAX_DERIV_ORDER <= 3.')
+
         xctype = 'GGA'
         deriv = 4
         nvar = 4

--- a/pyscf/dft/test/test_xcfun.py
+++ b/pyscf/dft/test/test_xcfun.py
@@ -46,6 +46,7 @@ def fp(a):
     w = numpy.cos(numpy.arange(a.size))
     return numpy.dot(w, a.ravel())
 
+@unittest.skipIf(not hasattr(dft, 'xcfun'), 'PySCF was not built with XCFun.')
 class KnownValues(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/pyscf/grad/test/test_tdrks_grad.py
+++ b/pyscf/grad/test/test_tdrks_grad.py
@@ -83,8 +83,9 @@ class KnownValues(unittest.TestCase):
         g1 = tdg.kernel(state=3)
         self.assertAlmostEqual(g1[0,2], -9.32506535e-02, 6)
 
-    @unittest.skipIf(not hasattr(dft, 'xcfun'), 'xcfun not available')
     def test_tda_singlet_b3lyp_xcfun(self):
+        if not hasattr(dft, 'xcfun'):
+            raise unittest.SkipTest('PySCF not built with XCFun.')
         mf = dft.RKS(mol)
         mf.xc = 'b3lyp5'
         mf._numint.libxc = dft.xcfun
@@ -151,6 +152,8 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs((e1[2]-e2[2])/.002 - g1[0,2]).max(), 0, 3)
 
     def test_tddft_b3lyp_high_cost(self):
+        if not hasattr(dft, 'xcfun'):
+            raise unittest.SkipTest('PySCF not built with XCFun.')
         mf = dft.RKS(mol)
         mf.xc = 'b3lyp5'
         mf._numint.libxc = dft.xcfun
@@ -162,6 +165,8 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(g1[0,2], -1.55778110e-01, 6)
 
     def test_range_separated_high_cost(self):
+        if not hasattr(dft, 'xcfun'):
+            raise unittest.SkipTest('PySCF not built with XCFun.')
         mol = gto.M(atom="H; H 1 1.", basis='631g', verbose=0)
         mf = dft.RKS(mol).set(xc='CAMB3LYP')
         mf._numint.libxc = dft.xcfun


### PR DESCRIPTION
## Changes
When XCFun is not enabled the following changes now occur
- **test_xcfun.py**: skips whole module
- **test_he.py**: skips a test that previously gave an attribute error
- **test_xc_deriv.py**: skips actually show up on pytest now and give more useful messages.
- **test_tdrks_grad.py**: Again, skips actually show up on pytest. Also two more skips added.

## Explanation
### Problem 1: Some tests did not check for XCFun in the first place, and failed.
For `pyscf/dft/test/test_xcfun.py` I just added a module-level skip. I also added skips for a few other tests.

### Problem 2: skipIf decorators for tests within classes deselect instead of skipping.
I'm using pytest v9.0.2, perhaps this isn't the case for you. I'd be interested in hearing other peoples experiences. On tests within classes, the decorator syntax (`@unittest.skipIf(not has_xcfun, "...")`) deselects instead of actually skipping. I added lines like
```py
if not hasattr(dft, 'xcfun'):
    raise unittest.SkipTest('PySCF was not built with XCFun.')
```
**Effect:** When running `pytest`, you see the actual skip markers `......s..` and skip message. This is the expected behavior.

## Questions
There are many tests that have problem 2. Here are some files where this is the case:
- `tdscf/test/test_tdrks.py`
- `dft/test/test_xc_deriv.py`
- `grad/test/test_tdrks_grad.py`

Do you want me to change these as well?