### PR TITLE
Analytic gradients for CASCI with UHF/RKS/UKS orbitals

### DIFF
--- a/examples/grad/15-casci_hf_orbital_grad.py
+++ b/examples/grad/15-casci_hf_orbital_grad.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+'''
+Analytical nuclear gradients of CASCI with HF and restricted KS orbitals.
+
+The restricted example uses RHF orbitals and the unrestricted example uses UHF
+orbitals.  The final restricted example uses RKS orbitals.  UKS-orbital CASCI
+and CASSCF-orbital CASCI gradients require different orbital-response
+formulations and are not handled by these gradient classes.
+'''
+
+from pyscf import gto
+from pyscf import scf
+from pyscf import dft
+from pyscf import mcscf
+
+
+mol = gto.M(
+    atom = '''
+    H  0.000  0.000  0.000
+    H  0.000  0.000  1.000
+    H  0.200  1.050  0.000
+    ''',
+    basis = 'sto-3g',
+    spin = 1,
+    verbose = 0,
+)
+
+mf = scf.UHF(mol).run()
+mc = mcscf.UCASCI(mf, 2, (1, 1), ncore=(1, 0)).run()
+
+de = mc.nuc_grad_method().kernel()
+print('UHF-orbital UCASCI gradients')
+print(de)
+
+mc.fcisolver.nroots = 3
+mc.kernel()
+de = mc.nuc_grad_method().kernel(state=1)
+print('UHF-orbital UCASCI gradients for state 1')
+print(de)
+
+
+mol = gto.M(
+    atom = '''
+    H  0.000  0.000  0.000
+    H  0.000  0.000  1.000
+    H  0.000  1.000  0.000
+    H  0.200  1.000  1.000
+    ''',
+    basis = 'sto-3g',
+    verbose = 0,
+)
+
+mf = scf.RHF(mol).run()
+mc = mcscf.CASCI(mf, 2, 2, ncore=1).run()
+
+de = mc.Gradients().kernel()
+print('RHF-orbital CASCI gradients')
+print(de)
+
+mf = dft.RKS(mol, xc='b3lyp').run()
+mc = mcscf.CASCI(mf, 2, 2, ncore=1).run()
+
+de = mc.Gradients().kernel()
+print('RKS-orbital CASCI gradients')
+print(de)

--- a/examples/grad/20-casci_orbital_grad.py
+++ b/examples/grad/20-casci_orbital_grad.py
@@ -2,11 +2,6 @@
 
 '''
 Analytical nuclear gradients of CASCI with HF and restricted KS orbitals.
-
-The restricted example uses RHF orbitals and the unrestricted example uses UHF
-orbitals.  The final restricted example uses RKS orbitals.  UKS-orbital CASCI
-and CASSCF-orbital CASCI gradients require different orbital-response
-formulations and are not handled by these gradient classes.
 '''
 
 from pyscf import gto

--- a/pyscf/grad/__init__.py
+++ b/pyscf/grad/__init__.py
@@ -41,6 +41,7 @@ grad_nuc = rhf.grad_nuc
 
 try:
     from . import casci
+    from . import kscasci
     from . import casscf
     from . import sacasscf
     from . import ccsd

--- a/pyscf/grad/__init__.py
+++ b/pyscf/grad/__init__.py
@@ -58,6 +58,7 @@ try:
     #from . import uccsd_t
     from . import ucisd
     from . import ucasci
+    from . import ukscasci
     from . import uks
     from . import ump2
 

--- a/pyscf/grad/__init__.py
+++ b/pyscf/grad/__init__.py
@@ -56,6 +56,7 @@ try:
     from . import uccsd
     #from . import uccsd_t
     from . import ucisd
+    from . import ucasci
     from . import uks
     from . import ump2
 

--- a/pyscf/grad/casci.py
+++ b/pyscf/grad/casci.py
@@ -21,6 +21,11 @@ CASCI analytical nuclear gradients
 
 Ref.
 J. Comput. Chem., 5, 589
+
+This module implements the HF-orbital CASCI gradient formulation.  The
+orbital response is the CPHF response of the underlying RHF reference.  CASCI
+gradients with KS-generated orbitals require a distinct CPKS/XC-response
+formulation and are not implemented here.
 '''
 
 import sys
@@ -33,7 +38,8 @@ from pyscf import ao2mo
 from pyscf.lib import logger
 from pyscf.grad import rhf as rhf_grad
 from pyscf.grad.mp2 import _shell_prange
-from pyscf.scf import cphf
+from pyscf.grad import tdrks as tdrks_grad
+from pyscf.scf import cphf, hf
 from pyscf.mcscf.addons import StateAverageMCSCFSolver
 
 if sys.version_info < (3,):
@@ -42,7 +48,21 @@ else:
     RANGE_TYPE = range
 
 
+def _check_supported_orbital_source(mc):
+    if isinstance(mc._scf, hf.KohnShamDFT):
+        raise NotImplementedError(
+            'CASCI gradients with KS orbitals require the RKS/CPKS '
+            'orbital response, which is not implemented')
+
+
 def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
+    mc = mc_grad.base
+    _check_supported_orbital_source(mc)
+    return _grad_elec(mc_grad, mo_coeff, ci, atmlst, verbose)
+
+
+def _grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None,
+               with_ks_response=False):
     mc = mc_grad.base
     if mo_coeff is None: mo_coeff = mc._scf.mo_coeff
     if ci is None: ci = mc.ci
@@ -65,6 +85,27 @@ def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
     assert (neleca == nelecb)
     orbo = mo_coeff[:,:neleca]
     orbv = mo_coeff[:,neleca:]
+    hyb = 1
+    is_ks = with_ks_response
+    if is_ks:
+        if not isinstance(mc._scf, hf.KohnShamDFT):
+            raise RuntimeError('KS-CASCI gradients require a KohnShamDFT '
+                               'reference')
+        ni = mc._scf._numint
+        xctype = ni._xc_type(mc._scf.xc)
+        if xctype == 'MGGA':
+            raise NotImplementedError('RKS-CASCI gradients for meta-GGA '
+                                      'functionals')
+        if xctype not in ('LDA', 'GGA'):
+            raise NotImplementedError('RKS-CASCI gradients for %s functionals' %
+                                      xctype)
+        if mc._scf.do_nlc():
+            raise NotImplementedError('RKS-CASCI gradients for NLC '
+                                      'functionals')
+        omega, _, hyb = ni.rsh_and_hybrid_coeff(mc._scf.xc, mol.spin)
+        if omega != 0:
+            raise NotImplementedError('RKS-CASCI gradients for range-separated '
+                                      'hybrid functionals')
 
     casdm1, casdm2 = mc.fcisolver.make_rdm12(ci, ncas, nelecas)
     dm_core = numpy.dot(mo_core, mo_core.T) * 2
@@ -82,6 +123,10 @@ def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
     Imat[:,ncore:nocc] += lib.einsum('uviw,vuwt->it', aapa, casdm2)
     aapa = vj = vk = vhf_c = vhf_a = h1 = None
 
+    # Imat is the CASCI orbital-gradient intermediate.  Rotations inside
+    # closed, active, or external spaces are redundant; the cross-boundary
+    # redundant blocks are handled by orbital-energy denominators before the
+    # occupied-virtual source-orbital CPHF/CPKS solve below.
     ee = mo_energy[:,None] - mo_energy
     zvec = numpy.zeros_like(Imat)
     zvec[:ncore,ncore:neleca] = Imat[:ncore,ncore:neleca] / -ee[:ncore,ncore:neleca]
@@ -89,14 +134,17 @@ def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
     zvec[nocc:,neleca:nocc] = Imat[nocc:,neleca:nocc] / -ee[nocc:,neleca:nocc]
     zvec[neleca:nocc,nocc:] = Imat[neleca:nocc,nocc:] / -ee[neleca:nocc,nocc:]
 
+    # gen_response supplies the source-orbital Hessian action: CPHF for RHF
+    # orbitals and CPKS, including the XC kernel, for RKS orbitals.
+    vresp = mc._scf.gen_response(singlet=None, hermi=1)
     zvec_ao = reduce(numpy.dot, (mo_coeff, zvec+zvec.T, mo_coeff.T))
-    vhf = mc._scf.get_veff(mol, zvec_ao) * 2
+    vhf = vresp(zvec_ao) * 2
     xvo = reduce(numpy.dot, (orbv.T, vhf, orbo))
     xvo += Imat[neleca:,:neleca] - Imat[:neleca,neleca:].T
     def fvind(x):
         x = x.reshape(xvo.shape)
         dm = reduce(numpy.dot, (orbv, x, orbo.T))
-        v = mc._scf.get_veff(mol, dm + dm.T)
+        v = vresp(dm + dm.T)
         v = reduce(numpy.dot, (orbv.T, v, orbo))
         return v * 2
     dm1resp = cphf.solve(fvind, mo_energy, mc._scf.mo_occ, xvo, max_cycle=30)[0]
@@ -107,7 +155,17 @@ def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
 
     zvec_ao = reduce(numpy.dot, (mo_coeff, zvec+zvec.T, mo_coeff.T))
     p1 = numpy.dot(mo_coeff[:,:neleca], mo_coeff[:,:neleca].T)
-    vhf_s1occ = reduce(numpy.dot, (p1, mc._scf.get_veff(mol, zvec_ao), p1))
+    vhf_s1occ = reduce(numpy.dot, (p1, vresp(zvec_ao), p1))
+    if is_ks:
+        # RKS-CASCI needs the bare nuclear derivative of the XC source
+        # constraint in addition to the CPKS Hessian action above.
+        max_memory = mc_grad.max_memory - lib.current_memory()[0]
+        fxcz, _, vxc1, _ = tdrks_grad._contract_xc_kernel(
+            mc_grad, mc._scf.xc, zvec_ao, None, True, False, True,
+            max_memory)
+    else:
+        fxcz = None
+        vxc1 = None
 
     Imat[:ncore,ncore:neleca] = 0
     Imat[ncore:neleca,:ncore] = 0
@@ -160,8 +218,8 @@ def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
                 eri1tmp = eri1tmp.reshape(p1-p0,nf,nao,nao)
                 de[k,i] -= numpy.einsum('ijkl,ij,kl', eri1tmp, hf_dm1[p0:p1,q0:q1], zvec_ao) * 2
                 de[k,i] -= numpy.einsum('ijkl,kl,ij', eri1tmp, hf_dm1, zvec_ao[p0:p1,q0:q1]) * 2
-                de[k,i] += numpy.einsum('ijkl,il,kj', eri1tmp, hf_dm1[p0:p1], zvec_ao[:,q0:q1])
-                de[k,i] += numpy.einsum('ijkl,jk,il', eri1tmp, hf_dm1[q0:q1], zvec_ao[p0:p1])
+                de[k,i] += hyb * numpy.einsum('ijkl,il,kj', eri1tmp, hf_dm1[p0:p1], zvec_ao[:,q0:q1])
+                de[k,i] += hyb * numpy.einsum('ijkl,jk,il', eri1tmp, hf_dm1[q0:q1], zvec_ao[p0:p1])
 
                 #:vhf1c, vhf1a = mc_grad.get_veff(mol, (dm_core, dm_cas))
                 #:de[k] += numpy.einsum('xij,ij->x', vhf1c[:,p0:p1], casci_dm1[p0:p1]) * 2
@@ -171,6 +229,12 @@ def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
                 de[k,i] -= numpy.einsum('ijkl,lk,ij', eri1tmp, dm_cas, dm_core[p0:p1,q0:q1]) * 2
                 de[k,i] += numpy.einsum('ijkl,jk,il', eri1tmp, dm_cas[q0:q1], dm_core[p0:p1])
             eri1 = eri1tmp = None
+
+        if fxcz is not None:
+            de[k] += numpy.einsum('xij,ij->x',
+                                  vxc1[1:,p0:p1], zvec_ao[p0:p1]) * 2
+            de[k] += numpy.einsum('xij,ij->x',
+                                  fxcz[1:,p0:p1], hf_dm1[p0:p1])
 
         de[k] -= numpy.einsum('xij,ij->x', s1[:,p0:p1], im1[p0:p1])
         de[k] -= numpy.einsum('xij,ji->x', s1[:,p0:p1], im1[:,p0:p1])
@@ -255,7 +319,7 @@ class CASCI_GradScanner(lib.GradScanner):
 
 
 class Gradients(rhf_grad.GradientsBase):
-    '''Non-relativistic restricted Hartree-Fock gradients'''
+    '''Non-relativistic RHF-CASCI gradients'''
 
     _keys = {'state'}
 
@@ -350,4 +414,11 @@ class Gradients(rhf_grad.GradientsBase):
 Grad = Gradients
 
 from pyscf import mcscf
-mcscf.casci.CASCI.Gradients = lib.class_as_method(Gradients)
+def _casci_grad_method(mc, *args, **kwargs):
+    # Keep mc.Gradients() source-aware, matching CASCI.nuc_grad_method().
+    if isinstance(mc._scf, hf.KohnShamDFT):
+        from pyscf.grad import kscasci
+        return kscasci.Gradients(mc, *args, **kwargs)
+    return Gradients(mc, *args, **kwargs)
+
+mcscf.casci.CASCI.Gradients = _casci_grad_method

--- a/pyscf/grad/casci.py
+++ b/pyscf/grad/casci.py
@@ -34,7 +34,7 @@ from pyscf.lib import logger
 from pyscf.grad import rhf as rhf_grad
 from pyscf.grad.mp2 import _shell_prange
 from pyscf.grad import tdrks as tdrks_grad
-from pyscf.scf import cphf, hf
+from pyscf.scf import cphf, hf, rohf
 from pyscf.mcscf.addons import StateAverageMCSCFSolver
 
 if sys.version_info < (3,):
@@ -44,6 +44,9 @@ else:
 
 
 def _check_supported_orbital_source(mc):
+    if isinstance(mc._scf, rohf.ROHF):
+        raise NotImplementedError(
+            'CASCI gradients with ROHF orbitals are not implemented')
     if isinstance(mc._scf, hf.KohnShamDFT):
         raise NotImplementedError(
             'CASCI gradients with KS orbitals require the RKS/CPKS '

--- a/pyscf/grad/casci.py
+++ b/pyscf/grad/casci.py
@@ -47,7 +47,7 @@ def _check_supported_orbital_source(mc):
     if isinstance(mc._scf, hf.KohnShamDFT):
         raise NotImplementedError(
             'CASCI gradients with KS orbitals require the RKS/CPKS '
-            'orbital response, which is not implemented')
+            'orbital response; use pyscf.grad.kscasci')
 
 
 def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
@@ -124,6 +124,8 @@ def _grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None,
     # occupied-virtual source-orbital CPHF/CPKS solve below.
     ee = mo_energy[:,None] - mo_energy
     zvec = numpy.zeros_like(Imat)
+    # ee[p,q] = eps_p - eps_q; dividing by -ee gives the canonical
+    # eps_q - eps_p denominator for these redundant rotation blocks.
     zvec[:ncore,ncore:neleca] = Imat[:ncore,ncore:neleca] / -ee[:ncore,ncore:neleca]
     zvec[ncore:neleca,:ncore] = Imat[ncore:neleca,:ncore] / -ee[ncore:neleca,:ncore]
     zvec[nocc:,neleca:nocc] = Imat[nocc:,neleca:nocc] / -ee[nocc:,neleca:nocc]
@@ -213,6 +215,9 @@ def _grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None,
                 eri1tmp = eri1tmp.reshape(p1-p0,nf,nao,nao)
                 de[k,i] -= numpy.einsum('ijkl,ij,kl', eri1tmp, hf_dm1[p0:p1,q0:q1], zvec_ao) * 2
                 de[k,i] -= numpy.einsum('ijkl,kl,ij', eri1tmp, hf_dm1, zvec_ao[p0:p1,q0:q1]) * 2
+                # Hybrid scaling applies only to the KS source-Fock response
+                # term; the CASCI skeleton below differentiates the bare WFT
+                # Hamiltonian.
                 de[k,i] += hyb * numpy.einsum('ijkl,il,kj', eri1tmp, hf_dm1[p0:p1], zvec_ao[:,q0:q1])
                 de[k,i] += hyb * numpy.einsum('ijkl,jk,il', eri1tmp, hf_dm1[q0:q1], zvec_ao[p0:p1])
 

--- a/pyscf/grad/casci.py
+++ b/pyscf/grad/casci.py
@@ -21,11 +21,6 @@ CASCI analytical nuclear gradients
 
 Ref.
 J. Comput. Chem., 5, 589
-
-This module implements the HF-orbital CASCI gradient formulation.  The
-orbital response is the CPHF response of the underlying RHF reference.  CASCI
-gradients with KS-generated orbitals require a distinct CPKS/XC-response
-formulation and are not implemented here.
 '''
 
 import sys

--- a/pyscf/grad/kscasci.py
+++ b/pyscf/grad/kscasci.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# Copyright 2026 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+CASCI analytical nuclear gradients with restricted KS orbitals
+
+This module implements the RKS-orbital CASCI gradient formulation.  The
+orbital response is the CPKS response of the underlying RKS reference, with
+the associated XC first-derivative terms in the KS orbital-source constraints.
+'''
+
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf.scf import hf
+from pyscf.grad import casci as casci_grad
+
+
+def _check_supported_orbital_source(mc):
+    if not isinstance(mc._scf, hf.KohnShamDFT):
+        raise RuntimeError('KS-CASCI gradients require a KohnShamDFT reference')
+
+
+def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
+    _check_supported_orbital_source(mc_grad.base)
+    return casci_grad._grad_elec(mc_grad, mo_coeff, ci, atmlst, verbose,
+                                 with_ks_response=True)
+
+
+class Gradients(casci_grad.Gradients):
+    '''Non-relativistic RKS-CASCI gradients'''
+
+    grad_elec = grad_elec
+
+    def dump_flags(self, verbose=None):
+        casci_grad.Gradients.dump_flags(self, verbose)
+        logger.info(self, 'KS orbital source = %s', self.base._scf.xc)
+        return self
+
+
+Grad = Gradients

--- a/pyscf/grad/kscasci.py
+++ b/pyscf/grad/kscasci.py
@@ -23,11 +23,14 @@ the associated XC first-derivative terms in the KS orbital-source constraints.
 
 from pyscf import lib
 from pyscf.lib import logger
-from pyscf.scf import hf
+from pyscf.scf import hf, rohf
 from pyscf.grad import casci as casci_grad
 
 
 def _check_supported_orbital_source(mc):
+    if isinstance(mc._scf, rohf.ROHF):
+        raise NotImplementedError(
+            'CASCI gradients with ROKS orbitals are not implemented')
     if not isinstance(mc._scf, hf.KohnShamDFT):
         raise RuntimeError('KS-CASCI gradients require a KohnShamDFT reference')
 

--- a/pyscf/grad/test/test_casci.py
+++ b/pyscf/grad/test/test_casci.py
@@ -10,6 +10,7 @@ import numpy
 from pyscf import lib
 from pyscf import gto
 from pyscf import scf
+from pyscf import dft
 from pyscf import mcscf
 from pyscf import ao2mo
 from pyscf.scf import cphf
@@ -17,6 +18,35 @@ from pyscf.grad import rhf as rhf_grad
 from pyscf.grad import casci as casci_grad
 from pyscf.grad import ccsd as ccsd_grad
 from pyscf.grad.mp2 import _shell_prange, has_frozen_orbitals
+
+
+def _move_atom(atom, ia, ix, dx):
+    coords = []
+    for line in atom.splitlines():
+        if line.strip():
+            sym, x, y, z = line.split()
+            coords.append([sym, float(x), float(y), float(z)])
+    if ia is not None:
+        coords[ia][ix+1] += dx
+    return coords
+
+
+def _five_point_fd_grad(run, natm, step, state=None):
+    def energy(ia, ix, dx):
+        e_tot = run(ia, ix, dx).e_tot
+        if state is not None:
+            e_tot = e_tot[state]
+        return e_tot
+
+    ref = numpy.zeros((natm, 3))
+    for ia in range(natm):
+        for ix in range(3):
+            ep2 = energy(ia, ix, 2*step)
+            ep1 = energy(ia, ix, step)
+            em1 = energy(ia, ix, -step)
+            em2 = energy(ia, ix, -2*step)
+            ref[ia,ix] = (-ep2 + 8*ep1 - 8*em1 + em2) / (12*step)
+    return ref * lib.param.BOHR
 
 
 def kernel(mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=None,
@@ -326,6 +356,156 @@ class KnownValues(unittest.TestCase):
         e1 = mcs(pmol.set_geom_('N 0 0 0; N 0 0 1.201; H 1 1 0; H 1 1 1.2'))
         e2 = mcs(pmol.set_geom_('N 0 0 0; N 0 0 1.199; H 1 1 0; H 1 1 1.2'))
         self.assertAlmostEqual(g1[1,2], (e1-e2)/0.002*lib.param.BOHR, 5)
+
+    def test_rks_orbital_casci_finite_diff(self):
+        atom = '''
+        O 0.000  0.000 0.000
+        H 0.000  0.800 0.600
+        H 0.000 -0.800 0.600
+        '''
+
+        def run(xc, ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='sto-3g', verbose=0)
+            mf = dft.RKS(mol, xc=xc).run(conv_tol=1e-12)
+            return mcscf.CASCI(mf, 4, 4, ncore=3).run()
+
+        step = 1e-3
+        for xc in ('lda,vwn', 'b88,p86', 'b3lyp'):
+            mc = run(xc)
+            self.assertEqual(mc.nuc_grad_method().__class__.__module__,
+                             'pyscf.grad.kscasci')
+            self.assertEqual(mc.Gradients().__class__.__module__,
+                             'pyscf.grad.kscasci')
+            grad = mc.nuc_grad_method().kernel()
+            ep2 = run(xc, 1, 2, 2*step).e_tot
+            ep1 = run(xc, 1, 2, step).e_tot
+            em1 = run(xc, 1, 2, -step).e_tot
+            em2 = run(xc, 1, 2, -2*step).e_tot
+            ref = (-ep2 + 8*ep1 - 8*em1 + em2) / (12*step)
+            ref *= lib.param.BOHR
+            self.assertLess(abs(grad[1,2] - ref), 2e-6)
+
+    def test_rks_orbital_casci_formaldehyde_all_components_finite_diff(self):
+        atom = '''
+        C  0.012000 -0.018000  0.004000
+        O -0.043000  0.026000  1.213000
+        H  0.091000  0.954000 -0.602000
+        H -0.068000 -0.912000 -0.551000
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='6-31g', verbose=0)
+            mf = dft.RKS(mol, xc='b3lyp').run(conv_tol=1e-11)
+            return mcscf.CASCI(mf, 4, 4, ncore=6).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        ref = _five_point_fd_grad(run, mc.mol.natm, 1e-3)
+        err = abs(grad - ref)
+        self.assertLess(err.max(), 1e-6)
+        self.assertLess(numpy.linalg.norm(err) / err.size**.5, 5e-7)
+
+    def test_rhf_casci_formaldehyde_all_components_finite_diff(self):
+        atom = '''
+        C  0.012000 -0.018000  0.004000
+        O -0.043000  0.026000  1.213000
+        H  0.091000  0.954000 -0.602000
+        H -0.068000 -0.912000 -0.551000
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='6-31g', verbose=0)
+            mf = scf.RHF(mol).run(conv_tol=1e-12)
+            return mcscf.CASCI(mf, 4, 4, ncore=6).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        ref = _five_point_fd_grad(run, mc.mol.natm, 1e-3)
+        err = abs(grad - ref)
+        self.assertLess(err.max(), 5e-7)
+        self.assertLess(numpy.linalg.norm(err) / err.size**.5, 2e-7)
+
+    def test_rks_orbital_casci_hcn_all_components_finite_diff(self):
+        atom = '''
+        H  0.052000 -0.031000 -1.066000
+        C  0.011000  0.024000  0.000000
+        N -0.038000 -0.017000  1.154000
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='6-31g', verbose=0)
+            mf = dft.RKS(mol, xc='lda,vwn').run(conv_tol=1e-11)
+            return mcscf.CASCI(mf, 4, 4, ncore=5).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        ref = _five_point_fd_grad(run, mc.mol.natm, 1e-3)
+        err = abs(grad - ref)
+        self.assertLess(err.max(), 5e-7)
+        self.assertLess(numpy.linalg.norm(err) / err.size**.5, 2e-7)
+
+    def test_rks_gga_casci_hcn_all_components_finite_diff(self):
+        atom = '''
+        H  0.052000 -0.031000 -1.066000
+        C  0.011000  0.024000  0.000000
+        N -0.038000 -0.017000  1.154000
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='6-31g', verbose=0)
+            mf = dft.RKS(mol, xc='pbe,pbe').run(conv_tol=1e-11)
+            return mcscf.CASCI(mf, 4, 4, ncore=5).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        ref = _five_point_fd_grad(run, mc.mol.natm, 1e-3)
+        err = abs(grad - ref)
+        self.assertLess(err.max(), 5e-7)
+        self.assertLess(numpy.linalg.norm(err) / err.size**.5, 2e-7)
+
+    def test_rks_excited_root_casci_hcn_all_components_finite_diff(self):
+        atom = '''
+        H  0.052000 -0.031000 -1.066000
+        C  0.011000  0.024000  0.000000
+        N -0.038000 -0.017000  1.154000
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='6-31g', verbose=0)
+            mf = dft.RKS(mol, xc='lda,vwn').run(conv_tol=1e-11)
+            mc = mcscf.CASCI(mf, 4, 4, ncore=5)
+            mc.fcisolver.nroots = 2
+            return mc.run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel(state=1)
+        ref = _five_point_fd_grad(run, mc.mol.natm, 1e-3, state=1)
+        err = abs(grad - ref)
+        self.assertLess(err.max(), 5e-7)
+        self.assertLess(numpy.linalg.norm(err) / err.size**.5, 2e-7)
+
+    def test_rks_casci_unsupported_functionals(self):
+        mol = gto.M(atom='H 0 0 0; H 0 0 1.0', basis='sto-3g', verbose=0)
+        mf = dft.RKS(mol, xc='lda,vwn').run(conv_tol=1e-12)
+
+        # The SCF object is already converged; only the gradient guard behavior
+        # depends on these fields in this test.
+        mf.xc = 'tpss'
+        mc = mcscf.CASCI(mf, 2, 2).run()
+        with self.assertRaisesRegex(NotImplementedError, 'meta-GGA'):
+            mc.nuc_grad_method().kernel()
+
+        mf.xc = 'lda,vwn'
+        mf.nlc = 'vv10'
+        mc = mcscf.CASCI(mf, 2, 2).run()
+        with self.assertRaisesRegex(NotImplementedError, 'NLC'):
+            mc.nuc_grad_method().kernel()
 
     def test_casci_grad_excited_state(self):
         mc = mcscf.CASCI(mf, 4, 4)

