### PR TITLE
Stabilize UHF smearing test against extra-cycle variation

### DIFF
--- a/pyscf/scf/test/test_addons.py
+++ b/pyscf/scf/test/test_addons.py
@@ -469,6 +469,7 @@ class KnownValues(unittest.TestCase):
         myhf_s.sigma = 0.1
         myhf_s.fix_spin = False
         myhf_s.conv_tol = 1e-7
+        myhf_s.conv_check = False
         myhf_s.kernel()
         self.assertAlmostEqual(myhf_s.e_tot, -243.086989253, 5)
         self.assertAlmostEqual(myhf_s.entropy, 17.11431, 4)


### PR DESCRIPTION
## Summary

- skip the optional post-convergence SCF check in `test_uhf_smearing`
- keep the existing convergence tolerance and scientific assertions unchanged

## Why

The test intermittently reaches `-243.086994x` on Linux and Windows, just outside its five-decimal energy assertion. Focused telemetry showed that the main SCF loop was already converged and its energy stayed within the reference tolerance, but the optional extra diagonalization could shift the final energy by up to about `5.2e-6` Ha.

Tightening `conv_tol` did not reduce that shift. Tightening `conv_tol_grad` instead introduced genuine 50-cycle non-convergence samples. Disabling only the optional post-convergence check preserves the converged main-loop result and leaves the test's energy, entropy, and convergence assertions intact.

## Validation

- Windows Python 3.13, `OMP/BLAS=1/1`: exact nodeid passed
- Windows Python 3.13, `OMP/BLAS=4/4`: exact nodeid passed; 20/20 focused repetitions passed
- Windows Python 3.13, `OMP/BLAS=4/4`: `pyscf/scf/test/test_addons.py` passed (`19 passed, 1 deselected`)
- Ubuntu Python 3.12, `OMP/BLAS=4/4`: [20/20 focused repetitions passed](https://github.com/psiQAQ/pyscf/actions/runs/29566272814), all main loops converged, with 20 logs and complete runtime provenance
