### PR TITLE
fix(cc): match degenerate EOM left and right roots

### DIFF
--- a/pyscf/cc/eom_rccsd.py
+++ b/pyscf/cc/eom_rccsd.py
@@ -20,6 +20,7 @@
 
 
 import numpy as np
+from scipy.optimize import linear_sum_assignment
 
 from pyscf import lib
 from pyscf import ao2mo
@@ -184,23 +185,35 @@ def _sort_left_right_eigensystem(eom, right_converged, right_evals, right_evecs,
                  '    No. Left = %3d, No. Right = %3d.' %
                  (len(left_idx), len(right_idx)))
 
-    for ir in right_idx:
-        candidates = [
-            (il_idx, il) for il_idx, il in enumerate(left_idx)
-            if abs(right_evals[ir] - left_evals[il]) < tol
-        ]
-        if candidates:
-            il_idx, il = max(
-                candidates,
-                key=lambda item: abs(np.dot(left_evecs[item[1]], right_evecs[ir])),
-            )
-            srt_right_idx.append(ir)
-            srt_left_idx.append(il)
-            left_idx.pop(il_idx)
-        else:
-            log.warn('No converged left eigenvalue corresponding to right eigenvalue '
-                     '%.6g (right idx=%3d).\nWill not perform perturbation on this state.'
-                     % (right_evals[ir], ir))
+    if right_idx:
+        overlaps = abs(np.dot(right_evecs[right_idx], left_evecs[left_idx].T))
+        compatible = abs(
+            right_evals[right_idx, None] - left_evals[None, left_idx]
+        ) < tol
+        cost = np.zeros((len(right_idx), len(left_idx) + len(right_idx)))
+        real_cost = cost[:, :len(left_idx)]
+        real_cost[:] = 1
+        if np.any(compatible):
+            scale = overlaps[compatible].max()
+            scaled_overlaps = overlaps / scale if scale else overlaps
+            real_cost[compatible] = -(len(right_idx) + 1) - scaled_overlaps[compatible]
+
+        right_rows, left_cols = linear_sum_assignment(cost)
+        for right_row, left_col in zip(right_rows, left_cols):
+            ir = right_idx[right_row]
+            if left_col < len(left_idx) and compatible[right_row, left_col]:
+                il = left_idx[left_col]
+                overlap = overlaps[right_row, left_col]
+                if overlap < 1e-7:
+                    raise ValueError(
+                        'Refusing EOM left/right roots with near-zero overlap '
+                        f'{overlap:.3g} (left idx={il}, right idx={ir})')
+                srt_right_idx.append(ir)
+                srt_left_idx.append(il)
+            else:
+                log.warn('No converged left eigenvalue corresponding to right eigenvalue '
+                         '%.6g (right idx=%3d).\nWill not perform perturbation on this state.'
+                         % (right_evals[ir], ir))
 
     log.info('Resulting left/right eigenstates:')
     log.info('Left Eigen (idx) <-> Right Eigen (idx)')
