### PR TITLE
fix(tdscf): retain raw residual fallback

### DIFF
--- a/pyscf/tdscf/_lr_eig.py
+++ b/pyscf/tdscf/_lr_eig.py
@@ -707,6 +707,11 @@ def real_eig(aop, x0, precond, tol_residual=1e-5, nroots=1, x0sym=None, pick=Non
         if x0sym is None:
             V, W = VW_Gram_Schmidt_fill_holder(
                 V_holder[:,:m1], W_holder[:,:m1], X_new, Y_new, lindep)
+            # A dependent preconditioned basis can still leave independent raw Ritz residuals.
+            if len(V) == 0:
+                V, W = VW_Gram_Schmidt_fill_holder(
+                    V_holder[:,:m1], W_holder[:,:m1],
+                    R_x[:,r_index].copy(), R_y[:,r_index].copy(), lindep)
         else:
             xt_ir = xt_ir[r_index]
             xt_orth_ir = []

--- a/pyscf/tdscf/test/test_lr_eig.py
+++ b/pyscf/tdscf/test/test_lr_eig.py
@@ -86,6 +86,23 @@ class KnownValues(unittest.TestCase):
         self.assertTrue(converged[0])
         self.assertAlmostEqual(energy[0], 0.9991663794740591, 12)
 
+    def test_real_eig_uses_raw_residual_when_preconditioner_returns_zero(self):
+        def zero_precond(dx, energy):
+            return numpy.zeros_like(dx)
+
+        converged, energy, _ = _lr_eig.real_eig(
+            self.aop,
+            self.guess,
+            zero_precond,
+            nroots=1,
+            tol_residual=1e-9,
+            max_cycle=30,
+            verbose=logger.Logger(sys.stdout, logger.QUIET),
+        )
+
+        self.assertTrue(converged[0])
+        self.assertAlmostEqual(energy[0], 0.9991663794740591, 12)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Problem

The TD-SCF Davidson solver can stop after every preconditioned residual direction is projected out, even when a corresponding raw Ritz residual still contains an independent expansion direction. In the selected CAM-B3LYP TDDFT calculation, this produced intermittent non-convergence and an incorrect root fingerprint.

## Root cause

The condition occurs in the real `test_tddft_camb3lyp` system without mocking the solver state. With `OMP_NUM_THREADS=4` and `OPENBLAS_NUM_THREADS=1`, attempt 49 reached a trial-space size of 39. The existing orthogonalizer accepted 0 of 20 preconditioned residual candidates, while the same orthogonalizer accepted 1 independent direction from the corresponding 20 raw Ritz residuals. With that direction, all four TD roots converged to `[0.2611815441, 0.2905656337, 0.3254425081, 0.3680400043]`.

The unfixed intermittent failures are recorded in [run 29213311767](https://github.com/psiQAQ/pyscf/actions/runs/29213311767).

## Scope and change

When all preconditioned candidates are linearly dependent in the non-symmetry-partitioned path, retry trial-space expansion once with the raw Ritz residuals. If those residuals are also dependent, the existing restart/exit behavior remains unchanged. Symmetry-partitioned solves keep their existing filtered path.

A focused regression makes the observed empty preconditioned basis deterministic. This PR does not change tolerances, iteration limits, root selection, or scientific assertions.

## Verification

- The regression uses a zero preconditioner to distinguish the existing Ritz restart from the raw-residual fallback.
- Current rebased head `913c8778e` passed `test_lr_eig.py`, the real CAM-B3LYP nodeid, and the PBC TDHF nodeid that shares the eigensolver with `OMP_NUM_THREADS=1` and `OPENBLAS_NUM_THREADS=1`: `5 passed`.
- [Formal diagnostics run 29301363348](https://github.com/psiQAQ/pyscf/actions/runs/29301363348) covered seven OS/Python combinations, four OpenMP/BLAS profiles, and 200 attempts per profile. All 5,600 original direct-root and fingerprint assertions passed, with complete artifacts.

## Related

Related to the CAM-B3LYP TDDFT item tracked in #3312.
