### PR TITLE
KRPA and KURPA: improve the numerical stablity of ACFD EXX

### DIFF
--- a/pyscf/pbc/gw/krpa.py
+++ b/pyscf/pbc/gw/krpa.py
@@ -694,7 +694,6 @@ def get_rpa_exx(rpa, acfd=False, correction_only=False):
     ex : double
         exchange energy
     """
-    mo_energy = np.array(_mo_energy_frozen(rpa, rpa._scf.mo_energy))
     mo_coeff = np.array(_mo_frozen(rpa, rpa._scf.mo_coeff))
     mo_occ = np.array(_mo_occ_frozen(rpa, rpa._scf.mo_occ))
 
@@ -753,24 +752,7 @@ def get_rpa_exx(rpa, acfd=False, correction_only=False):
                         mo_occ_ij = np.minimum(mo_occ[km][:nocc_i, None], mo_occ[kn][None, :nocc_j]) / 2.0
                         mo_occ_ij -= mo_occ[km][:nocc_i, None] * mo_occ[kn][None, :nocc_j] / 4.0
                     else:
-                        # numerical integration for equation 12 in doi.org/10.1103/PhysRevB.81.115126
-                        # NOTE: this integration is not stable!!!
-                        # w, wts = _get_scaled_legendre_roots(200)
-                        #eij = mo_energy[km][:nocc_i, None] - mo_energy[kn][None, :nocc_j]
-                        ##integrad = eij[:, :, None] / lib.direct_sum("ij+w->ijw", eij**2, w**2) * wts[None, None]
-                        #integrand = eij[:, :, None] / (eij[:, :, None]**2 + w**2) * wts[None, None]
-                        #integrand = np.sum(integrand, axis=2) * 2.0 / np.pi
-
-                        # The following line is equivalent to the frequency integration in equation 12 in
-                        # doi.org/10.1103/PhysRevB.81.115126
-                        # TODO: add a detailed note
-                        eij = mo_energy[km][:nocc_i, None] - mo_energy[kn][None, :nocc_j]
-                        integrand = np.zeros((nocc_i, nocc_j), dtype=np.complex128)
-                        integrand[eij > 1e-6] = 1
-                        integrand[eij < -1e-6] = -1
-                        mo_occ_ij = 1.0 - integrand
-                        # spin-restricted mo_occ should be divided by 2
-                        mo_occ_ij = mo_occ_ij * mo_occ[km][:nocc_i, None] / 2.0
+                        mo_occ_ij = np.minimum(mo_occ[km][:nocc_i, None], mo_occ[kn][None, :nocc_j]) / 2.0
                 else:
                     mo_occ_ij = mo_occ[km][:nocc_i, None] * mo_occ[kn][None, :nocc_j] / 4.0
                 Lij_occ = Lij * mo_occ_ij[None]

--- a/pyscf/pbc/gw/kurpa.py
+++ b/pyscf/pbc/gw/kurpa.py
@@ -524,7 +524,6 @@ def get_rpa_exx(rpa, acfd=False, correction_only=False):
     ex : double
         exchange energy
     """
-    mo_energy = np.asarray(rpa._scf.mo_energy)
     mo_coeff = np.asarray(rpa._scf.mo_coeff)
     mo_occ = np.asarray(rpa._scf.mo_occ)
 
@@ -584,15 +583,7 @@ def get_rpa_exx(rpa, acfd=False, correction_only=False):
                             mo_occ_ij = np.minimum(mo_occ[s][km][:nocc_i, None], mo_occ[s][kn][None, :nocc_j])
                             mo_occ_ij -= mo_occ[s][km][:nocc_i, None] * mo_occ[s][kn][None, :nocc_j]
                         else:
-                            # The following line is equivalent to the frequency integration in equation 12 in
-                            # doi.org/10.1103/PhysRevB.81.115126
-                            # TODO: add a detailed note
-                            eij = mo_energy[s][km][:nocc_i, None] - mo_energy[s][kn][None, :nocc_j]
-                            integrand = np.zeros((nocc_i, nocc_j), dtype=np.complex128)
-                            integrand[eij > 1e-6] = 1
-                            integrand[eij < -1e-6] = -1
-                            mo_occ_ij = 1.0 - integrand
-                            mo_occ_ij = mo_occ_ij * mo_occ[s][km][:nocc_i, None]
+                            mo_occ_ij = np.minimum(mo_occ[s][km][:nocc_i, None], mo_occ[s][kn][None, :nocc_j])
                     else:
                         mo_occ_ij = mo_occ[s][km][:nocc_i, None] * mo_occ[s][kn][None, :nocc_j]
                     Lij_occ = Lij * mo_occ_ij[None]

--- a/pyscf/pbc/gw/test/test_krpa.py
+++ b/pyscf/pbc/gw/test/test_krpa.py
@@ -58,6 +58,16 @@ def test_krpa_no_fc_outcore(diamond_krhf):
     assert rpa.e_tot == pytest.approx(-10.694392044197565, abs=1e-6)
 
 
+def test_krpa_acfd_exx_high_cost(diamond_krhf):
+    rpa = KRPA(diamond_krhf)
+    rpa.fc = False
+    rpa.acfd_exx = True
+    rpa.kernel()
+
+    assert rpa.e_corr == pytest.approx(-0.18527720400362488, abs=1e-6)
+    assert rpa.e_tot == pytest.approx(-10.694392045437178, abs=1e-6)
+
+
 def test_krpa_with_fc(diamond_krhf):
     rpa = KRPA(diamond_krhf)
     rpa.fc = True
@@ -76,4 +86,3 @@ def test_krpa_with_fc_outcore(diamond_krhf):
 
     assert rpa.e_corr == pytest.approx(-0.20723389722097715, abs=1e-6)
     assert rpa.e_tot == pytest.approx(-10.716348738655793, abs=1e-6)
-

--- a/pyscf/pbc/gw/test/test_kurpa.py
+++ b/pyscf/pbc/gw/test/test_kurpa.py
@@ -57,6 +57,16 @@ def test_kurpa_no_fc_outcore(hydrogen_kuhf):
     assert rpa.e_tot == pytest.approx(-1.584806462873674, abs=1e-6)
 
 
+def test_kurpa_acfd_exx_high_cost(hydrogen_kuhf):
+    rpa = KURPA(hydrogen_kuhf)
+    rpa.fc = False
+    rpa.acfd_exx = True
+    rpa.kernel()
+
+    assert rpa.e_corr == pytest.approx(-0.042883522669012034, abs=1e-6)
+    assert rpa.e_tot == pytest.approx(-1.5848064557082748, abs=1e-6)
+
+
 def test_kurpa_with_fc(hydrogen_kuhf):
     rpa = KURPA(hydrogen_kuhf)
     rpa.fc = True
@@ -73,4 +83,3 @@ def test_kurpa_with_fc_outcore(hydrogen_kuhf):
     rpa.kernel()
 
     assert rpa.e_corr == pytest.approx(-0.04295466718074476, abs=1e-6)
-


### PR DESCRIPTION
In previous implementation for evaluating HF+ACFD exchange together, it's numerically unstable when systems have orbitals small fractional occupation numbers.

For example, diamond GTH-Pade/GTH-DZVP, RPA@PBE, old implementation gives non-smooth ACFD exchange with respect to the lattice constant
<img width="1760" height="1584" alt="image" src="https://github.com/user-attachments/assets/251f3f70-89a1-4f0a-bb23-c752641200e2" />

Current implementation solves the problem
<img width="1760" height="1584" alt="image" src="https://github.com/user-attachments/assets/e829bf46-2f42-4f4a-8cbf-3141f869b577" />
