### PR TITLE
Continue SCF after rejected smearing extra cycles

### DIFF
--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -190,6 +190,7 @@ Keyword argument "init_dm" is replaced by "dm0"''')
         log.info('cycle= %d E= %.15g  delta_E= %4.3g  |g|= %4.3g  |ddm|= %4.3g',
                  cycle+1, e_tot, e_tot-last_hf_e, norm_gorb, norm_ddm)
 
+        extra_cycle = False
         if callable(mf.check_convergence):
             scf_conv = mf.check_convergence(locals())
         elif abs(e_tot-last_hf_e) < conv_tol and norm_gorb < conv_tol_grad:
@@ -203,11 +204,12 @@ Keyword argument "init_dm" is replaced by "dm0"''')
 
         cput1 = log.timer('cycle= %d'%(cycle+1), *cput1)
 
-        if scf_conv:
+        if not scf_conv:
+            continue
+        if not conv_check:
             break
 
-    mf.cycles = cycle + 1
-    if scf_conv and conv_check:
+        extra_cycle = True
         # An extra diagonalization, to remove level shift
         #fock = mf.get_fock(h1e, s1e, vhf, dm)  # = h1e + vhf
         mo_energy, mo_coeff = mf.eig(fock, s1e, x=x_orth)
@@ -222,18 +224,27 @@ Keyword argument "init_dm" is replaced by "dm0"''')
             norm_gorb = norm_gorb / numpy.sqrt(norm_gorb.size)
         norm_ddm = numpy.linalg.norm(dm-dm_last)
 
-        conv_tol = conv_tol * 10
-        conv_tol_grad = conv_tol_grad * 3
+        extra_envs = dict(locals(),
+                          conv_tol=conv_tol * 10,
+                          conv_tol_grad=conv_tol_grad * 3)
         if callable(mf.check_convergence):
-            scf_conv = mf.check_convergence(locals())
-        elif abs(e_tot-last_hf_e) < conv_tol or norm_gorb < conv_tol_grad:
+            scf_conv = mf.check_convergence(extra_envs)
+        elif (abs(e_tot-last_hf_e) < extra_envs['conv_tol'] or
+              norm_gorb < extra_envs['conv_tol_grad']):
             scf_conv = True
         else:
             scf_conv = False
         log.info('Extra cycle  E= %.15g  delta_E= %4.3g  |g|= %4.3g  |ddm|= %4.3g',
                  e_tot, e_tot-last_hf_e, norm_gorb, norm_ddm)
         if dump_chk and mf.chkfile:
-            mf.dump_chk(locals())
+            extra_envs['scf_conv'] = scf_conv
+            mf.dump_chk(extra_envs)
+        if scf_conv:
+            break
+        # Continue from the physical-Fock density rejected by the extra check.
+        fock_last = fock
+
+    mf.cycles = cycle + 1
 
     log.timer('scf_cycle', *cput0)
     # A post-processing hook before return

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -190,6 +190,7 @@ Keyword argument "init_dm" is replaced by "dm0"''')
         log.info('cycle= %d E= %.15g  delta_E= %4.3g  |g|= %4.3g  |ddm|= %4.3g',
                  cycle+1, e_tot, e_tot-last_hf_e, norm_gorb, norm_ddm)
 
+        extra_cycle = False
         if callable(mf.check_convergence):
             scf_conv = mf.check_convergence(locals())
         elif abs(e_tot-last_hf_e) < conv_tol and norm_gorb < conv_tol_grad:
@@ -203,11 +204,12 @@ Keyword argument "init_dm" is replaced by "dm0"''')
 
         cput1 = log.timer('cycle= %d'%(cycle+1), *cput1)
 
-        if scf_conv:
+        if not scf_conv:
+            continue
+        if not conv_check:
             break
 
-    mf.cycles = cycle + 1
-    if scf_conv and conv_check:
+        extra_cycle = True
         # An extra diagonalization, to remove level shift
         #fock = mf.get_fock(h1e, s1e, vhf, dm)  # = h1e + vhf
         mo_energy, mo_coeff = mf.eig(fock, s1e, x=x_orth)
@@ -222,18 +224,27 @@ Keyword argument "init_dm" is replaced by "dm0"''')
             norm_gorb = norm_gorb / numpy.sqrt(norm_gorb.size)
         norm_ddm = numpy.linalg.norm(dm-dm_last)
 
-        conv_tol = conv_tol * 10
-        conv_tol_grad = conv_tol_grad * 3
+        extra_envs = dict(locals(),
+                          conv_tol=conv_tol * 10,
+                          conv_tol_grad=conv_tol_grad * 3)
         if callable(mf.check_convergence):
