### PR TITLE
test(sgx): bound translational force noise

### DIFF
--- a/pyscf/sgx/grad/test/test_rks.py
+++ b/pyscf/sgx/grad/test/test_rks.py
@@ -67,7 +67,8 @@ class KnownValues(unittest.TestCase):
         e2 = mf_scanner(mol1.set_geom_(
             f'O  0. 0. -{delta:f}; 1  0. -0.757 0.587; 1  0. 0.757 0.587'
         ))
-        self.assertAlmostEqual(numpy.abs(g.sum(axis=0)).sum(), 0, 13)
+        # Allow round-off from thread-dependent reductions while still bounding translational noise.
+        self.assertAlmostEqual(numpy.abs(g.sum(axis=0)).sum(), 0, 12)
         self.assertAlmostEqual(g[0,2], (e1-e2)/(2*delta)*lib.param.BOHR, order)
 
     def test_finite_diff_grad(self):


### PR DESCRIPTION
## Problem

The SGX gradient regression checked translational force cancellation to 13 decimal places. Cross-platform artifacts showed stable cancellation noise between about `5e-14` and `6.6e-14`, so the assertion could fail solely from floating-point reduction order even when the finite-difference gradient remained correct.

## Change

Check the force sum to 12 decimal places and document why. The finite-difference gradient assertions for PBE0, HSE06, and WB97X are unchanged; no production code or solver tolerance changes.

## Verification

Local Windows Python 3.13 with the `1/1` OpenMP/BLAS profile:

```text
python -m pytest pyscf/sgx/grad/test/test_rks.py -q
1 passed
```

Formal PBE0 [run 29222554524](https://github.com/psiQAQ/pyscf/actions/runs/29222554524) and WB97X [run 29222187662](https://github.com/psiQAQ/pyscf/actions/runs/29222187662) each covered seven OS/Python combinations, four thread profiles, three SGX settings, and 200 attempts. Both passed 16,800/16,800 original finite-difference assertions with complete artifacts and no missing references. The largest observed force sum remained below `6.6e-14`.

HSE06 is tracked separately because its remaining failure comes from LibXC WPBEH, not this test boundary. Related to #3312.