--- a/pyscf/grad/test/test_casci.py
+++ b/pyscf/grad/test/test_casci.py
@@ -5,6 +5,8 @@
 
 
 from functools import reduce
+import os
+import time
 import unittest
 import numpy
 from pyscf import lib
@@ -20,6 +22,7 @@ from pyscf.grad import ccsd as ccsd_grad
 from pyscf.grad.mp2 import _shell_prange, has_frozen_orbitals
 
 
+# Helpers for comparing analytic and finite difference gradients
 def _move_atom(atom, ia, ix, dx):
     coords = []
     for line in atom.splitlines():
@@ -30,14 +33,7 @@ def _move_atom(atom, ia, ix, dx):
         coords[ia][ix+1] += dx
     return coords
 
-
-def _five_point_fd_grad(run, natm, step, state=None):
-    def energy(ia, ix, dx):
-        e_tot = run(ia, ix, dx).e_tot
-        if state is not None:
-            e_tot = e_tot[state]
-        return e_tot
-
+def _five_point_fd_grad(energy, natm, step=1e-3):
     ref = numpy.zeros((natm, 3))
     for ia in range(natm):
         for ix in range(3):
@@ -47,6 +43,31 @@ def _five_point_fd_grad(run, natm, step, state=None):
             em2 = energy(ia, ix, -2*step)
             ref[ia,ix] = (-ep2 + 8*ep1 - 8*em1 + em2) / (12*step)
     return ref * lib.param.BOHR
+
+def _check_fd_grad(test, grad_fn, energy_fn, natm, max_tol, step=1e-3,
+                   rms_tol=None):
+    t0 = time.perf_counter()
+    grad = grad_fn()
+    analytic_sec = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    ref = _five_point_fd_grad(energy_fn, natm, step)
+    fd_sec = time.perf_counter() - t0
+
+    err = abs(grad - ref)
+    max_err = err.max()
+    mean_err = err.mean()
+    rms_err = numpy.linalg.norm(err) / err.size**.5
+    if os.environ.get('PYSCF_CASCI_FD_STATS'):
+        label = test.id().rsplit('.', 1)[-1]
+        print('FD_STATS %s max %.6g mean %.6g rms %.6g analytic %.3fs fd %.3fs ratio %.1f' %
+              (label, max_err, mean_err, rms_err, analytic_sec, fd_sec,
+               fd_sec / max(analytic_sec, 1e-12)))
+
+    test.assertLess(max_err, max_tol)
+    if rms_tol is not None:
+        test.assertLess(rms_err, rms_tol)
+    return grad, ref
 
 
 def kernel(mc, mo_coeff=None, ci=None, atmlst=None, mf_grad=None,
@@ -357,7 +378,8 @@ class KnownValues(unittest.TestCase):
         e2 = mcs(pmol.set_geom_('N 0 0 0; N 0 0 1.199; H 1 1 0; H 1 1 1.2'))
         self.assertAlmostEqual(g1[1,2], (e1-e2)/0.002*lib.param.BOHR, 5)
 
-    def test_rks_orbital_casci_finite_diff(self):
+    # RKS-CASCI h2o against FD for supported functionals
+    def test_rks_casci_h2o_fd(self):
         atom = '''
         O 0.000  0.000 0.000
         H 0.000  0.800 0.600
@@ -371,22 +393,18 @@ class KnownValues(unittest.TestCase):
             return mcscf.CASCI(mf, 4, 4, ncore=3).run()
 
         step = 1e-3
-        for xc in ('lda,vwn', 'b88,p86', 'b3lyp'):
+        for xc in ('lda,vwn', 'b88,p86', 'pbe,pbe', 'b3lyp'):
             mc = run(xc)
             self.assertEqual(mc.nuc_grad_method().__class__.__module__,
                              'pyscf.grad.kscasci')
             self.assertEqual(mc.Gradients().__class__.__module__,
                              'pyscf.grad.kscasci')
-            grad = mc.nuc_grad_method().kernel()
-            ep2 = run(xc, 1, 2, 2*step).e_tot
-            ep1 = run(xc, 1, 2, step).e_tot
-            em1 = run(xc, 1, 2, -step).e_tot
-            em2 = run(xc, 1, 2, -2*step).e_tot
-            ref = (-ep2 + 8*ep1 - 8*em1 + em2) / (12*step)
-            ref *= lib.param.BOHR
-            self.assertLess(abs(grad[1,2] - ref), 2e-6)
+            _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                           lambda ia, ix, dx: run(xc, ia, ix, dx).e_tot,
+                           mc.mol.natm, 2e-6, step=step)
 
-    def test_rks_orbital_casci_formaldehyde_all_components_finite_diff(self):
+    # RKS(B3LYP)-CASCI coh2 against FD
+    def test_rks_casci_formaldehyde_fd(self):
         atom = '''
         C  0.012000 -0.018000  0.004000
         O -0.043000  0.026000  1.213000
@@ -401,95 +419,54 @@ class KnownValues(unittest.TestCase):
             return mcscf.CASCI(mf, 4, 4, ncore=6).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        ref = _five_point_fd_grad(run, mc.mol.natm, 1e-3)
-        err = abs(grad - ref)
-        self.assertLess(err.max(), 1e-6)
-        self.assertLess(numpy.linalg.norm(err) / err.size**.5, 5e-7)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 1e-6, rms_tol=5e-7)
 
-    def test_rhf_casci_formaldehyde_all_components_finite_diff(self):
-        atom = '''
-        C  0.012000 -0.018000  0.004000
-        O -0.043000  0.026000  1.213000
-        H  0.091000  0.954000 -0.602000
-        H -0.068000 -0.912000 -0.551000
-        '''
-
-        def run(ia=None, ix=None, dx=0):
-            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
-                        basis='6-31g', verbose=0)
-            mf = scf.RHF(mol).run(conv_tol=1e-12)
-            return mcscf.CASCI(mf, 4, 4, ncore=6).run()
-
-        mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        ref = _five_point_fd_grad(run, mc.mol.natm, 1e-3)
-        err = abs(grad - ref)
-        self.assertLess(err.max(), 5e-7)
-        self.assertLess(numpy.linalg.norm(err) / err.size**.5, 2e-7)
-
-    def test_rks_orbital_casci_hcn_all_components_finite_diff(self):
+    # RKS-CASCI HCN against FD for LDA and PBE orbitals.
+    def test_rks_casci_hcn_fd(self):
         atom = '''
         H  0.052000 -0.031000 -1.066000
         C  0.011000  0.024000  0.000000
         N -0.038000 -0.017000  1.154000
         '''
 
-        def run(ia=None, ix=None, dx=0):
+        def run(xc, ia=None, ix=None, dx=0):
             mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
                         basis='6-31g', verbose=0)
-            mf = dft.RKS(mol, xc='lda,vwn').run(conv_tol=1e-11)
+            mf = dft.RKS(mol, xc=xc).run(conv_tol=1e-11)
             return mcscf.CASCI(mf, 4, 4, ncore=5).run()
 
-        mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        ref = _five_point_fd_grad(run, mc.mol.natm, 1e-3)
-        err = abs(grad - ref)
-        self.assertLess(err.max(), 5e-7)
-        self.assertLess(numpy.linalg.norm(err) / err.size**.5, 2e-7)
+        for xc in ('lda,vwn', 'pbe,pbe'):
+            mc = run(xc)
+            _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                           lambda ia, ix, dx: run(xc, ia, ix, dx).e_tot,
+                           mc.mol.natm, 5e-7, rms_tol=2e-7)
 
-    def test_rks_gga_casci_hcn_all_components_finite_diff(self):
+    # RKS-CASCI excited state gradients against FD
+    def test_rks_excited_state_hcn_fd(self):
         atom = '''
         H  0.052000 -0.031000 -1.066000
         C  0.011000  0.024000  0.000000
         N -0.038000 -0.017000  1.154000
         '''
 
-        def run(ia=None, ix=None, dx=0):
+        def run(xc, ia=None, ix=None, dx=0):
             mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
                         basis='6-31g', verbose=0)
-            mf = dft.RKS(mol, xc='pbe,pbe').run(conv_tol=1e-11)
-            return mcscf.CASCI(mf, 4, 4, ncore=5).run()
-
-        mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        ref = _five_point_fd_grad(run, mc.mol.natm, 1e-3)
-        err = abs(grad - ref)
-        self.assertLess(err.max(), 5e-7)
-        self.assertLess(numpy.linalg.norm(err) / err.size**.5, 2e-7)
-
-    def test_rks_excited_root_casci_hcn_all_components_finite_diff(self):
-        atom = '''
-        H  0.052000 -0.031000 -1.066000
-        C  0.011000  0.024000  0.000000
-        N -0.038000 -0.017000  1.154000
-        '''
-
-        def run(ia=None, ix=None, dx=0):
-            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
-                        basis='6-31g', verbose=0)
-            mf = dft.RKS(mol, xc='lda,vwn').run(conv_tol=1e-11)
+            mf = dft.RKS(mol, xc=xc).run(conv_tol=1e-11)
             mc = mcscf.CASCI(mf, 4, 4, ncore=5)
             mc.fcisolver.nroots = 2
             return mc.run()
 
-        mc = run()
-        grad = mc.nuc_grad_method().kernel(state=1)
-        ref = _five_point_fd_grad(run, mc.mol.natm, 1e-3, state=1)
-        err = abs(grad - ref)
-        self.assertLess(err.max(), 5e-7)
-        self.assertLess(numpy.linalg.norm(err) / err.size**.5, 2e-7)
+        step = 5e-4
+        for xc in ('lda,vwn', 'pbe,pbe', 'b3lyp'):
+            mc = run(xc)
+            _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(state=1),
+                           lambda ia, ix, dx: run(xc, ia, ix, dx).e_tot[1],
+                           mc.mol.natm, 5e-7, step=step, rms_tol=2e-7)
 
+    # Error out when requesting RKS-CASCI gradients for unsupported functionals
     def test_rks_casci_unsupported_functionals(self):
         mol = gto.M(atom='H 0 0 0; H 0 0 1.0', basis='sto-3g', verbose=0)
         mf = dft.RKS(mol, xc='lda,vwn').run(conv_tol=1e-12)
@@ -499,6 +476,11 @@ class KnownValues(unittest.TestCase):
         mf.xc = 'tpss'
         mc = mcscf.CASCI(mf, 2, 2).run()
         with self.assertRaisesRegex(NotImplementedError, 'meta-GGA'):
+            mc.nuc_grad_method().kernel()
+
+        mf.xc = 'cam-b3lyp'
+        mc = mcscf.CASCI(mf, 2, 2).run()
+        with self.assertRaisesRegex(NotImplementedError, 'range-separated'):
             mc.nuc_grad_method().kernel()
 
         mf.xc = 'lda,vwn'

--- a/pyscf/grad/test/test_casci.py
+++ b/pyscf/grad/test/test_casci.py
@@ -489,6 +489,20 @@ class KnownValues(unittest.TestCase):
         with self.assertRaisesRegex(NotImplementedError, 'NLC'):
             mc.nuc_grad_method().kernel()
 
+    # AD: Error out for restricted open-shell orbital sources.
+    def test_restricted_open_shell_orbitals_unsupported(self):
+        mol = gto.M(atom='Li 0 0 0', basis='sto-3g', spin=1, verbose=0)
+
+        mf = scf.ROHF(mol).run(conv_tol=1e-12)
+        mc = mcscf.CASCI(mf, 2, 1, ncore=1).run()
+        with self.assertRaisesRegex(NotImplementedError, 'ROHF'):
+            mc.nuc_grad_method().kernel()
+
+        mf = dft.ROKS(mol, xc='lda,vwn').run(conv_tol=1e-12)
+        mc = mcscf.CASCI(mf, 2, 1, ncore=1).run()
+        with self.assertRaisesRegex(NotImplementedError, 'ROKS'):
+            mc.nuc_grad_method().kernel()
+
     def test_casci_grad_excited_state(self):
         mc = mcscf.CASCI(mf, 4, 4)
         mc.fcisolver.nroots = 3

--- a/pyscf/grad/test/test_ucasci.py
+++ b/pyscf/grad/test/test_ucasci.py
@@ -21,6 +21,14 @@ def _move_atom(atom, ia, ix, dx):
     return coords
 
 
+def _five_point_fd(run, ia, ix, h=1e-3):
+    ep2 = run((ia, ix,  2*h)).e_tot
+    ep1 = run((ia, ix,    h)).e_tot
+    em1 = run((ia, ix,   -h)).e_tot
+    em2 = run((ia, ix, -2*h)).e_tot
+    return (-ep2 + 8*ep1 - 8*em1 + em2) / (12*h) * lib.param.BOHR
+
+
 def _pair_symmetric_eri(nmo, seed):
     rng = numpy.random.default_rng(seed)
     eri = rng.standard_normal((nmo,nmo,nmo,nmo))
@@ -389,13 +397,268 @@ class KnownValues(unittest.TestCase):
             ref = (e1-e2) / 0.002 * lib.param.BOHR
             self.assertLess(abs(grad[1,2] - ref), tol)
 
-    def test_uks_orbitals_not_implemented(self):
-        mol = gto.M(atom='H 0 0 0; H 0 0 1; H 0 1 0',
-                    basis='sto-3g', spin=1, verbose=0)
-        mf = dft.UKS(mol).run(conv_tol=1e-12)
-        mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
-        with self.assertRaises(NotImplementedError):
-            mc.nuc_grad_method().kernel()
+    def test_uks_casci_h3_all_component_finite_diff(self):
+        def run(disp=None):
+            coords = numpy.asarray(((0., 0., 0.),
+                                    (0., 0., 1.),
+                                    (0., 1., 0.)))
+            if disp is not None:
+                ia, ix, dx = disp
+                coords[ia, ix] += dx
+            mol = gto.M(atom=[('H', coords[i]) for i in range(3)],
+                        unit='Angstrom', basis='sto-3g', spin=1, verbose=0)
+            mf = dft.UKS(mol)
+            mf.xc = 'lda,vwn'
+            mf.run(conv_tol=1e-12)
+            return mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        h = 1e-3
+        fd = numpy.zeros_like(grad)
+        for ia in range(3):
+            for ix in range(3):
+                ep2 = run((ia, ix,  2*h)).e_tot
+                ep1 = run((ia, ix,    h)).e_tot
+                em1 = run((ia, ix,   -h)).e_tot
+                em2 = run((ia, ix, -2*h)).e_tot
+                fd[ia,ix] = (-ep2 + 8*ep1 - 8*em1 + em2) / (12*h)
+                fd[ia,ix] *= lib.param.BOHR
+        self.assertLess(abs(grad - fd).max(), 2e-7)
+
+    def test_uks_casci_ch3_all_component_finite_diff(self):
+        atom = '''
+        C  0.000000  0.000000  0.000000
+        H  0.000000  0.000000  1.090000
+        H  1.026719  0.000000 -0.363333
+        H -0.513360  0.889165 -0.363333
+        '''
+
+        def run(disp=None):
+            mol0 = gto.M(atom=atom, basis='3-21g', spin=1,
+                         unit='Angstrom', verbose=0)
+            if disp is not None:
+                ia, ix, dx = disp
+                coords = mol0.atom_coords(unit='Angstrom')
+                coords[ia,ix] += dx
+                mol0 = gto.M(atom=[(mol0.atom_symbol(i), coords[i])
+                                   for i in range(mol0.natm)],
+                             basis='3-21g', spin=1, unit='Angstrom',
+                             verbose=0)
+            mf = dft.UKS(mol0)
+            mf.xc = 'lda,vwn'
+            mf.grids.level = 1
+            mf.run(conv_tol=1e-11)
+            return mcscf.UCASCI(mf, 6, (3,2), ncore=(2,2)).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        h = 1e-3
+        fd = numpy.zeros_like(grad)
+        for ia in range(mc.mol.natm):
+            for ix in range(3):
+                ep2 = run((ia, ix,  2*h)).e_tot
+                ep1 = run((ia, ix,    h)).e_tot
+                em1 = run((ia, ix,   -h)).e_tot
+                em2 = run((ia, ix, -2*h)).e_tot
+                fd[ia,ix] = (-ep2 + 8*ep1 - 8*em1 + em2) / (12*h)
+                fd[ia,ix] *= lib.param.BOHR
+        self.assertLess(abs(grad - fd).max(), 3e-5)
+
+    def test_uks_casci_nh2_all_component_finite_diff(self):
+        atom = '''
+        N  0.000000  0.000000  0.000000
+        H  0.000000  0.000000  1.030000
+        H  0.968000  0.000000 -0.344000
+        '''
+
+        def run(disp=None):
+            mol = gto.M(atom=atom if disp is None else
+                        _move_atom(atom, disp[0], disp[1], disp[2]),
+                        basis='3-21g', spin=1, unit='Angstrom',
+                        verbose=0)
+            mf = dft.UKS(mol)
+            mf.xc = 'lda,vwn'
+            mf.grids.level = 1
+            mf.run(conv_tol=1e-11)
+            return mcscf.UCASCI(mf, 6, (3,2), ncore=(2,2)).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        fd = numpy.zeros_like(grad)
+        for ia in range(mc.mol.natm):
+            for ix in range(3):
+                fd[ia,ix] = _five_point_fd(run, ia, ix)
+        self.assertLess(abs(grad - fd).max(), 3e-6)
+
+    def test_uks_casci_ch2_triplet_gga_finite_diff(self):
+        atom = '''
+        C  0.000000  0.000000  0.000000
+        H  0.000000  0.000000  1.080000
+        H  1.020000  0.000000 -0.360000
+        '''
+
+        def run(disp=None):
+            mol = gto.M(atom=atom if disp is None else
+                        _move_atom(atom, disp[0], disp[1], disp[2]),
+                        basis='3-21g', spin=2, unit='Angstrom',
+                        verbose=0)
+            mf = dft.UKS(mol)
+            mf.xc = 'pbe,pbe'
+            mf.grids.level = 1
+            mf.run(conv_tol=1e-11)
+            return mcscf.UCASCI(mf, 7, (4,2), ncore=(1,1)).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        for ia, ix in ((0,2), (1,0), (2,2)):
+            self.assertLess(abs(grad[ia,ix] - _five_point_fd(run, ia, ix)),
+                            1e-5)
+
+    def test_uks_casci_zero_active_sector_finite_diff(self):
+        atom = '''
+        Li 0.000000  0.000000  0.000000
+        H  0.000000  0.000000  1.650000
+        '''
+
+        def run(disp=None):
+            mol = gto.M(atom=atom if disp is None else
+                        _move_atom(atom, disp[0], disp[1], disp[2]),
+                        basis='sto-3g', spin=1, charge=1,
+                        unit='Angstrom', verbose=0)
+            mf = dft.UKS(mol)
+            mf.xc = 'lda,vwn'
+            mf.grids.level = 4
+            mf.run(conv_tol=1e-12)
+            return mcscf.UCASCI(mf, 1, (1,0), ncore=(1,1)).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        self.assertLess(abs(grad[1,2] - _five_point_fd(run, 1, 2)), 1e-7)
+
+    def test_uks_casci_no_core_full_active_finite_diff(self):
+        atom = '''
+        H  0.000000  0.000000  0.000000
+        H  0.000000  0.000000  1.000000
+        H  0.000000  1.050000  0.100000
+        '''
+
+        def run(disp=None):
+            mol = gto.M(atom=atom if disp is None else
+                        _move_atom(atom, disp[0], disp[1], disp[2]),
+                        basis='sto-3g', spin=1, unit='Angstrom',
+                        verbose=0)
+            mf = dft.UKS(mol)
+            mf.xc = 'lda,vwn'
+            mf.run(conv_tol=1e-11)
+            return mcscf.UCASCI(mf, 3, (2,1), ncore=(0,0)).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        fd = numpy.zeros_like(grad)
+        for ia in range(mc.mol.natm):
+            for ix in range(3):
+                fd[ia,ix] = _five_point_fd(run, ia, ix)
+        self.assertLess(abs(grad - fd).max(), 1e-8)
+
+    def test_uks_casci_global_hybrid_finite_diff(self):
+        def run(disp=None):
+            coords = numpy.asarray(((0., 0., 0.),
+                                    (0., 0., 1.),
+                                    (0., 1., 0.)))
+            if disp is not None:
+                ia, ix, dx = disp
+                coords[ia, ix] += dx
+            mol = gto.M(atom=[('H', coords[i]) for i in range(3)],
+                        unit='Angstrom', basis='sto-3g', spin=1,
+                        verbose=0)
+            mf = dft.UKS(mol)
+            mf.xc = 'b3lyp'
+            mf.grids.level = 1
+            mf.run(conv_tol=1e-11)
+            return mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        fd = numpy.zeros_like(grad)
+        for ia in range(mc.mol.natm):
+            for ix in range(3):
+                fd[ia,ix] = _five_point_fd(run, ia, ix)
+        self.assertLess(abs(grad - fd).max(), 3e-6)
+
+    def test_uks_casci_excited_root_finite_diff(self):
+        atom = '''
+        H  0.000000  0.000000  0.000000
+        H  0.000000  0.000000  1.000000
+        H  0.000000  1.000000  0.150000
+        '''
+
+        def run(disp=None):
+            mol = gto.M(atom=atom if disp is None else
+                        _move_atom(atom, disp[0], disp[1], disp[2]),
+                        basis='sto-3g', spin=1, unit='Angstrom',
+                        verbose=0)
+            mf = dft.UKS(mol)
+            mf.xc = 'lda,vwn'
+            mf.run(conv_tol=1e-11)
+            mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0))
+            mc.fcisolver.nroots = 3
+            return mc.run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel(state=1)
+        h = 1e-3
+        for ia, ix in ((0,2), (1,0), (2,2)):
+            ep2 = run((ia, ix,  2*h)).e_tot[1]
+            ep1 = run((ia, ix,    h)).e_tot[1]
+            em1 = run((ia, ix,   -h)).e_tot[1]
+            em2 = run((ia, ix, -2*h)).e_tot[1]
+            fd = (-ep2 + 8*ep1 - 8*em1 + em2) / (12*h)
+            fd *= lib.param.BOHR
+            self.assertLess(abs(grad[ia,ix] - fd), 5e-7)
+
+    def test_uks_casci_state_average_finite_diff(self):
+        atom = '''
+        H  0.000000  0.000000  0.000000
+        H  0.000000  0.000000  1.000000
+        H  0.000000  1.000000  0.150000
+        '''
+
+        def run(disp=None):
+            mol = gto.M(atom=atom if disp is None else
+                        _move_atom(atom, disp[0], disp[1], disp[2]),
+                        basis='sto-3g', spin=1, unit='Angstrom',
+                        verbose=0)
+            mf = dft.UKS(mol)
+            mf.xc = 'lda,vwn'
+            mf.run(conv_tol=1e-11)
+            mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0))
+            mc.fcisolver.nroots = 2
+            return mc.state_average_([.3, .7]).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        for ia, ix in ((0,2), (1,0), (2,2)):
+            self.assertLess(abs(grad[ia,ix] - _five_point_fd(run, ia, ix)),
+                            5e-7)
+
+    def test_uks_restricted_collapse_matches_rks_casci(self):
+        mol = gto.M(atom='''
+                    O 0.000  0.000 0.000
+                    H 0.000 -0.757 0.587
+                    H 0.000  0.757 0.587''',
+                    basis='sto-3g', verbose=0)
+        rks = dft.RKS(mol)
+        rks.xc = 'lda,vwn'
+        rks.run(conv_tol=1e-12)
+        uks = dft.UKS(mol)
+        uks.xc = 'lda,vwn'
+        uks.run(conv_tol=1e-12)
+        rcas = mcscf.CASCI(rks, 4, 4, ncore=3).run()
+        ucas = mcscf.UCASCI(uks, 4, (2,2), ncore=(3,3)).run()
+        g_r = rcas.nuc_grad_method().kernel()
+        g_u = ucas.nuc_grad_method().kernel()
+        self.assertAlmostEqual(abs(g_r - g_u).max(), 0, 9)
 
     def test_restricted_casci_carbon_finite_diff_benchmark(self):
         atom = '''

--- a/pyscf/grad/test/test_ucasci.py
+++ b/pyscf/grad/test/test_ucasci.py
@@ -7,28 +7,15 @@ from pyscf import scf
 from pyscf import dft
 from pyscf import mcscf
 from pyscf import ci
-from pyscf import lib
 from pyscf.lib import logger
+from pyscf.grad.test.test_casci import _check_fd_grad
+from pyscf.grad.test.test_casci import _move_atom
 
 
-def _move_atom(atom, ia, ix, dx):
-    coords = []
-    for line in atom.splitlines():
-        if line.strip():
-            sym, x, y, z = line.split()
-            coords.append([sym, float(x), float(y), float(z)])
-    coords[ia][ix+1] += dx
-    return coords
-
-
-def _five_point_fd(run, ia, ix, h=1e-3):
-    ep2 = run((ia, ix,  2*h)).e_tot
-    ep1 = run((ia, ix,    h)).e_tot
-    em1 = run((ia, ix,   -h)).e_tot
-    em2 = run((ia, ix, -2*h)).e_tot
-    return (-ep2 + 8*ep1 - 8*em1 + em2) / (12*h) * lib.param.BOHR
-
-
+# Helper functions to build an independent reference full spin RDM and
+# generic pair-symmetric two-electron tensors. The RDM-intermediate tests
+# use them to check the UCASCI RDM -> UCCSD d1/d2 conversion
+# with a more literal construction
 def _pair_symmetric_eri(nmo, seed):
     rng = numpy.random.default_rng(seed)
     eri = rng.standard_normal((nmo,nmo,nmo,nmo))
@@ -92,7 +79,8 @@ def _make_full_rdm12s(casdm1s, casdm2s, nmo, ncore, ncas):
 
 
 class KnownValues(unittest.TestCase):
-    def test_full_active_matches_restricted_casci(self):
+    # Closed shell UCASCI matches restricted CASCI gradient.
+    def test_full_active_matches_restricted(self):
         mol = gto.M(atom='H 0 0 0; H 0 0 1',
                     basis='sto-3g', verbose=0)
         mf = scf.RHF(mol).run(conv_tol=1e-12)
@@ -104,22 +92,26 @@ class KnownValues(unittest.TestCase):
         grad = ucas.nuc_grad_method().kernel()
         self.assertAlmostEqual(abs(ref-grad).max(), 0, 9)
 
-    def test_full_active_one_electron_finite_diff(self):
-        def run(bond):
-            mol = gto.M(atom=f'H 0 0 0; H 0 0 {bond}',
+    def test_full_active_one_electron_fd(self):
+        atom = '''
+        H 0 0 0
+        H 0 0 1
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
                         basis='sto-3g', charge=1, spin=1, verbose=0)
             mf = scf.UHF(mol).run(conv_tol=1e-12)
             mc = mcscf.UCASCI(mf, mf.mo_coeff[0].shape[1], mol.nelec).run()
             return mc
 
