### PR TITLE
Preserve SCIvector subclass in __array_wrap__ for same-shape ufuncs

### DIFF
--- a/pyscf/fci/selected_ci.py
+++ b/pyscf/fci/selected_ci.py
@@ -917,7 +917,7 @@ class SCIvector(numpy.ndarray):
     # Special cases for ndarray when the array was modified (through ufunc)
     def __array_wrap__(self, out, context=None, return_scalar=False):
         if out.shape == self.shape:
-            return out
+            return out.view(SCIvector)
         elif out.shape == ():  # if ufunc returns a scalar
             return out[()]
         else:

--- a/pyscf/fci/test/test_selected_ci.py
+++ b/pyscf/fci/test/test_selected_ci.py
@@ -55,6 +55,18 @@ def tearDownModule():
     del ci_strs, ci_coeff, civec_strs, eri, h1, spin0_ci_strs, spin0_ci_coeff
 
 class KnownValues(unittest.TestCase):
+    def test_SCIvector_array_wrap(self):
+        # A ufunc that returns an array of the same shape (e.g. scalar
+        # multiplication) must preserve the SCIvector type so that the
+        # ._strs attribute tagged onto the array survives the operation.
+        civec = selected_ci._as_SCIvector(ci_coeff.copy(), ci_strs)
+        out = civec * 2.0
+        self.assertIsInstance(out, selected_ci.SCIvector)
+        self.assertTrue(numpy.allclose(out, ci_coeff * 2.0))
+
+        out2 = civec + civec
+        self.assertIsInstance(out2, selected_ci.SCIvector)
+
     def test_select_strs(self):
         myci = selected_ci.SCI()
         myci.select_cutoff = 1e-3


### PR DESCRIPTION
### Summary

`SCIvector.__array_wrap__` drops the subclass on any ufunc whose output has the same shape as the input. When `out.shape == self.shape` it returns the bare `out` instead of viewing it back as `SCIvector`, so the result is a plain `ndarray` and the `._strs` attribute (the determinant-string bookkeeping tagged onto every SCI vector) is lost.

That means routine arithmetic on a selected-CI vector silently demotes it:

```python
civec = _as_SCIvector(ci_coeff, ci_strs)
type(civec * 2.0)     # ndarray  (was SCIvector)
(civec * 2.0)._strs   # AttributeError
```

Any code that scales, adds, or otherwise ufunc-processes an `SCIvector` and then reads `._strs` breaks. The scalar-output and shape-changing branches were already handled; only the same-shape branch was wrong.

### Fix

Return `out.view(SCIvector)` in the same-shape branch so the subclass (and, via `__array_finalize__`, `._strs`) is preserved.

### Verification

Against released pyscf 2.13.1:

| | `type(civec * 2.0)` | `._strs` |
| --- | --- | --- |
| current | `ndarray` | lost (AttributeError) |
| this PR | `SCIvector` | preserved |

Added `test_SCIvector_array_wrap` covering scalar multiplication and vector addition, asserting the result stays an `SCIvector`. The other `__array_wrap__` branches are unchanged.

---

*Disclosure: found with LLM-assisted analysis and prepared with LLM assistance. I (Mike German) am the human contributor, reproduced the type-demotion against released pyscf and confirmed the fix before submitting, and am accountable for the PR.*