### PR TITLE
Fix shape handling for spinor 4-center integrals in getints4c

### DIFF
--- a/pyscf/gto/moleintor.py
+++ b/pyscf/gto/moleintor.py
@@ -657,14 +657,15 @@ def getints4c(intor_name, atm, bas, env, shls_slice=None, comp=1,
             assert (numpy.all(ao_loc[k0:k1]-ao_loc[k0] == ao_loc[l0:l1]-ao_loc[l0]))
         else:
             nkl = [naok, naol]
-        shape = [comp] + nij + nkl
 
         if '_spinor' in intor_name:
+            shape = nij + nkl + [comp]
             drv = libcgto.GTOr4c_drv
             fill = libcgto.GTOr4c_fill_s1
-            out = numpy.ndarray(shape[::-1], dtype=numpy.complex128, buffer=out, order='F')
+            out = numpy.ndarray(shape, dtype=numpy.complex128, buffer=out, order='F')
             out = numpy.rollaxis(out, -1, 0)
         else:
+            shape = [comp] + nij + nkl
             drv = libcgto.GTOnr2e_fill_drv
             fill = getattr(libcgto, 'GTOnr2e_fill_'+aosym)
             out = numpy.ndarray(shape, buffer=out)

--- a/pyscf/gto/test/test_moleintor.py
+++ b/pyscf/gto/test/test_moleintor.py
@@ -227,6 +227,23 @@ class KnownValues(unittest.TestCase):
                 jp += dj
             ip += di
 
+    def test_intor_r2e_spinor_shape(self):
+        """Regression test for spinor 4-center integral shape in getints4c.
+
+        The bug produced shape[::-1] for spinor integrals, which only reveals
+        itself when shell-slice dimensions are asymmetric (naoi != naol etc.).
+        shls_slice (0,1, 0,2, 0,3, 0,4) gives naoi=2,naoj=4,naok=6,naol=8.
+        Buggy code returns (8,6,4,2) and (3,8,6,4,2); fixed code (2,4,6,8) and (3,2,4,6,8).
+        """
+        mol = gto.M(atom='H 0 -0.7 0; H 0 0.7 0', basis='631g')
+        ao_loc = mol.ao_loc_2c()
+        shls_slice = (0, 1, 0, 2, 0, 3, 0, mol.nbas)
+        expected = tuple(int(ao_loc[i1] - ao_loc[i0])
+                         for i0, i1 in zip(shls_slice[::2], shls_slice[1::2]))
+
+        self.assertEqual(mol.intor('int2e_spinor', shls_slice=shls_slice).shape, expected)
+        self.assertEqual(mol.intor('int2e_ip1_spinor', shls_slice=shls_slice).shape, (3,) + expected)
+
     def test_input_cint(self):
         '''Compatibility to old cint functions
         '''


### PR DESCRIPTION
Fixes #3362 

## Summary
In `getints4c()`, the shape for spinor integrals (`'_spinor' in intor_name`) was constructed incorrectly:
```python
# Before (buggy)
shape = [comp] + nij + nkl
out = numpy.ndarray(shape[::-1], dtype=numpy.complex128, buffer=out, order='F')
```
The shape was defined with `comp` first, then reversed via `[::-1]`. For Fortran-ordered arrays, the C library writes data expecting the layout `(nij, nkl, comp)`, but the reversed shape caused the index order to be transposed, producing wrong results whenever the i,j shell-slice dimensions differ from k,l.
## Fix
```python
# After (fixed)
shape = nij + nkl + [comp]
out = numpy.ndarray(shape, dtype=numpy.complex128, buffer=out, order='F')
out = numpy.rollaxis(out, -1, 0)
```
The shape is now constructed correctly as `nij + nkl + [comp]` and used directly, matching what the C code expects in Fortran order. Then `rollaxis` moves `comp` to the front for the Python API.
## Regression Test
Added `test_intor_r2e_spinor_shape` in `pyscf/gto/test/test_moleintor.py`. It uses an asymmetric `shls_slice` `(0,1, 0,2, 0,3, 0,nbas)` giving dimensions `(2,4,6,8)`, so the buggy `shape[::-1]` produces `(8,6,4,2)` and is caught by the shape assertion.