-        mc = run(1.0)
-        grad = mc.nuc_grad_method().kernel()
-        e1 = run(1.001).e_tot
-        e2 = run(0.999).e_tot
-        ref = (e1-e2) / 0.002 * lib.param.BOHR
-        self.assertAlmostEqual(grad[1,2], ref, 5)
+        mc = run()
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 1e-6)
 
-    def test_inactive_orbitals_openshell_multicomponent_finite_diff(self):
+    # One core electron
+    def test_inactive_openshell_fd(self):
         atom = '''
         H 0 0 0
         H 0 0 1
@@ -134,14 +126,12 @@ class KnownValues(unittest.TestCase):
             return mc
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        for ia, ix in ((0,1), (0,2), (1,1), (1,2), (2,1), (2,2)):
-            e1 = run(ia, ix, 0.001).e_tot
-            e2 = run(ia, ix, -0.001).e_tot
-            ref = (e1-e2) / 0.002 * lib.param.BOHR
-            self.assertLess(abs(grad[ia,ix] - ref), 5e-7)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 5e-7)
 
-    def test_ucasci_matches_ucisd_complete_active_space(self):
+    # UCASCI and UCISD should be the same for a 2-electron case.
+    def test_ucasci_matches_ucisd(self):
         mol = gto.M(atom='H 0 0 0; H 0 0 1; H 0 1 0',
                     basis='sto-3g', spin=1, verbose=0)
         mf = scf.UHF(mol).run(conv_tol=1e-12)
@@ -152,6 +142,8 @@ class KnownValues(unittest.TestCase):
         g_ucis = myci.nuc_grad_method().kernel()
         self.assertAlmostEqual(abs(g_ucas - g_ucis).max(), 0, 10)
 
+
+    # Convert UCASCI RDMs into UCCSD d1/d2 intermediates and back.
     def test_rdm_intermediates_round_trip(self):
         from pyscf.cc import uccsd_rdm
         from pyscf.grad import ucasci
@@ -173,7 +165,9 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(max(abs(rdm2[i]-full2[i]).max()
                                    for i in range(3)), 0, 12)
 
-    def test_general_rdm_intermediates_contract_symmetric_integrals(self):
+    # Check the larger-space RDM conversion with generic pair-symmetric
+    # two-electron tensor contractions.
+    def test_rdm_intermediates_contraction(self):
         from pyscf.cc import uccsd_rdm
         from pyscf.grad import ucasci
         mol = gto.M(atom='''
@@ -208,22 +202,27 @@ class KnownValues(unittest.TestCase):
                   .5 * numpy.einsum('pqrs,pqrs', eribb, rdm2[2]))
         self.assertAlmostEqual(e_test, e_ref, 10)
 
-    def test_full_active_openshell_finite_diff(self):
-        def run(bond):
-            mol = gto.M(atom=f'H 0 0 0; H 0 0 {bond}; H 0 1 0',
+    def test_all_active_fd(self):
+        atom = '''
+        H 0 0 0
+        H 0 0 1
+        H 0 1 0
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
                         basis='sto-3g', spin=1, verbose=0)
             mf = scf.UHF(mol).run(conv_tol=1e-12)
             mc = mcscf.UCASCI(mf, mf.mo_coeff[0].shape[1], mol.nelec).run()
             return mc
 
-        mc = run(1.0)
-        grad = mc.nuc_grad_method().kernel()
-        e1 = run(1.001).e_tot
-        e2 = run(0.999).e_tot
-        ref = (e1-e2) / 0.002 * lib.param.BOHR
-        self.assertAlmostEqual(grad[1,2], ref, 5)
+        mc = run()
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 1e-6)
 
-    def test_general_casci_carbon_multicomponent_finite_diff(self):
+    # CH3 radical against FD
+    def test_ch3_fd(self):
         atom = '''
         C  0.00  0.00  0.00
         H  0.10  0.02  1.09
@@ -238,15 +237,13 @@ class KnownValues(unittest.TestCase):
             return mcscf.UCASCI(mf, 7, (3,2), ncore=(2,2)).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
         step = 2.5e-4
-        for ia, ix in ((0,0), (1,2), (2,0), (3,1)):
-            e1 = run(ia, ix, step).e_tot
-            e2 = run(ia, ix, -step).e_tot
-            ref = (e1-e2) / (2*step) * lib.param.BOHR
-            self.assertLess(abs(grad[ia,ix] - ref), 1e-6)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 1e-6, step=step)
 
-    def test_general_casci_nitrogen_hydride_finite_diff(self):
+    # NH2 radical against FD
+    def test_nh2_fd(self):
         atom = '''
         N 0.000  0.000 0.000
         H 0.000  0.900 0.650
@@ -260,14 +257,13 @@ class KnownValues(unittest.TestCase):
             return mcscf.UCASCI(mf, 6, (3,2), ncore=(2,2)).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
         step = 5e-4
-        e1 = run(1, 2, step).e_tot
-        e2 = run(1, 2, -step).e_tot
-        ref = (e1-e2) / (2*step) * lib.param.BOHR
-        self.assertLess(abs(grad[1,2] - ref), 1e-6)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 1e-6, step=step)
 
-    def test_general_casci_high_spin_carbon_finite_diff(self):
+    # CH2 triplet against FD
+    def test_ch2_fd(self):
         atom = '''
         C 0.000 0.000  0.000
         H 0.000 0.000  1.080
@@ -281,14 +277,13 @@ class KnownValues(unittest.TestCase):
             return mcscf.UCASCI(mf, 7, (4,2), ncore=(1,1)).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
         step = 5e-4
-        e1 = run(1, 2, step).e_tot
-        e2 = run(1, 2, -step).e_tot
-        ref = (e1-e2) / (2*step) * lib.param.BOHR
-        self.assertLess(abs(grad[1,2] - ref), 1e-6)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 1e-6, step=step)
 
-    def test_general_casci_ccpvtz_five_point_finite_diff(self):
+    # CH2 triplet against FD with triple-zeta basis
+    def test_ch2_tz_fd(self):
         atom = '''
         C 0.000 0.000  0.000
         H 0.000 0.000  1.080
@@ -302,16 +297,13 @@ class KnownValues(unittest.TestCase):
             return mcscf.UCASCI(mf, 7, (4,2), ncore=(1,1)).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
         step = 1e-3
-        ep2 = run(1, 2, 2*step).e_tot
-        ep1 = run(1, 2, step).e_tot
-        em1 = run(1, 2, -step).e_tot
-        em2 = run(1, 2, -2*step).e_tot
-        ref = (-ep2 + 8*ep1 - 8*em1 + em2) / (12*step) * lib.param.BOHR
-        self.assertLess(abs(grad[1,2] - ref), 5e-7)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 5e-7, step=step)
 
-    def test_general_casci_excited_root_finite_diff(self):
+    # CH3 excited states against FD
+    def test_ch3_excited_state_fd(self):
         atom = '''
         C  0.00  0.00  0.00
         H  0.10  0.02  1.09
@@ -328,14 +320,13 @@ class KnownValues(unittest.TestCase):
             return mc.run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel(state=1)
         step = 5e-4
-        e1 = run(1, 2, step).e_tot[1]
-        e2 = run(1, 2, -step).e_tot[1]
-        ref = (e1-e2) / (2*step) * lib.param.BOHR
-        self.assertLess(abs(grad[1,2] - ref), 2e-6)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(state=1),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot[1],
+                       mc.mol.natm, 2e-6, step=step)
 
-    def test_general_casci_state_average_finite_diff(self):
+    # CH3 state average against FD
+    def test_ch3_state_average_fd(self):
         atom = '''
         C  0.00  0.00  0.00
         H  0.10  0.02  1.09
@@ -352,16 +343,21 @@ class KnownValues(unittest.TestCase):
             return mc.state_average_([.4, .6]).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
         step = 5e-4
-        e1 = run(1, 2, step).e_tot
-        e2 = run(1, 2, -step).e_tot
-        ref = (e1-e2) / (2*step) * lib.param.BOHR
-        self.assertLess(abs(grad[1,2] - ref), 2e-6)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 2e-6, step=step)
 
-    def test_state_specific_excited_root_finite_diff(self):
-        def run(dz=0):
-            mol = gto.M(atom=f'H 0 0 0; H 0 0 {1+dz}; H 0 1 0',
+    # All active excited state against FD
+    def test_all_active_excited_state_fd(self):
+        atom = '''
+        H 0 0 0
+        H 0 0 1
+        H 0 1 0
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
                         basis='sto-3g', spin=1, verbose=0)
             mf = scf.UHF(mol).run(conv_tol=1e-12)
             mc = mcscf.UCASCI(mf, 3, (2,1))
@@ -369,41 +365,75 @@ class KnownValues(unittest.TestCase):
             return mc.run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel(state=2)
-        e1 = run(0.001).e_tot[2]
-        e2 = run(-0.001).e_tot[2]
-        ref = (e1-e2) / 0.002 * lib.param.BOHR
-        self.assertLess(abs(grad[1,2] - ref), 1e-6)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(state=2),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot[2],
+                       mc.mol.natm, 1e-6)
 
-    def test_symmetry_x2c_df_finite_diff(self):
-        def run(dz=0, symmetry=False, x2c=False, density_fit=False):
-            mol = gto.M(atom=f'H 0 0 0; H 0 0 {1+dz}; H 0 1 0',
-                        basis='sto-3g', spin=1, symmetry=symmetry, verbose=0)
-            mf = scf.UHF(mol)
-            if x2c:
-                mf = mf.x2c()
-            if density_fit:
-                mf = mf.density_fit()
-            mf.run(conv_tol=1e-12)
+    # UCASCI with symmetry against FD
+    def test_symmetry_fd(self):
+        atom = '''
+        H 0 0 0
+        H 0 0 1
+        H 0 1 0
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='sto-3g', spin=1, symmetry=True, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-12)
             return mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
 
-        for kwargs, tol in (((dict(symmetry=True)), 1e-6),
-                            ((dict(x2c=True)), 1e-6),
-                            ((dict(density_fit=True)), 3e-6)):
-            mc = run(**kwargs)
-            grad = mc.nuc_grad_method().kernel()
-            e1 = run(0.001, **kwargs).e_tot
-            e2 = run(-0.001, **kwargs).e_tot
-            ref = (e1-e2) / 0.002 * lib.param.BOHR
-            self.assertLess(abs(grad[1,2] - ref), tol)
+        mc = run()
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 1e-6)
 
-    def test_uks_casci_h3_all_component_finite_diff(self):
-        def run(disp=None):
+    # X2C on open-shell OH2+ against FD
+    def test_x2c_oh2_fd(self):
+        atom = '''
+        O 0.000000  0.000000 0.000000
+        H 0.000000  0.757000 0.587000
+        H 0.000000 -0.757000 0.587000
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='6-31g', charge=1, spin=1, unit='Angstrom',
+                        verbose=0)
+            mf = scf.UHF(mol).x2c().run(conv_tol=1e-12)
+            return mcscf.UCASCI(mf, 4, (2,1), ncore=(3,3)).run()
+
+        mc = run()
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 1e-6)
+
+    # Error out when DF-generated UHF/UKS orbital sources are used
+    def test_density_fitted_orbitals_unsupported(self):
+        mol = gto.M(atom='H 0 0 0; H 0 0 1; H 0 1 0',
+                    basis='sto-3g', spin=1, verbose=0)
+
+        mf = scf.UHF(mol).density_fit().run(conv_tol=1e-12)
+        mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
+        self.assertTrue(getattr(mc, '_scf_df_source', False))
+        with self.assertRaisesRegex(NotImplementedError, 'DF-UHF'):
+            mc.nuc_grad_method().kernel()
+
+        mf = dft.UKS(mol)
+        mf.xc = 'lda,vwn'
+        mf = mf.density_fit()
+        mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0))
+        self.assertTrue(getattr(mc, '_scf_df_source', False))
+        with self.assertRaisesRegex(NotImplementedError, 'DF-UKS'):
+            mc.nuc_grad_method().grad_elec(ci=0)
+
+    # UKS-CASCI with one core electron
+    def test_uks_casci_h3_finite_diff(self):
+        def run(ia=None, ix=None, dx=0):
             coords = numpy.asarray(((0., 0., 0.),
                                     (0., 0., 1.),
                                     (0., 1., 0.)))
-            if disp is not None:
-                ia, ix, dx = disp
+            if ia is not None:
                 coords[ia, ix] += dx
             mol = gto.M(atom=[('H', coords[i]) for i in range(3)],
                         unit='Angstrom', basis='sto-3g', spin=1, verbose=0)
@@ -417,19 +447,11 @@ class KnownValues(unittest.TestCase):
                          'pyscf.grad.ukscasci')
         self.assertEqual(mc.Gradients().__class__.__module__,
                          'pyscf.grad.ukscasci')
-        grad = mc.nuc_grad_method().kernel()
-        h = 1e-3
-        fd = numpy.zeros_like(grad)
-        for ia in range(3):
-            for ix in range(3):
-                ep2 = run((ia, ix,  2*h)).e_tot
-                ep1 = run((ia, ix,    h)).e_tot
-                em1 = run((ia, ix,   -h)).e_tot
-                em2 = run((ia, ix, -2*h)).e_tot
-                fd[ia,ix] = (-ep2 + 8*ep1 - 8*em1 + em2) / (12*h)
-                fd[ia,ix] *= lib.param.BOHR
-        self.assertLess(abs(grad - fd).max(), 2e-7)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 2e-7)
 
+    # Error out when requesting UKS-CASCI gradients for unsupported functionals
     def test_uks_casci_unsupported_functionals(self):
         mol = gto.M(atom='H 0 0 0; H 0 0 1; H 0 1 0',
                     basis='sto-3g', spin=1, verbose=0)
@@ -437,8 +459,6 @@ class KnownValues(unittest.TestCase):
         mf.xc = 'lda,vwn'
         mf.run(conv_tol=1e-12)
 
-        # The CASCI Hamiltonian is independent of the source XC functional.
-        # Only the gradient guard behavior depends on these fields here.
         mf.xc = 'tpss'
         mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
         with self.assertRaisesRegex(NotImplementedError, 'meta-GGA'):
@@ -455,7 +475,8 @@ class KnownValues(unittest.TestCase):
         with self.assertRaisesRegex(NotImplementedError, 'NLC'):
             mc.nuc_grad_method().kernel()
 
-    def test_uks_casci_ch3_all_component_finite_diff(self):
+    # CH3 radical against FD with UKS(lda,vwn) orbitals
+    def test_uks_ch3_fd(self):
         atom = '''
         C  0.000000  0.000000  0.000000
         H  0.000000  0.000000  1.090000
@@ -463,11 +484,10 @@ class KnownValues(unittest.TestCase):
         H -0.513360  0.889165 -0.363333
         '''
 
-        def run(disp=None):
+        def run(ia=None, ix=None, dx=0):
             mol0 = gto.M(atom=atom, basis='3-21g', spin=1,
                          unit='Angstrom', verbose=0)
-            if disp is not None:
-                ia, ix, dx = disp
+            if ia is not None:
                 coords = mol0.atom_coords(unit='Angstrom')
                 coords[ia,ix] += dx
                 mol0 = gto.M(atom=[(mol0.atom_symbol(i), coords[i])
@@ -481,29 +501,20 @@ class KnownValues(unittest.TestCase):
             return mcscf.UCASCI(mf, 6, (3,2), ncore=(2,2)).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        h = 1e-3
-        fd = numpy.zeros_like(grad)
-        for ia in range(mc.mol.natm):
-            for ix in range(3):
-                ep2 = run((ia, ix,  2*h)).e_tot
-                ep1 = run((ia, ix,    h)).e_tot
-                em1 = run((ia, ix,   -h)).e_tot
-                em2 = run((ia, ix, -2*h)).e_tot
-                fd[ia,ix] = (-ep2 + 8*ep1 - 8*em1 + em2) / (12*h)
-                fd[ia,ix] *= lib.param.BOHR
-        self.assertLess(abs(grad - fd).max(), 3e-5)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 3e-6)
 
-    def test_uks_casci_nh2_all_component_finite_diff(self):
+    # NH2 radical against FD with UKS(lda,vwn) orbitals
+    def test_uks_nh2_fd(self):
         atom = '''
         N  0.000000  0.000000  0.000000
         H  0.000000  0.000000  1.030000
         H  0.968000  0.000000 -0.344000
         '''
 
-        def run(disp=None):
-            mol = gto.M(atom=atom if disp is None else
-                        _move_atom(atom, disp[0], disp[1], disp[2]),
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
                         basis='3-21g', spin=1, unit='Angstrom',
                         verbose=0)
             mf = dft.UKS(mol)
@@ -513,46 +524,42 @@ class KnownValues(unittest.TestCase):
             return mcscf.UCASCI(mf, 6, (3,2), ncore=(2,2)).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        fd = numpy.zeros_like(grad)
-        for ia in range(mc.mol.natm):
-            for ix in range(3):
-                fd[ia,ix] = _five_point_fd(run, ia, ix)
-        self.assertLess(abs(grad - fd).max(), 3e-6)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 3e-6)
 
-    def test_uks_casci_ch2_triplet_gga_finite_diff(self):
+    # CH2 triplet against FD with UKS(pbe,pbe)
+    def test_uks_ch2_fd(self):
         atom = '''
         C  0.000000  0.000000  0.000000
         H  0.000000  0.000000  1.080000
         H  1.020000  0.000000 -0.360000
         '''
 
-        def run(disp=None):
-            mol = gto.M(atom=atom if disp is None else
-                        _move_atom(atom, disp[0], disp[1], disp[2]),
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
                         basis='3-21g', spin=2, unit='Angstrom',
                         verbose=0)
             mf = dft.UKS(mol)
             mf.xc = 'pbe,pbe'
-            mf.grids.level = 1
+            mf.grids.level = 3
             mf.run(conv_tol=1e-11)
             return mcscf.UCASCI(mf, 7, (4,2), ncore=(1,1)).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        for ia, ix in ((0,2), (1,0), (2,2)):
-            self.assertLess(abs(grad[ia,ix] - _five_point_fd(run, ia, ix)),
-                            1e-5)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 3e-6)
 
-    def test_uks_casci_zero_active_sector_finite_diff(self):
+    # one-electron UKS-CASCI against FD
+    def test_uks_emptybeta_fd(self):
         atom = '''
         Li 0.000000  0.000000  0.000000
         H  0.000000  0.000000  1.650000
         '''
 
-        def run(disp=None):
-            mol = gto.M(atom=atom if disp is None else
-                        _move_atom(atom, disp[0], disp[1], disp[2]),
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
                         basis='sto-3g', spin=1, charge=1,
                         unit='Angstrom', verbose=0)
             mf = dft.UKS(mol)
@@ -562,19 +569,19 @@ class KnownValues(unittest.TestCase):
             return mcscf.UCASCI(mf, 1, (1,0), ncore=(1,1)).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        self.assertLess(abs(grad[1,2] - _five_point_fd(run, 1, 2)), 1e-7)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 1e-7)
 
-    def test_uks_casci_no_core_full_active_finite_diff(self):
+    def test_uks_all_active_fd(self):
         atom = '''
         H  0.000000  0.000000  0.000000
         H  0.000000  0.000000  1.000000
         H  0.000000  1.050000  0.100000
         '''
 
-        def run(disp=None):
-            mol = gto.M(atom=atom if disp is None else
-                        _move_atom(atom, disp[0], disp[1], disp[2]),
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
                         basis='sto-3g', spin=1, unit='Angstrom',
                         verbose=0)
             mf = dft.UKS(mol)
@@ -583,20 +590,17 @@ class KnownValues(unittest.TestCase):
             return mcscf.UCASCI(mf, 3, (2,1), ncore=(0,0)).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        fd = numpy.zeros_like(grad)
-        for ia in range(mc.mol.natm):
-            for ix in range(3):
-                fd[ia,ix] = _five_point_fd(run, ia, ix)
-        self.assertLess(abs(grad - fd).max(), 1e-8)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 1e-8)
 
-    def test_uks_casci_global_hybrid_finite_diff(self):
-        def run(disp=None):
+    # UKS-CASCI gradient against FD when using B3LYP.
+    def test_uks_b3lyp_fd(self):
+        def run(ia=None, ix=None, dx=0):
             coords = numpy.asarray(((0., 0., 0.),
                                     (0., 0., 1.),
                                     (0., 1., 0.)))
-            if disp is not None:
-                ia, ix, dx = disp
+            if ia is not None:
                 coords[ia, ix] += dx
             mol = gto.M(atom=[('H', coords[i]) for i in range(3)],
                         unit='Angstrom', basis='sto-3g', spin=1,
@@ -608,23 +612,20 @@ class KnownValues(unittest.TestCase):
             return mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        fd = numpy.zeros_like(grad)
-        for ia in range(mc.mol.natm):
-            for ix in range(3):
-                fd[ia,ix] = _five_point_fd(run, ia, ix)
-        self.assertLess(abs(grad - fd).max(), 3e-6)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 3e-6)
 
-    def test_uks_casci_excited_root_finite_diff(self):
+    # excited state UKS-CASCI gradients against FD.
+    def test_uks_casci_excited_state_fd(self):
         atom = '''
         H  0.000000  0.000000  0.000000
         H  0.000000  0.000000  1.000000
         H  0.000000  1.000000  0.150000
         '''
 
-        def run(disp=None):
-            mol = gto.M(atom=atom if disp is None else
-                        _move_atom(atom, disp[0], disp[1], disp[2]),
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
                         basis='sto-3g', spin=1, unit='Angstrom',
                         verbose=0)
             mf = dft.UKS(mol)
