### PR TITLE
Fix UHF gradients for selected atoms

### DIFF
--- a/pyscf/grad/test/test_uhf.py
+++ b/pyscf/grad/test/test_uhf.py
@@ -61,6 +61,8 @@ class KnownValues(unittest.TestCase):
         mf.conv_tol = 1e-14
         e0 = mf.kernel()
         g = grad.UHF(mf).kernel()
+        g1 = grad.UHF(mf).kernel(atmlst=[1])
+        self.assertAlmostEqual(abs(g1 - g[[1]]).max(), 0, 8)
         mf_scanner = mf.as_scanner()
 
         e1 = mf_scanner('''O    0.   0.       0.

--- a/pyscf/grad/uhf.py
+++ b/pyscf/grad/uhf.py
@@ -66,7 +66,6 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
         atmlst = range(mol.natm)
     else:
         de = de[atmlst]
-        atmlst = range(mol.natm)
 
     aoslices = mol.aoslice_by_atom()
     for k, ia in enumerate(atmlst):


### PR DESCRIPTION
In 2.14.0, `uhf.grad_elec` resets `atmlst` after slicing the output array, causing an
IndexError or incorrect atom ordering for selected-atom gradients.

This removes the reset and adds a regression test comparing a selected-atom
gradient against the corresponding row of the full gradient.