### PR TITLE
test(cc): exercise EOM star wrapper for degenerate roots

### DIFF
--- a/pyscf/cc/test/test_eom_gccsd.py
+++ b/pyscf/cc/test/test_eom_gccsd.py
@@ -101,9 +101,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e[1], 0.4278908208680482, 5)
         self.assertAlmostEqual(e[2], 0.5022686041399118, 5)
 
-        # Sometimes these tests can fail due to left and right evecs
-        # having small (~zero) overlap, causing numerical error. FIXME
-        e = myeom.ipccsd_star_contract(e, v, lv)
+        e = myeom.ipccsd_star(nroots=3, right_guess=v)
         self.assertAlmostEqual(e[0], 0.4358615224789573, 5)
         self.assertAlmostEqual(e[1], 0.4358615224789594, 5)
         #self.assertAlmostEqual(e[2], 0.5095767839056080, 5)
@@ -136,7 +134,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e[1], 0.1905059282334538, 5)
         self.assertAlmostEqual(e[2], 0.2834522921515028, 5)
 
-        e = myeom.eaccsd_star_contract(e, v, lv)
+        e = myeom.eaccsd_star(nroots=3, right_guess=v)
         self.assertAlmostEqual(e[0], 0.1894169322207168, 5)
         self.assertAlmostEqual(e[1], 0.1894169322207168, 5)
         self.assertAlmostEqual(e[2], 0.2820757599337823, 5)


### PR DESCRIPTION
## Problem

PR #3316 added overlap-based pairing for degenerate EOM left/right roots, but the existing GCCSD regressions still called `ipccsd_star_contract` and `eaccsd_star_contract` directly. Those low-level calls bypass the matched-root wrapper and remained numerically unstable on Windows, as seen in [run 29560836901](https://github.com/psiQAQ/pyscf/actions/runs/29560836901).

## Scope

- Do: route the existing IP/EA GCCSD star assertions through the public star wrappers.
- Do not: change production algorithms, tolerances, iteration limits, or scientific assertions.

## Root cause

The two test-call changes existed on the diagnostic branch used for the large validation matrix, but were omitted when the focused #3316 branch was reconstructed from upstream `master`. As a result, the validation commit and the merged PR head did not have identical test trees.

## Change

- Use `ipccsd_star(nroots=3, right_guess=v)`.
- Use `eaccsd_star(nroots=3, right_guess=v)`.

## Compatibility

Test-only change; package behavior and public APIs are unchanged.

## Verification

Tested commit: `5f6d0b31e5c0511ba02b8b9cc178d39d0c285fca`

- `OMP_NUM_THREADS=4 OPENBLAS_NUM_THREADS=4 MKL_NUM_THREADS=4 python -m pytest pyscf/cc/test/test_eom_gccsd.py::KnownValues::test_ipccsd pyscf/cc/test/test_eom_gccsd.py::KnownValues::test_eaccsd -c pytest.ini -q` — 2 passed.
- `OMP_NUM_THREADS=4 OPENBLAS_NUM_THREADS=4 MKL_NUM_THREADS=4 python -m pytest pyscf/cc/test/test_eom_rccsd.py pyscf/cc/test/test_eom_gccsd.py -c pytest.ini -q` — 67 passed, 2 deselected.

The commit includes `[skip ci]` intentionally because this is a two-line test-only follow-up with focused local verification; it avoids launching the unrelated full upstream matrix.

## Artifacts

- Historical failing installed-wheel run: [29560836901](https://github.com/psiQAQ/pyscf/actions/runs/29560836901)
- The earlier large diagnostic run remains algorithm evidence only; it is not presented as validation of this PR head.

## Related

Follow-up to #3316.

Related to #3312.