-            scf_conv = mf.check_convergence(locals())
-        elif abs(e_tot-last_hf_e) < conv_tol or norm_gorb < conv_tol_grad:
+            scf_conv = mf.check_convergence(extra_envs)
+        elif (abs(e_tot-last_hf_e) < extra_envs['conv_tol'] or
+              norm_gorb < extra_envs['conv_tol_grad']):
             scf_conv = True
         else:
             scf_conv = False
+        extra_envs['scf_conv'] = scf_conv
         log.info('Extra cycle  E= %.15g  delta_E= %4.3g  |g|= %4.3g  |ddm|= %4.3g',
                  e_tot, e_tot-last_hf_e, norm_gorb, norm_ddm)
         if dump_chk and mf.chkfile:
-            mf.dump_chk(locals())
+            mf.dump_chk(extra_envs)
+        if scf_conv:
+            break
+        # Continue from the physical-Fock density rejected by the extra check.
+        fock_last = fock
+
+    mf.cycles = cycle + 1
 
     log.timer('scf_cycle', *cput0)
     # A post-processing hook before return

--- a/pyscf/scf/smearing.py
+++ b/pyscf/scf/smearing.py
@@ -144,6 +144,17 @@ class _SmearingSCF:
         del obj.e_zero
         return obj
 
+    def check_convergence(self, envs):
+        energy_converged = abs(envs['e_tot'] - envs['last_hf_e']) < envs['conv_tol']
+        gradient_converged = envs['norm_gorb'] < envs['conv_tol_grad']
+        if self.sigma and self.smearing_method:
+            # Fractional occupations can change the density while the orbital
+            # gradient alone is small.
+            return energy_converged and gradient_converged
+        if envs.get('extra_cycle', False):
+            return energy_converged or gradient_converged
+        return energy_converged and gradient_converged
+
     def get_occ(self, mo_energy=None, mo_coeff=None):
         '''Label the occupancies for each orbital
         '''

--- a/pyscf/scf/smearing.py
+++ b/pyscf/scf/smearing.py
@@ -144,6 +144,18 @@ class _SmearingSCF:
         del obj.e_zero
         return obj
 
+    def check_convergence(self, envs):
+        energy_converged = (
+            abs(envs['e_tot'] - envs['last_hf_e']) < envs['conv_tol'])
+        gradient_converged = envs['norm_gorb'] < envs['conv_tol_grad']
+        if self.sigma and self.smearing_method:
+            # Fractional occupations can change the density while the orbital
+            # gradient alone is small.
+            return energy_converged and gradient_converged
+        if envs.get('extra_cycle', False):
+            return energy_converged or gradient_converged
+        return energy_converged and gradient_converged
+
     def get_occ(self, mo_energy=None, mo_coeff=None):
         '''Label the occupancies for each orbital
         '''

--- a/pyscf/scf/test/test_addons.py
+++ b/pyscf/scf/test/test_addons.py
@@ -479,6 +479,37 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(myhf_s.e_tot, -243.086989253, 5)
         self.assertAlmostEqual(myhf_s.entropy, 17.11431, 4)
 
+        observed_extra = {
+            'e_tot': -243.086993624352,
+            'last_hf_e': -243.086988432792,
+            'conv_tol': 1e-6,
+            'norm_gorb': 1.08e-5,
+            'conv_tol_grad': 3 * numpy.sqrt(1e-7),
+            'extra_cycle': True,
+        }
+        with self.subTest('smearing requires stable energy after extra cycle'):
+            self.assertTrue(callable(myhf_s.check_convergence))
+            if callable(myhf_s.check_convergence):
+                self.assertFalse(myhf_s.check_convergence(observed_extra))
+
+        extra_checks = 0
+        def reject_first_extra(envs):
+            nonlocal extra_checks
+            energy_converged = abs(envs['e_tot'] - envs['last_hf_e']) < envs['conv_tol']
+            gradient_converged = envs['norm_gorb'] < envs['conv_tol_grad']
+            is_extra = envs.get('extra_cycle', envs['conv_tol'] > myhf_s.conv_tol)
+            if is_extra:
+                extra_checks += 1
+                if extra_checks == 1:
+                    return False
+            return energy_converged and gradient_converged
+
+        myhf_s.check_convergence = reject_first_extra
+        myhf_s.kernel(dm0=myhf_s.make_rdm1())
+        with self.subTest('rejected extra cycle resumes SCF'):
+            self.assertGreaterEqual(extra_checks, 2)
+            self.assertTrue(myhf_s.converged)
+
     def test_rhf_smearing_nelec(self):
         mol = gto.Mole()
         mol.verbose = 5

--- a/pyscf/scf/test/test_addons.py
+++ b/pyscf/scf/test/test_addons.py
@@ -505,6 +505,29 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(myhf_s.e_tot, -243.086989253, 5)
         self.assertAlmostEqual(myhf_s.entropy, 17.11431, 4)
 
