### PR TITLE
fix: exclude INVALID_ORBITAL_ENERGY MOs in kmp2.get_frozen_mask (#3298)

### DIFF
--- a/pyscf/pbc/mp/kmp2.py
+++ b/pyscf/pbc/mp/kmp2.py
@@ -538,6 +538,17 @@ def get_frozen_mask(mp):
 
     '''
     moidx = [np.ones(x.size, dtype=bool) for x in mp.mo_occ]
+
+    # Exclude linearly-dependent orbitals removed during SCF via canonical
+    # orthogonalization (flagged with INVALID_ORBITAL_ENERGY).  get_nmo already
+    # excludes them from the MO count; without this matching exclusion here the
+    # frozen mask has more True entries than get_nmo reports, causing a shape
+    # mismatch in padded_mo_coeff. Fixes #3298.
+    if hasattr(mp, 'mo_energy') and mp.mo_energy is not None:
+        from pyscf.pbc.scf.hf import INVALID_ORBITAL_ENERGY
+        for idx, e in zip(moidx, mp.mo_energy):
+            idx[np.asarray(e) == INVALID_ORBITAL_ENERGY] = False
+
     if mp.frozen is None:
         pass
     elif isinstance(mp.frozen, (int, np.integer)):


### PR DESCRIPTION
## Problem

`KMP2.get_frozen_mask` and `KMP2.get_nmo` are inconsistent when a cell has
linearly-dependent orbitals that were removed during SCF canonical
orthogonalization.

Since commit `9fe5b82`, PySCF flags such orbitals with `INVALID_ORBITAL_ENERGY`
(≈ 1e30) rather than removing them from the array. `get_nmo` already accounts
for this:

```python
# get_nmo, line ~487
nmo = np.count_nonzero(mp.mo_energy != INVALID_ORBITAL_ENERGY, axis=1)
```

However `get_frozen_mask` initialises its boolean mask from `mp.mo_occ` size,
which **includes** the invalid orbitals:

```python
# get_frozen_mask, current code
moidx = [np.ones(x.size, dtype=bool) for x in mp.mo_occ]
```

When `mp.frozen is None`, every entry of `moidx` is `True`, so
`count_nonzero(moidx[k])` = *all* MOs, while `get_nmo` returns only *valid* MOs.
This mismatch propagates to `padded_mo_coeff`:

```python
result[np.ix_([k], np.arange(result.shape[1]), padding_convention[k])] =     mo_coeff[k][:, frozen_mask[k]]
```

`mo_coeff[k][:, frozen_mask[k]]` selects all MOs (including invalid), but
`result` is only allocated for the `nmo` valid MOs → **`ValueError: shape mismatch`**.

## Fix

Add the same `INVALID_ORBITAL_ENERGY` exclusion to `get_frozen_mask`, immediately
after the initial mask creation and before the explicit `mp.frozen` logic:

```python
if hasattr(mp, 'mo_energy') and mp.mo_energy is not None:
    from pyscf.pbc.scf.hf import INVALID_ORBITAL_ENERGY
    for idx, e in zip(moidx, mp.mo_energy):
        idx[np.asarray(e) == INVALID_ORBITAL_ENERGY] = False
```

This matches `get_nmo`'s treatment and restores consistency.

## Verification (mock test)

```python
# 9 total MOs, 2 with INVALID_ORBITAL_ENERGY
# Before fix: get_frozen_mask returns 9 True entries; get_nmo returns 7
# After fix:  both agree at 7
assert n_valid == n_masked  # PASS
```

Closes #3298.