@@ -635,27 +636,20 @@ class KnownValues(unittest.TestCase):
             return mc.run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel(state=1)
-        h = 1e-3
-        for ia, ix in ((0,2), (1,0), (2,2)):
-            ep2 = run((ia, ix,  2*h)).e_tot[1]
-            ep1 = run((ia, ix,    h)).e_tot[1]
-            em1 = run((ia, ix,   -h)).e_tot[1]
-            em2 = run((ia, ix, -2*h)).e_tot[1]
-            fd = (-ep2 + 8*ep1 - 8*em1 + em2) / (12*h)
-            fd *= lib.param.BOHR
-            self.assertLess(abs(grad[ia,ix] - fd), 5e-7)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(state=1),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot[1],
+                       mc.mol.natm, 5e-7)
 
-    def test_uks_casci_state_average_finite_diff(self):
+    # state-averaged UKS(lda,vwn)-CASCI gradients against FD.
+    def test_uks_state_average_fd(self):
         atom = '''
         H  0.000000  0.000000  0.000000
         H  0.000000  0.000000  1.000000
         H  0.000000  1.000000  0.150000
         '''
 
-        def run(disp=None):
-            mol = gto.M(atom=atom if disp is None else
-                        _move_atom(atom, disp[0], disp[1], disp[2]),
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
                         basis='sto-3g', spin=1, unit='Angstrom',
                         verbose=0)
             mf = dft.UKS(mol)
@@ -666,12 +660,12 @@ class KnownValues(unittest.TestCase):
             return mc.state_average_([.3, .7]).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        for ia, ix in ((0,2), (1,0), (2,2)):
-            self.assertLess(abs(grad[ia,ix] - _five_point_fd(run, ia, ix)),
-                            5e-7)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 5e-7)
 
-    def test_uks_restricted_collapse_matches_rks_casci(self):
+    # Closed shell UKS-CASCI matches RKS-CASCI gradient.
+    def test_ukscasci_matches_restricted(self):
         mol = gto.M(atom='''
                     O 0.000  0.000 0.000
                     H 0.000 -0.757 0.587
@@ -689,50 +683,9 @@ class KnownValues(unittest.TestCase):
         g_u = ucas.nuc_grad_method().kernel()
         self.assertAlmostEqual(abs(g_r - g_u).max(), 0, 9)
 
-    def test_restricted_casci_carbon_finite_diff_benchmark(self):
-        atom = '''
-        C  0.00  0.00  0.00
-        H  0.10  0.02  1.09
-        H  1.02  0.08 -0.35
-        H -0.42  0.96 -0.28
-        H -0.62 -0.78 -0.42
-        '''
 
-        def run(dx=0):
-            coords = []
-            for line in atom.splitlines():
-                if line.strip():
-                    sym, x, y, z = line.split()
-                    coords.append([sym, float(x), float(y), float(z)])
-            coords[4][1] += dx
-            mol = gto.M(atom=coords, basis='6-31g', verbose=0)
-            mf = scf.RHF(mol).run(conv_tol=1e-12)
-            return mcscf.CASCI(mf, 8, 6, ncore=2).run()
-
-        mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        e1 = run(0.001).e_tot
-        e2 = run(-0.001).e_tot
-        ref = (e1-e2) / 0.002 * lib.param.BOHR
-        self.assertLess(abs(grad[4,0] - ref), 1e-6)
-
-    def test_restricted_collapse_h4_inactive(self):
-        mol = gto.M(atom='''
-                    H 0.0 0.0 0.0
-                    H 0.0 0.0 1.0
-                    H 0.0 1.0 0.0
-                    H 0.2 1.0 1.0''',
-                    basis='sto-3g', verbose=0)
-        rhf = scf.RHF(mol).run(conv_tol=1e-12)
-        uhf = scf.UHF(mol).run(conv_tol=1e-12)
-        rcas = mcscf.CASCI(rhf, 2, 2, ncore=1).run()
-        ucas = mcscf.UCASCI(uhf, 2, (1,1), ncore=(1,1)).run()
-        self.assertAlmostEqual(rcas.e_tot, ucas.e_tot, 10)
-        g_r = rcas.nuc_grad_method().kernel()
-        g_u = ucas.nuc_grad_method().kernel()
-        self.assertAlmostEqual(abs(g_r - g_u).max(), 0, 9)
-
-    def test_restricted_collapse_ch4_larger_active_space(self):
+    # Closed shell UCASCI matches restricted CASCI gradient.
+    def test_ucasci_matches_restricted(self):
         mol = gto.M(atom='''
                     C  0.00  0.00  0.00
                     H  0.10  0.02  1.09
@@ -749,9 +702,16 @@ class KnownValues(unittest.TestCase):
         g_u = ucas.nuc_grad_method().kernel()
         self.assertAlmostEqual(abs(g_r - g_u).max(), 0, 7)
 
-    def test_state_average_finite_diff(self):
-        def run(dz=0):
-            mol = gto.M(atom=f'H 0 0 0; H 0 0 {1+dz}; H 0 1 0',
+    # State averaged gradient against FD
+    def test_state_average_fd(self):
+        atom = '''
+        H 0 0 0
+        H 0 0 1
+        H 0 1 0
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
                         basis='sto-3g', spin=1, verbose=0)
             mf = scf.UHF(mol).run(conv_tol=1e-12)
             mc = mcscf.UCASCI(mf, 3, (2,1))
@@ -759,53 +719,71 @@ class KnownValues(unittest.TestCase):
             return mc.state_average_([.5, .5]).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        e1 = run(0.001).e_tot
-        e2 = run(-0.001).e_tot
-        ref = (e1-e2) / 0.002 * lib.param.BOHR
-        self.assertLess(abs(grad[1,2] - ref), 1e-6)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 1e-6)
 
-    def test_zero_active_occupied_spin_sector(self):
-        def run(dz=0):
-            mol = gto.M(atom=f'Li 0 0 0; H 0 0 {1.6+dz}',
-                        basis='sto-3g', charge=1, spin=1, verbose=0)
+    # one-electron against FD
+    def test_emptybeta_fd(self):
+        atom = '''
+        Li 0.000000  0.000000  0.000000
+        H  0.000000  0.000000  1.650000
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='sto-3g', spin=1, charge=1,
+                        unit='Angstrom', verbose=0)
             mf = scf.UHF(mol).run(conv_tol=1e-12)
             return mcscf.UCASCI(mf, 2, (1,0), ncore=(1,1)).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        e1 = run(0.001).e_tot
-        e2 = run(-0.001).e_tot
-        ref = (e1-e2) / 0.002 * lib.param.BOHR
-        self.assertLess(abs(grad[1,2] - ref), 1e-6)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 1e-6)
 
-    def test_zero_active_virtual_spin_sector(self):
-        def run(dz=0):
-            mol = gto.M(atom=f'Li 0 0 0; H 0 0 {1.6+dz}',
-                        basis='sto-3g', charge=1, spin=1, verbose=0)
+    # single orbital single electron (no excitations) edgecase
+    def test_single_determinant(self):
+        atom = '''
+        Li 0.000000  0.000000  0.000000
+        H  0.000000  0.000000  1.650000
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='sto-3g', spin=1, charge=1,
+                        unit='Angstrom', verbose=0)
             mf = scf.UHF(mol).run(conv_tol=1e-12)
             return mcscf.UCASCI(mf, 1, (1,0), ncore=(1,1)).run()
 
         mc = run()
-        grad = mc.nuc_grad_method().kernel()
-        e1 = run(0.001).e_tot
-        e2 = run(-0.001).e_tot
-        ref = (e1-e2) / 0.002 * lib.param.BOHR
-        self.assertLess(abs(grad[1,2] - ref), 1e-6)
+        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+                       lambda ia, ix, dx: run(ia, ix, dx).e_tot,
+                       mc.mol.natm, 1e-6)
 
+    # check UCASCI gradient scanner path against FD
     def test_scanner(self):
-        mol = gto.M(atom='H 0 0 0; H 0 0 1; H 0 1 0',
+        atom = '''
+        H 0 0 0
+        H 0 0 1
+        H 0 1 0
+        '''
+        mol = gto.M(atom=atom,
                     basis='sto-3g', spin=1, verbose=0)
         mf = scf.UHF(mol).run(conv_tol=1e-12)
         mc = mcscf.UCASCI(mf, mf.mo_coeff[0].shape[1], mol.nelec)
         gs = mc.nuc_grad_method().as_scanner()
-        e, grad = gs(mol)
-        e1 = gs.base('H 0 0 0; H 0 0 1.001; H 0 1 0')
-        e2 = gs.base('H 0 0 0; H 0 0 0.999; H 0 1 0')
-        ref = (e1-e2) / 0.002 * lib.param.BOHR
-        self.assertAlmostEqual(e, -1.5056055923848675, 8)
-        self.assertAlmostEqual(grad[1,2], ref, 5)
+        e0 = [None]
+        def analytic_grad():
+            e0[0], grad = gs(mol)
+            return grad
+        _check_fd_grad(
+            self, analytic_grad,
+            lambda ia, ix, dx: gs.base(_move_atom(atom, ia, ix, dx)),
+            mol.natm, 1e-5)
+        self.assertAlmostEqual(e0[0], -1.5056055923848675, 8)
 
+    # Ensure verbose UCASCI gradient finalization runs without error
     def test_verbose_finalize(self):
         mol = gto.M(atom='H 0 0 0; H 0 0 1; H 0 1 0',
                     basis='sto-3g', spin=1, verbose=0)

--- a/pyscf/grad/test/test_ucasci.py
+++ b/pyscf/grad/test/test_ucasci.py
@@ -106,7 +106,11 @@ class KnownValues(unittest.TestCase):
             return mc
 
         mc = run()
-        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+        grad = mc.nuc_grad_method()
+        self.assertIsNone(grad.state)
+        with self.assertRaises(AssertionError):
+            grad.kernel(state=1)
+        _check_fd_grad(self, lambda: grad.kernel(),
                        lambda ia, ix, dx: run(ia, ix, dx).e_tot,
                        mc.mol.natm, 1e-6)
 

--- a/pyscf/grad/test/test_ucasci.py
+++ b/pyscf/grad/test/test_ucasci.py
@@ -4,9 +4,11 @@ import unittest
 import numpy
 from pyscf import gto
 from pyscf import scf
+from pyscf import dft
 from pyscf import mcscf
 from pyscf import ci
 from pyscf import lib
+from pyscf.lib import logger
 
 
 def _move_atom(atom, ia, ix, dx):
@@ -387,6 +389,14 @@ class KnownValues(unittest.TestCase):
             ref = (e1-e2) / 0.002 * lib.param.BOHR
             self.assertLess(abs(grad[1,2] - ref), tol)
 
+    def test_uks_orbitals_not_implemented(self):
+        mol = gto.M(atom='H 0 0 0; H 0 0 1; H 0 1 0',
+                    basis='sto-3g', spin=1, verbose=0)
+        mf = dft.UKS(mol).run(conv_tol=1e-12)
+        mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
+        with self.assertRaises(NotImplementedError):
+            mc.nuc_grad_method().kernel()
+
     def test_restricted_casci_carbon_finite_diff_benchmark(self):
         atom = '''
         C  0.00  0.00  0.00
@@ -503,6 +513,16 @@ class KnownValues(unittest.TestCase):
         ref = (e1-e2) / 0.002 * lib.param.BOHR
         self.assertAlmostEqual(e, -1.5056055923848675, 8)
         self.assertAlmostEqual(grad[1,2], ref, 5)
+
+    def test_verbose_finalize(self):
+        mol = gto.M(atom='H 0 0 0; H 0 0 1; H 0 1 0',
+                    basis='sto-3g', spin=1, verbose=0)
+        mf = scf.UHF(mol).run(conv_tol=1e-12)
+        mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
+        grad = mc.nuc_grad_method()
+        grad.verbose = logger.NOTE
+        de = grad.kernel()
+        self.assertEqual(de.shape, (3,3))
 
 
 if __name__ == "__main__":

--- a/pyscf/grad/test/test_ucasci.py
+++ b/pyscf/grad/test/test_ucasci.py
@@ -413,6 +413,10 @@ class KnownValues(unittest.TestCase):
             return mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
 
         mc = run()
+        self.assertEqual(mc.nuc_grad_method().__class__.__module__,
+                         'pyscf.grad.ukscasci')
+        self.assertEqual(mc.Gradients().__class__.__module__,
+                         'pyscf.grad.ukscasci')
         grad = mc.nuc_grad_method().kernel()
         h = 1e-3
         fd = numpy.zeros_like(grad)
@@ -425,6 +429,31 @@ class KnownValues(unittest.TestCase):
                 fd[ia,ix] = (-ep2 + 8*ep1 - 8*em1 + em2) / (12*h)
                 fd[ia,ix] *= lib.param.BOHR
         self.assertLess(abs(grad - fd).max(), 2e-7)