+        observed_extra = {
+            'e_tot': -243.086993624352,
+            'last_hf_e': -243.086988432792,
+            'conv_tol': 1e-6,
+            'norm_gorb': 1.08e-5,
+            'conv_tol_grad': 3 * numpy.sqrt(1e-7),
+            'extra_cycle': True,
+        }
+        with self.subTest('active smearing requires stable energy'):
+            self.assertTrue(callable(myhf_s.check_convergence))
+            self.assertFalse(myhf_s.check_convergence(observed_extra))
+
+        saved_sigma = myhf_s.sigma
+        try:
+            myhf_s.sigma = 0
+            with self.subTest('inactive smearing keeps extra-cycle OR'):
+                self.assertTrue(myhf_s.check_convergence(observed_extra))
+            main_envs = dict(observed_extra, extra_cycle=False)
+            with self.subTest('inactive smearing keeps main-cycle AND'):
+                self.assertFalse(myhf_s.check_convergence(main_envs))
+        finally:
+            myhf_s.sigma = saved_sigma
+
         extra_checks = 0
         rejected_extra_energy = None
         continued_from_rejected_extra = None

--- a/pyscf/scf/test/test_addons.py
+++ b/pyscf/scf/test/test_addons.py
@@ -505,6 +505,37 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(myhf_s.e_tot, -243.086989253, 5)
         self.assertAlmostEqual(myhf_s.entropy, 17.11431, 4)
 
+        extra_checks = 0
+        rejected_extra_energy = None
+        continued_from_rejected_extra = None
+
+        def reject_first_extra(envs):
+            nonlocal extra_checks
+            nonlocal rejected_extra_energy
+            nonlocal continued_from_rejected_extra
+            energy_converged = (
+                abs(envs['e_tot'] - envs['last_hf_e']) < envs['conv_tol'])
+            gradient_converged = envs['norm_gorb'] < envs['conv_tol_grad']
+            is_extra = envs.get(
+                'extra_cycle', envs['conv_tol'] > myhf_s.conv_tol)
+            if (rejected_extra_energy is not None and not is_extra
+                    and continued_from_rejected_extra is None):
+                continued_from_rejected_extra = (
+                    abs(envs['last_hf_e'] - rejected_extra_energy) < 1e-12)
+            if is_extra:
+                extra_checks += 1
+                if extra_checks == 1:
+                    rejected_extra_energy = envs['e_tot']
+                    return False
+            return energy_converged and gradient_converged
+
+        myhf_s.check_convergence = reject_first_extra
+        myhf_s.kernel(dm0=myhf_s.make_rdm1())
+        with self.subTest('rejected extra cycle resumes SCF'):
+            self.assertGreaterEqual(extra_checks, 2)
+            self.assertTrue(continued_from_rejected_extra)
+            self.assertTrue(myhf_s.converged)
+
     def test_rhf_smearing_nelec(self):
         mol = gto.Mole()
         mol.verbose = 5


### PR DESCRIPTION
## Problem

`test_uhf_smearing` has intermittently failed on Linux and Windows with
energies near `-243.0869946`, about `5.4e-6 Ha` below the reference. These are
real failures of the unchanged five-place assertion, not collection or wheel
errors:

