### PR TITLE
Fix #3342 (pbc KUHF get_occ when nelecb==0)

### DIFF
--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -153,8 +153,8 @@ def get_occ(mf, mo_energy_kpts=None, mo_coeff_kpts=None):
                            f'nelec ({nocc_a}, {nocc_b}) > Nmo ({nmo})')
 
     fermi_a = mo_energy_a[nocc_a-1]
+    mo_energy_b = np.sort(mo_energy_kpts[1].ravel())
     if nocc_b > 0:
-        mo_energy_b = np.sort(mo_energy_kpts[1].ravel())
         nmo = mo_energy_b.size
         fermi_b = mo_energy_b[nocc_b-1]
     else:

--- a/pyscf/pbc/scf/test/test_uhf.py
+++ b/pyscf/pbc/scf/test/test_uhf.py
@@ -59,6 +59,16 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(mf.e_tot, -3.3634535013441855, 8)
         mf.analyze()
 
+    def test_kuhf_uhf_limit (self):
+        cell0 = pgto.Cell()
+        cell0.spin = 2
+        cell0.build(atom="H 0 0 0; H 0 0 1", basis="6-31g", a=np.diag([3.0, 3.0, 5.0]), output='/dev/null', verbose=0)
+        mf0 = pscf.UHF(cell0).density_fit().run ()
+        kpts0 = cell0.make_kpts((1,1,1))
+        kmf0 = pscf.KUHF(cell0, kpts=kpts0).density_fit().run ()
+        self.assertAlmostEqual (mf0.e_tot, kmf0.e_tot, 6)
+        self.assertAlmostEqual (mf0.scf_summary['gap'], kmf0.scf_summary['gap'], 6)
+
     def test_kuhf_vs_uhf(self):
         np.random.seed(1)
         k = np.random.random(3)


### PR DESCRIPTION
Define mo_energy_b unconditionally. Also confirm that this gives the right answer by adding a unittest that compares KUHF at the gamma-point limit to gamma-point periodic UHF, both for the total energies and the gap.

I was curious if the LLM that wrote #3343 would actually update the unit test as I suggested but I'm running out of patience waiting for it so I just did it myself.