+
+    def test_uks_casci_unsupported_functionals(self):
+        mol = gto.M(atom='H 0 0 0; H 0 0 1; H 0 1 0',
+                    basis='sto-3g', spin=1, verbose=0)
+        mf = dft.UKS(mol)
+        mf.xc = 'lda,vwn'
+        mf.run(conv_tol=1e-12)
+
+        # The CASCI Hamiltonian is independent of the source XC functional.
+        # Only the gradient guard behavior depends on these fields here.
+        mf.xc = 'tpss'
+        mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
+        with self.assertRaisesRegex(NotImplementedError, 'meta-GGA'):
+            mc.nuc_grad_method().kernel()
+
+        mf.xc = 'cam-b3lyp'
+        mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
+        with self.assertRaisesRegex(NotImplementedError, 'range-separated'):
+            mc.nuc_grad_method().kernel()
+
+        mf.xc = 'lda,vwn'
+        mf.nlc = 'vv10'
+        mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
+        with self.assertRaisesRegex(NotImplementedError, 'NLC'):
+            mc.nuc_grad_method().kernel()
 
     def test_uks_casci_ch3_all_component_finite_diff(self):
         atom = '''

--- a/pyscf/grad/test/test_ucasci.py
+++ b/pyscf/grad/test/test_ucasci.py
@@ -107,9 +107,6 @@ class KnownValues(unittest.TestCase):
 
         mc = run()
         grad = mc.nuc_grad_method()
-        self.assertIsNone(grad.state)
-        with self.assertRaises(AssertionError):
-            grad.kernel(state=1)
         _check_fd_grad(self, lambda: grad.kernel(),
                        lambda ia, ix, dx: run(ia, ix, dx).e_tot,
                        mc.mol.natm, 1e-6)
@@ -723,7 +720,11 @@ class KnownValues(unittest.TestCase):
             return mc.state_average_([.5, .5]).run()
 
         mc = run()
-        _check_fd_grad(self, lambda: mc.nuc_grad_method().kernel(),
+        grad = mc.nuc_grad_method()
+        self.assertIsNone(grad.state)
+        with self.assertRaises(AssertionError):
+            grad.kernel(state=1)
+        _check_fd_grad(self, lambda: grad.kernel(),
                        lambda ia, ix, dx: run(ia, ix, dx).e_tot,
                        mc.mol.natm, 1e-6)
 

--- a/pyscf/grad/test/test_ucasci.py
+++ b/pyscf/grad/test/test_ucasci.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python
+
+import unittest
+import numpy
+from pyscf import gto
+from pyscf import scf
+from pyscf import mcscf
+from pyscf import ci
+from pyscf import lib
+
+
+def _move_atom(atom, ia, ix, dx):
+    coords = []
+    for line in atom.splitlines():
+        if line.strip():
+            sym, x, y, z = line.split()
+            coords.append([sym, float(x), float(y), float(z)])
+    coords[ia][ix+1] += dx
+    return coords
+
+
+def _pair_symmetric_eri(nmo, seed):
+    rng = numpy.random.default_rng(seed)
+    eri = rng.standard_normal((nmo,nmo,nmo,nmo))
+    eri = (eri + eri.transpose(1,0,2,3) +
+           eri.transpose(0,1,3,2) + eri.transpose(1,0,3,2)) * .25
+    return (eri + eri.transpose(2,3,0,1)) * .5
+
+
+def _pair_symmetric_eri_ab(nmoa, nmob, seed):
+    rng = numpy.random.default_rng(seed)
+    eri = rng.standard_normal((nmoa,nmoa,nmob,nmob))
+    return (eri + eri.transpose(1,0,2,3) +
+            eri.transpose(0,1,3,2) + eri.transpose(1,0,3,2)) * .25
+
+
+def _make_full_rdm12s(casdm1s, casdm2s, nmo, ncore, ncas):
+    ncorea, ncoreb = ncore
+    nacca = ncorea + ncas
+    naccb = ncoreb + ncas
+    casdm1a, casdm1b = casdm1s
+    casdm2aa, casdm2ab, casdm2bb = casdm2s
+
+    dm1a = numpy.zeros((nmo,nmo))
+    dm1b = numpy.zeros((nmo,nmo))
+    dm1a[numpy.arange(ncorea),numpy.arange(ncorea)] = 1
+    dm1b[numpy.arange(ncoreb),numpy.arange(ncoreb)] = 1
+    dm1a[ncorea:nacca,ncorea:nacca] = casdm1a
+    dm1b[ncoreb:naccb,ncoreb:naccb] = casdm1b
+
+    dm2aa = numpy.zeros((nmo,nmo,nmo,nmo))
+    dm2ab = numpy.zeros((nmo,nmo,nmo,nmo))
+    dm2bb = numpy.zeros((nmo,nmo,nmo,nmo))
+    for i in range(ncorea):
+        for j in range(ncorea):
+            dm2aa[i,i,j,j] += 1
+            dm2aa[i,j,j,i] -= 1
+        dm2aa[i,i,ncorea:nacca,ncorea:nacca] += casdm1a
+        dm2aa[ncorea:nacca,ncorea:nacca,i,i] += casdm1a
+        dm2aa[i,ncorea:nacca,ncorea:nacca,i] -= casdm1a
+        dm2aa[ncorea:nacca,i,i,ncorea:nacca] -= casdm1a
+    for i in range(ncoreb):
+        for j in range(ncoreb):
+            dm2bb[i,i,j,j] += 1
+            dm2bb[i,j,j,i] -= 1
+        dm2bb[i,i,ncoreb:naccb,ncoreb:naccb] += casdm1b
+        dm2bb[ncoreb:naccb,ncoreb:naccb,i,i] += casdm1b
+        dm2bb[i,ncoreb:naccb,ncoreb:naccb,i] -= casdm1b
+        dm2bb[ncoreb:naccb,i,i,ncoreb:naccb] -= casdm1b
+
+    for i in range(ncorea):
+        for j in range(ncoreb):
+            dm2ab[i,i,j,j] += 1
+        dm2ab[i,i,ncoreb:naccb,ncoreb:naccb] += casdm1b
+    for j in range(ncoreb):
+        dm2ab[ncorea:nacca,ncorea:nacca,j,j] += casdm1a
+
+    dm2aa[ncorea:nacca,ncorea:nacca,ncorea:nacca,ncorea:nacca] += casdm2aa
+    dm2ab[ncorea:nacca,ncorea:nacca,ncoreb:naccb,ncoreb:naccb] += casdm2ab
+    dm2bb[ncoreb:naccb,ncoreb:naccb,ncoreb:naccb,ncoreb:naccb] += casdm2bb
+    return (dm1a, dm1b), (dm2aa, dm2ab, dm2bb)
+
+
+class KnownValues(unittest.TestCase):
+    def test_full_active_matches_restricted_casci(self):
+        mol = gto.M(atom='H 0 0 0; H 0 0 1',
+                    basis='sto-3g', verbose=0)
+        mf = scf.RHF(mol).run(conv_tol=1e-12)
+        rcas = mcscf.CASCI(mf, mf.mo_coeff.shape[1], mol.nelectron).run()
+        ref = rcas.nuc_grad_method().kernel()
+
+        mf = scf.UHF(mol).run(conv_tol=1e-12)
+        ucas = mcscf.UCASCI(mf, mf.mo_coeff[0].shape[1], mol.nelec).run()
+        grad = ucas.nuc_grad_method().kernel()
+        self.assertAlmostEqual(abs(ref-grad).max(), 0, 9)
+
+    def test_full_active_one_electron_finite_diff(self):
+        def run(bond):
+            mol = gto.M(atom=f'H 0 0 0; H 0 0 {bond}',
+                        basis='sto-3g', charge=1, spin=1, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-12)
+            mc = mcscf.UCASCI(mf, mf.mo_coeff[0].shape[1], mol.nelec).run()
+            return mc
+
+        mc = run(1.0)
+        grad = mc.nuc_grad_method().kernel()
+        e1 = run(1.001).e_tot
+        e2 = run(0.999).e_tot
+        ref = (e1-e2) / 0.002 * lib.param.BOHR
+        self.assertAlmostEqual(grad[1,2], ref, 5)
+
+    def test_inactive_orbitals_openshell_multicomponent_finite_diff(self):
+        atom = '''
+        H 0 0 0
+        H 0 0 1
+        H 0 1 0
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='sto-3g', spin=1, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-12)
+            mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
+            return mc
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        for ia, ix in ((0,1), (0,2), (1,1), (1,2), (2,1), (2,2)):
+            e1 = run(ia, ix, 0.001).e_tot
+            e2 = run(ia, ix, -0.001).e_tot
+            ref = (e1-e2) / 0.002 * lib.param.BOHR
+            self.assertLess(abs(grad[ia,ix] - ref), 5e-7)
+
+    def test_ucasci_matches_ucisd_complete_active_space(self):
+        mol = gto.M(atom='H 0 0 0; H 0 0 1; H 0 1 0',
+                    basis='sto-3g', spin=1, verbose=0)
+        mf = scf.UHF(mol).run(conv_tol=1e-12)
+        mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
+        myci = ci.UCISD(mf, frozen=[[0], [2]]).run()
+        self.assertAlmostEqual(mc.e_tot, myci.e_tot, 12)
+        g_ucas = mc.nuc_grad_method().kernel()
+        g_ucis = myci.nuc_grad_method().kernel()
+        self.assertAlmostEqual(abs(g_ucas - g_ucis).max(), 0, 10)
+
+    def test_rdm_intermediates_round_trip(self):
+        from pyscf.cc import uccsd_rdm
+        from pyscf.grad import ucasci
+        mol = gto.M(atom='H 0 0 0; H 0 0 1; H 0 1 0',
+                    basis='sto-3g', spin=1, verbose=0)
+        mf = scf.UHF(mol).run(conv_tol=1e-12)
+        mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
+        casdm1s, casdm2s = mc.fcisolver.make_rdm12s(mc.ci, mc.ncas,
+                                                     mc.nelecas)
+        d1, d2 = ucasci._casci_active_rdm_to_uccsd_intermediates(
+            casdm1s, casdm2s, mc.nelecas)
+        full1, full2 = _make_full_rdm12s(
+            casdm1s, casdm2s, mf.mo_coeff[0].shape[1], mc.ncore, mc.ncas)
+        with ucasci._uccsd_env(mc, mc.mo_coeff):
+            rdm1 = uccsd_rdm._make_rdm1(mc, d1, with_frozen=True)
+            rdm2 = uccsd_rdm._make_rdm2(mc, d1, d2, with_frozen=True)
+        self.assertAlmostEqual(max(abs(rdm1[0]-full1[0]).max(),
+                                   abs(rdm1[1]-full1[1]).max()), 0, 12)
+        self.assertAlmostEqual(max(abs(rdm2[i]-full2[i]).max()
+                                   for i in range(3)), 0, 12)
+
+    def test_general_rdm_intermediates_contract_symmetric_integrals(self):
+        from pyscf.cc import uccsd_rdm
+        from pyscf.grad import ucasci
+        mol = gto.M(atom='''
+                    C  0.00  0.00  0.00
+                    H  0.10  0.02  1.09
+                    H  1.02  0.08 -0.35
+                    H -0.42  0.96 -0.28''',
+                    basis='6-31g', spin=1, verbose=0)
+        mf = scf.UHF(mol).run(conv_tol=1e-12)
+        mc = mcscf.UCASCI(mf, 7, (3,2), ncore=(2,2)).run()
+        casdm1s, casdm2s = mc.fcisolver.make_rdm12s(mc.ci, mc.ncas,
+                                                     mc.nelecas)
+        d1, d2 = ucasci._casci_active_rdm_to_uccsd_intermediates(
+            casdm1s, casdm2s, mc.nelecas)
+        full1, full2 = _make_full_rdm12s(
+            casdm1s, casdm2s, mf.mo_coeff[0].shape[1], mc.ncore, mc.ncas)
+        with ucasci._uccsd_env(mc, mc.mo_coeff):
+            rdm1 = uccsd_rdm._make_rdm1(mc, d1, with_frozen=True)
+            rdm2 = uccsd_rdm._make_rdm2(mc, d1, d2, with_frozen=True)
+        self.assertAlmostEqual(max(abs(rdm1[0]-full1[0]).max(),
+                                   abs(rdm1[1]-full1[1]).max()), 0, 12)
+
+        nmo = mf.mo_coeff[0].shape[1]
+        eriaa = _pair_symmetric_eri(nmo, 1)
+        eriab = _pair_symmetric_eri_ab(nmo, nmo, 2)
+        eribb = _pair_symmetric_eri(nmo, 3)
+        e_ref = (.5 * numpy.einsum('pqrs,pqrs', eriaa, full2[0]) +
+                 numpy.einsum('pqrs,pqrs', eriab, full2[1]) +
+                 .5 * numpy.einsum('pqrs,pqrs', eribb, full2[2]))
+        e_test = (.5 * numpy.einsum('pqrs,pqrs', eriaa, rdm2[0]) +
+                  numpy.einsum('pqrs,pqrs', eriab, rdm2[1]) +
+                  .5 * numpy.einsum('pqrs,pqrs', eribb, rdm2[2]))
+        self.assertAlmostEqual(e_test, e_ref, 10)
+
+    def test_full_active_openshell_finite_diff(self):
+        def run(bond):
+            mol = gto.M(atom=f'H 0 0 0; H 0 0 {bond}; H 0 1 0',
+                        basis='sto-3g', spin=1, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-12)
+            mc = mcscf.UCASCI(mf, mf.mo_coeff[0].shape[1], mol.nelec).run()
+            return mc
+
+        mc = run(1.0)
+        grad = mc.nuc_grad_method().kernel()
+        e1 = run(1.001).e_tot
+        e2 = run(0.999).e_tot
+        ref = (e1-e2) / 0.002 * lib.param.BOHR
+        self.assertAlmostEqual(grad[1,2], ref, 5)
+
+    def test_general_casci_carbon_multicomponent_finite_diff(self):
+        atom = '''
+        C  0.00  0.00  0.00
+        H  0.10  0.02  1.09
+        H  1.02  0.08 -0.35
+        H -0.42  0.96 -0.28
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='6-31g', spin=1, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-13)
+            return mcscf.UCASCI(mf, 7, (3,2), ncore=(2,2)).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        step = 2.5e-4
+        for ia, ix in ((0,0), (1,2), (2,0), (3,1)):
+            e1 = run(ia, ix, step).e_tot
+            e2 = run(ia, ix, -step).e_tot
+            ref = (e1-e2) / (2*step) * lib.param.BOHR
+            self.assertLess(abs(grad[ia,ix] - ref), 1e-6)
+
+    def test_general_casci_nitrogen_hydride_finite_diff(self):
+        atom = '''
+        N 0.000  0.000 0.000
+        H 0.000  0.900 0.650
+        H 0.000 -0.850 0.700
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='3-21g', spin=1, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-12)
+            return mcscf.UCASCI(mf, 6, (3,2), ncore=(2,2)).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        step = 5e-4
+        e1 = run(1, 2, step).e_tot
+        e2 = run(1, 2, -step).e_tot
+        ref = (e1-e2) / (2*step) * lib.param.BOHR
+        self.assertLess(abs(grad[1,2] - ref), 1e-6)
+
+    def test_general_casci_high_spin_carbon_finite_diff(self):
+        atom = '''
+        C 0.000 0.000  0.000
+        H 0.000 0.000  1.080
+        H 1.020 0.000 -0.320
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='3-21g', spin=2, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-12)
+            return mcscf.UCASCI(mf, 7, (4,2), ncore=(1,1)).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        step = 5e-4
+        e1 = run(1, 2, step).e_tot
+        e2 = run(1, 2, -step).e_tot
+        ref = (e1-e2) / (2*step) * lib.param.BOHR
+        self.assertLess(abs(grad[1,2] - ref), 1e-6)
+
+    def test_general_casci_ccpvtz_five_point_finite_diff(self):
+        atom = '''
+        C 0.000 0.000  0.000
+        H 0.000 0.000  1.080
+        H 1.020 0.000 -0.320
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='cc-pVTZ', spin=2, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-11)
+            return mcscf.UCASCI(mf, 7, (4,2), ncore=(1,1)).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        step = 1e-3
+        ep2 = run(1, 2, 2*step).e_tot
+        ep1 = run(1, 2, step).e_tot
+        em1 = run(1, 2, -step).e_tot
+        em2 = run(1, 2, -2*step).e_tot
+        ref = (-ep2 + 8*ep1 - 8*em1 + em2) / (12*step) * lib.param.BOHR
+        self.assertLess(abs(grad[1,2] - ref), 5e-7)
+
+    def test_general_casci_excited_root_finite_diff(self):
+        atom = '''
+        C  0.00  0.00  0.00
+        H  0.10  0.02  1.09
+        H  1.02  0.08 -0.35
+        H -0.42  0.96 -0.28
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='3-21g', spin=1, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-12)
+            mc = mcscf.UCASCI(mf, 6, (3,2), ncore=(2,2))
+            mc.fcisolver.nroots = 3
+            return mc.run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel(state=1)
+        step = 5e-4
+        e1 = run(1, 2, step).e_tot[1]
+        e2 = run(1, 2, -step).e_tot[1]
+        ref = (e1-e2) / (2*step) * lib.param.BOHR
+        self.assertLess(abs(grad[1,2] - ref), 2e-6)
+
+    def test_general_casci_state_average_finite_diff(self):
+        atom = '''
+        C  0.00  0.00  0.00
+        H  0.10  0.02  1.09
+        H  1.02  0.08 -0.35
+        H -0.42  0.96 -0.28
+        '''
+
+        def run(ia=None, ix=None, dx=0):
+            mol = gto.M(atom=_move_atom(atom, ia, ix, dx) if ia is not None else atom,
+                        basis='3-21g', spin=1, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-12)
+            mc = mcscf.UCASCI(mf, 6, (3,2), ncore=(2,2))
+            mc.fcisolver.nroots = 2
+            return mc.state_average_([.4, .6]).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        step = 5e-4
+        e1 = run(1, 2, step).e_tot
+        e2 = run(1, 2, -step).e_tot
+        ref = (e1-e2) / (2*step) * lib.param.BOHR
+        self.assertLess(abs(grad[1,2] - ref), 2e-6)
+
+    def test_state_specific_excited_root_finite_diff(self):
+        def run(dz=0):
+            mol = gto.M(atom=f'H 0 0 0; H 0 0 {1+dz}; H 0 1 0',
+                        basis='sto-3g', spin=1, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-12)
+            mc = mcscf.UCASCI(mf, 3, (2,1))
+            mc.fcisolver.nroots = 3
+            return mc.run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel(state=2)
+        e1 = run(0.001).e_tot[2]
+        e2 = run(-0.001).e_tot[2]
+        ref = (e1-e2) / 0.002 * lib.param.BOHR
+        self.assertLess(abs(grad[1,2] - ref), 1e-6)
+
+    def test_symmetry_x2c_df_finite_diff(self):
+        def run(dz=0, symmetry=False, x2c=False, density_fit=False):
+            mol = gto.M(atom=f'H 0 0 0; H 0 0 {1+dz}; H 0 1 0',
+                        basis='sto-3g', spin=1, symmetry=symmetry, verbose=0)
+            mf = scf.UHF(mol)
+            if x2c:
+                mf = mf.x2c()
+            if density_fit:
+                mf = mf.density_fit()
+            mf.run(conv_tol=1e-12)
+            return mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
+
+        for kwargs, tol in (((dict(symmetry=True)), 1e-6),
+                            ((dict(x2c=True)), 1e-6),
+                            ((dict(density_fit=True)), 3e-6)):
+            mc = run(**kwargs)
+            grad = mc.nuc_grad_method().kernel()
+            e1 = run(0.001, **kwargs).e_tot
+            e2 = run(-0.001, **kwargs).e_tot
+            ref = (e1-e2) / 0.002 * lib.param.BOHR
+            self.assertLess(abs(grad[1,2] - ref), tol)
+
+    def test_restricted_casci_carbon_finite_diff_benchmark(self):
+        atom = '''
+        C  0.00  0.00  0.00
+        H  0.10  0.02  1.09
+        H  1.02  0.08 -0.35
+        H -0.42  0.96 -0.28
+        H -0.62 -0.78 -0.42
+        '''
+
+        def run(dx=0):
+            coords = []
+            for line in atom.splitlines():
+                if line.strip():
+                    sym, x, y, z = line.split()
+                    coords.append([sym, float(x), float(y), float(z)])
+            coords[4][1] += dx
+            mol = gto.M(atom=coords, basis='6-31g', verbose=0)
+            mf = scf.RHF(mol).run(conv_tol=1e-12)
+            return mcscf.CASCI(mf, 8, 6, ncore=2).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        e1 = run(0.001).e_tot
+        e2 = run(-0.001).e_tot
+        ref = (e1-e2) / 0.002 * lib.param.BOHR
+        self.assertLess(abs(grad[4,0] - ref), 1e-6)
+
+    def test_restricted_collapse_h4_inactive(self):
+        mol = gto.M(atom='''
+                    H 0.0 0.0 0.0
+                    H 0.0 0.0 1.0
+                    H 0.0 1.0 0.0
+                    H 0.2 1.0 1.0''',
+                    basis='sto-3g', verbose=0)
+        rhf = scf.RHF(mol).run(conv_tol=1e-12)
+        uhf = scf.UHF(mol).run(conv_tol=1e-12)
+        rcas = mcscf.CASCI(rhf, 2, 2, ncore=1).run()
+        ucas = mcscf.UCASCI(uhf, 2, (1,1), ncore=(1,1)).run()
+        self.assertAlmostEqual(rcas.e_tot, ucas.e_tot, 10)
+        g_r = rcas.nuc_grad_method().kernel()
+        g_u = ucas.nuc_grad_method().kernel()
+        self.assertAlmostEqual(abs(g_r - g_u).max(), 0, 9)
+
+    def test_restricted_collapse_ch4_larger_active_space(self):
+        mol = gto.M(atom='''
+                    C  0.00  0.00  0.00
+                    H  0.10  0.02  1.09
+                    H  1.02  0.08 -0.35
+                    H -0.42  0.96 -0.28
+                    H -0.62 -0.78 -0.42''',
+                    basis='3-21g', verbose=0)
+        rhf = scf.RHF(mol).run(conv_tol=1e-12)
+        uhf = scf.UHF(mol).run(conv_tol=1e-12)
+        rcas = mcscf.CASCI(rhf, 8, 6, ncore=2).run()
+        ucas = mcscf.UCASCI(uhf, 8, (3,3), ncore=(2,2)).run()
+        self.assertAlmostEqual(rcas.e_tot, ucas.e_tot, 8)
+        g_r = rcas.nuc_grad_method().kernel()
+        g_u = ucas.nuc_grad_method().kernel()
+        self.assertAlmostEqual(abs(g_r - g_u).max(), 0, 7)
+
+    def test_state_average_finite_diff(self):
+        def run(dz=0):
+            mol = gto.M(atom=f'H 0 0 0; H 0 0 {1+dz}; H 0 1 0',
+                        basis='sto-3g', spin=1, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-12)
+            mc = mcscf.UCASCI(mf, 3, (2,1))
+            mc.fcisolver.nroots = 2
+            return mc.state_average_([.5, .5]).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        e1 = run(0.001).e_tot
+        e2 = run(-0.001).e_tot
+        ref = (e1-e2) / 0.002 * lib.param.BOHR
+        self.assertLess(abs(grad[1,2] - ref), 1e-6)
+
+    def test_zero_active_occupied_spin_sector(self):
+        def run(dz=0):
+            mol = gto.M(atom=f'Li 0 0 0; H 0 0 {1.6+dz}',
+                        basis='sto-3g', charge=1, spin=1, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-12)
+            return mcscf.UCASCI(mf, 2, (1,0), ncore=(1,1)).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        e1 = run(0.001).e_tot
+        e2 = run(-0.001).e_tot
+        ref = (e1-e2) / 0.002 * lib.param.BOHR
+        self.assertLess(abs(grad[1,2] - ref), 1e-6)
+
+    def test_zero_active_virtual_spin_sector(self):
+        def run(dz=0):
+            mol = gto.M(atom=f'Li 0 0 0; H 0 0 {1.6+dz}',
+                        basis='sto-3g', charge=1, spin=1, verbose=0)
+            mf = scf.UHF(mol).run(conv_tol=1e-12)
+            return mcscf.UCASCI(mf, 1, (1,0), ncore=(1,1)).run()
+
+        mc = run()
+        grad = mc.nuc_grad_method().kernel()
+        e1 = run(0.001).e_tot
+        e2 = run(-0.001).e_tot
+        ref = (e1-e2) / 0.002 * lib.param.BOHR
+        self.assertLess(abs(grad[1,2] - ref), 1e-6)
+
+    def test_scanner(self):
+        mol = gto.M(atom='H 0 0 0; H 0 0 1; H 0 1 0',
+                    basis='sto-3g', spin=1, verbose=0)
+        mf = scf.UHF(mol).run(conv_tol=1e-12)
+        mc = mcscf.UCASCI(mf, mf.mo_coeff[0].shape[1], mol.nelec)
+        gs = mc.nuc_grad_method().as_scanner()
+        e, grad = gs(mol)
+        e1 = gs.base('H 0 0 0; H 0 0 1.001; H 0 1 0')
+        e2 = gs.base('H 0 0 0; H 0 0 0.999; H 0 1 0')
+        ref = (e1-e2) / 0.002 * lib.param.BOHR
+        self.assertAlmostEqual(e, -1.5056055923848675, 8)
+        self.assertAlmostEqual(grad[1,2], ref, 5)
+
+
+if __name__ == "__main__":
+    print("Tests for UCASCI gradients")
+    unittest.main()

--- a/pyscf/grad/ucasci.py
+++ b/pyscf/grad/ucasci.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python
+# Copyright 2026 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0
+
+'''
+UCASCI analytical nuclear gradients
+'''
+
+import numpy
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf.grad import uhf as uhf_grad
+from pyscf.grad import rhf as rhf_grad
+from pyscf.grad import casci as casci_grad
+from pyscf.grad import uccsd as uccsd_grad
+from pyscf import ao2mo
+from pyscf.mcscf.addons import StateAverageMCSCFSolver
+
+RANGE_TYPE = range
+
+
+def _uccsd_env(mc, mo_coeff):
+    ncorea, ncoreb = mc.ncore
+    neleca, nelecb = mc.nelecas
+    nmoa = mo_coeff[0].shape[1]
+    nmob = mo_coeff[1].shape[1]
+    mo_occ = (numpy.zeros(nmoa), numpy.zeros(nmob))
+    mo_occ[0][:ncorea] = 1
+    mo_occ[0][ncorea:ncorea+neleca] = 1
+    mo_occ[1][:ncoreb] = 1
+    mo_occ[1][ncoreb:ncoreb+nelecb] = 1
+    masks = (numpy.zeros(nmoa, dtype=bool), numpy.zeros(nmob, dtype=bool))
+    masks[0][ncorea:ncorea+mc.ncas] = True
+    masks[1][ncoreb:ncoreb+mc.ncas] = True
+    frozen = [numpy.where(~mask)[0] for mask in masks]
+    frozen = None if all(x.size == 0 for x in frozen) else frozen
+    return lib.temporary_env(mc, mo_coeff=mo_coeff, mo_occ=mo_occ,
+                             frozen=frozen,
+                             get_frozen_mask=lambda *args: masks)
+
+
+# The UHF-CASCI gradient can be written in the same AO contraction and UCPHF
+# response form used by UCCSD after the CASCI RDMs are expressed relative to a
+# single UHF determinant.  The determinant is artificial: core orbitals are
+# occupied and the first nelecas active orbitals are used as the alpha/beta
+# reference.  This routine removes those reference 1- and 2-particle density
+# contributions from the exact active-space CASCI RDMs, then repacks the
+# reference-subtracted CASCI RDM blocks into the d1/d2 intermediate layout
+# expected by grad.uccsd.  grad_elec passes these intermediates to the UCCSD
+# gradient driver, which then supplies the shared MO-to-AO 2-RDM
+# transformation, generalized Fock contractions, and UCPHF orbital-response
+# terms.
+def _casci_active_rdm_to_uccsd_intermediates(casdm1s, casdm2s, nelecas):
+    nocca, noccb = nelecas
+    casdm1a, casdm1b = casdm1s
+    casdm2aa, casdm2ab, casdm2bb = casdm2s
+    ncas = casdm1a.shape[0]
+    nvira = ncas - nocca
+    nvirb = ncas - noccb
+    oa = slice(0, nocca)
+    va = slice(nocca, ncas)
+    ob = slice(0, noccb)
+    vb = slice(noccb, ncas)
+
+    dm1a = casdm1a.copy()
+    dm1b = casdm1b.copy()
+    dm1a[numpy.diag_indices(nocca)] -= 1
+    dm1b[numpy.diag_indices(noccb)] -= 1
+    d1 = ((dm1a[oa,oa], dm1b[ob,ob]),
+          (dm1a[oa,va], dm1b[ob,vb]),
+          (dm1a[va,oa], dm1b[vb,ob]),
+          (dm1a[va,va], dm1b[vb,vb]))
+
+    # uccsd_rdm._make_rdm2 builds an internal tensor and returns
+    # internal.transpose(1,0,3,2).  Undo that final transpose, then remove the
+    # UHF-reference and 1-pdm terms that _make_rdm2 adds when with_dm1=True.
+    dm2aa = casdm2aa.transpose(1,0,3,2).copy()
+    dm2ab = casdm2ab.transpose(1,0,3,2).copy()
+    dm2bb = casdm2bb.transpose(1,0,3,2).copy()
+
+    for i in range(nocca):
+        dm2aa[i,i,:,:] -= dm1a
+        dm2aa[:,:,i,i] -= dm1a
+        dm2aa[:,i,i,:] += dm1a
+        dm2aa[i,:,:,i] += dm1a.T
+        dm2ab[i,i,:,:] -= dm1b
+    for i in range(noccb):
+        dm2bb[i,i,:,:] -= dm1b
+        dm2bb[:,:,i,i] -= dm1b
+        dm2bb[:,i,i,:] += dm1b
+        dm2bb[i,:,:,i] += dm1b.T
+        dm2ab[:,:,i,i] -= dm1a
+
+    for i in range(nocca):
+        for j in range(nocca):
+            dm2aa[i,i,j,j] -= 1
+            dm2aa[i,j,j,i] += 1
+    for i in range(noccb):
+        for j in range(noccb):
+            dm2bb[i,i,j,j] -= 1
+            dm2bb[i,j,j,i] += 1
+    for i in range(nocca):
+        for j in range(noccb):
+            dm2ab[i,i,j,j] -= 1
+
+    dovov = dm2aa[oa,va,oa,va]
+    dovvo = dm2aa[oa,va,va,oa]
+    doovv = dm2aa[oa,oa,va,va]
+    dvvvv = dm2aa[va,va,va,va]
+    dvvvv = ao2mo.restore(4, dvvvv + dvvvv.transpose(1,0,2,3),
+                           nvira) * .5
+    doooo = dm2aa[oa,oa,oa,oa]
+    dovvv = dm2aa[oa,va,va,va]
+    dooov = dm2aa[oa,oa,oa,va]
+
+    dOVOV = dm2bb[ob,vb,ob,vb]
+    dOVVO = dm2bb[ob,vb,vb,ob]
+    dOOVV = dm2bb[ob,ob,vb,vb]
+    dVVVV = dm2bb[vb,vb,vb,vb]
+    dVVVV = ao2mo.restore(4, dVVVV + dVVVV.transpose(1,0,2,3),
+                           nvirb) * .5
+    dOOOO = dm2bb[ob,ob,ob,ob]
+    dOVVV = dm2bb[ob,vb,vb,vb]
+    dOOOV = dm2bb[ob,ob,ob,vb]
+
+    dovOV = dm2ab[oa,va,ob,vb]
+    dooOO = dm2ab[oa,oa,ob,ob]
+    dvvVV = dm2ab[va,va,vb,vb]
+    dvvVV = dvvVV + dvvVV.transpose(1,0,2,3)
+    dvvVV = lib.pack_tril(dvvVV[numpy.tril_indices(nvira)]) * .5
+    dovVO = dm2ab[oa,va,vb,ob]
+    dooOV = dm2ab[oa,oa,ob,vb]
+    dovVV = dm2ab[oa,va,vb,vb]
+    dooVV = dm2ab[oa,oa,vb,vb]
+
+    dOVvo = dm2ab[va,oa,ob,vb].transpose(3,2,1,0).conj()
+    dOOov = dm2ab[oa,va,ob,ob].transpose(2,3,0,1)
+    dOVvv = dm2ab[va,va,ob,vb].transpose(2,3,0,1)
+    dOOvv = dm2ab[va,va,ob,ob].transpose(2,3,0,1)
+
+    d2 = ((dovov, dovOV, None, dOVOV),
+          (dvvvv, dvvVV, None, dVVVV),
+          (doooo, dooOO, None, dOOOO),
+          (doovv, dooVV, dOOvv, dOOVV),
+          (dovvo, dovVO, dOVvo, dOVVO),
+          (None, None, None, None),
+          (dovvv, dovVV, dOVvv, dOVVV),
+          (dooov, dooOV, dOOov, dOOOV))
+    return d1, d2
+
+
+def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
+    mc = mc_grad.base
+    if mo_coeff is None:
+        mo_coeff = mc.mo_coeff
+    if ci is None:
+        ci = mc.ci
+
+    ncas = mc.ncas
+
+    casdm1s, casdm2s = mc.fcisolver.make_rdm12s(ci, ncas, mc.nelecas)
+    d1, d2 = _casci_active_rdm_to_uccsd_intermediates(
+        casdm1s, casdm2s, mc.nelecas)
+    t1 = t2 = l1 = l2 = ()
+    with _uccsd_env(mc, mo_coeff):
+        return uccsd_grad.grad_elec(mc_grad, t1, t2, l1, l2, None, atmlst,
+                                    d1, d2, verbose)
+
+
+class Gradients(uhf_grad.Gradients):
+    '''Non-relativistic unrestricted CASCI gradients'''
+
+    grad_elec = grad_elec
+
+    def __init__(self, mc):
+        self.state = 0
+        uhf_grad.Gradients.__init__(self, mc)
+
+    def kernel(self, mo_coeff=None, ci=None, atmlst=None,
+               state=None, verbose=None):
+        log = logger.new_logger(self, verbose)
+        if ci is None:
+            if self.base.ci is None:
+                self.base.ci.run()
+            ci = self.base.ci
+        if (isinstance(ci, (list, tuple, RANGE_TYPE)) and
+            not isinstance(self.base, StateAverageMCSCFSolver)):
+            if state is None:
+                state = self.state
+            else:
+                self.state = state
+            ci = ci[state]
+            log.info('Multiple roots are found in UCASCI solver. '
+                     'Nuclear gradients of root %d are computed.', state)
+        if atmlst is None:
+            atmlst = self.atmlst
+        else:
+            self.atmlst = atmlst
+        if self.verbose >= logger.WARN:
+            self.check_sanity()
+        if self.verbose >= logger.INFO:
+            self.dump_flags()
+        de = self.grad_elec(mo_coeff, ci, atmlst, log)
+        self.de = de = de + self.grad_nuc(atmlst=atmlst)
+        if self.mol.symmetry:
+            self.de = self.symmetrize(self.de, atmlst)
+        self._finalize()
+        return self.de
+
+    def hcore_generator(self, mol=None):
+        mf_grad = self.base._scf.nuc_grad_method()
+        return mf_grad.hcore_generator(mol)
+
+    def grad_nuc(self, mol=None, atmlst=None):
+        mf_grad = self.base._scf.nuc_grad_method()
+        return mf_grad.grad_nuc(mol, atmlst)
+
+    def _finalize(self):
+        if self.verbose >= logger.NOTE:
+            logger.note(self, '--------- %s gradients ----------',
+                        self.base.__class__.__name__)
+            rhf_grad._write(self.stdout, self.mol, self.de, self.atmlst)
+            logger.note(self, '----------------------------------------------')
+
+    as_scanner = casci_grad.as_scanner
+
+    to_gpu = lib.to_gpu
+
+
+Grad = Gradients
+
+from pyscf import mcscf
+mcscf.ucasci.UCASCI.Gradients = lib.class_as_method(Gradients)

--- a/pyscf/grad/ucasci.py
+++ b/pyscf/grad/ucasci.py
@@ -36,6 +36,10 @@ def _check_supported_orbital_source(mc):
             'orbital response; use pyscf.grad.ukscasci')
 
 
+# Present the UCASCI object with the attributes expected by grad.uccsd: the
+# CAS active space is the CC active space, and inactive/external orbitals are
+# hidden through the frozen mask while the temporary occupations define the
+# artificial UHF reference used by the repacked RDM intermediates.
 def _uccsd_env(mc, mo_coeff):
     ncorea, ncoreb = mc.ncore
     neleca, nelecb = mc.nelecas

--- a/pyscf/grad/ucasci.py
+++ b/pyscf/grad/ucasci.py
@@ -7,9 +7,8 @@
 UCASCI analytical nuclear gradients
 
 This module implements the UHF-orbital UCASCI gradient formulation.  The
-orbital response is the UCPHF response of the underlying UHF reference.  CASCI
-gradients with UKS-generated orbitals require a distinct CPKS/XC-response
-formulation and are not implemented here.
+orbital response is the UCPHF response of the underlying UHF reference.  The
+UKS-orbital formulation is exposed through pyscf.grad.ukscasci.
 '''
 
 import numpy
