### PR TITLE
fix(mcscf): restart zero Newton AH steps

### DIFF
--- a/pyscf/mcscf/newton_casscf.py
+++ b/pyscf/mcscf/newton_casscf.py
@@ -539,6 +539,9 @@ def update_orb_ci(casscf, mo, ci0, eris, x0_guess=None,
               stat.imic, norm_gall, norm_gorb, norm_gci,
               numpy.linalg.norm(u-numpy.eye(nmo)),
               numpy.linalg.norm(dci_kf))
+    if numpy.linalg.norm(dxi) < casscf.ah_lindep:
+        # Avoid reusing a degenerate zero AH step as the next macro initial guess.
+        dxi = g_all
     return u, ci_kf, norm_gkf, stat, dxi
 
 

--- a/pyscf/mcscf/test/test_newton_casscf.py
+++ b/pyscf/mcscf/test/test_newton_casscf.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import unittest
+from types import SimpleNamespace
+from unittest import mock
 from functools import reduce
 import numpy
 from pyscf import gto, scf, lib, fci
@@ -81,6 +83,31 @@ def tearDownModule():
 
 
 class KnownValues(unittest.TestCase):
+    def test_zero_ah_step_uses_gradient_as_next_guess(self):
+        fake = SimpleNamespace(
+            max_stepsize=1.0, ah_level_shift=0.0, ah_conv_tol=1e-12,
+            ah_max_cycle=30, ah_lindep=1e-14, ah_start_tol=1.0,
+            ah_start_cycle=0, max_cycle_micro=10, kf_interval=99,
+            kf_trust_region=1.5, ah_grad_trust_region=1.5,
+            fcisolver=SimpleNamespace(nroots=1), mo_coeff=numpy.eye(1),
+            ncore=0, ncas=1, frozen=None, verbose=0, stdout=None,
+            uniq_var_indices=lambda *args: numpy.array([True]),
+        )
+
+        def davidson(*args, **kwargs):
+            yield True, 1, 0.0, numpy.zeros(1), numpy.zeros(1), numpy.zeros(1), 0.0
+
+        with mock.patch.object(newton_casscf, 'gen_g_hop', return_value=(
+                numpy.array([1.0]), lambda u, ci: numpy.array([1.0]),
+                lambda x: x, numpy.ones(1))), \
+             mock.patch.object(newton_casscf.ciah, 'davidson_cc', davidson), \
+             mock.patch.object(newton_casscf, 'extract_rotation',
+                               lambda casscf, dr, u, ci: (u, ci)):
+            *_, next_guess = newton_casscf.update_orb_ci(
+                fake, numpy.eye(1), numpy.ones(1), None, conv_tol_grad=1e-6)
+
+        self.assertAlmostEqual(next_guess[0], 1.0, 15)
+
     def test_gen_g_hop(self):
         numpy.random.seed(1)
         mo = numpy.random.random(mf.mo_coeff.shape)


### PR DESCRIPTION
## Problem

In the SA4 Newton regression, a nonzero orbital gradient can be followed by a zero augmented-Hessian step. Reusing that zero vector as the next macro-cycle guess rebuilds the same degenerate subspace and can run to the macro-cycle limit without convergence.

## Root cause

This path is reachable without mocking. In [run 29273789045](https://github.com/psiQAQ/pyscf/actions/runs/29273789045), Ubuntu Python 3.13 with `omp4-blas1`, attempt 11 recorded the following values in the same microstep:

```text
|g|=1.57e-04
|dxi|=0.00e+00
max(x)=0.00e+00
|dr|=0.00e+00
seig=1.6e-28
```

The zero step was then reused as the next macro initial guess. The calculation repeated with `dE=0` and the same gradient through macro 50 and ended unconverged. The corresponding artifact is `precision-thread-paired-split-sa4-newton-ubuntu-py3.13`, file `omp4-blas1/logs/sa4-newton.attempt-11.log`.

## Scope and change

When the returned AH step is below the existing `ah_lindep` threshold, use the current full gradient as the next macro-cycle initial guess. `update_orb_ci` already uses this gradient as the default guess when no prior guess is supplied, so this fallback reuses the existing initialization path.

The deterministic Davidson stub covers the intermittent nonzero-gradient/zero-step branch. This PR does not change convergence tolerances, iteration limits, step sizes, or numerical assertions.

## Verification

- Current rebased head `5283f6e6b` passed `test_newton_casscf.py` and the real `test_nosymm_sa4_newton` regression: `7 passed`.
- [Formal cross-platform run 29295297005](https://github.com/psiQAQ/pyscf/actions/runs/29295297005) covered seven OS/Python combinations, four OpenMP/BLAS profiles, and 200 attempts per profile. All 5,600 original SA4 assertions passed.
- The artifacts contain 5,600 logs, 28 snapshots, 26 checkpoints, summaries, environment captures, and no missing references.

## Related

Related to #3312.
