### PR TITLE
Fix divide-by-zero in selected_ci.contract_2e when nelec contains zero (fixes #3091)

### DIFF
--- a/pyscf/fci/selected_ci.py
+++ b/pyscf/fci/selected_ci.py
@@ -95,9 +95,14 @@ def contract_2e(eri, civec_strs, norb, nelec, link_index=None):
     # the second term is the source of h_ps
     h_ps = numpy.einsum('pqqs->ps', eri)
     eri1 = eri * 2
+    # Guard against divide-by-zero when nelec[i] == 0 (fixes #3091).
+    # When no electrons of a given spin are present, the 2-electron
+    # correction term for that spin is physically zero.
+    alpha_factor = h_ps / nelec[0] if nelec[0] > 0 else 0
+    beta_factor = h_ps / nelec[1] if nelec[1] > 0 else 0
     for k in range(norb):
-        eri1[:,:,k,k] += h_ps/nelec[0]
-        eri1[k,k,:,:] += h_ps/nelec[1]
+        eri1[:,:,k,k] += alpha_factor
+        eri1[k,k,:,:] += beta_factor
     eri1 = ao2mo.restore(4, eri1, norb)
     # (bb|aa)
     libfci.SCIcontract_2e_bbaa(eri1.ctypes.data_as(ctypes.c_void_p),


### PR DESCRIPTION
## Problem

Fixes #3091.

`pyscf.fci.selected_ci.contract_2e` raises a numpy `RuntimeWarning: divide by zero encountered in scalar divide`
and produces incorrect output when the system has zero electrons of one spin
(e.g., H₂⁺ with `nelec = (1, 0)`).

### Root cause

Lines 99–100 compute a correction to the 2-electron ERI tensor:

```python
for k in range(norb):
    eri1[:,:,k,k] += h_ps/nelec[0]   # fine when nelec[0] > 0
    eri1[k,k,:,:] += h_ps/nelec[1]   # ZeroDivisionError when nelec[1] == 0
```

This correction arises from the identity used to convert from the
`p⁺ r⁺ s q` ordering (used by `SCIcontract_2e_aaaa`) to the
`p⁺ q r⁺ s` ordering. When `nelec[1] == 0`, there are no beta electrons
and the corresponding 2-electron term is physically zero — but the division
by zero produces `inf`, corrupting `eri1` and hence the contracted CI vector.

### Fix

Guard both terms:

```python
alpha_factor = h_ps / nelec[0] if nelec[0] > 0 else 0
beta_factor  = h_ps / nelec[1] if nelec[1] > 0 else 0
for k in range(norb):
    eri1[:,:,k,k] += alpha_factor
    eri1[k,k,:,:] += beta_factor
```

When `nelec[i] == 0`, setting the factor to 0 is physically correct:
no electrons of that spin means no pairs and the correction term vanishes.

## Verification

Reproducer from the original issue (H₂⁺, `nelec=(1,0)`):

```python
from pyscf.fci.selected_ci import contract_2e, SCIvector, _as_SCIvector
from pyscf.fci.direct_nosym import absorb_h1e
import numpy as np

h1e = np.array([[-1.2473, 0.], [0., -0.4813]])
h2e = np.array([[0.6728, 0., 0.662], [-0., 0.1818, 0.], [0.662, 0., 0.6958]])
ci  = np.array([[1.], [0.]])
sci = _as_SCIvector(ci, (np.array([1, 2]), np.array([0])))
h2e_eff = absorb_h1e(h1e, h2e, 2, (1, 0), fac=0.5)

# Before fix: RuntimeWarning + wrong answer
# After fix: clean result
hci = contract_2e(h2e_eff, sci, 2, (1, 0))
print(hci)
```
