### PR TITLE
docs: improve KUHF/KROHF nelec error to mention nkpts scaling for cell.spin (#3321)

### DIFF
--- a/pyscf/pbc/scf/krohf.py
+++ b/pyscf/pbc/scf/krohf.py
@@ -294,9 +294,13 @@ class KROHF(khf.KRHF):
             nalpha = (ne + cell.spin) // 2
             nbeta = nalpha - cell.spin
             if nalpha + nbeta != ne:
-                raise RuntimeError('Electron number %d and spin %d are not consistent\n'
-                                   'Note cell.spin = 2S = Nalpha - Nbeta, not 2S+1' %
-                                   (ne, cell.spin))
+                raise RuntimeError(
+                    'Electron number %d and spin %d are not consistent\n'
+                    'Note cell.spin = 2S = Nalpha - Nbeta, not 2S+1.\n'
+                    'For k-point calculations (nkpts=%d), cell.spin must be '
+                    'the per-cell spin multiplied by nkpts: '
+                    'cell.spin = (Nalpha - Nbeta per cell) * nkpts' %
+                    (ne, cell.spin, nkpts))
             return nalpha, nbeta
     @nelec.setter
     def nelec(self, x):

--- a/pyscf/pbc/scf/kuhf.py
+++ b/pyscf/pbc/scf/kuhf.py
@@ -447,9 +447,13 @@ class KUHF(khf.KSCF):
             nalpha = (ne + cell.spin) // 2
             nbeta = nalpha - cell.spin
             if nalpha + nbeta != ne:
-                raise RuntimeError('Electron number %d and spin %d are not consistent\n'
-                                   'Note cell.spin = 2S = Nalpha - Nbeta, not 2S+1' %
-                                   (ne, cell.spin))
+                raise RuntimeError(
+                    'Electron number %d and spin %d are not consistent\n'
+                    'Note cell.spin = 2S = Nalpha - Nbeta, not 2S+1.\n'
+                    'For k-point calculations (nkpts=%d), cell.spin must be '
+                    'the per-cell spin multiplied by nkpts: '
+                    'cell.spin = (Nalpha - Nbeta per cell) * nkpts' %
+                    (ne, cell.spin, nkpts))
             return nalpha, nbeta
     @nelec.setter
     def nelec(self, x):


### PR DESCRIPTION
## Problem

`KUHF.nelec` and `KROHF.nelec` raise a `RuntimeError` with an unhelpful message when
an open-shell k-point calculation is attempted with `cell.spin` set to the physical
per-cell spin rather than `cell.spin * nkpts`.

The current error reads:

```
RuntimeError: Electron number 264 and spin 1 are not consistent
Note cell.spin = 2S = Nalpha - Nbeta, not 2S+1
```

This does not explain **why** there is a mismatch, leaving users confused about the
k-point scaling requirement.

## Root cause

`KUHF.nelec` computes total electrons as `ne = cell.tot_electrons(nkpts)` — which
scales by `nkpts` — but then does:

```python
nalpha = (ne + cell.spin) // 2  # cell.spin is per-cell, ne is total
```

For consistency, `cell.spin` must equal `(Nalpha - Nbeta per cell) * nkpts` when
using k-point sampling with `nkpts > 1`. Gamma-point (single k-point) calculations
are unaffected since the scaling factor is 1.

## Fix

Improve the error message to explicitly state the k-points scaling requirement:

```
RuntimeError: Electron number 264 and spin 1 are not consistent
Note cell.spin = 2S = Nalpha - Nbeta, not 2S+1.
For k-point calculations (nkpts=8), cell.spin must be the per-cell spin
multiplied by nkpts: cell.spin = (Nalpha - Nbeta per cell) * nkpts
```

This makes the path to resolution immediately clear.

Closes #3321.
