### PR TITLE
Fix metaGGA second derivative ordering for external XC-eval

### DIFF
--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -1217,11 +1217,11 @@ def define_xc_(ni, description, xctype='LDA', hyb=0, rsh=(0,0,0)):
                 assert len(fxc) == 3, 'fxc for GGA should be arranged as (v2rho2, v2rhosigma, v2sigma2)'
             elif xctype == 'MGGA':
                 if len(fxc) == 10:
-                    fxc = [fxc[i] for i in [0, 1, 2, 6, 4, 9]]
+                    fxc = [fxc[i] for i in [0, 1, 2, 6, 9, 4]]
                 else:
                     assert len(fxc) == 6, (
                         'fxc for MGGA should be arranged as\n'
-                        '(v2rho2, v2rhosigma, v2sigma2, v2tau2, v2rhotau, v2sigmatau)\nor\n'
+                        '(v2rho2, v2rhosigma, v2sigma2, v2rhotau, v2sigmatau, v2tau2)\nor\n'
                         '(v2rho2, v2rhosigma, v2sigma2, v2lapl2, v2tau2, '
                         'v2rholapl, v2rhotau, v2lapltau, v2sigmalapl, v2sigmatau)')
             assert all(x is not None for x in fxc)

--- a/pyscf/dft/test/test_libxc.py
+++ b/pyscf/dft/test/test_libxc.py
@@ -306,6 +306,12 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(vxc0[0]-vxc1[0]).max(), 0, 9)
         self.assertAlmostEqual(abs(vxc0[1]-vxc1[1]).max(), 0, 9)
 
+        ni = dft.numint.NumInt()
+        ref = ni.eval_xc1('pbe', rho, deriv=2)
+        ni = dft.libxc.define_xc_(ni, 'pbe*1.0', xctype='GGA')
+        dat = ni.eval_xc1('abc', rho, deriv=2)
+        self.assertAlmostEqual(abs(ref - dat).max(), 0, 9)
+
     def test_define_xc_mgga(self):
         def eval_mgga_xc(xc_code, rho, spin=0, relativity=0, deriv=1, omega=None, verbose=None):
             # A fictitious XC functional to demonstrate the usage
@@ -332,6 +338,12 @@ class KnownValues(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             ni.eval_xc_eff(None, rho, deriv=2)
+
+        ni = dft.numint.NumInt()
+        ref = ni.eval_xc1('r2scan', rho, deriv=2)
+        ni = dft.libxc.define_xc_(ni, 'r2scan*1.0', xctype='MGGA')
+        dat = ni.eval_xc1('abc', rho, deriv=2)
+        self.assertAlmostEqual(abs(ref - dat).max(), 0, 9)
 
     def test_m05x(self):
         rho =(numpy.array([1., 1., 0., 0., 0., 0.165 ]).reshape(-1,1),


### PR DESCRIPTION
Second derivatives of metaGGA functionals, when supplied as ten elements (including the Laplacian-dependent ones) were not picked out in the order that is expected by `_MGGA_SORT`.
`_MGGA_SORT` expects v2rho2, v2rhosigma, v2sigma2, v2rhotau, v2sigmatau, v2tau2 as input. The code was picking out v2sigmatau and v2tau2 switched, though.

The script below directly plugs in libxc output into `define_xc_`, which gives results differing from normal pyscf calculations. Modifying the order then gives identical results (of course, with the proposed source-code change, this would not be necessary).

```
from pyscf import gto, dft, tddft

mol = gto.M(
    atom='H 0 0 0; H 1 0 0',
    basis='sto-3g',
    unit='Angstrom',
)

def eval_tpss_x(xc_code, rho, spin=0, relativity=0, deriv=2, omega=None, verbose=None):
    r = dft.libxc.eval_xc('MGGA_X_TPSS,', rho, spin=spin, relativity=0, deriv=deriv, verbose=None)
    return [r[0], r[1], r[2], None]

def eval_tpss_x_mod(xc_code, rho, spin=0, relativity=0, deriv=2, omega=None, verbose=None):
    r = dft.libxc.eval_xc('MGGA_X_TPSS,', rho, spin=spin, relativity=0, deriv=deriv, verbose=None)
    fxc = (r[2][0], r[2][1], r[2][2], r[2][6], r[2][9], r[2][4]) if r[2] is not None else None
    return [r[0], r[1], fxc, None]


mf = dft.RKS(mol)
mf.xc = 'MGGA_X_TPSS,'
e_gs_normal = mf.kernel()
mytd = tddft.TDA(mf)
e_exc_normal = mytd.kernel()[0][0]


mf = dft.RKS(mol)
mf = mf.define_xc_(eval_tpss_x, 'MGGA')
e_gs_custom = mf.kernel()
mytd = tddft.TDA(mf)
e_exc_custom = mytd.kernel()[0][0]

print("e_gs_normal:", e_gs_normal, "e_gs_custom:", e_gs_custom, "diff:", e_gs_custom - e_gs_normal)
print("e_exc_normal:", e_exc_normal, "e_exc_custom:", e_exc_custom, "diff:", e_exc_custom - e_exc_normal)

mf = dft.RKS(mol)
mf = mf.define_xc_(eval_tpss_x_mod, 'MGGA')
e_gs_custom = mf.kernel()
mytd = tddft.TDA(mf)
e_exc_custom = mytd.kernel()[0][0]

print("e_gs_normal:", e_gs_normal, "e_gs_custom:", e_gs_custom, "diff:", e_gs_custom - e_gs_normal)
print("e_exc_normal:", e_exc_normal, "e_exc_custom:", e_exc_custom, "diff:", e_exc_custom - e_exc_normal)
```

Output is:
```
converged SCF energy = -1.08594342634548
Excitation energies (eV)
[21.50905586]
converged SCF energy = -1.08594342634548
Excitation energies (eV)
[11.46576701]
e_gs_normal: -1.0859434263454837 e_gs_custom: -1.0859434263454841 diff: -4.440892098500626e-16
e_exc_normal: 0.7904432300640891 e_exc_custom: 0.42135916926412165 diff: -0.3690840607999675
converged SCF energy = -1.08594342634548
Excitation energies (eV)
[21.50905586]
e_gs_normal: -1.0859434263454837 e_gs_custom: -1.0859434263454837 diff: 0.0
e_exc_normal: 0.7904432300640891 e_exc_custom: 0.7904432300640891 diff: 0.0
```