### PR TITLE
test(sgx): stabilize finite-difference sampling

### DIFF
--- a/pyscf/sgx/grad/test/test_rks.py
+++ b/pyscf/sgx/grad/test/test_rks.py
@@ -60,7 +60,7 @@ class KnownValues(unittest.TestCase):
         g = mf.nuc_grad_method().set(sgx_grid_response=True, grid_response=True).kernel()
         mol1 = mol.copy()
         mf_scanner = mf.as_scanner()
-        delta = 1e-4
+        delta = 2e-4
         e1 = mf_scanner(mol1.set_geom_(
             f'O  0. 0. {delta:f}; 1  0. -0.757 0.587; 1  0. 0.757 0.587'
         ))


### PR DESCRIPTION
## Problem

The HSE06 `settings-2` finite-difference regression intermittently fails on Windows Python 3.13 with the `4/4` OpenMP/BLAS profile even though the analytical gradient and the main SCF solutions are stable.

## Root cause

The displaced SCF energies contain thread-dependent variation after convergence. In two independent reproductions, one displaced energy moved by about `2.63e-10 Ha` during the normal `conv_check` cycle.

The `1e-4` displacement amplifies that energy variation into a finite-difference gradient error of about `7.18e-7`, which exceeds the existing six-decimal assertion. The analytical gradients of the two reproductions differ by only about `7.1e-15`.

## Scope and change

Increase the finite-difference displacement from `1e-4` to `2e-4`. This reduces the amplification of the observed energy variation while preserving the existing central-difference accuracy.

`conv_check` remains enabled. Production behavior, convergence thresholds, iteration limits, and all numerical assertions remain unchanged. The PR changes one test line.

## Verification

- The original mismatch occurred in [run 29343395032](https://github.com/psiQAQ/pyscf/actions/runs/29343395032), Windows Python 3.13, `omp4-blas4`, setting 2, and was reproduced in a second workflow attempt.
- A `1e-3` trial was rejected because the HSE06 settings-0 truncation error increased to `5.02e-5` and failed the existing five-decimal assertion.
- With `2e-4`, all nine SGX gradient cases pass under both `omp1-blas1` and `omp4-blas4` against the existing Windows installed wheel with LibXC 7.0.0.
- The original failure profile (`omp4-blas4`, settings-2 HSE06) passed 200/200 repeated trials with `conv_check` enabled. The maximum absolute gradient error was `2.42684e-7`, below the existing six-decimal assertion boundary.
- Current head: `77e493fc8`.

## Related

Related to #3312.
