### PR TITLE
Fix UnboundLocalError in pbc KUHF get_occ when there are no beta electrons

### DIFF
--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -153,9 +153,9 @@ def get_occ(mf, mo_energy_kpts=None, mo_coeff_kpts=None):
                            f'nelec ({nocc_a}, {nocc_b}) > Nmo ({nmo})')
 
     fermi_a = mo_energy_a[nocc_a-1]
+    mo_energy_b = np.sort(mo_energy_kpts[1].ravel())
+    nmo = mo_energy_b.size
     if nocc_b > 0:
-        mo_energy_b = np.sort(mo_energy_kpts[1].ravel())
-        nmo = mo_energy_b.size
         fermi_b = mo_energy_b[nocc_b-1]
     else:
         fermi_b = -np.inf

--- a/pyscf/pbc/scf/test/test_uhf.py
+++ b/pyscf/pbc/scf/test/test_uhf.py
@@ -148,6 +148,22 @@ class KnownValues(unittest.TestCase):
         mf = cell.KUHF(kpts=cell.make_kpts([2,1,1]))
         self.assertRaises(RuntimeError, mf.run)
 
+    def test_get_occ_no_beta_electrons(self):
+        # nelec = (nocc_a, 0): get_occ used to raise UnboundLocalError because
+        # mo_energy_b was only computed when nocc_b > 0.
+        cell = pgto.M(a=np.eye(3)*3.,
+                      atom='H 0 0 0; H 0 0 1',
+                      basis='6-31g', spin=2)
+        mf = pscf.KUHF(cell, kpts=cell.make_kpts([1,1,1]))
+        self.assertEqual(tuple(mf.nelec), (2, 0))
+        nkpts = len(mf.kpts)
+        nmo = cell.nao
+        mo_energy = np.zeros((2, nkpts, nmo))
+        mo_energy[:] = np.arange(nmo)
+        mo_occ = mf.get_occ(mo_energy)
+        self.assertEqual(mo_occ.shape, (2, nkpts, nmo))
+        self.assertTrue(np.all(mo_occ[1] == 0))
+
 if __name__ == '__main__':
     print("Tests for PBC UHF and PBC KUHF")
     unittest.main()


### PR DESCRIPTION
Since 2.14.0, `KUHF.get_occ` in `pyscf/pbc/scf/kuhf.py` only computes `mo_energy_b` inside the `if nocc_b > 0` branch, but the HOMO/LUMO block that follows reads `mo_energy_b[nocc_b]` unconditionally. For a cell with no beta electrons (`nelec = (n, 0)`) this raises `UnboundLocalError: cannot access local variable 'mo_energy_b'`, so a KUHF run on a fully spin-polarized cell crashes. This matches the molecular `scf.uhf.get_occ`, which always has the full beta energy array available and handles `n_b == 0` fine.

This computes `mo_energy_b` (and `nmo`) unconditionally and keeps only `fermi_b` guarded, so the beta LUMO (`mo_energy_b[nocc_b]`) is always defined. The existing `homo_b = None` path already covers the missing beta HOMO.

Fixes #3342.

Added `test_get_occ_no_beta_electrons` in `pyscf/pbc/scf/test/test_uhf.py`, reproducing the reporter's H2 `spin=2` case (`nelec = (2, 0)`); it raises `UnboundLocalError` on the current code and passes with this change.