@@ -30,7 +29,7 @@ def _check_supported_orbital_source(mc):
     if isinstance(mc._scf, hf.KohnShamDFT):
         raise NotImplementedError(
             'UCASCI gradients with KS orbitals require the UKS/CPKS '
-            'orbital response, which is not implemented')
+            'orbital response; use pyscf.grad.ukscasci')
 
 
 def _uccsd_env(mc, mo_coeff):
@@ -247,4 +246,11 @@ class Gradients(uhf_grad.Gradients):
 Grad = Gradients
 
 from pyscf import mcscf
-mcscf.ucasci.UCASCI.Gradients = lib.class_as_method(Gradients)
+def _ucasci_grad_method(mc, *args, **kwargs):
+    # Keep mc.Gradients() source-aware, matching UCASCI.nuc_grad_method().
+    if isinstance(mc._scf, hf.KohnShamDFT):
+        from pyscf.grad import ukscasci
+        return ukscasci.Gradients(mc, *args, **kwargs)
+    return Gradients(mc, *args, **kwargs)
+
+mcscf.ucasci.UCASCI.Gradients = _ucasci_grad_method

--- a/pyscf/grad/ucasci.py
+++ b/pyscf/grad/ucasci.py
@@ -197,7 +197,10 @@ class Gradients(uhf_grad.Gradients):
     grad_elec = grad_elec
 
     def __init__(self, mc):
