### PR TITLE
Fix UnboundLocalError in KUHF get_occ when nelec_beta == 0

### DIFF
--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -153,8 +153,8 @@ def get_occ(mf, mo_energy_kpts=None, mo_coeff_kpts=None):
                            f'nelec ({nocc_a}, {nocc_b}) > Nmo ({nmo})')
 
     fermi_a = mo_energy_a[nocc_a-1]
+    mo_energy_b = np.sort(mo_energy_kpts[1].ravel())
     if nocc_b > 0:
-        mo_energy_b = np.sort(mo_energy_kpts[1].ravel())
         nmo = mo_energy_b.size
         fermi_b = mo_energy_b[nocc_b-1]
     else:


### PR DESCRIPTION
## Summary

Fixes #3342. In `pyscf/pbc/scf/kuhf.py`, `get_occ` assigns `mo_energy_b` only inside the `if nocc_b > 0` branch:

```python
if nocc_b > 0:
    mo_energy_b = np.sort(mo_energy_kpts[1].ravel())
    nmo = mo_energy_b.size
    fermi_b = mo_energy_b[nocc_b-1]
else:
    fermi_b = -np.inf
```

But the block below is entered whenever `0 < nocc_a < nmo and nocc_b < nmo` — which includes `nocc_b == 0` — and dereferences `mo_energy_b`:

```python
lumo = lumo_b = mo_energy_b[nocc_b]
```

So a KUHF calculation on a cell with **zero spin-down electrons** raises `UnboundLocalError: cannot access local variable 'mo_energy_b'`.

## Fix

Sort the beta orbital energies unconditionally, mirroring the molecular UHF `get_occ` (`pyscf/scf/uhf.py`), which computes `e_idx_b` unconditionally and uses it at `lumo_b = mo_energy[1, e_idx_b[n_b]]`. With `nocc_b == 0`, `mo_energy_b[0]` is the lowest beta orbital, i.e. the correct beta LUMO. Behavior for `nocc_b > 0` is unchanged.

```diff
     fermi_a = mo_energy_a[nocc_a-1]
+    mo_energy_b = np.sort(mo_energy_kpts[1].ravel())
     if nocc_b > 0:
-        mo_energy_b = np.sort(mo_energy_kpts[1].ravel())
         nmo = mo_energy_b.size
         fermi_b = mo_energy_b[nocc_b-1]
     else:
         fermi_b = -np.inf
```

## Verification

pyscf's compiled extensions aren't available in my environment, so I verified by extracting the `get_occ` branch logic into a standalone reproduction: the original raises the exact `UnboundLocalError` from the issue for `nocc_b == 0`, and the patched version returns the correct `lumo_b` (lowest beta orbital) while leaving the `nocc_b > 0` path identical. Happy to add a regression test based on the reporter's MWE if you'd like.