### PR TITLE
Fix #3346: numpy.int32 overflow in PBC DFT aft.py

### DIFF
--- a/pyscf/pbc/df/aft.py
+++ b/pyscf/pbc/df/aft.py
@@ -448,12 +448,12 @@ class AFTDFMixin:
             shls_slice = (0, cell.nbas, 0, cell.nbas)
         if aosym == 's2':
             assert (shls_slice[2] == 0)
-            i0 = ao_loc[shls_slice[0]]
-            i1 = ao_loc[shls_slice[1]]
+            i0 = int(ao_loc[shls_slice[0]])
+            i1 = int(ao_loc[shls_slice[1]])
             nij = i1*(i1+1)//2 - i0*(i0+1)//2
         else:
-            ni = ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]]
-            nj = ao_loc[shls_slice[3]] - ao_loc[shls_slice[2]]
+            ni = int(ao_loc[shls_slice[1]]) - int(ao_loc[shls_slice[0]])
+            nj = int(ao_loc[shls_slice[3]]) - int(ao_loc[shls_slice[2]])
             nij = ni*nj
 
         if blksize is None:
@@ -517,12 +517,12 @@ class AFTDFMixin:
             shls_slice = (0, cell.nbas, 0, cell.nbas)
         if aosym == 's2':
             assert (shls_slice[2] == 0)
-            i0 = ao_loc[shls_slice[0]]
-            i1 = ao_loc[shls_slice[1]]
+            i0 = int(ao_loc[shls_slice[0]])
+            i1 = int(ao_loc[shls_slice[1]])
             nij = i1*(i1+1)//2 - i0*(i0+1)//2
         else:
-            ni = ao_loc[shls_slice[1]] - ao_loc[shls_slice[0]]
-            nj = ao_loc[shls_slice[3]] - ao_loc[shls_slice[2]]
+            ni = int(ao_loc[shls_slice[1]]) - int(ao_loc[shls_slice[0]])
+            nj = int(ao_loc[shls_slice[3]]) - int(ao_loc[shls_slice[2]])
             nij = ni*nj
 
         if bvk_kmesh is None:


### PR DESCRIPTION
This is a fix to #3346. This change explicitly converts `nij` to a Python int, preventing the calculated buffer size from being silently converted to `numpy.int32`, which could cause overflow for large buffer sizes.