-        self.state = 0
+        if isinstance(mc, StateAverageMCSCFSolver):
+            self.state = None
+        else:
+            self.state = 0
         uhf_grad.Gradients.__init__(self, mc)
 
     def kernel(self, mo_coeff=None, ci=None, atmlst=None,
@@ -207,8 +210,9 @@ class Gradients(uhf_grad.Gradients):
             if self.base.ci is None:
                 self.base.ci.run()
             ci = self.base.ci
-        if (isinstance(ci, (list, tuple, RANGE_TYPE)) and
-            not isinstance(self.base, StateAverageMCSCFSolver)):
+        if self.state is None:
+            assert state is None
+        elif isinstance(ci, (list, tuple, RANGE_TYPE)):
             if state is None:
                 state = self.state
             else:

--- a/pyscf/grad/ucasci.py
+++ b/pyscf/grad/ucasci.py
@@ -4,11 +4,7 @@
 # Licensed under the Apache License, Version 2.0
 
 '''
-UCASCI analytical nuclear gradients
-
-This module implements the UHF-orbital UCASCI gradient formulation.  The
-orbital response is the UCPHF response of the underlying UHF reference.  The
-UKS-orbital formulation is exposed through pyscf.grad.ukscasci.
+UHF-orbital UCASCI analytical nuclear gradients
 '''
 
 import numpy
@@ -26,6 +22,14 @@ RANGE_TYPE = range
 
 
 def _check_supported_orbital_source(mc):
+    if getattr(mc, '_scf_df_source', False):
+        raise NotImplementedError(
+            'UCASCI gradients with density-fitted UHF orbitals require '
+            'DF-UHF orbital-response terms')
+    if getattr(mc._scf, 'with_df', None):
+        raise NotImplementedError(
+            'UCASCI gradients with density-fitted UHF orbitals require '
+            'DF-UHF orbital-response terms')
     if isinstance(mc._scf, hf.KohnShamDFT):
         raise NotImplementedError(
             'UCASCI gradients with KS orbitals require the UKS/CPKS '

--- a/pyscf/grad/ucasci.py
+++ b/pyscf/grad/ucasci.py
@@ -5,11 +5,17 @@
 
 '''
 UCASCI analytical nuclear gradients
+
+This module implements the UHF-orbital UCASCI gradient formulation.  The
+orbital response is the UCPHF response of the underlying UHF reference.  CASCI
+gradients with UKS-generated orbitals require a distinct CPKS/XC-response
+formulation and are not implemented here.
 '''
 
 import numpy
 from pyscf import lib
 from pyscf.lib import logger
+from pyscf.scf import hf
 from pyscf.grad import uhf as uhf_grad
 from pyscf.grad import rhf as rhf_grad
 from pyscf.grad import casci as casci_grad
@@ -18,6 +24,13 @@ from pyscf import ao2mo
 from pyscf.mcscf.addons import StateAverageMCSCFSolver
 
 RANGE_TYPE = range
+
+
+def _check_supported_orbital_source(mc):
+    if isinstance(mc._scf, hf.KohnShamDFT):
+        raise NotImplementedError(
+            'UCASCI gradients with KS orbitals require the UKS/CPKS '
+            'orbital response, which is not implemented')
 
 
 def _uccsd_env(mc, mo_coeff):
@@ -152,6 +165,7 @@ def _casci_active_rdm_to_uccsd_intermediates(casdm1s, casdm2s, nelecas):
 
 def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
     mc = mc_grad.base
+    _check_supported_orbital_source(mc)
     if mo_coeff is None:
         mo_coeff = mc.mo_coeff
     if ci is None:
@@ -169,7 +183,9 @@ def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
 
 
 class Gradients(uhf_grad.Gradients):
-    '''Non-relativistic unrestricted CASCI gradients'''
+    '''Non-relativistic UHF-CASCI gradients'''
+
+    _keys = {'state'}
 
     grad_elec = grad_elec
 
@@ -220,7 +236,7 @@ class Gradients(uhf_grad.Gradients):
         if self.verbose >= logger.NOTE:
             logger.note(self, '--------- %s gradients ----------',
                         self.base.__class__.__name__)
-            rhf_grad._write(self.stdout, self.mol, self.de, self.atmlst)
+            self._write(self.mol, self.de, self.atmlst)
             logger.note(self, '----------------------------------------------')
 
     as_scanner = casci_grad.as_scanner

--- a/pyscf/grad/uccsd.py
+++ b/pyscf/grad/uccsd.py
@@ -340,39 +340,48 @@ def _rdm2_mo2ao(mycc, d2, mo_coeff, fsave=None):
 
     fswap = lib.H5TmpFile()
     max_memory = mycc.max_memory - lib.current_memory()[0]
-    blksize_a = int(max_memory*.9e6/8/(nao_pair+nmoa**2))
-    blksize_a = min(nvira_pair, max(ccsd.BLKMIN, blksize_a))
-    chunks_a = (int(min(nao_pair, 4e8/blksize_a)), blksize_a)
-    v_aa = fswap.create_dataset('v_aa', (nao_pair,nvira_pair), 'f8',
-                                chunks=chunks_a)
-    for p0, p1 in lib.prange(0, nvira_pair, blksize_a):
-        v_aa[:,p0:p1] = _trans(lib.unpack_tril(dvvvv[p0:p1]*.25), mo_a,
-                               (nocca,nmoa,nocca,nmoa)).T
+    if nvira_pair > 0:
+        blksize_a = int(max_memory*.9e6/8/(nao_pair+nmoa**2))
+        blksize_a = min(nvira_pair, max(ccsd.BLKMIN, blksize_a))
+        chunks_a = (int(min(nao_pair, 4e8/blksize_a)), blksize_a)
+        v_aa = fswap.create_dataset('v_aa', (nao_pair,nvira_pair), 'f8',
+                                    chunks=chunks_a)
+        for p0, p1 in lib.prange(0, nvira_pair, blksize_a):
+            v_aa[:,p0:p1] = _trans(lib.unpack_tril(dvvvv[p0:p1]*.25), mo_a,
+                                   (nocca,nmoa,nocca,nmoa)).T
 
-    v_ba = fswap.create_dataset('v_ab', (nao_pair,nvira_pair), 'f8',
-                                chunks=chunks_a)
-    dvvOP = fswap.create_dataset('dvvOP', (nvira_pair,noccb,nmob), 'f8',
-                                 chunks=(int(min(blksize_a,4e8/nmob)),1,nmob))
-    for i in range(noccb):
-        buf1 = numpy.empty((nmob,nvira,nvira))
-        buf1[:noccb] = dOOvv[i] * .5
-        buf1[noccb:] = dOVvv[i]
-        buf1 = buf1.transpose(1,2,0) + buf1.transpose(2,1,0)
-        dvvOP[:,i] = buf1[numpy.tril_indices(nvira)]
-    for p0, p1 in lib.prange(0, nvira_pair, blksize_a):
-        buf1 = numpy.zeros((p1-p0,nmob,nmob))
-        buf1[:,noccb:,noccb:] = lib.unpack_tril(dvvVV[p0:p1] * .5)
-        buf1[:,:noccb,:] = dvvOP[p0:p1] * .5
-        v_ba[:,p0:p1] = _trans(buf1, mo_b, (0,nmob,0,nmob)).T
+        v_ba = fswap.create_dataset('v_ab', (nao_pair,nvira_pair), 'f8',
+                                    chunks=chunks_a)
+        if noccb > 0:
+            dvvOP = fswap.create_dataset('dvvOP', (nvira_pair,noccb,nmob), 'f8',
+                                         chunks=(int(min(blksize_a,4e8/nmob)),1,nmob))
+            for i in range(noccb):
+                buf1 = numpy.empty((nmob,nvira,nvira))
+                buf1[:noccb] = dOOvv[i] * .5
+                buf1[noccb:] = dOVvv[i]
+                buf1 = buf1.transpose(1,2,0) + buf1.transpose(2,1,0)
+                dvvOP[:,i] = buf1[numpy.tril_indices(nvira)]
+        for p0, p1 in lib.prange(0, nvira_pair, blksize_a):
+            buf1 = numpy.zeros((p1-p0,nmob,nmob))
+            if nvirb > 0:
+                buf1[:,noccb:,noccb:] = lib.unpack_tril(dvvVV[p0:p1] * .5)
+            if noccb > 0:
+                buf1[:,:noccb,:] = dvvOP[p0:p1] * .5
+            v_ba[:,p0:p1] = _trans(buf1, mo_b, (0,nmob,0,nmob)).T
+    else:
+        v_aa = v_ba = None
 
-    blksize_b = int(max_memory*.9e6/8/(nao_pair+nmob**2))
-    blksize_b = min(nvirb_pair, max(ccsd.BLKMIN, blksize_b))
-    chunks_b = (int(min(nao_pair, 4e8/blksize_b)), blksize_b)
-    v_bb = fswap.create_dataset('v_bb', (nao_pair,nvirb_pair), 'f8',
-                                chunks=chunks_b)
-    for p0, p1 in lib.prange(0, nvirb_pair, blksize_b):
-        v_bb[:,p0:p1] = _trans(lib.unpack_tril(dVVVV[p0:p1]*.25), mo_b,
-                               (noccb,nmob,noccb,nmob)).T
+    if nvirb_pair > 0:
+        blksize_b = int(max_memory*.9e6/8/(nao_pair+nmob**2))
+        blksize_b = min(nvirb_pair, max(ccsd.BLKMIN, blksize_b))
+        chunks_b = (int(min(nao_pair, 4e8/blksize_b)), blksize_b)
+        v_bb = fswap.create_dataset('v_bb', (nao_pair,nvirb_pair), 'f8',
+                                    chunks=chunks_b)
+        for p0, p1 in lib.prange(0, nvirb_pair, blksize_b):
+            v_bb[:,p0:p1] = _trans(lib.unpack_tril(dVVVV[p0:p1]*.25), mo_b,
+                                   (noccb,nmob,noccb,nmob)).T
+    else:
+        v_bb = None
     time1 = log.timer_debug1('_rdm2_mo2ao pass 1', *time1)
 
 # transform dm2_ij to get lower triangular (dm2+dm2.transpose(0,1,3,2))
@@ -380,7 +389,11 @@ def _rdm2_mo2ao(mycc, d2, mo_coeff, fsave=None):
     blksize = min(nao_pair, max(ccsd.BLKMIN, blksize))
     o_aa = fswap.create_dataset('o_aa', (nmoa,nocca,nao_pair), 'f8', chunks=(nocca,nocca,blksize))
     o_ab = fswap.create_dataset('o_ab', (nmoa,nocca,nao_pair), 'f8', chunks=(nocca,nocca,blksize))
-    o_bb = fswap.create_dataset('o_bb', (nmob,noccb,nao_pair), 'f8', chunks=(noccb,noccb,blksize))
+    if noccb > 0:
+        o_bb = fswap.create_dataset('o_bb', (nmob,noccb,nao_pair), 'f8',
+                                    chunks=(noccb,noccb,blksize))
+    else:
+        o_bb = None
     buf1 = numpy.zeros((nocca,nocca,nmoa,nmoa))
     buf1[:,:,:nocca,:nocca] = _cp(doooo) * .25
     buf1[:,:,nocca:,nocca:] = _cp(doovv) * .5
@@ -394,11 +407,12 @@ def _rdm2_mo2ao(mycc, d2, mo_coeff, fsave=None):
     buf1 = _trans(buf1.reshape(nocca**2,-1), mo_b, (0,nmob,0,nmob))
     o_ab[:nocca] = buf1.reshape(nocca,nocca,nao_pair)
 
-    buf1 = numpy.zeros((noccb,noccb,nmob,nmob))
-    buf1[:,:,:noccb,:noccb] = _cp(dOOOO) * .25
-    buf1[:,:,noccb:,noccb:] = _cp(dOOVV) * .5
-    buf1 = _trans(buf1.reshape(noccb**2,-1), mo_b, (0,nmob,0,nmob))
-    o_bb[:noccb] = buf1.reshape(noccb,noccb,nao_pair)
+    if noccb > 0:
+        buf1 = numpy.zeros((noccb,noccb,nmob,nmob))
+        buf1[:,:,:noccb,:noccb] = _cp(dOOOO) * .25
+        buf1[:,:,noccb:,noccb:] = _cp(dOOVV) * .5
+        buf1 = _trans(buf1.reshape(noccb**2,-1), mo_b, (0,nmob,0,nmob))
+        o_bb[:noccb] = buf1.reshape(noccb,noccb,nao_pair)
 
     dovoo = numpy.asarray(dooov).transpose(2,3,0,1)
     dovOO = numpy.asarray(dOOov).transpose(2,3,0,1)
@@ -422,15 +436,16 @@ def _rdm2_mo2ao(mycc, d2, mo_coeff, fsave=None):
         buf1 = _trans(buf1, mo_b, (0,nmob,0,nmob))
         o_ab[p0:p1] = buf1.reshape(p1-p0,nocca,nao_pair)
 
-    for p0, p1 in lib.prange(noccb, nmob, noccb):
-        buf1 = numpy.zeros((noccb,p1-p0,nmob,nmob))
-        buf1[:,:,:noccb,:noccb] = dOVOO[:,p0-noccb:p1-noccb]
-        buf1[:,:,noccb:,:noccb] = dOVVO[:,p0-noccb:p1-noccb] * .5
-        buf1[:,:,:noccb,noccb:] = dOVOV[:,p0-noccb:p1-noccb] * .5
-        buf1[:,:,noccb:,noccb:] = dOVVV[:,p0-noccb:p1-noccb]
-        buf1 = buf1.transpose(1,0,3,2).reshape((p1-p0)*noccb,-1)
-        buf1 = _trans(buf1, mo_b, (0,nmob,0,nmob))
-        o_bb[p0:p1] = buf1.reshape(p1-p0,noccb,nao_pair)
+    if noccb > 0:
+        for p0, p1 in lib.prange(noccb, nmob, noccb):
+            buf1 = numpy.zeros((noccb,p1-p0,nmob,nmob))
+            buf1[:,:,:noccb,:noccb] = dOVOO[:,p0-noccb:p1-noccb]
+            buf1[:,:,noccb:,:noccb] = dOVVO[:,p0-noccb:p1-noccb] * .5
+            buf1[:,:,:noccb,noccb:] = dOVOV[:,p0-noccb:p1-noccb] * .5
+            buf1[:,:,noccb:,noccb:] = dOVVV[:,p0-noccb:p1-noccb]
+            buf1 = buf1.transpose(1,0,3,2).reshape((p1-p0)*noccb,-1)
+            buf1 = _trans(buf1, mo_b, (0,nmob,0,nmob))
+            o_bb[p0:p1] = buf1.reshape(p1-p0,noccb,nao_pair)
     time1 = log.timer_debug1('_rdm2_mo2ao pass 2', *time1)
     dovoo = buf1 = None
 
@@ -441,7 +456,8 @@ def _rdm2_mo2ao(mycc, d2, mo_coeff, fsave=None):
                                 chunks=(int(min(nao_pair,4e8/blksize)),blksize))
     for p0, p1 in lib.prange(0, nao_pair, blksize):
         buf1 = numpy.zeros((p1-p0,nmoa,nmoa))
-        buf1[:,nocca:,nocca:] = lib.unpack_tril(_cp(v_aa[p0:p1]))
+        if nvira > 0:
+            buf1[:,nocca:,nocca:] = lib.unpack_tril(_cp(v_aa[p0:p1]))
         buf1[:,:,:nocca] = o_aa[:,:,p0:p1].transpose(2,0,1)
         buf2 = _trans(buf1, mo_a, (0,nmoa,0,nmoa))
         if p0 > 0:
@@ -455,8 +471,10 @@ def _rdm2_mo2ao(mycc, d2, mo_coeff, fsave=None):
 
     for p0, p1 in lib.prange(0, nao_pair, blksize):
         buf1 = numpy.zeros((p1-p0,nmob,nmob))
-        buf1[:,noccb:,noccb:] = lib.unpack_tril(_cp(v_bb[p0:p1]))
-        buf1[:,:,:noccb] = o_bb[:,:,p0:p1].transpose(2,0,1)
+        if nvirb > 0:
+            buf1[:,noccb:,noccb:] = lib.unpack_tril(_cp(v_bb[p0:p1]))
+        if noccb > 0:
+            buf1[:,:,:noccb] = o_bb[:,:,p0:p1].transpose(2,0,1)
         buf2 = _trans(buf1, mo_b, (0,nmob,0,nmob))
         if p0 > 0:
             buf1 = _cp(dm2b[:p0,p0:p1])
@@ -469,7 +487,8 @@ def _rdm2_mo2ao(mycc, d2, mo_coeff, fsave=None):
 
     for p0, p1 in lib.prange(0, nao_pair, blksize):
         buf1 = numpy.zeros((p1-p0,nmoa,nmoa))
-        buf1[:,nocca:,nocca:] = lib.unpack_tril(_cp(v_ba[p0:p1]))
+        if nvira > 0:
+            buf1[:,nocca:,nocca:] = lib.unpack_tril(_cp(v_ba[p0:p1]))
         buf1[:,:,:nocca] = o_ab[:,:,p0:p1].transpose(2,0,1)
         buf2 = _trans(buf1, mo_a, (0,nmoa,0,nmoa))
         dm2a[:,p0:p1] = dm2a[:,p0:p1] + buf2.T

--- a/pyscf/grad/ukscasci.py
+++ b/pyscf/grad/ukscasci.py
@@ -14,12 +14,21 @@
 # limitations under the License.
 
 '''
-UCASCI analytical nuclear gradients with unrestricted KS orbitals
+UCASCI analytical nuclear gradients with UKS orbitals
 
-This module implements the UKS-orbital UCASCI gradient formulation.  The
-orbital response is the CPKS response of the underlying UKS reference, with
+The orbital response is the CPKS response of the underlying UKS reference, with
 the associated spin-resolved XC first-derivative terms in the KS orbital-source
 constraints.
+
+Supported functionals include:
+  LDA: lda, lda,vwn, slater,vwn, svwn
+  GGA: pbe, pbe,pbe, b88,p86, bp86, b88,lyp, blyp, pw91,pw91, b97-d
+  global hybrid GGA: b3lyp, b3lyp5, b3p86, b3pw91, pbe0, pbe1pbe, o3lyp, x3lyp
+
+Unsupported functionals include:
+  meta-GGA: tpss, scan, m06-l, m06, m06-2x, mn15
+  range-separated hybrids: cam-b3lyp, wb97x
+  NLC: vv10
 '''
 
 from functools import reduce
@@ -58,6 +67,14 @@ def _check_supported_orbital_source(mc):
     if not isinstance(mc._scf, hf.KohnShamDFT):
         raise RuntimeError('UKS-CASCI gradients require a KohnShamDFT '
                            'reference')
+    if getattr(mc, '_scf_df_source', False):
+        raise NotImplementedError(
+            'UKS-CASCI gradients with density-fitted KS orbitals require '
+            'DF-UKS orbital-response terms')
+    if getattr(mc._scf, 'with_df', None):
+        raise NotImplementedError(
+            'UKS-CASCI gradients with density-fitted KS orbitals require '
+            'DF-UKS orbital-response terms')
     _check_supported_functional(mc)
 
 
@@ -138,8 +155,9 @@ def _casci_orbital_intermediates(mc, mo_coeff, ci, casdm1s, casdm2s):
     eris = casscf.ao2mo(mo_coeff)
 
     # UCASSCF uses the antisymmetric orbital-gradient vector as the orbital
-    # optimization RHS.  The same object is Delta X in the Sherrill CI-gradient
-    # orbital-response term.
+    # optimization RHS.  The same object is Delta X in the Sherrill's notes
+    # for CI-gradient orbital-response term
+    # https://vergil.chemistry.gatech.edu/static/content/cigrad.pdf
     g_orb = umc1step.gen_g_hop(casscf, mo_coeff, None,
                                casdm1s, casdm2s, eris)[0]
     dx = casscf.unpack_uniq_var(g_orb)

--- a/pyscf/grad/ukscasci.py
+++ b/pyscf/grad/ukscasci.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python
+# Copyright 2026 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+UCASCI analytical nuclear gradients with unrestricted KS orbitals
+
+This module implements the UKS-orbital UCASCI gradient formulation.  The
+orbital response is the CPKS response of the underlying UKS reference, with
+the associated spin-resolved XC first-derivative terms in the KS orbital-source
+constraints.
+'''
+
+from functools import reduce
+
+from pyscf.lib import logger
+import numpy
+from pyscf.scf import hf
+from pyscf.scf import ucphf
+from pyscf import scf
+from pyscf import mcscf
+from pyscf import lib
+from pyscf.mcscf import umc1step
+from pyscf.grad import ucasci as ucasci_grad
+from pyscf.grad import kscasci as kscasci_grad
+
+
+def _check_supported_functional(mc):
+    ni = mc._scf._numint
+    xctype = ni._xc_type(mc._scf.xc)
+    if xctype == 'MGGA':
+        raise NotImplementedError('UKS-CASCI gradients for meta-GGA '
+                                  'functionals')
+    if xctype not in ('LDA', 'GGA'):
+        raise NotImplementedError('UKS-CASCI gradients for %s functionals' %
+                                  xctype)
+    if mc._scf.do_nlc():
+        raise NotImplementedError('UKS-CASCI gradients for NLC functionals')
+    omega, _, _ = ni.rsh_and_hybrid_coeff(mc._scf.xc, mc.mol.spin)
+    if omega != 0:
+        raise NotImplementedError('UKS-CASCI gradients for range-separated '
+                                  'hybrid functionals')
+
+
+def _check_supported_orbital_source(mc):
+    if not isinstance(mc._scf, hf.KohnShamDFT):
+        raise RuntimeError('UKS-CASCI gradients require a KohnShamDFT '
+                           'reference')
+    _check_supported_functional(mc)
+
+
+def _is_restricted_collapse(mc, mo_coeff):
+    if mc.mol.spin != 0:
+        return False
+    ncorea, ncoreb = mc.ncore
+    neleca, nelecb = mc.nelecas
+    return (ncorea == ncoreb and neleca == nelecb and
+            numpy.allclose(mo_coeff[0], mo_coeff[1], atol=1e-8, rtol=1e-8))
+
+
+def _restricted_collapse_grad(mc_grad, mo_coeff, ci, atmlst, verbose):
+    mc = mc_grad.base
+    mf = scf.addons.convert_to_rhf(mc._scf)
+    mf.mo_coeff = mo_coeff[0]
+    mf.mo_occ = mc._scf.mo_occ[0] * 2
+    mf.mo_energy = mc._scf.mo_energy[0]
+    mf.converged = mc._scf.converged
+    rmc = mcscf.CASCI(mf, mc.ncas, sum(mc.nelecas), ncore=mc.ncore[0])
+    rmc.mo_coeff = mo_coeff[0]
+    rmc.ci = ci
+    rmc.e_tot = mc.e_tot
+    rmc.e_cas = mc.e_cas
+    rmc.converged = getattr(mc, 'converged', True)
+    rmc.fcisolver = mc.fcisolver
+    with lib.temporary_env(mc_grad, base=rmc):
+        return kscasci_grad.grad_elec(mc_grad, mo_coeff[0], ci, atmlst,
+                                      verbose)
+
+
+def _full_rdm12s(casdm1s, casdm2s, nmo, ncore, ncas):
+    ncorea, ncoreb = ncore
+    nacca = ncorea + ncas
+    naccb = ncoreb + ncas
+    casdm1a, casdm1b = casdm1s
+    casdm2aa, casdm2ab, casdm2bb = casdm2s
+
+    dm1a = numpy.zeros((nmo,nmo))
+    dm1b = numpy.zeros((nmo,nmo))
+    dm1a[numpy.arange(ncorea),numpy.arange(ncorea)] = 1
+    dm1b[numpy.arange(ncoreb),numpy.arange(ncoreb)] = 1
+    dm1a[ncorea:nacca,ncorea:nacca] = casdm1a
+    dm1b[ncoreb:naccb,ncoreb:naccb] = casdm1b
+
+    dm2aa = numpy.zeros((nmo,nmo,nmo,nmo))
+    dm2ab = numpy.zeros((nmo,nmo,nmo,nmo))
+    dm2bb = numpy.zeros((nmo,nmo,nmo,nmo))
+    for i in range(ncorea):
+        for j in range(ncorea):
+            dm2aa[i,i,j,j] += 1
+            dm2aa[i,j,j,i] -= 1
+        dm2aa[i,i,ncorea:nacca,ncorea:nacca] += casdm1a
+        dm2aa[ncorea:nacca,ncorea:nacca,i,i] += casdm1a
+        dm2aa[i,ncorea:nacca,ncorea:nacca,i] -= casdm1a
+        dm2aa[ncorea:nacca,i,i,ncorea:nacca] -= casdm1a
+    for i in range(ncoreb):
+        for j in range(ncoreb):
+            dm2bb[i,i,j,j] += 1
+            dm2bb[i,j,j,i] -= 1
+        dm2bb[i,i,ncoreb:naccb,ncoreb:naccb] += casdm1b
+        dm2bb[ncoreb:naccb,ncoreb:naccb,i,i] += casdm1b
+        dm2bb[i,ncoreb:naccb,ncoreb:naccb,i] -= casdm1b
+        dm2bb[ncoreb:naccb,i,i,ncoreb:naccb] -= casdm1b
+    for i in range(ncorea):
+        for j in range(ncoreb):
+            dm2ab[i,i,j,j] += 1
+        dm2ab[i,i,ncoreb:naccb,ncoreb:naccb] += casdm1b
+    for j in range(ncoreb):
+        dm2ab[ncorea:nacca,ncorea:nacca,j,j] += casdm1a
+
+    dm2aa[ncorea:nacca,ncorea:nacca,ncorea:nacca,ncorea:nacca] += casdm2aa
+    dm2ab[ncorea:nacca,ncorea:nacca,ncoreb:naccb,ncoreb:naccb] += casdm2ab
+    dm2bb[ncoreb:naccb,ncoreb:naccb,ncoreb:naccb,ncoreb:naccb] += casdm2bb
+    return (dm1a, dm1b), (dm2aa, dm2ab, dm2bb)
+
+
+def _casci_orbital_gradient(mc, mo_coeff, ci, casdm1s, casdm2s):
+    # UCASSCF uses the antisymmetric orbital-gradient vector as the orbital
+    # optimization RHS.  The same object is Delta X in the Sherrill CI-gradient
+    # orbital-response term.
+    casscf = mcscf.UCASSCF(mc._scf, mc.ncas, mc.nelecas, ncore=mc.ncore)
+    casscf.mo_coeff = mo_coeff
+    casscf.ci = ci
+    casscf.fcisolver = mc.fcisolver
+    eris = casscf.ao2mo(mo_coeff)
+    g_orb = umc1step.gen_g_hop(casscf, mo_coeff, None,
+                               casdm1s, casdm2s, eris)[0]
+    return casscf.unpack_uniq_var(g_orb)
+
+
+def _casci_generalized_fock(mc, mo_coeff, ci, casdm1s, casdm2s):
+    # The overlap/Lagrangian term needs the unsymmetrized generalized Fock X,
+    # not the antisymmetric orbital-gradient matrix returned by gen_g_hop.
+    casscf = mcscf.UCASSCF(mc._scf, mc.ncas, mc.nelecas, ncore=mc.ncore)
+    casscf.mo_coeff = mo_coeff
+    casscf.ci = ci
+    casscf.fcisolver = mc.fcisolver
+    eris = casscf.ao2mo(mo_coeff)
+    ncas = mc.ncas
+    ncore = mc.ncore
+    nocc = (ncore[0] + ncas, ncore[1] + ncas)
+    nmo = mo_coeff[0].shape[1]
+    dm1 = numpy.zeros((2,nmo,nmo))
+    dm1[0,numpy.arange(ncore[0]),numpy.arange(ncore[0])] = 1
+    dm1[1,numpy.arange(ncore[1]),numpy.arange(ncore[1])] = 1
+    dm1[0,ncore[0]:nocc[0],ncore[0]:nocc[0]] = casdm1s[0]
+    dm1[1,ncore[1]:nocc[1],ncore[1]:nocc[1]] = casdm1s[1]
+
+    vhf_c = eris.vhf_c
+    vhf_ca = (
+        vhf_c[0]
+        + numpy.einsum('uvpq,uv->pq', eris.aapp, casdm1s[0])
+        - numpy.einsum('upqv,uv->pq', eris.appa, casdm1s[0])
+        + numpy.einsum('uvpq,uv->pq', eris.AApp, casdm1s[1]),
+        vhf_c[1]
+        + numpy.einsum('uvpq,uv->pq', eris.aaPP, casdm1s[0])
+        + numpy.einsum('uvpq,uv->pq', eris.AAPP, casdm1s[1])
+        - numpy.einsum('upqv,uv->pq', eris.APPA, casdm1s[1]))
+    hdm2 = [
+        numpy.einsum('tuvw,vwpq->tupq', casdm2s[0], eris.aapp)
+        + numpy.einsum('tuvw,vwpq->tupq', casdm2s[1], eris.AApp),
+        numpy.einsum('vwtu,vwpq->tupq', casdm2s[1], eris.aaPP)
+        + numpy.einsum('tuvw,vwpq->tupq', casdm2s[2], eris.AAPP)]
+    hcore = casscf.get_hcore()
+    h1e_mo = (reduce(numpy.dot, (mo_coeff[0].T, hcore[0], mo_coeff[0])),
+              reduce(numpy.dot, (mo_coeff[1].T, hcore[1], mo_coeff[1])))
+    xmat = [numpy.dot(h1e_mo[0], dm1[0]),
+            numpy.dot(h1e_mo[1], dm1[1])]
+    for s in range(2):
+        xmat[s][:,:ncore[s]] += vhf_ca[s][:,:ncore[s]]
+        xmat[s][:,ncore[s]:nocc[s]] += (
+            numpy.einsum('vuuq->qv', hdm2[s][:,:,ncore[s]:nocc[s]])
+            + numpy.dot(vhf_c[s][:,ncore[s]:nocc[s]], casdm1s[s]))
+    return tuple(xmat)
+
+
+def _reference_occ(mc, mo_coeff):
+    ncorea, ncoreb = mc.ncore
+    neleca, nelecb = mc.nelecas
+    nmoa = mo_coeff[0].shape[1]
+    nmob = mo_coeff[1].shape[1]
+    mo_occ = (numpy.zeros(nmoa), numpy.zeros(nmob))
+    mo_occ[0][:ncorea+neleca] = 1
+    mo_occ[1][:ncoreb+nelecb] = 1
+    return mo_occ
+
+
+def _orbital_response_grad(mc_grad, mo_coeff, ci, casdm1s, casdm2s, atmlst):
+    mc = mc_grad.base
+    mol = mc_grad.mol
+    mo_occ = _reference_occ(mc, mo_coeff)
+    nocc = (numpy.count_nonzero(mo_occ[0] > 0),
+            numpy.count_nonzero(mo_occ[1] > 0))
+    nmo = (mo_coeff[0].shape[1], mo_coeff[1].shape[1])
+    nao = mo_coeff[0].shape[0]
+    dx = _casci_orbital_gradient(mc, mo_coeff, ci, casdm1s, casdm2s)
+    h1ao = mc._scf.Hessian().make_h1(mo_coeff, mo_occ)
+    s1a = mc_grad.get_ovlp(mol)
+    aoslices = mol.aoslice_by_atom()
+    vresp = mc._scf.gen_response(mo_coeff, mo_occ, hermi=1)
+
+    def fvind(x):
+        x = x.reshape(-1, nmo[0]*nocc[0] + nmo[1]*nocc[1])
+        vout = []
+        for x1 in x:
+            xa = x1[:nmo[0]*nocc[0]].reshape(nmo[0], nocc[0])
+            xb = x1[nmo[0]*nocc[0]:].reshape(nmo[1], nocc[1])
+            dm = numpy.empty((2,nao,nao))
+            dm[0] = reduce(numpy.dot, (mo_coeff[0], xa,
+                                       mo_coeff[0][:,:nocc[0]].T))
+            dm[1] = reduce(numpy.dot, (mo_coeff[1], xb,
+                                       mo_coeff[1][:,:nocc[1]].T))
+            dm = dm + dm.transpose(0,2,1)
+            v1 = vresp(dm)
+            va = reduce(numpy.dot, (mo_coeff[0].T, v1[0],
+                                    mo_coeff[0][:,:nocc[0]]))
+            vb = reduce(numpy.dot, (mo_coeff[1].T, v1[1],
+                                    mo_coeff[1][:,:nocc[1]]))
+            vout.append(numpy.hstack((va.ravel(), vb.ravel())))
+        return numpy.asarray(vout)
+
+    de = numpy.zeros((len(atmlst),3))
+    for k, ia in enumerate(atmlst):
+        p0, p1 = aoslices[ia][2:]
+        s1 = numpy.zeros_like(s1a)
+        s1[:,p0:p1] += s1a[:,p0:p1]
+        s1[:,:,p0:p1] += s1a[:,p0:p1].transpose(0,2,1)
+
+        h1mo = []
+        s1mo = []
+        for s in range(2):
+            h1mo.append(numpy.einsum('xij,ip,jq->xpq',
+                                     h1ao[s][ia], mo_coeff[s],
+                                     mo_coeff[s][:,:nocc[s]]))
+            s1mo.append(numpy.einsum('xij,ip,jq->xpq',
+                                     s1, mo_coeff[s],
+                                     mo_coeff[s][:,:nocc[s]]))
+
+        mo1 = ucphf.solve(fvind, mc._scf.mo_energy, mo_occ,
+                          (h1mo[0], h1mo[1]), (s1mo[0], s1mo[1]),
+                          max_cycle=50)[0]
+        for x in range(3):
+            dm1 = numpy.empty((2,nao,nao))
+            for s in range(2):
+                dm1[s] = reduce(numpy.dot, (mo_coeff[s], mo1[s][x],
+                                            mo_coeff[s][:,:nocc[s]].T))
+            dm1 = dm1 + dm1.transpose(0,2,1)
+            v1 = vresp(dm1)
+
+            for s in range(2):
+                u = numpy.zeros_like(dx[s])
+                u[:,:nocc[s]] = mo1[s][x]
+
+                b0 = reduce(numpy.dot, (mo_coeff[s].T,
+                                        h1ao[s][ia][x] + v1[s],
+                                        mo_coeff[s]))
+                smo = reduce(numpy.dot, (mo_coeff[s].T, s1[x], mo_coeff[s]))
+                b0 -= smo * mc._scf.mo_energy[s][None,:]
+                eps = mc._scf.mo_energy[s]
+                ncore = mc.ncore[s]
+                nref = ncore + mc.nelecas[s]
+                ncasocc = ncore + mc.ncas
+
+                # ucphf.solve(with s1) fixes the occupied-occupied response
+                # gauge to -S1/2.  CASCI also needs the canonical
+                # active-occupied/core rotation, so add the off-diagonal
+                # first-order Fock correction in the UCASSCF unique-variable
+                # orientation.
+                for p in range(ncore, nref):
+                    for q in range(ncore):
+                        u[p,q] += b0[p,q] / (eps[q] - eps[p])
+                for p in range(ncasocc, nmo[s]):
+                    for q in range(nref, ncasocc):
+                        u[p,q] = b0[p,q] / (eps[q] - eps[p])
+
+                de[k,x] += 2 * numpy.einsum('pq,pq->', u, dx[s])
+    return de
+
+
+def _skeleton_grad(mc_grad, mo_coeff, ci, casdm1s, casdm2s, atmlst):
+    mc = mc_grad.base
+    mol = mc_grad.mol
+    nmo = mo_coeff[0].shape[1]
+    dm1mo, dm2mo = _full_rdm12s(casdm1s, casdm2s, nmo, mc.ncore, mc.ncas)
+    dm1ao = (reduce(numpy.dot, (mo_coeff[0], dm1mo[0], mo_coeff[0].T)),
+             reduce(numpy.dot, (mo_coeff[1], dm1mo[1], mo_coeff[1].T)))
+    dm2aa = lib.einsum('pi,qj,rk,sl,ijkl->pqrs',
+                       mo_coeff[0], mo_coeff[0], mo_coeff[0], mo_coeff[0],
+                       dm2mo[0])
+    dm2ab = lib.einsum('pi,qj,rk,sl,ijkl->pqrs',
+                       mo_coeff[0], mo_coeff[0], mo_coeff[1], mo_coeff[1],
+                       dm2mo[1])
+    dm2bb = lib.einsum('pi,qj,rk,sl,ijkl->pqrs',
+                       mo_coeff[1], mo_coeff[1], mo_coeff[1], mo_coeff[1],
+                       dm2mo[2])
+    # Same-spin FCI RDMs already carry the convention needed by PySCF's
+    # one-index derivative integral contraction.  Do not halve them here as in
+    # the spin-free energy expression.
+    dm2a = dm2aa + dm2ab
+    dm2b = dm2bb + dm2ab.transpose(2,3,0,1)
+
+    hcore_deriv = mc_grad.hcore_generator(mol)
+    s1a = mc_grad.get_ovlp(mol)
+    aoslices = mol.aoslice_by_atom()
+    eri1 = mol.intor('int2e_ip1', comp=3, aosym='s1')
+    eri1 = eri1.reshape(3, mol.nao, mol.nao, mol.nao, mol.nao)
+    xmo = _casci_generalized_fock(mc, mo_coeff, ci, casdm1s, casdm2s)
+    xtilde = []
+    for s in range(2):
+        x = xmo[s].copy()
+        idx = numpy.tril_indices(x.shape[0], -1)
+        x[idx] = xmo[s].T[idx]
+        xtilde.append(x)
+
+    de = numpy.zeros((len(atmlst),3))
+    for k, ia in enumerate(atmlst):
+        p0, p1 = aoslices[ia][2:]
+        de[k] += numpy.einsum('xij,ij->x', hcore_deriv(ia),
+                              dm1ao[0] + dm1ao[1])
+        de[k] -= numpy.einsum('xpqrs,pqrs->x',
+                              eri1[:,p0:p1], dm2a[p0:p1]) * 2
+        de[k] -= numpy.einsum('xpqrs,pqrs->x',
+                              eri1[:,p0:p1], dm2b[p0:p1]) * 2
+        s1 = numpy.zeros_like(s1a)
+        s1[:,p0:p1] += s1a[:,p0:p1]
+        s1[:,:,p0:p1] += s1a[:,p0:p1].transpose(0,2,1)
+        for s in range(2):
+            s1mo = numpy.einsum('xij,ip,jq->xpq',
+                                s1, mo_coeff[s], mo_coeff[s])
+            de[k] -= numpy.einsum('xij,ij->x', s1mo, xtilde[s])
+    return de
+
+
+def _direct_grad_elec(mc_grad, mo_coeff, ci, atmlst):
+    mc = mc_grad.base
+    casdm1s, casdm2s = mc.fcisolver.make_rdm12s(ci, mc.ncas, mc.nelecas)
+    de = _skeleton_grad(mc_grad, mo_coeff, ci, casdm1s, casdm2s, atmlst)
+    de += _orbital_response_grad(
+        mc_grad, mo_coeff, ci, casdm1s, casdm2s, atmlst)
+    return de
+
+
+def grad_elec(mc_grad, mo_coeff=None, ci=None, atmlst=None, verbose=None):
+    mc = mc_grad.base
+    _check_supported_orbital_source(mc)
+    if mo_coeff is None:
+        mo_coeff = mc.mo_coeff
+    if ci is None:
+        ci = mc.ci
+    if _is_restricted_collapse(mc, mo_coeff):
+        return _restricted_collapse_grad(mc_grad, mo_coeff, ci, atmlst,
+                                         verbose)
+    if atmlst is None:
+        atmlst = range(mc_grad.mol.natm)
+    return _direct_grad_elec(mc_grad, mo_coeff, ci, list(atmlst))
+
+
+class Gradients(ucasci_grad.Gradients):
+    '''Non-relativistic UKS-CASCI gradients'''
+
+    grad_elec = grad_elec
+
+    def dump_flags(self, verbose=None):
+        ucasci_grad.Gradients.dump_flags(self, verbose)
+        logger.info(self, 'KS orbital source = %s', self.base._scf.xc)
+        return self
+
+
+Grad = Gradients

--- a/pyscf/grad/ukscasci.py
+++ b/pyscf/grad/ukscasci.py
@@ -253,6 +253,9 @@ def _orbital_response_grad(mc_grad, mo_coeff, dx, atmlst):
         ncore = mc.ncore[s]
         nref = ncore + mc.nelecas[s]
         ncasocc = ncore + mc.ncas
+        # The UKS orbital-gradient matrix is antisymmetric, so each redundant
+        # rotation only needs to be stored once.  The restricted CASCI path
+        # stores both directions because it starts from the unsymmetrized Imat.
         for p in range(ncore, nref):
             for q in range(ncore):
                 zvec[s][p,q] = dx[s][p,q] / (eps[q] - eps[p])

--- a/pyscf/grad/ukscasci.py
+++ b/pyscf/grad/ukscasci.py
@@ -34,6 +34,7 @@ from pyscf import lib
 from pyscf.mcscf import umc1step
 from pyscf.grad import ucasci as ucasci_grad
 from pyscf.grad import kscasci as kscasci_grad
+from pyscf.grad.mp2 import _shell_prange
 
 
 def _check_supported_functional(mc):
@@ -88,74 +89,63 @@ def _restricted_collapse_grad(mc_grad, mo_coeff, ci, atmlst, verbose):
                                       verbose)
 
 
-def _full_rdm12s(casdm1s, casdm2s, nmo, ncore, ncas):
-    ncorea, ncoreb = ncore
-    nacca = ncorea + ncas
-    naccb = ncoreb + ncas
-    casdm1a, casdm1b = casdm1s
-    casdm2aa, casdm2ab, casdm2bb = casdm2s
-
-    dm1a = numpy.zeros((nmo,nmo))
-    dm1b = numpy.zeros((nmo,nmo))
-    dm1a[numpy.arange(ncorea),numpy.arange(ncorea)] = 1
-    dm1b[numpy.arange(ncoreb),numpy.arange(ncoreb)] = 1
-    dm1a[ncorea:nacca,ncorea:nacca] = casdm1a
-    dm1b[ncoreb:naccb,ncoreb:naccb] = casdm1b
-
-    dm2aa = numpy.zeros((nmo,nmo,nmo,nmo))
-    dm2ab = numpy.zeros((nmo,nmo,nmo,nmo))
-    dm2bb = numpy.zeros((nmo,nmo,nmo,nmo))
-    for i in range(ncorea):
-        for j in range(ncorea):
-            dm2aa[i,i,j,j] += 1
-            dm2aa[i,j,j,i] -= 1
-        dm2aa[i,i,ncorea:nacca,ncorea:nacca] += casdm1a
-        dm2aa[ncorea:nacca,ncorea:nacca,i,i] += casdm1a
-        dm2aa[i,ncorea:nacca,ncorea:nacca,i] -= casdm1a
-        dm2aa[ncorea:nacca,i,i,ncorea:nacca] -= casdm1a
-    for i in range(ncoreb):
-        for j in range(ncoreb):
-            dm2bb[i,i,j,j] += 1
-            dm2bb[i,j,j,i] -= 1
-        dm2bb[i,i,ncoreb:naccb,ncoreb:naccb] += casdm1b
-        dm2bb[ncoreb:naccb,ncoreb:naccb,i,i] += casdm1b
-        dm2bb[i,ncoreb:naccb,ncoreb:naccb,i] -= casdm1b
-        dm2bb[ncoreb:naccb,i,i,ncoreb:naccb] -= casdm1b
-    for i in range(ncorea):
-        for j in range(ncoreb):
-            dm2ab[i,i,j,j] += 1
-        dm2ab[i,i,ncoreb:naccb,ncoreb:naccb] += casdm1b
-    for j in range(ncoreb):
-        dm2ab[ncorea:nacca,ncorea:nacca,j,j] += casdm1a
-
-    dm2aa[ncorea:nacca,ncorea:nacca,ncorea:nacca,ncorea:nacca] += casdm2aa
-    dm2ab[ncorea:nacca,ncorea:nacca,ncoreb:naccb,ncoreb:naccb] += casdm2ab
-    dm2bb[ncoreb:naccb,ncoreb:naccb,ncoreb:naccb,ncoreb:naccb] += casdm2bb
-    return (dm1a, dm1b), (dm2aa, dm2ab, dm2bb)
+def _ao_density_components(casdm1s, mo_coeff, ncore, ncas):
+    mo_core = (mo_coeff[0][:,:ncore[0]], mo_coeff[1][:,:ncore[1]])
+    mo_act = (mo_coeff[0][:,ncore[0]:ncore[0]+ncas],
+              mo_coeff[1][:,ncore[1]:ncore[1]+ncas])
+    dm_core = [numpy.dot(mo_core[s], mo_core[s].T) for s in range(2)]
+    dm_act = [reduce(numpy.dot, (mo_act[s], casdm1s[s], mo_act[s].T))
+              for s in range(2)]
+    return mo_act, dm_core, dm_act
 
 
-def _casci_orbital_gradient(mc, mo_coeff, ci, casdm1s, casdm2s):
+def _same_spin_dm2ao_slice(dm_core, dm_act, mo_act, casdm2,
+                           p0, p1, q0, q1):
+    # Same-spin CASCI 2-RDM = core determinant + core-active terms + active
+    # CAS 2-RDM.  Only the AO slice needed for the current derivative-ERI block
+    # is transformed.
+    dm2 = lib.einsum('pq,rs->pqrs', dm_core[p0:p1,q0:q1], dm_core)
+    dm2 -= lib.einsum('ps,qr->pqrs', dm_core[p0:p1], dm_core[q0:q1])
+    dm2 += lib.einsum('pq,rs->pqrs', dm_core[p0:p1,q0:q1], dm_act)
+    dm2 += lib.einsum('pq,rs->pqrs', dm_act[p0:p1,q0:q1], dm_core)
+    dm2 -= lib.einsum('ps,qr->pqrs', dm_core[p0:p1], dm_act[q0:q1])
+    dm2 -= lib.einsum('ps,qr->pqrs', dm_act[p0:p1], dm_core[q0:q1])
+    dm2 += lib.einsum('pi,qj,rk,sl,ijkl->pqrs',
+                      mo_act[p0:p1], mo_act[q0:q1], mo_act, mo_act,
+                      casdm2)
+    return dm2
+
+
+def _mixed_spin_dm2ao_slice(dm_core0, dm_act0, mo_act0,
+                            dm_core1, dm_act1, mo_act1, casdm2,
+                            p0, p1, q0, q1):
+    # Mixed-spin 2-RDM has no exchange terms.  The first spin occupies the
+    # derivative index pair (p,q); the second spin occupies (r,s).
+    dm2 = lib.einsum('pq,rs->pqrs', dm_core0[p0:p1,q0:q1],
+                     dm_core1 + dm_act1)
+    dm2 += lib.einsum('pq,rs->pqrs', dm_act0[p0:p1,q0:q1], dm_core1)
+    dm2 += lib.einsum('pi,qj,rk,sl,ijkl->pqrs',
+                      mo_act0[p0:p1], mo_act0[q0:q1], mo_act1, mo_act1,
+                      casdm2)
+    return dm2
+
+
+def _casci_orbital_intermediates(mc, mo_coeff, ci, casdm1s, casdm2s):
+    casscf = mcscf.UCASSCF(mc._scf, mc.ncas, mc.nelecas, ncore=mc.ncore)
+    casscf.mo_coeff = mo_coeff
+    casscf.ci = ci
+    casscf.fcisolver = mc.fcisolver
+    eris = casscf.ao2mo(mo_coeff)
+
     # UCASSCF uses the antisymmetric orbital-gradient vector as the orbital
     # optimization RHS.  The same object is Delta X in the Sherrill CI-gradient
     # orbital-response term.
-    casscf = mcscf.UCASSCF(mc._scf, mc.ncas, mc.nelecas, ncore=mc.ncore)
-    casscf.mo_coeff = mo_coeff
-    casscf.ci = ci
-    casscf.fcisolver = mc.fcisolver
-    eris = casscf.ao2mo(mo_coeff)
     g_orb = umc1step.gen_g_hop(casscf, mo_coeff, None,
                                casdm1s, casdm2s, eris)[0]
-    return casscf.unpack_uniq_var(g_orb)
+    dx = casscf.unpack_uniq_var(g_orb)
 
-
-def _casci_generalized_fock(mc, mo_coeff, ci, casdm1s, casdm2s):
     # The overlap/Lagrangian term needs the unsymmetrized generalized Fock X,
     # not the antisymmetric orbital-gradient matrix returned by gen_g_hop.
-    casscf = mcscf.UCASSCF(mc._scf, mc.ncas, mc.nelecas, ncore=mc.ncore)
-    casscf.mo_coeff = mo_coeff
-    casscf.ci = ci
-    casscf.fcisolver = mc.fcisolver
-    eris = casscf.ao2mo(mo_coeff)
     ncas = mc.ncas
     ncore = mc.ncore
     nocc = (ncore[0] + ncas, ncore[1] + ncas)
@@ -191,7 +181,7 @@ def _casci_generalized_fock(mc, mo_coeff, ci, casdm1s, casdm2s):
         xmat[s][:,ncore[s]:nocc[s]] += (
             numpy.einsum('vuuq->qv', hdm2[s][:,:,ncore[s]:nocc[s]])
             + numpy.dot(vhf_c[s][:,ncore[s]:nocc[s]], casdm1s[s]))
-    return tuple(xmat)
+    return dx, tuple(xmat)
 
 
 def _reference_occ(mc, mo_coeff):
@@ -205,39 +195,89 @@ def _reference_occ(mc, mo_coeff):
     return mo_occ
 
 
-def _orbital_response_grad(mc_grad, mo_coeff, ci, casdm1s, casdm2s, atmlst):
+def _orbital_response_grad(mc_grad, mo_coeff, dx, atmlst):
     mc = mc_grad.base
     mol = mc_grad.mol
+    atmlst = list(atmlst)
     mo_occ = _reference_occ(mc, mo_coeff)
     nocc = (numpy.count_nonzero(mo_occ[0] > 0),
             numpy.count_nonzero(mo_occ[1] > 0))
     nmo = (mo_coeff[0].shape[1], mo_coeff[1].shape[1])
     nao = mo_coeff[0].shape[0]
-    dx = _casci_orbital_gradient(mc, mo_coeff, ci, casdm1s, casdm2s)
     h1ao = mc._scf.Hessian().make_h1(mo_coeff, mo_occ)
     s1a = mc_grad.get_ovlp(mol)
     aoslices = mol.aoslice_by_atom()
     vresp = mc._scf.gen_response(mo_coeff, mo_occ, hermi=1)
+    viridx = (mo_occ[0] == 0, mo_occ[1] == 0)
+
+    def occ_response_dm(mo1):
+        nset = mo1[0].shape[0]
+        dm = numpy.empty((2,nset,nao,nao))
+        for s in range(2):
+            dm[s] = numpy.einsum('pi,xij,qj->xpq',
+                                 mo_coeff[s], mo1[s],
+                                 mo_coeff[s][:,:nocc[s]])
+        return dm + dm.transpose(0,1,3,2)
+
+    def full_response_dm(u):
+        dm = numpy.empty((2,nao,nao))
+        for s in range(2):
+            dm[s] = reduce(numpy.dot, (mo_coeff[s], u[s], mo_coeff[s].T))
+        return dm + dm.transpose(0,2,1)
+
+    # Put CASCI-independent rotations that are redundant for the UKS
+    # determinant directly into zvec with canonical-orbital denominators.  Their
+    # induced KS response potential contributes to the occupied-virtual adjoint
+    # RHS below, matching the restricted CASCI Z-vector strategy.
+    zvec = [numpy.zeros((nmo[s], nmo[s])) for s in range(2)]
+    for s in range(2):
+        eps = mc._scf.mo_energy[s]
+        ncore = mc.ncore[s]
+        nref = ncore + mc.nelecas[s]
+        ncasocc = ncore + mc.ncas
+        for p in range(ncore, nref):
+            for q in range(ncore):
+                zvec[s][p,q] = dx[s][p,q] / (eps[q] - eps[p])
+        for p in range(ncasocc, nmo[s]):
+            for q in range(nref, ncasocc):
+                zvec[s][p,q] = dx[s][p,q] / (eps[q] - eps[p])
+
+    vden = vresp(full_response_dm(zvec))
+    wvo = []
+    for s in range(2):
+        w = dx[s] + reduce(numpy.dot, (mo_coeff[s].T, vden[s],
+                                       mo_coeff[s]))
+        wvo.append(w[viridx[s]][:,:nocc[s]])
 
     def fvind(x):
-        x = x.reshape(-1, nmo[0]*nocc[0] + nmo[1]*nocc[1])
+        # UCPHF may ask for several right-hand sides at once.  Keep the leading
+        # dimension through the AO density build so the UKS response kernel can
+        # contract all corresponding XC potentials in one call.
+        x = x.reshape(-1, wvo[0].size + wvo[1].size)
+        nset = x.shape[0]
+        mo1 = []
+        p0 = 0
+        for s in range(2):
+            p1 = p0 + wvo[s].size
+            z = numpy.zeros((nset, nmo[s], nocc[s]))
+            z[:,viridx[s]] = x[:,p0:p1].reshape((nset,) + wvo[s].shape)
+            mo1.append(z)
+            p0 = p1
+        dm = occ_response_dm(mo1)
+        v1 = vresp(dm)
         vout = []
-        for x1 in x:
-            xa = x1[:nmo[0]*nocc[0]].reshape(nmo[0], nocc[0])
-            xb = x1[nmo[0]*nocc[0]:].reshape(nmo[1], nocc[1])
-            dm = numpy.empty((2,nao,nao))
-            dm[0] = reduce(numpy.dot, (mo_coeff[0], xa,
-                                       mo_coeff[0][:,:nocc[0]].T))
-            dm[1] = reduce(numpy.dot, (mo_coeff[1], xb,
-                                       mo_coeff[1][:,:nocc[1]].T))
-            dm = dm + dm.transpose(0,2,1)
-            v1 = vresp(dm)
-            va = reduce(numpy.dot, (mo_coeff[0].T, v1[0],
-                                    mo_coeff[0][:,:nocc[0]]))
-            vb = reduce(numpy.dot, (mo_coeff[1].T, v1[1],
-                                    mo_coeff[1][:,:nocc[1]]))
-            vout.append(numpy.hstack((va.ravel(), vb.ravel())))
-        return numpy.asarray(vout)
+        for s in range(2):
+            v = numpy.einsum('pi,xpq,qj->xij', mo_coeff[s], v1[s],
+                             mo_coeff[s][:,:nocc[s]])
+            vout.append(v[:,viridx[s]].reshape(nset,-1))
+        return numpy.hstack(vout)
+
+    # This is the single perturbation-independent adjoint CPKS solve.  The
+    # nuclear derivative enters only later through B0-like contractions.
+    zvo = ucphf.solve(fvind, mc._scf.mo_energy, mo_occ, tuple(wvo),
+                      max_cycle=50)[0]
+    for s in range(2):
+        zvec[s][viridx[s],:nocc[s]] = zvo[s]
 
     de = numpy.zeros((len(atmlst),3))
     for k, ia in enumerate(atmlst):
@@ -246,85 +286,45 @@ def _orbital_response_grad(mc_grad, mo_coeff, ci, casdm1s, casdm2s, atmlst):
         s1[:,p0:p1] += s1a[:,p0:p1]
         s1[:,:,p0:p1] += s1a[:,p0:p1].transpose(0,2,1)
 
-        h1mo = []
-        s1mo = []
+        # ucphf.solve(with s1) fixes the occupied-occupied response gauge to
+        # -S1/2.  In the adjoint form this gauge is a direct source term and
+        # its induced UKS response potential contributes to the B0 contraction.
+        smo = []
+        ug = []
         for s in range(2):
-            h1mo.append(numpy.einsum('xij,ip,jq->xpq',
-                                     h1ao[s][ia], mo_coeff[s],
-                                     mo_coeff[s][:,:nocc[s]]))
-            s1mo.append(numpy.einsum('xij,ip,jq->xpq',
-                                     s1, mo_coeff[s],
-                                     mo_coeff[s][:,:nocc[s]]))
+            sm = numpy.einsum('xij,ip,jq->xpq', s1, mo_coeff[s],
+                              mo_coeff[s])
+            u = numpy.zeros((3,nmo[s],nmo[s]))
+            u[:,:nocc[s],:nocc[s]] = -.5 * sm[:,:nocc[s],:nocc[s]]
+            smo.append(sm)
+            ug.append(u)
 
-        mo1 = ucphf.solve(fvind, mc._scf.mo_energy, mo_occ,
-                          (h1mo[0], h1mo[1]), (s1mo[0], s1mo[1]),
-                          max_cycle=50)[0]
+        dm_g = numpy.empty((2,3,nao,nao))
         for x in range(3):
-            dm1 = numpy.empty((2,nao,nao))
-            for s in range(2):
-                dm1[s] = reduce(numpy.dot, (mo_coeff[s], mo1[s][x],
-                                            mo_coeff[s][:,:nocc[s]].T))
-            dm1 = dm1 + dm1.transpose(0,2,1)
-            v1 = vresp(dm1)
-
-            for s in range(2):
-                u = numpy.zeros_like(dx[s])
-                u[:,:nocc[s]] = mo1[s][x]
-
-                b0 = reduce(numpy.dot, (mo_coeff[s].T,
-                                        h1ao[s][ia][x] + v1[s],
-                                        mo_coeff[s]))
-                smo = reduce(numpy.dot, (mo_coeff[s].T, s1[x], mo_coeff[s]))
-                b0 -= smo * mc._scf.mo_energy[s][None,:]
-                eps = mc._scf.mo_energy[s]
-                ncore = mc.ncore[s]
-                nref = ncore + mc.nelecas[s]
-                ncasocc = ncore + mc.ncas
-
-                # ucphf.solve(with s1) fixes the occupied-occupied response
-                # gauge to -S1/2.  CASCI also needs the canonical
-                # active-occupied/core rotation, so add the off-diagonal
-                # first-order Fock correction in the UCASSCF unique-variable
-                # orientation.
-                for p in range(ncore, nref):
-                    for q in range(ncore):
-                        u[p,q] += b0[p,q] / (eps[q] - eps[p])
-                for p in range(ncasocc, nmo[s]):
-                    for q in range(nref, ncasocc):
-                        u[p,q] = b0[p,q] / (eps[q] - eps[p])
-
-                de[k,x] += 2 * numpy.einsum('pq,pq->', u, dx[s])
+            dm_g[:,x] = full_response_dm((ug[0][x], ug[1][x]))
+        vg = vresp(dm_g)
+        for s in range(2):
+            b0 = numpy.einsum('pi,xpq,qj->xij', mo_coeff[s],
+                              h1ao[s][ia] + vg[s], mo_coeff[s])
+            b0 -= smo[s] * mc._scf.mo_energy[s][None,None,:]
+            de[k] += 2 * numpy.einsum('pq,xpq->x', zvec[s], b0)
+            de[k] += 2 * numpy.einsum('xpq,pq->x',
+                                      ug[s][:,:nocc[s],:nocc[s]],
+                                      dx[s][:nocc[s],:nocc[s]])
     return de
 
 
-def _skeleton_grad(mc_grad, mo_coeff, ci, casdm1s, casdm2s, atmlst):
+def _skeleton_grad(mc_grad, mo_coeff, xmo, casdm1s, casdm2s, atmlst):
     mc = mc_grad.base
     mol = mc_grad.mol
-    nmo = mo_coeff[0].shape[1]
-    dm1mo, dm2mo = _full_rdm12s(casdm1s, casdm2s, nmo, mc.ncore, mc.ncas)
-    dm1ao = (reduce(numpy.dot, (mo_coeff[0], dm1mo[0], mo_coeff[0].T)),
-             reduce(numpy.dot, (mo_coeff[1], dm1mo[1], mo_coeff[1].T)))
-    dm2aa = lib.einsum('pi,qj,rk,sl,ijkl->pqrs',
-                       mo_coeff[0], mo_coeff[0], mo_coeff[0], mo_coeff[0],
-                       dm2mo[0])
-    dm2ab = lib.einsum('pi,qj,rk,sl,ijkl->pqrs',
-                       mo_coeff[0], mo_coeff[0], mo_coeff[1], mo_coeff[1],
-                       dm2mo[1])
-    dm2bb = lib.einsum('pi,qj,rk,sl,ijkl->pqrs',
-                       mo_coeff[1], mo_coeff[1], mo_coeff[1], mo_coeff[1],
-                       dm2mo[2])
-    # Same-spin FCI RDMs already carry the convention needed by PySCF's
-    # one-index derivative integral contraction.  Do not halve them here as in
-    # the spin-free energy expression.
-    dm2a = dm2aa + dm2ab
-    dm2b = dm2bb + dm2ab.transpose(2,3,0,1)
+    nao = mol.nao
+    mo_act, dm_core, dm_act = _ao_density_components(
+        casdm1s, mo_coeff, mc.ncore, mc.ncas)
+    dm1ao = (dm_core[0] + dm_act[0], dm_core[1] + dm_act[1])
 
     hcore_deriv = mc_grad.hcore_generator(mol)
     s1a = mc_grad.get_ovlp(mol)
     aoslices = mol.aoslice_by_atom()
-    eri1 = mol.intor('int2e_ip1', comp=3, aosym='s1')
-    eri1 = eri1.reshape(3, mol.nao, mol.nao, mol.nao, mol.nao)
-    xmo = _casci_generalized_fock(mc, mo_coeff, ci, casdm1s, casdm2s)
     xtilde = []
     for s in range(2):
         x = xmo[s].copy()
@@ -333,14 +333,45 @@ def _skeleton_grad(mc_grad, mo_coeff, ci, casdm1s, casdm2s, atmlst):
         xtilde.append(x)
 
     de = numpy.zeros((len(atmlst),3))
+    max_memory = max(2000, mc_grad.max_memory*.9 - lib.current_memory()[0])
+    max_atom_nao = max(aoslices[:,3] - aoslices[:,2])
+    blksize = int(max_memory*1e6/8 / (max_atom_nao * nao * nao * 6))
+    blksize = min(nao, max(2, blksize))
+
     for k, ia in enumerate(atmlst):
-        p0, p1 = aoslices[ia][2:]
+        shl0, shl1, p0, p1 = aoslices[ia]
         de[k] += numpy.einsum('xij,ij->x', hcore_deriv(ia),
                               dm1ao[0] + dm1ao[1])
-        de[k] -= numpy.einsum('xpqrs,pqrs->x',
-                              eri1[:,p0:p1], dm2a[p0:p1]) * 2
-        de[k] -= numpy.einsum('xpqrs,pqrs->x',
-                              eri1[:,p0:p1], dm2b[p0:p1]) * 2
+
+        q1 = 0
+        for b0, b1, nf in _shell_prange(mol, 0, mol.nbas, blksize):
+            q0, q1 = q1, q1 + nf
+            shls_slice = (shl0, shl1, b0, b1, 0, mol.nbas, 0, mol.nbas)
+            eri1 = mol.intor('int2e_ip1', comp=3, aosym='s1',
+                             shls_slice=shls_slice)
+            eri1 = eri1.reshape(3, p1-p0, nf, nao, nao)
+
+            # Same-spin FCI RDMs already carry the convention needed by
+            # PySCF's one-index derivative integral contraction.  Do not halve
+            # them here as in the spin-free energy expression.
+            dm2a = _same_spin_dm2ao_slice(
+                dm_core[0], dm_act[0], mo_act[0], casdm2s[0],
+                p0, p1, q0, q1)
+            dm2a += _mixed_spin_dm2ao_slice(
+                dm_core[0], dm_act[0], mo_act[0],
+                dm_core[1], dm_act[1], mo_act[1], casdm2s[1],
+                p0, p1, q0, q1)
+            dm2b = _same_spin_dm2ao_slice(
+                dm_core[1], dm_act[1], mo_act[1], casdm2s[2],
+                p0, p1, q0, q1)
+            dm2b += _mixed_spin_dm2ao_slice(
+                dm_core[1], dm_act[1], mo_act[1],
+                dm_core[0], dm_act[0], mo_act[0],
+                casdm2s[1].transpose(2,3,0,1), p0, p1, q0, q1)
+
+            de[k] -= numpy.einsum('xpqrs,pqrs->x', eri1, dm2a) * 2
+            de[k] -= numpy.einsum('xpqrs,pqrs->x', eri1, dm2b) * 2
+
         s1 = numpy.zeros_like(s1a)
         s1[:,p0:p1] += s1a[:,p0:p1]
         s1[:,:,p0:p1] += s1a[:,p0:p1].transpose(0,2,1)
@@ -354,9 +385,10 @@ def _skeleton_grad(mc_grad, mo_coeff, ci, casdm1s, casdm2s, atmlst):
 def _direct_grad_elec(mc_grad, mo_coeff, ci, atmlst):
     mc = mc_grad.base
     casdm1s, casdm2s = mc.fcisolver.make_rdm12s(ci, mc.ncas, mc.nelecas)
-    de = _skeleton_grad(mc_grad, mo_coeff, ci, casdm1s, casdm2s, atmlst)
-    de += _orbital_response_grad(
-        mc_grad, mo_coeff, ci, casdm1s, casdm2s, atmlst)
+    dx, xmo = _casci_orbital_intermediates(
+        mc, mo_coeff, ci, casdm1s, casdm2s)
+    de = _skeleton_grad(mc_grad, mo_coeff, xmo, casdm1s, casdm2s, atmlst)
+    de += _orbital_response_grad(mc_grad, mo_coeff, dx, atmlst)
     return de
 
 

--- a/pyscf/mcscf/__init__.py
+++ b/pyscf/mcscf/__init__.py
@@ -238,8 +238,12 @@ def UCASCI(mf_or_mol, ncas, nelecas, ncore=None):
         from pyscf.lib import logger
         logger.warn(mf, f'DF-UCASCI for DFHF method {mf} is not available. '
                     'Normal UCASCI method is called.')
+        df_source = True
         mf = mf.undo_df()
+    else:
+        df_source = False
     mc = ucasci.UCASCI(mf, ncas, nelecas, ncore)
+    mc._scf_df_source = df_source # need flag to reject gradients for DF orbitals
     return mc
 
 

--- a/pyscf/mcscf/casci.py
+++ b/pyscf/mcscf/casci.py
@@ -1183,6 +1183,12 @@ class CASCI(CASBase):
     as_scanner = as_scanner
 
     def nuc_grad_method(self):
+        # Dispatch by orbital source.  HF-CASCI and KS-CASCI have different
+        # orbital-response equations.
+        from pyscf.scf import hf
+        if isinstance(self._scf, hf.KohnShamDFT):
+            from pyscf.grad import kscasci
+            return kscasci.Gradients(self)
         from pyscf.grad import casci
         return casci.Gradients(self)
 

--- a/pyscf/mcscf/test/test_ucasci.py
+++ b/pyscf/mcscf/test/test_ucasci.py
@@ -20,6 +20,7 @@ from pyscf import gto
 from pyscf import scf
 from pyscf import dft
 from pyscf import fci
+from pyscf import ci
 from pyscf import mcscf
 
 def setUpModule():
@@ -93,6 +94,14 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(eri1[0]-eri2[0]).max(), 0, 12)
         self.assertAlmostEqual(abs(eri1[1]-eri2[1]).max(), 0, 12)
         self.assertAlmostEqual(abs(eri1[2]-eri2[2]).max(), 0, 12)
+
+    def test_spin_asymmetric_ncore(self):
+        mol1 = gto.M(atom='H 0 0 0; H 0 0 1; H 0 1 0',
+                     basis='sto-3g', spin=1, verbose=0)
+        mf = scf.UHF(mol1).run(conv_tol=1e-12)
+        mc = mcscf.UCASCI(mf, 2, (1,1), ncore=(1,0)).run()
+        myci = ci.UCISD(mf, frozen=[[0], [2]]).run()
+        self.assertAlmostEqual(mc.e_tot, myci.e_tot, 12)
 
     def test_get_veff(self):
         mc1 = mcscf.UCASCI(m.to_rks(), 5, (4,2))

--- a/pyscf/mcscf/ucasci.py
+++ b/pyscf/mcscf/ucasci.py
@@ -443,6 +443,10 @@ class UCASCI(UCASBase):
     as_scanner = as_scanner
 
     def nuc_grad_method(self):
+        # Select the gradient implementation from the source orbitals.
+        if isinstance(self._scf, scf.hf.KohnShamDFT):
+            from pyscf.grad import ukscasci
+            return ukscasci.Gradients(self)
         from pyscf.grad import ucasci
         return ucasci.Gradients(self)
 

--- a/pyscf/mcscf/ucasci.py
+++ b/pyscf/mcscf/ucasci.py
@@ -48,9 +48,10 @@ else:
 def extract_orbs(mo_coeff, ncas, nelecas, ncore):
     ncore_a, ncore_b = ncore
     nocc_a = ncore_a + ncas
-    mo_core = (mo_coeff[0][:,:ncore_a]      , mo_coeff[1][:,:ncore_a]      )
-    mo_cas  = (mo_coeff[0][:,ncore_a:nocc_a], mo_coeff[1][:,ncore_a:nocc_a])
-    mo_vir  = (mo_coeff[0][:,nocc_a:]       , mo_coeff[1][:,nocc_a:]       )
+    nocc_b = ncore_b + ncas
+    mo_core = (mo_coeff[0][:,:ncore_a]      , mo_coeff[1][:,:ncore_b]      )
+    mo_cas  = (mo_coeff[0][:,ncore_a:nocc_a], mo_coeff[1][:,ncore_b:nocc_b])
+    mo_vir  = (mo_coeff[0][:,nocc_a:]       , mo_coeff[1][:,nocc_b:]       )
     return mo_core, mo_cas, mo_vir
 
 def h1e_for_cas(casci, mo_coeff=None, ncas=None, ncore=None):
@@ -440,6 +441,10 @@ class UCASCI(UCASBase):
         return self.e_tot, self.e_cas, self.ci
 
     as_scanner = as_scanner
+
+    def nuc_grad_method(self):
+        from pyscf.grad import ucasci
+        return ucasci.Gradients(self)
 
 CASCI = UCASCI
 

--- a/pyscf/scf/ucphf.py
+++ b/pyscf/scf/ucphf.py
@@ -64,10 +64,29 @@ def solve_nos1(fvind, mo_energy, mo_occ, h1,
         ((mo_ea[viridxa,None]+level_shift - mo_ea[occidxa]).ravel(),
          (mo_eb[viridxb,None]+level_shift - mo_eb[occidxb]).ravel()))
     e_ai = 1 / e_ai
-    mo1base = numpy.hstack((h1[0].reshape(-1,nvira*nocca),
-                            h1[1].reshape(-1,nvirb*noccb)))
+    nova = nvira * nocca
+    novb = nvirb * noccb
+    nseta = 1 if h1[0].ndim == 2 else h1[0].shape[0]
+    nsetb = 1 if h1[1].ndim == 2 else h1[1].shape[0]
+    nset = max(nseta, nsetb)
+    h1a = numpy.zeros((nset, nova))
+    h1b = numpy.zeros((nset, novb))
+    if nova > 0:
+        h1a[:nseta] = h1[0].reshape(nseta,nova)
+    if novb > 0:
+        h1b[:nsetb] = h1[1].reshape(nsetb,novb)
+    mo1base = numpy.hstack((h1a, h1b))
     mo1base *= -e_ai
     nov = e_ai.size
+    if nov == 0:
+        mo1_a = numpy.zeros((nset,nvira,nocca))
+        mo1_b = numpy.zeros((nset,nvirb,noccb))
+        if isinstance(h1[0], numpy.ndarray) and h1[0].ndim == 2:
+            mo1 = (mo1_a[0], mo1_b[0])
+        else:
+            assert h1[0].ndim == 3
+            mo1 = (mo1_a, mo1_b)
+        return mo1, None
 
     def vind_vo(mo1):
         nd = mo1.shape[0]
@@ -81,8 +100,8 @@ def solve_nos1(fvind, mo_energy, mo_occ, h1,
     log.timer('krylov solver in CPHF', *t0)
 
     mo1 = mo1.reshape(mo1base.shape)
-    mo1_a = mo1[:,:nvira*nocca].reshape(-1,nvira,nocca)
-    mo1_b = mo1[:,nvira*nocca:].reshape(-1,nvirb,noccb)
+    mo1_a = mo1[:,:nova].reshape(nset,nvira,nocca)
+    mo1_b = mo1[:,nova:].reshape(nset,nvirb,noccb)
     if isinstance(h1[0], numpy.ndarray) and h1[0].ndim == 2:
         mo1 = (mo1_a[0], mo1_b[0])
     else:


### PR DESCRIPTION
This PR adds analytic gradient support for CASCI when UHF, RKS, or UKS reference orbitals are used. 

- UHF-CASCI gradient we transform the CASCI density into d1/d2 intermediates usable by the UCCSD - RKS-CASCI we reuse the RHF-CASCI skeleton with CPKS, plus the remaining XC derivative and hybrid-exchange orbital response terms. 
-  UKS-CASCI we used UCASSCF's `mcscf.umc1step.gen_g_hop` for the orbital gradient, and existing UKS response for CPKS. 

LDA, GGA, and global-hybrid GGA functionals are supported. Gradients requested with unsupported orbital sources raise `NotImplementedError`

PR includes tests against 5-point finite difference and analytic gradients agree within 2e-6 Hartree/Bohr. 

Issue #3308 