### PR TITLE
fix(tdscf): restart degenerate trial subspaces

### DIFF
--- a/pyscf/tdscf/_lr_eig.py
+++ b/pyscf/tdscf/_lr_eig.py
@@ -612,31 +612,39 @@ def real_eig(aop, x0, precond, tol_residual=1e-5, nroots=1, x0sym=None, pick=Non
         pi[:m1,m0:m1] = -pi_block.T
         pi[m0:m1,:m1] = pi_block
 
-        if x0sym is None:
-            omega, x, y = TDDFT_subspace_eigen_solver(
-                a[:m1,:m1], b[:m1,:m1], sigma[:m1,:m1], pi[:m1,:m1], space_inc)
-        else:
-            # Diagonalize within eash symmetry sectors
-            omega = np.empty(m1)
-            x = np.zeros((m1, m1))
-            y = np.zeros_like(x)
-            v_ir = []
-            i1 = 0
-            for ir in set(xs_ir):
-                idx = np.nonzero(xs_ir[:m1] == ir)[0]
-                _w, _x, _y = TDDFT_subspace_eigen_solver(
-                    a[idx[:,None],idx], b[idx[:,None],idx],
-                    sigma[idx[:,None],idx], pi[idx[:,None],idx], idx.size)
-                i0, i1 = i1, i1 + idx.size
-                omega[i0:i1] = _w
-                x[idx,i0:i1] = _x
-                y[idx,i0:i1] = _y
-                v_ir.append([ir] * _w.size)
-            idx = np.argsort(omega)
-            omega = omega[idx]
-            v_ir = np.hstack(v_ir)[idx]
-            x = x[:,idx]
-            y = y[:,idx]
+        try:
+            if x0sym is None:
+                omega, x, y = TDDFT_subspace_eigen_solver(
+                    a[:m1,:m1], b[:m1,:m1], sigma[:m1,:m1], pi[:m1,:m1], space_inc)
+            else:
+                # Diagonalize within eash symmetry sectors
+                omega = np.empty(m1)
+                x = np.zeros((m1, m1))
+                y = np.zeros_like(x)
+                v_ir = []
+                i1 = 0
+                for ir in set(xs_ir):
+                    idx = np.nonzero(xs_ir[:m1] == ir)[0]
+                    _w, _x, _y = TDDFT_subspace_eigen_solver(
+                        a[idx[:,None],idx], b[idx[:,None],idx],
+                        sigma[idx[:,None],idx], pi[idx[:,None],idx], idx.size)
+                    i0, i1 = i1, i1 + idx.size
+                    omega[i0:i1] = _w
+                    x[idx,i0:i1] = _x
+                    y[idx,i0:i1] = _y
+                    v_ir.append([ir] * _w.size)
+                idx = np.argsort(omega)
+                omega = omega[idx]
+                v_ir = np.hstack(v_ir)[idx]
+                x = x[:,idx]
+                y = y[:,idx]
+        except np.linalg.LinAlgError:
+            if fresh_start:
+                raise
+            # Reuse the last valid Ritz vectors instead of the singular expanded metric.
+            log.debug('Singular trial subspace; restart from the previous Ritz vectors')
+            fresh_start = True
+            continue
 
         w, e, elast = omega[:space_inc], omega[:nroots], e
         v_sub = x[:,:space_inc]
@@ -718,7 +726,11 @@ def real_eig(aop, x0, precond, tol_residual=1e-5, nroots=1, x0sym=None, pick=Non
 
         if len(V) == 0:
             log.debug(f'Linear dependency in trial subspace. |r| for each state {r_norms}')
-            break
+            if fresh_start:
+                break
+            # Retry once from the current Ritz vectors before declaring the space exhausted.
+            fresh_start = True
+            continue
 
         log.debug1('Generate %d trial vectors. Drop %d vectors',
                    len(V), r_norms.size - len(V))

--- a/pyscf/tdscf/_lr_eig.py
+++ b/pyscf/tdscf/_lr_eig.py
@@ -640,7 +640,8 @@ def real_eig(aop, x0, precond, tol_residual=1e-5, nroots=1, x0sym=None, pick=Non
                 y = y[:,idx]
         except np.linalg.LinAlgError:
             if fresh_start:
-                raise RuntimeError('This error is often caused by a problematic SCF solution, such as a saddle-point solution.')
+                raise RuntimeError('This error is often caused by a problematic '
+                                   'SCF solution, such as a saddle-point solution.')
             # Reuse the last valid Ritz vectors instead of the singular expanded metric.
             log.debug('Singular trial subspace; restart from the previous Ritz vectors')
             fresh_start = True

--- a/pyscf/tdscf/_lr_eig.py
+++ b/pyscf/tdscf/_lr_eig.py
@@ -640,7 +640,7 @@ def real_eig(aop, x0, precond, tol_residual=1e-5, nroots=1, x0sym=None, pick=Non
                 y = y[:,idx]
         except np.linalg.LinAlgError:
             if fresh_start:
-                raise
+                raise RuntimeError('This error is often caused by a problematic SCF solution, such as a saddle-point solution.')
             # Reuse the last valid Ritz vectors instead of the singular expanded metric.
             log.debug('Singular trial subspace; restart from the previous Ritz vectors')
             fresh_start = True

--- a/pyscf/tdscf/test/test_lr_eig.py
+++ b/pyscf/tdscf/test/test_lr_eig.py
@@ -1,0 +1,91 @@
+# Copyright 2026 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import unittest
+from unittest import mock
+
+import numpy
+
+from pyscf.lib import logger
+from pyscf.tdscf import _lr_eig
+
+
+class KnownValues(unittest.TestCase):
+    def setUp(self):
+        a = numpy.diag([1.0, 2.0, 3.0])
+        b = numpy.array([[0.0, 0.05, 0.0], [0.05, 0.0, 0.02], [0.0, 0.02, 0.0]])
+        self.matrix = numpy.block([[a, b], [-b, -a]])
+        self.hdiag = numpy.r_[numpy.diag(a), -numpy.diag(a)]
+        self.guess = numpy.array([[1.0, 1.0, 0.0, 0.0, 0.0, 0.0]])
+
+    def aop(self, x):
+        return numpy.asarray(x).dot(self.matrix.T)
+
+    def precond(self, dx, energy):
+        denominator = self.hdiag[None, :] - numpy.asarray(energy)[:, None]
+        denominator[abs(denominator) < 1e-8] = 1e-8
+        return dx / denominator
+
+    def solve(self):
+        return _lr_eig.real_eig(
+            self.aop,
+            self.guess,
+            self.precond,
+            nroots=1,
+            tol_residual=1e-9,
+            max_cycle=30,
+            verbose=logger.Logger(sys.stdout, logger.QUIET),
+        )
+
+    def test_real_eig_restarts_after_singular_subspace(self):
+        subspace_solver = _lr_eig.TDDFT_subspace_eigen_solver
+        failed = False
+
+        def fail_full_subspace_once(*args, **kwargs):
+            nonlocal failed
+            if args[0].shape[0] == 3 and not failed:
+                failed = True
+                raise numpy.linalg.LinAlgError('singular subspace metric')
+            return subspace_solver(*args, **kwargs)
+
+        with mock.patch.object(_lr_eig, 'TDDFT_subspace_eigen_solver', fail_full_subspace_once):
+            converged, energy, _ = self.solve()
+
+        self.assertTrue(failed)
+        self.assertTrue(converged[0])
+        self.assertAlmostEqual(energy[0], 0.9991663794740591, 12)
+
+    def test_real_eig_restarts_when_residual_basis_is_dependent(self):
+        orthogonalize = _lr_eig.VW_Gram_Schmidt_fill_holder
+        empty_calls = 0
+
+        def empty_expanded_basis_once(*args, **kwargs):
+            nonlocal empty_calls
+            if args[0].shape[1] == 2 and empty_calls < 2:
+                empty_calls += 1
+                size = args[2].shape[0]
+                return numpy.zeros((0, size)), numpy.zeros((0, size))
+            return orthogonalize(*args, **kwargs)
+
+        with mock.patch.object(_lr_eig, 'VW_Gram_Schmidt_fill_holder', empty_expanded_basis_once):
+            converged, energy, _ = self.solve()
+
+        self.assertEqual(empty_calls, 2)
+        self.assertTrue(converged[0])
+        self.assertAlmostEqual(energy[0], 0.9991663794740591, 12)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Restart `real_eig` from the last valid Ritz vectors when an expanded trial-subspace metric is singular.
- Retry once from the current Ritz vectors when no independent residual direction remains.
- Keep invalid initial subspaces raising unchanged.

## Why

The selected `test_analyze` reproducer exposed two terminal paths after a valid Ritz approximation already existed: a Cholesky failure in a singular overlap metric, and an early exit after residual directions became linearly dependent. In both cases, restarting from the latest Ritz vectors preserves the existing convergence criteria without changing tolerances or `max_cycle`.

## Verification

- `python -m pytest pyscf/tdscf/test/test_lr_eig.py pyscf/tdscf/test/test_tduks.py pyscf/tdscf/test/test_tdrhf.py -c pytest.ini -q` — 28 passed.
- [Formal diagnostics run 29295966321](https://github.com/psiQAQ/pyscf/actions/runs/29295966321): seven OS/Python combinations × four OpenMP/BLAS profiles × 200 attempts; 5600/5600 original logger and numerical assertions passed, with complete artifacts.

This addresses the `test_analyze` item tracked in #3312.
