### PR TITLE
Allow scalar coord in Mole.set_rinv_origin

### DIFF
--- a/pyscf/gto/mole.py
+++ b/pyscf/gto/mole.py
@@ -2911,7 +2911,7 @@ class MoleBase(lib.StreamObject):
         >>> mol.set_rinv_origin(0)
         >>> mol.set_rinv_origin((0,1,0))
         '''
-        self._env[PTR_RINV_ORIG:PTR_RINV_ORIG+3] = coord[:3]
+        self._env[PTR_RINV_ORIG:PTR_RINV_ORIG+3] = coord
         return self
     set_rinv_orig = set_rinv_origin
     set_rinv_orig_ = set_rinv_orig    # for backward compatibility

--- a/pyscf/gto/test/test_mole.py
+++ b/pyscf/gto/test/test_mole.py
@@ -931,6 +931,18 @@ O    SP
         v = numpy.einsum('pqk->pq', v)
         self.assertAlmostEqual(abs(vref-v).max(), 0, 12)
 
+    def test_set_rinv_origin_scalar(self):
+        # set_rinv_origin(0) is documented as a valid call (see docstring),
+        # matching the behavior of the sibling set_common_origin(0).
+        mol = mol0.copy()
+        mol.set_rinv_origin(0)
+        orig = mol._env[gto.mole.PTR_RINV_ORIG:gto.mole.PTR_RINV_ORIG+3]
+        self.assertAlmostEqual(abs(orig).max(), 0, 12)
+
+        mol.set_rinv_origin((0, 1, 0))
+        orig = mol._env[gto.mole.PTR_RINV_ORIG:gto.mole.PTR_RINV_ORIG+3]
+        self.assertAlmostEqual(abs(orig - numpy.array((0., 1., 0.))).max(), 0, 12)
+
     def test_to_uncontracted_cartesian_basis(self):
         pmol, ctr_coeff = mol0.to_uncontracted_cartesian_basis()
         c = scipy.linalg.block_diag(*ctr_coeff)


### PR DESCRIPTION
`Mole.set_rinv_origin(0)` is shown in the method's own docstring, but it raised `TypeError: 'int' object is not subscriptable` because the implementation sliced `coord[:3]`. The sibling `set_common_origin` assigns `coord` directly and relies on numpy broadcasting, so this change matches that pattern.

Reproduced the `TypeError` on current master. After the fix, both `set_rinv_origin(0)` and `set_rinv_origin((0, 1, 0))` work, and a real `int1e_rinv` integral evaluated at the origin succeeds. Regression test added to `test_mole.py`.
