### PR TITLE
Fix numpy.int32 overflow in PBC DFT aft.py nij buffer allocation (closes #3346)

### DIFF
--- a/pyscf/pbc/df/aft.py
+++ b/pyscf/pbc/df/aft.py
@@ -450,11 +450,11 @@ class AFTDFMixin:
             assert (shls_slice[2] == 0)
             i0 = ao_loc[shls_slice[0]]
             i1 = ao_loc[shls_slice[1]]
-            nij = i1*(i1+1)//2 - i0*(i0+1)//2
+            nij = int(i1*(i1+1)//2 - i0*(i0+1)//2)
         else:
             ni = ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]]
             nj = ao_loc[shls_slice[3]] - ao_loc[shls_slice[2]]
-            nij = ni*nj
+            nij = int(ni*nj)
 
         if blksize is None:
             blksize = min(max(64, int(max_memory*1e6*.75/(nij*16*comp))), 16384)
@@ -519,11 +519,11 @@ class AFTDFMixin:
             assert (shls_slice[2] == 0)
             i0 = ao_loc[shls_slice[0]]
             i1 = ao_loc[shls_slice[1]]
-            nij = i1*(i1+1)//2 - i0*(i0+1)//2
+            nij = int(i1*(i1+1)//2 - i0*(i0+1)//2)
         else:
             ni = ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]]
             nj = ao_loc[shls_slice[3]] - ao_loc[shls_slice[2]]
-            nij = ni*nj
+            nij = int(ni*nj)
 
         if bvk_kmesh is None:
             if kpts is None:


### PR DESCRIPTION
Fixes #3346

## Problem

`cell.ao_loc_nr()` returns a `numpy.int32` array on some platforms. When computing `nij = ni*nj` or `nij = i1*(i1+1)//2 - i0*(i0+1)//2`, the result is also `numpy.int32`. For large systems, subsequent multiplications:

```python
buf = np.empty(nkpts*nij*blksize*comp, dtype=np.complex128)
```

can overflow `int32`. For example, with `nij=277729` and `blksize=16384`, the product `nij*blksize ≈ 4.55×10^9` exceeds the `int32` limit of `~2.1×10^9`.

## Fix

Cast `nij` to Python `int` immediately after assignment in both occurrence patterns across both `get_pp_loc_part1` and `weighted_ft_ao` (4 assignment sites total):

```python
# Before:
nij = i1*(i1+1)//2 - i0*(i0+1)//2  # numpy.int32
nij = ni*nj                          # numpy.int32

# After:
nij = int(i1*(i1+1)//2 - i0*(i0+1)//2)  # Python int
nij = int(ni*nj)                          # Python int
```

This is a minimal, targeted fix with no behavior change — Python `int` has arbitrary precision and will not overflow.