### PR TITLE
allow customizing functional by param name

### DIFF
--- a/examples/dft/24-custom_xc_functional.py
+++ b/examples/dft/24-custom_xc_functional.py
@@ -3,12 +3,18 @@
 '''
 User defined XC functional
 
+Two approaches are demonstrated:
+1. parse_xc: string-based functional composition (combines existing LibXC
+   functionals but cannot modify their internal parameters)
+2. register_custom_functional_: modify a LibXC functional's internal
+   parameters and register it under a custom name
+
 See also
-* The parser parse_xc function implemented in pyscf.dft.libxc
-* Example 24-define_xc_functional.py to input a functional which is not
-  provided in Libxc or XcFun library.
+* pyscf.dft.libxc for implementation details
+* Example 24-define_xc_functional.py to define a completely new functional
 '''
 
+import numpy
 from pyscf import gto
 from pyscf import dft
 
@@ -19,6 +25,8 @@ mol = gto.M(
     H  0.   0.757    0.587 ''',
     basis = 'ccpvdz')
 
+#
+# ---- parse_xc: string-based XC functional composition ----
 #
 # DFT can parse the custom XC functional, following the rules:
 # * The given functional description must be a one-line string.
@@ -143,4 +151,72 @@ mf.xc = 'PBE + SLATER*.5'
 
 # The above input is equivalent to
 mf.xc = 'PBE + SLATER*.5, PBE'
+
+#
+# ---- register_custom_functional_: modify LibXC functional parameters ----
+#
+# register_custom_functional_ registers a custom functional based on an
+# existing LibXC functional with modified parameters. Only the exchange
+# component MGGA_X_TPSS (ID 202) is modified below; MGGA_C_TPSS is
+# unmodified. MGGA_X_TPSS has 7 parameters: _b, _c, _e, _kappa, _mu,
+# _BLOC_a, _BLOC_b.
+#
+
+XC_ID_TPSS_X = 202
+mf = dft.RKS(mol)
+
+#
+# Example 1: Array-style ext_params.
+#
+param_arr = numpy.array([0.15, 0.88491, 0.047, 0.872, 0.16952, 2.0, 0.0])
+dft.libxc.register_custom_functional_(
+    'my-tpss-arr', 'tpss',
+    ext_params={XC_ID_TPSS_X: param_arr})
+
+mf.xc = 'my-tpss-arr'
+e_arr = mf.kernel()
+print('E(my-tpss-arr) = %.15g' % e_arr)
+
+#
+# Example 2: Named-dict ext_params.
+#
+named = {
+    '_b': 0.15, '_c': 0.88491, '_e': 0.047, '_kappa': 0.872,
+    '_mu': 0.16952, '_BLOC_a': 2.0, '_BLOC_b': 0.0,
+}
+dft.libxc.register_custom_functional_(
+    'my-tpss-dict', 'tpss',
+    ext_params={XC_ID_TPSS_X: named})
+
+mf.xc = 'my-tpss-dict'
+e_dict = mf.kernel()
+print('E(my-tpss-dict) = %.15g  (should equal %.15g)' % (e_dict, e_arr))
+
+#
+# Example 3: Partial named-dict ext_params. Omitted keys (_BLOC_a, _BLOC_b)
+# keep native defaults.
+#
+named_partial = {'_b': 0.15, '_c': 0.88491, '_e': 0.047,
+                 '_kappa': 0.872, '_mu': 0.16952}
+dft.libxc.register_custom_functional_(
+    'my-tpss-partial', 'tpss',
+    ext_params={XC_ID_TPSS_X: named_partial})
+
+mf.xc = 'my-tpss-partial'
+e_partial = mf.kernel()
+print('E(my-tpss-partial) = %.15g  (should equal %.15g)' % (e_partial, e_arr))
+
+#
+# Compare with native TPSS.
+#
+mf.xc = 'tpss'
+e_tpss = mf.kernel()
+print('E(tpss) = %.15g' % e_tpss)
+
+#
+# unregister_custom_functional_ removes a custom functional.
+#
+dft.libxc.unregister_custom_functional_('my-tpss-arr')
+dft.libxc.unregister_custom_functional_('my-tpss-dict')
+dft.libxc.unregister_custom_functional_('my-tpss-partial')
 

--- a/examples/dft/24-custom_xc_functional.py
+++ b/examples/dft/24-custom_xc_functional.py
@@ -156,10 +156,9 @@ mf.xc = 'PBE + SLATER*.5, PBE'
 # ---- register_custom_functional_: modify LibXC functional parameters ----
 #
 # register_custom_functional_ registers a custom functional based on an
-# existing LibXC functional with modified parameters. Only the exchange
-# component MGGA_X_TPSS (ID 202) is modified below; MGGA_C_TPSS is
-# unmodified. MGGA_X_TPSS has 7 parameters: _b, _c, _e, _kappa, _mu,
-# _BLOC_a, _BLOC_b.
+# existing LibXC functional with modified parameters. Take TPSS as an example.
+# Only the exchange component MGGA_X_TPSS (ID 202) is modified; MGGA_C_TPSS is
+# unmodified. 
 #
 
 XC_ID_TPSS_X = 202

--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -1353,14 +1353,23 @@ class XCFunctionalCache:
             self.facs = facs
         if ext_params is not None:
             for xid, param in ext_params.items():
-                param = numpy.asarray(param, dtype=numpy.double)
                 func = obj_by_id[xid]
-                info = _itrf.xc_func_get_info(func)
-                n = _itrf.xc_func_info_get_n_ext_params(info)
-                assert param.size == n, \
-                    f"""Unexpected size of external parameters for functional {xid}.
+                if isinstance(param, dict):
+                    _itrf.xc_func_set_ext_params_name.restype = None
+                    _itrf.xc_func_set_ext_params_name.argtypes = [
+                        ctypes.c_void_p, ctypes.c_char_p, ctypes.c_double]
+                    for k, v in param.items():
+                        _itrf.xc_func_set_ext_params_name(
+                            func, str(k).encode(), float(v))
+                else:
+                    param = numpy.asarray(param, dtype=numpy.double)
+                    info = _itrf.xc_func_get_info(func)
+                    n = _itrf.xc_func_info_get_n_ext_params(info)
+                    assert param.size == n, \
+                        f"""Unexpected size of external parameters for functional {xid}.
 Expected {n} but {param.size} provided."""
-                _itrf.xc_func_set_ext_params(func, param.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
+                    _itrf.xc_func_set_ext_params(
+                        func, param.ctypes.data_as(ctypes.POINTER(ctypes.c_double)))
         if callable(callback):
             callback(self, obj_by_id, self.spin)
 

--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -95,6 +95,8 @@ _itrf.xc_func_get_info.restype = ctypes.c_void_p
 _itrf.xc_func_info_get_n_ext_params.argtypes = (ctypes.c_void_p, )
 _itrf.xc_func_info_get_n_ext_params.restype = ctypes.c_int
 _itrf.xc_func_set_ext_params.argtypes = (ctypes.c_void_p, ctypes.POINTER(ctypes.c_double))
+_itrf.xc_func_set_ext_params_name.argtypes = (ctypes.c_void_p, ctypes.c_char_p, ctypes.c_double)
+_itrf.xc_func_set_ext_params_name.restype = None
 
 _XC_FUNC_TYPE_SIZE = _itrf.LIBXC_xc_func_type_size()
 
@@ -1355,9 +1357,6 @@ class XCFunctionalCache:
             for xid, param in ext_params.items():
                 func = obj_by_id[xid]
                 if isinstance(param, dict):
-                    _itrf.xc_func_set_ext_params_name.restype = None
-                    _itrf.xc_func_set_ext_params_name.argtypes = [
-                        ctypes.c_void_p, ctypes.c_char_p, ctypes.c_double]
                     for k, v in param.items():
                         _itrf.xc_func_set_ext_params_name(
                             func, str(k).encode(), float(v))

--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -97,6 +97,8 @@ _itrf.xc_func_info_get_n_ext_params.restype = ctypes.c_int
 _itrf.xc_func_set_ext_params.argtypes = (ctypes.c_void_p, ctypes.POINTER(ctypes.c_double))
 _itrf.xc_func_set_ext_params_name.argtypes = (ctypes.c_void_p, ctypes.c_char_p, ctypes.c_double)
 _itrf.xc_func_set_ext_params_name.restype = None
+_itrf.LIBXC_xc_func_find_ext_params_name.argtypes = (ctypes.c_void_p, ctypes.c_char_p)
+_itrf.LIBXC_xc_func_find_ext_params_name.restype = ctypes.c_int
 
 _XC_FUNC_TYPE_SIZE = _itrf.LIBXC_xc_func_type_size()
 
@@ -1358,6 +1360,10 @@ class XCFunctionalCache:
                 func = obj_by_id[xid]
                 if isinstance(param, dict):
                     for k, v in param.items():
+                        if _itrf.LIBXC_xc_func_find_ext_params_name(
+                                func, str(k).encode()) < 0:
+                            raise ValueError(
+                                f"Unknown ext_params name '{k}' for functional {xid}.")
                         _itrf.xc_func_set_ext_params_name(
                             func, str(k).encode(), float(v))
                 else:

--- a/pyscf/dft/test/test_libxc.py
+++ b/pyscf/dft/test/test_libxc.py
@@ -531,6 +531,47 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(f[1] / f_ref[1] - 1).max(), 0, 14)
         self.assertAlmostEqual(abs(f[2] / f_ref[2] - 1).max(), 0, 14)
 
+    def test_set_param_named(self):
+        XC_ID_TPSS_X = 202  # MGGA_X_TPSS
+
+        ao_mgga = dft.numint.eval_ao(mol, mf.grids.coords, deriv=2)
+        rho_mgga = dft.numint.eval_rho(mol, ao_mgga, dm, xctype='MGGA')
+
+        # Array param (matching PTPSS defaults, positional)
+        param_tpss = numpy.array([0.15, 0.88491, 0.047, 0.872, 0.16952, 2.0, 0.0])
+
+        dft.libxc.register_custom_functional_('test_arr', 'MGGA_X_TPSS',
+                                              ext_params={XC_ID_TPSS_X: param_tpss})
+        e_ref, v_ref, f_ref = dft.libxc.eval_xc('test_arr', rho_mgga, 0, deriv=2)[:3]
+
+        # Same params as named dict (lowercase keys)
+        named = {
+            '_b': 0.15, '_c': 0.88491, '_e': 0.047, '_kappa': 0.872,
+            '_mu': 0.16952, '_BLOC_a': 2.0, '_BLOC_b': 0.0,
+        }
+        dft.libxc.register_custom_functional_('test_dict', 'MGGA_X_TPSS',
+                                              ext_params={XC_ID_TPSS_X: named})
+        e_dict, v_dict, f_dict = dft.libxc.eval_xc('test_dict', rho_mgga, 0, deriv=2)[:3]
+
+        self.assertTrue(numpy.allclose(e_ref, e_dict, 1e-7))
+        self.assertTrue(numpy.allclose(v_ref[0], v_dict[0], 1e-7))
+        self.assertTrue(numpy.allclose(f_ref[0], f_dict[0], 1e-7))
+
+        # Partial dict: omit _BLOC_a and _BLOC_b (same as native defaults)
+        named_partial = {'_b': 0.15, '_c': 0.88491, '_e': 0.047,
+                         '_kappa': 0.872, '_mu': 0.16952}
+        dft.libxc.register_custom_functional_('test_partial', 'MGGA_X_TPSS',
+                                              ext_params={XC_ID_TPSS_X: named_partial})
+        e_partial, v_partial, f_partial = dft.libxc.eval_xc(
+            'test_partial', rho_mgga, 0, deriv=2)[:3]
+        self.assertTrue(numpy.allclose(e_ref, e_partial, 1e-7))
+        self.assertTrue(numpy.allclose(v_ref[0], v_partial[0], 1e-7))
+        self.assertTrue(numpy.allclose(f_ref[0], f_partial[0], 1e-7))
+
+        dft.libxc.unregister_custom_functional_('test_arr')
+        dft.libxc.unregister_custom_functional_('test_dict')
+        dft.libxc.unregister_custom_functional_('test_partial')
+
 if __name__ == "__main__":
     print("Test libxc")
     unittest.main()

--- a/pyscf/lib/dft/libxc_itrf.c
+++ b/pyscf/lib/dft/libxc_itrf.c
@@ -1132,6 +1132,11 @@ void LIBXC_xc_func_set_params(const int nfn, xc_func_type *fn_obj, const double 
         }
 }
 
+int LIBXC_xc_func_find_ext_params_name(const xc_func_type *p, const char *name)
+{
+        return xc_func_find_ext_params_name(p, name);
+}
+
 xc_func_type *LIBXC_xc_func_init(const int nfn, const int *xc_ids, const int spin)
 {
         int i;


### PR DESCRIPTION
Now the ext_params in XCFunctionalCache customizing can be `{id: dict}`. The dict can cover all parameters or just part of them (leave the rest as default).