### PR TITLE
Fix pack_tril axis=0 non-square handling and unpack_tril complex conjugate

### DIFF
--- a/pyscf/lib/numpy_helper.py
+++ b/pyscf/lib/numpy_helper.py
@@ -362,6 +362,11 @@ def pack_tril(mat, axis=-1, out=None):
 
     else:  # pack the leading two dimension
         assert (axis == 0)
+        if mat.shape[0] != mat.shape[1]:
+            raise ValueError('pack_tril with axis=0 requires the leading '
+                              'two dimensions to be square, got shape %s'
+                              % (mat.shape,))
+        nd = mat.shape[0]
         out = mat[numpy.tril_indices(nd)]
         return out
 

--- a/pyscf/lib/numpy_helper.py
+++ b/pyscf/lib/numpy_helper.py
@@ -416,10 +416,17 @@ def unpack_tril(tril, filltriu=HERMITIAN, axis=-1, out=None):
     if (tril.dtype != numpy.double and tril.dtype != numpy.complex128):
         out = numpy.ndarray(shape, tril.dtype, buffer=out)
         idx, idy = numpy.tril_indices(nd)
+        is_complex = numpy.iscomplexobj(tril)
         if filltriu == ANTIHERMI:
-            out[...,idy,idx] = -tril
+            if is_complex:
+                out[...,idy,idx] = -tril.conj()
+            else:
+                out[...,idy,idx] = -tril
         else:
-            out[...,idy,idx] = tril
+            if is_complex and filltriu == HERMITIAN:
+                out[...,idy,idx] = tril.conj()
+            else:
+                out[...,idy,idx] = tril
         out[...,idx,idy] = tril
         return out
 

--- a/pyscf/lib/test/test_numpy_helper.py
+++ b/pyscf/lib/test/test_numpy_helper.py
@@ -122,6 +122,22 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(numpy.array_equal(a, numpy.array((0,3,4,6,7,8))))
         self.assertTrue(a.dtype == numpy.int32)
 
+    def test_pack_tril_axis0(self):
+        # axis=0 packs the leading two dimensions; they must be square.
+        n = 4
+        mat = numpy.arange(n*n*3.).reshape(n, n, 3)
+        packed = lib.pack_tril(mat, axis=0)
+        self.assertEqual(packed.shape, (n*(n+1)//2, 3))
+        ref = mat[numpy.tril_indices(n)]
+        self.assertAlmostEqual(abs(packed - ref).max(), 0, 12)
+
+        # Non-square leading dimensions must raise instead of silently
+        # returning a wrong-shape / wrong-content result.
+        bad = numpy.arange(2*4*5.).reshape(2, 4, 5)
+        self.assertRaises(ValueError, lib.pack_tril, bad, axis=0)
+        bad2 = numpy.arange(5*3*4.).reshape(5, 3, 4)
+        self.assertRaises(ValueError, lib.pack_tril, bad2, axis=0)
+
     def test_unpack_row(self):
         row = numpy.arange(28.)
         ref = lib.unpack_tril(row)[4]

--- a/pyscf/lib/test/test_numpy_helper.py
+++ b/pyscf/lib/test/test_numpy_helper.py
@@ -112,6 +112,36 @@ class KnownValues(unittest.TestCase):
         a = numpy.zeros((0, 5))
         self.assertEqual(lib.unpack_tril(a, axis=0).shape, (0, 0, 5))
 
+    def test_unpack_tril_complex64(self):
+        # unpack_tril for dtypes other than double/complex128 goes through
+        # a pure-Python fallback branch. For HERMITIAN/ANTIHERMI fills with
+        # a complex dtype, the upper triangle must be the conjugate of the
+        # lower triangle, matching the complex128 (ctypes-accelerated)
+        # reference path.
+        numpy.random.seed(2)
+        n = 6
+        nn = n*(n+1)//2
+        idx, idy = numpy.tril_indices(n)
+        diag = (idx == idy)
+
+        # HERMITIAN requires a real diagonal.
+        tril_h = numpy.random.random(nn) + numpy.random.random(nn)*1j
+        tril_h[diag] = tril_h[diag].real
+        tril_h64 = tril_h.astype(numpy.complex64)
+        ref = lib.unpack_tril(tril_h, filltriu=lib.HERMITIAN)
+        out = lib.unpack_tril(tril_h64, filltriu=lib.HERMITIAN)
+        self.assertAlmostEqual(abs(out - out.conj().T).max(), 0, 5)
+        self.assertAlmostEqual(abs(out - ref).max(), 0, 5)
+
+        # ANTIHERMI requires a zero diagonal.
+        tril_a = numpy.random.random(nn) + numpy.random.random(nn)*1j
+        tril_a[diag] = 0
+        tril_a64 = tril_a.astype(numpy.complex64)
+        ref = lib.unpack_tril(tril_a, filltriu=lib.ANTIHERMI)
+        out = lib.unpack_tril(tril_a64, filltriu=lib.ANTIHERMI)
+        self.assertAlmostEqual(abs(out + out.conj().T).max(), 0, 5)
+        self.assertAlmostEqual(abs(out - ref).max(), 0, 5)
+
     def test_unpack_tril_integer(self):
         a = lib.unpack_tril(numpy.arange(6, dtype=numpy.int32))
         self.assertTrue(a.dtype == numpy.int32)


### PR DESCRIPTION
Two related lower-triangular packing bugs in `pyscf/lib/numpy_helper.py`, bundled since they touch the same routines and the same file.

**`pack_tril(mat, axis=0)` on a non-square 3D array.** The packed size was computed from `mat.shape[1]` while the elements were read from `(shape[0], shape[1])`, so a non-square leading pair either raised `IndexError` or silently packed the wrong subblock. Added an explicit square-dimension check that raises a clear `ValueError`. Square inputs, the only shape real callers use, are unaffected, and an `ao2mo.kernel`/`restore` roundtrip is unchanged.

**`unpack_tril` complex conjugate in the Python fallback.** For dtypes outside the C-accelerated `double`/`complex128` paths (for example `complex64`), the fallback mirrored the triangle without conjugating for `HERMITIAN`/`ANTIHERMI` fills, producing a symmetric matrix instead of a Hermitian one. Added the conjugate so the result matches the C `complex128` reference bit-for-bit (to float32 precision).

Each fix has a regression test in `test_numpy_helper.py`, both verified against the C reference path.