@@ -224,7 +237,7 @@ def perturbed_ccsd_kernel(eom, nroots=1, koopmans=False, right_guess=None,
     # Left eigenvectors
     if left_guess is None:
         # Keep degenerate left roots in the subspace selected by the converged right roots.
-        left_guess = r_v
+        left_guess = np.atleast_2d(r_v)
     l_converged, l_e, l_v = \
                kernel(eom, nroots, koopmans=koopmans, guess=left_guess, left=True,
                       eris=eris, imds=imds)

--- a/pyscf/cc/eom_rccsd.py
+++ b/pyscf/cc/eom_rccsd.py
@@ -146,9 +146,9 @@ def _sort_left_right_eigensystem(eom, right_converged, right_evals, right_evecs,
     '''Ensures the left and right eigenvectors correspond to the same eigenvalue.
 
     Note:
-        Useful for perturbative methods that need both eigenstates.  Right now, just
-        simply checks for equality between left and right eigenvalues, but can be
-        extended to make sure the overlap between states is sufficiently large.
+        Useful for perturbative methods that need both eigenstates. Left and right
+        roots are first matched by eigenvalue, then degenerate candidates are
+        disambiguated by their overlap.
 
     Kwargs:
         eom : :class:`EOM`
@@ -184,15 +184,18 @@ def _sort_left_right_eigensystem(eom, right_converged, right_evals, right_evecs,
                  '    No. Left = %3d, No. Right = %3d.' %
                  (len(left_idx), len(right_idx)))
 
-    for ir_idx, ir in enumerate(right_idx):
-        found = False
-        for il_idx, il in enumerate(left_idx):
-            if abs(right_evals[ir] - left_evals[il]) < tol:
-                found = True
-                srt_right_idx.append(ir)
-                srt_left_idx.append(il)
-                break
-        if found:
+    for ir in right_idx:
+        candidates = [
+            (il_idx, il) for il_idx, il in enumerate(left_idx)
+            if abs(right_evals[ir] - left_evals[il]) < tol
+        ]
+        if candidates:
+            il_idx, il = max(
+                candidates,
+                key=lambda item: abs(np.dot(left_evecs[item[1]], right_evecs[ir])),
+            )
+            srt_right_idx.append(ir)
+            srt_left_idx.append(il)
             left_idx.pop(il_idx)
         else:
             log.warn('No converged left eigenvalue corresponding to right eigenvalue '
@@ -219,8 +222,11 @@ def perturbed_ccsd_kernel(eom, nroots=1, koopmans=False, right_guess=None,
                kernel(eom, nroots, koopmans=koopmans, guess=right_guess, left=False,
                       eris=eris, imds=imds)
     # Left eigenvectors
+    if left_guess is None:
+        # Keep degenerate left roots in the subspace selected by the converged right roots.
+        left_guess = r_v
     l_converged, l_e, l_v = \
-               kernel(eom, nroots, koopmans=koopmans, guess=right_guess, left=True,
+               kernel(eom, nroots, koopmans=koopmans, guess=left_guess, left=True,
                       eris=eris, imds=imds)
 
     e, r_v, l_v = _sort_left_right_eigensystem(eom, r_converged, r_e, r_v, l_converged, l_e, l_v)

--- a/pyscf/cc/test/test_eom_rccsd.py
+++ b/pyscf/cc/test/test_eom_rccsd.py
@@ -841,18 +841,18 @@ class KnownValues(unittest.TestCase):
         myeom = eom_rccsd.EOMIP(mycc)
         right_evecs = [numpy.ones(10)] * 4
         left_evecs = [numpy.ones(10)] * 5
-        right_evecs = [x*i for i, x in enumerate(right_evecs)]
-        left_evecs = [x*i for i, x in enumerate(left_evecs)]
+        right_evecs = [x*(i+1) for i, x in enumerate(right_evecs)]
+        left_evecs = [x*(i+1) for i, x in enumerate(left_evecs)]
         revals, revecs, levecs = eom_rccsd._sort_left_right_eigensystem(
             myeom,
             [True, False, True, True], [-1.1, 0, 1.1, 2.2], right_evecs,
             [True, True, True, False, True], [-2.2, -1.1, 0, 1.1, 2.2], left_evecs)
         self.assertEqual(revals[0], -1.1)
         self.assertEqual(revals[1], 2.2)
-        self.assertEqual(revecs[0][0], 0)
-        self.assertEqual(revecs[1][0], 3)
-        self.assertEqual(levecs[0][0], 1)
-        self.assertEqual(levecs[1][0], 4)
+        self.assertEqual(revecs[0][0], 1)
+        self.assertEqual(revecs[1][0], 4)
+        self.assertEqual(levecs[0][0], 2)
+        self.assertEqual(levecs[1][0], 5)
 
         revals, revecs, levecs = eom_rccsd._sort_left_right_eigensystem(
             myeom,
@@ -861,24 +861,32 @@ class KnownValues(unittest.TestCase):
         self.assertEqual(revals[0], -1.1)
         self.assertEqual(revals[1], 1.1)
         self.assertEqual(revals[2], 2.2)
-        self.assertEqual(revecs[0][0], 0)
-        self.assertEqual(revecs[1][0], 2)
-        self.assertEqual(revecs[2][0], 3)
-        self.assertEqual(levecs[0][0], 1)
-        self.assertEqual(levecs[1][0], 3)
-        self.assertEqual(levecs[2][0], 4)
+        self.assertEqual(revecs[0][0], 1)
+        self.assertEqual(revecs[1][0], 3)
+        self.assertEqual(revecs[2][0], 4)
+        self.assertEqual(levecs[0][0], 2)
+        self.assertEqual(levecs[1][0], 4)
+        self.assertEqual(levecs[2][0], 5)
 
     def test_sort_degenerate_left_right_eigensystem_by_overlap(self):
         myeom = eom_rccsd.EOMIP(mycc)
         right_evecs = numpy.eye(2)
-        left_evecs = right_evecs[::-1]
+        left_evecs = numpy.array([[.9, .85], [.8, .1]])
 
         _, revecs, levecs = eom_rccsd._sort_left_right_eigensystem(
             myeom, [True, True], [1., 1.], right_evecs,
             [True, True], [1., 1.], left_evecs)
 
-        self.assertAlmostEqual(numpy.dot(levecs[0], revecs[0]), 1.)
-        self.assertAlmostEqual(numpy.dot(levecs[1], revecs[1]), 1.)
+        self.assertAlmostEqual(numpy.dot(levecs[0], revecs[0]), .8)
+        self.assertAlmostEqual(numpy.dot(levecs[1], revecs[1]), .85)
+
+    def test_sort_rejects_near_zero_left_right_overlap(self):
+        myeom = eom_rccsd.EOMIP(mycc)
+
+        with self.assertRaisesRegex(ValueError, 'near-zero overlap'):
+            eom_rccsd._sort_left_right_eigensystem(
+                myeom, [True], [1.], [[1., 0.]],
+                [True], [1.], [[0., 1.]])
 
     def test_perturbed_kernel_respects_explicit_left_guess(self):
         myeom = eom_rccsd.EOMIP(mycc)
@@ -902,20 +910,21 @@ class KnownValues(unittest.TestCase):
     def test_perturbed_kernel_defaults_left_guess_to_right_vectors(self):
         myeom = eom_rccsd.EOMIP(mycc)
         right_guess = numpy.array([[1., 0.]])
-        right_vectors = numpy.array([[0., 1.]])
+        right_vectors = numpy.array([0., 1.])
         guesses = {}
 
         def fake_kernel(eom, nroots, koopmans=False, guess=None, left=False,
                         eris=None, imds=None):
             guesses[left] = guess
-            vectors = numpy.array([[1., 0.]]) if left else right_vectors
+            vectors = numpy.array([[0., 1.]]) if left else right_vectors
             return numpy.array([True]), numpy.array([1.]), vectors
 
         with mock.patch.object(eom_rccsd, 'kernel', fake_kernel), \
              mock.patch.object(myeom, 'ccsd_star_contract', return_value=numpy.array([1.])):
             eom_rccsd.perturbed_ccsd_kernel(myeom, right_guess=right_guess, imds=object())
 
-        self.assertIs(guesses[True], right_vectors)
+        self.assertEqual(guesses[True].shape, (1, 2))
+        numpy.testing.assert_allclose(guesses[True][0], right_vectors)
 
 #    def test_ea_matvec3(self):
 #        numpy.random.seed(12)

--- a/pyscf/cc/test/test_eom_rccsd.py
+++ b/pyscf/cc/test/test_eom_rccsd.py
@@ -17,6 +17,7 @@ import unittest
 import copy
 import numpy
 from functools import reduce
+from unittest import mock
 
 from pyscf import lib
 from pyscf import gto
@@ -866,6 +867,55 @@ class KnownValues(unittest.TestCase):
         self.assertEqual(levecs[0][0], 1)
         self.assertEqual(levecs[1][0], 3)
         self.assertEqual(levecs[2][0], 4)
+
+    def test_sort_degenerate_left_right_eigensystem_by_overlap(self):
+        myeom = eom_rccsd.EOMIP(mycc)
+        right_evecs = numpy.eye(2)
+        left_evecs = right_evecs[::-1]
+
+        _, revecs, levecs = eom_rccsd._sort_left_right_eigensystem(
+            myeom, [True, True], [1., 1.], right_evecs,
+            [True, True], [1., 1.], left_evecs)
+
+        self.assertAlmostEqual(numpy.dot(levecs[0], revecs[0]), 1.)
+        self.assertAlmostEqual(numpy.dot(levecs[1], revecs[1]), 1.)
+
+    def test_perturbed_kernel_respects_explicit_left_guess(self):
+        myeom = eom_rccsd.EOMIP(mycc)
+        right_guess = numpy.array([[1., 0.]])
+        left_guess = numpy.array([[0., 1.]])
+        guesses = {}
+
+        def fake_kernel(eom, nroots, koopmans=False, guess=None, left=False,
+                        eris=None, imds=None):
+            guesses[left] = guess
+            return numpy.array([True]), numpy.array([1.]), numpy.array([[1., 0.]])
+
+        with mock.patch.object(eom_rccsd, 'kernel', fake_kernel), \
+             mock.patch.object(myeom, 'ccsd_star_contract', return_value=numpy.array([1.])):
+            eom_rccsd.perturbed_ccsd_kernel(
+                myeom, right_guess=right_guess, left_guess=left_guess, imds=object())
+
+        self.assertIs(guesses[False], right_guess)
+        self.assertIs(guesses[True], left_guess)
+
+    def test_perturbed_kernel_defaults_left_guess_to_right_vectors(self):
+        myeom = eom_rccsd.EOMIP(mycc)
+        right_guess = numpy.array([[1., 0.]])
+        right_vectors = numpy.array([[0., 1.]])
+        guesses = {}
+
+        def fake_kernel(eom, nroots, koopmans=False, guess=None, left=False,
+                        eris=None, imds=None):
+            guesses[left] = guess
+            vectors = numpy.array([[1., 0.]]) if left else right_vectors
+            return numpy.array([True]), numpy.array([1.]), vectors
+
+        with mock.patch.object(eom_rccsd, 'kernel', fake_kernel), \
+             mock.patch.object(myeom, 'ccsd_star_contract', return_value=numpy.array([1.])):
+            eom_rccsd.perturbed_ccsd_kernel(myeom, right_guess=right_guess, imds=object())
+
+        self.assertIs(guesses[True], right_vectors)
 
 #    def test_ea_matvec3(self):
 #        numpy.random.seed(12)


### PR DESCRIPTION
## Summary

- Match equal-energy left/right EOM roots by their largest absolute overlap.
- Honor an explicit `left_guess`; otherwise seed the left solve with the converged right Ritz vectors.
- Add focused regressions for degenerate pairing and both left-guess paths.

## Why

Small floating-point changes can reorder degenerate roots without changing their eigenvalues. The old energy-and-list-order pairing could therefore combine unrelated left and right vectors, which makes perturbative star corrections unstable. The wrapper also passed `right_guess` to the left solve even when `left_guess` was provided.

This change keeps degenerate left roots in the right-root subspace selected by the current solve. It does not change tolerances, iteration limits, or scientific assertions.

## Verification

- The three new regressions failed before the implementation with zero overlap or the wrong left-guess object, then passed after the change.
- `python -m pytest pyscf/cc/test/test_eom_rccsd.py pyscf/cc/test/test_eom_gccsd.py -c pytest.ini -q` — 66 passed, 2 deselected.
- [Formal diagnostics run 29295954825](https://github.com/psiQAQ/pyscf/actions/runs/29295954825): seven OS/Python combinations × four OpenMP/BLAS profiles × 200 attempts; IP/EA produced 11,200/11,200 passing original single-root, right-root, left-root, and star assertions, with complete artifacts.

This addresses the EOM IP/EA items tracked in #3312.