- [upstream master run 27018642630](https://github.com/pyscf/pyscf/actions/runs/27018642630), Linux Python 3.12: `-243.0869942825039`;
- [PR run 27985567514](https://github.com/pyscf/pyscf/actions/runs/27985567514), Linux Python 3.12: `-243.08699464464115`;
- [installed-wheel run 29556061800](https://github.com/pyscf/pyscf/actions/runs/29556061800), Windows Python 3.13: `-243.08699462660468`.

All three samples land in the same `-243.086994x` energy cluster.

## Root cause

The main SCF loop can satisfy its energy and gradient checks, after which the
optional DIIS-free Extra cycle changes the smeared internal energy by several
microhartree while retaining a small orbital gradient. Two independent control
flow boundaries are involved:

1. active smearing needs stable energy **and** gradient before accepting the
   Extra-cycle state;
2. when an Extra cycle is rejected, `kernel()` must continue the remaining SCF
   cycles from its physical density/Fock state rather than return immediately.

The maintainer-suggested `conv_tol=1e-8` experiment improved the common case but
did not close the control-flow boundary. In focused
[run 29579542797](https://github.com/psiQAQ/pyscf/actions/runs/29579542797),
attempt 18 passed the main-loop tolerance, then the Extra cycle was rejected by
both existing relaxed checks and the unchanged driver returned unconverged.

## Why the failure is intermittent (mechanism)

The failing case is a deliberately hard system: an Fe2 dimer (UHF/LANL2DZ+ECP)
with `sigma = 0.1` Fermi smearing and `fix_spin = False`, converging to entropy
about 17 - a dense, near-degenerate 3d manifold with many fractionally occupied
levels near the Fermi surface, i.e. an extremely flat free-energy surface
`F = E - sigma*S` with neighboring stationary points only a few microhartree
apart. Three ingredients combine (see also the cross-profile catalog in #3312):

1. **Trigger - threaded floating-point non-determinism.** OpenMP/BLAS split
   long reductions across threads and the partial-sum ordering varies from run
   to run, so identical binaries and inputs produce Fock matrix elements that
   differ in the last bits (~1e-14 relative). This is the only run-to-run
   difference; with a single thread every run follows one identical trajectory.
2. **Amplifier - nonlinear SCF feedback on a flat surface.** Occupations pass
   through the Fermi function, so tiny changes in the ordering and spacing of
   near-degenerate levels reorder fractional occupations and are amplified
   cycle over cycle; the discrete `conv_tol` stopping decision further
   bifurcates trajectories. Most runs land inside the reference basin; a small
   fraction (measured ~0.5% at `omp4-blas4`) stop near a basin edge.
3. **Exit - the control-flow boundary.** The DIIS-free Extra cycle removes the
   stabilizer; for an edge state one bare step lets the occupations rearrange
   again, sliding the energy by ~5e-6 Ha toward the neighboring stationary
   point while the orbital gradient stays small, because the surface is flat.
   The driver then either accepted this drifted state or returned the
   intermediate state immediately - and that is exactly what the assertion
   observed.

This is why neither higher numerical precision nor disabling parallelism is the
durable fix: double-precision rounding (~1e-16 relative) can never directly
produce a 5e-6 energy shift, and single-threading merely makes every run take
the same trajectory instead of removing the wrong path. Closing the
control-flow boundary drives every trajectory back into the converged basin,
which matches the expectation recorded in #3312 that thread-profile
floating-point noise must not select another attraction basin or violate the
original assertion.

## Fix

This branch contains two focused commits:

- continue the existing SCF loop after a rejected Extra cycle while preserving
  the physical density, potential and Fock state;
- require energy and orbital-gradient convergence while smearing is active.

Non-smearing SCF and inactive smearing retain their existing convergence
semantics. The change does not disable `conv_check`, alter `conv_tol`, increase
`max_cycle`, change the reference energy, add retries, or relax the scientific
assertion.

## Verification

- the deterministic regression rejects the first Extra-cycle result, verifies
  that the next main cycle consumes that rejected physical state, and then
  converges without changing the scientific assertion;
- fresh local tests on the rebased candidate: exact UHF nodeid `1/1` and the
  related SCF test set `30/30`;
- focused diagnostic
  [run 29571809550](https://github.com/psiQAQ/pyscf/actions/runs/29571809550):
  Ubuntu Python 3.12, `omp4-blas4`, `20/20` original-nodeid passes; attempts 4,
  6, 18 and 20 reject an unstable Extra result, continue SCF, and subsequently
  satisfy the unchanged assertion;
- stacked validation head `2a2237bc323b8473d19979aaa56a0e8ff88cee04`:
  [Windows installed-wheel run 31595536823](https://github.com/psiQAQ/pyscf/actions/runs/31595536823)
  and [Linux source-tree run 31595587864](https://github.com/psiQAQ/pyscf/actions/runs/31595587864),
  each `20/20` passes at `omp4-blas4`; artifacts were independently checked for
  attempts 1-20, logs, runtime provenance and the original assertion. Windows
  loaded 26 wheel-local native libraries; Linux loaded 16 source-tree native
  libraries and recorded a zero runner exit. Both used LibXC 7.1.2.

- current-master 200-attempt comparison (`ubuntu-latest`, Python 3.12,
  `omp4-blas4`): base = master `14fb9315` + CI tooling only,
  [run 31689528256](https://github.com/psiQAQ/pyscf/actions/runs/31689528256)
  `199/200`, attempt 36 failing the unchanged assertion in the same
  `-243.086994x` cluster; head = base + these two commits,
  [run 31689531455](https://github.com/psiQAQ/pyscf/actions/runs/31689531455)
  `200/200`.

`py_compile`, focused diffs, EOL checks and `git diff --check` pass. Independent
spec-compliance and code-quality reviews found no actionable issue.

## SGX dependency boundary

The generic rejected-Extra continuation is also needed by the separately
reproduced SGX HSE06 finite-difference failure, but its SGX-specific
energy-and-gradient predicate is intentionally **not** included here. That
two-file change will be proposed as a separate PR after this generic SCF fix is
integrated. Its existing installed-wheel formal evidence is
[run 31535193241](https://github.com/psiQAQ/pyscf/actions/runs/31535193241),
`200/200` under the unchanged original finite-difference assertion.

