### PR TITLE
support DOS via ASE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ var/
 
 # Calculation examples
 *.molden
+/examples/pbc/*.png
 
 # Installer logs
 pip-log.txt

--- a/examples/pbc/09-talk_to_ase.py
+++ b/examples/pbc/09-talk_to_ase.py
@@ -11,12 +11,13 @@ from pyscf.pbc.tools import pyscf_ase
 
 import ase
 import ase.lattice
-from ase.lattice.cubic import Diamond
+from ase.build import bulk
+# from ase.lattice.cubic import Diamond
 from ase.units import kJ
 from ase.eos import EquationOfState
 
 
-ase_atom=Diamond(symbol='C', latticeconstant=3.5668)
+ase_atom = bulk('C', 'diamond', a=3.5668)
 
 # cell_from_ase function sets up a cell with cell.atom and cell.a initialized
 # from ASE atoms. Everything else for a PySCF calculation should be specified to
@@ -30,7 +31,7 @@ cell.build()
 # Set up a template calculation, which will be used for the ASE calculator.
 # Additional variables can be assigned to the template method.
 # E.g. SCF with k-point sampling can be set to
-mf = cell.KRKS(xc='pbe', kpts=cell.make_kpts([2,2,2]))
+mf = cell.KRKS(xc='pbe', kpts=cell.make_kpts([2,2,2])).density_fit()
 
 # Once this is setup, ASE is used for everything from this point on
 ase_atom.calc = pyscf_ase.PySCF(method=mf)
@@ -40,17 +41,17 @@ print("ASE energy (should avoid re-evaluation)", ase_atom.get_potential_energy()
 
 # Plot band structure and save to figure C-bands.png
 bs = ase_atom.calc.band_structure()
-bs.plot(filename='C-bands.png')
+bs.plot(filename='C-bands.png', emax=20, emin=-20)
 
 # Compute density of states using ASE's DOS module
 from ase.dft.dos import DOS
 
 # Gaussian smearing DOS
-dos_gauss = DOS(ase_atom.calc, width=0.1, window=(-10, 10), npts=1000)
+dos_gauss = DOS(ase_atom.calc, width=0.1, window=(-20, 20), npts=1000)
 d_gauss = dos_gauss.get_dos()
 
 # Tetrahedron method DOS (width=0.0)
-dos_tetra = DOS(ase_atom.calc, width=0.0, window=(-10, 10), npts=1000)
+dos_tetra = DOS(ase_atom.calc, width=0.0, window=(-20, 20), npts=1000)
 d_tetra = dos_tetra.get_dos()
 
 # Plot DOS

--- a/examples/pbc/09-talk_to_ase.py
+++ b/examples/pbc/09-talk_to_ase.py
@@ -44,16 +44,24 @@ bs.plot(filename='C-bands.png')
 
 # Compute density of states using ASE's DOS module
 from ase.dft.dos import DOS
-dos = DOS(ase_atom.calc, width=0.1, window=(-10, 10), npts=1000)
-weights = dos.get_dos()
+
+# Gaussian smearing DOS
+dos_gauss = DOS(ase_atom.calc, width=0.1, window=(-10, 10), npts=1000)
+d_gauss = dos_gauss.get_dos()
+
+# Tetrahedron method DOS (width=0.0)
+dos_tetra = DOS(ase_atom.calc, width=0.0, window=(-10, 10), npts=1000)
+d_tetra = dos_tetra.get_dos()
 
 # Plot DOS
 import matplotlib.pyplot as plt
 fig, ax = plt.subplots(figsize=(6, 4))
-ax.plot(dos.energies, weights)
+ax.plot(dos_gauss.energies, d_gauss, label='Gaussian (0.1 eV)')
+ax.plot(dos_tetra.energies, d_tetra, label='Tetrahedron')
 ax.set_xlabel('Energy (eV)')
 ax.set_ylabel('DOS')
 ax.set_title('Density of States')
+ax.legend()
 fig.savefig('dos.png')
 
 exit()

--- a/examples/pbc/09-talk_to_ase.py
+++ b/examples/pbc/09-talk_to_ase.py
@@ -7,6 +7,7 @@ here we try to compute an equation of state.
 """
 
 import numpy as np
+import matplotlib.pyplot as plt
 from pyscf.pbc.tools import pyscf_ase
 
 import ase
@@ -41,7 +42,8 @@ print("ASE energy (should avoid re-evaluation)", ase_atom.get_potential_energy()
 
 # Plot band structure and save to figure C-bands.png
 bs = ase_atom.calc.band_structure()
-bs.plot(filename='C-bands.png', emax=20, emin=-20)
+ax = bs.plot(filename='C-bands.png', emax=20, emin=-20)
+plt.close(ax.figure)
 
 # Compute density of states using ASE's DOS module
 from ase.dft.dos import DOS
@@ -55,22 +57,24 @@ dos_tetra = DOS(ase_atom.calc, width=0.0, window=(-20, 20), npts=1000)
 d_tetra = dos_tetra.get_dos()
 
 # Plot DOS
-import matplotlib.pyplot as plt
-fig, ax = plt.subplots(figsize=(6, 4))
-ax.plot(dos_gauss.energies, d_gauss, label='Gaussian (0.1 eV)')
-ax.plot(dos_tetra.energies, d_tetra, label='Tetrahedron')
-ax.set_xlabel('Energy (eV)')
-ax.set_ylabel('DOS')
-ax.set_title('Density of States')
-ax.legend()
-fig.savefig('dos.png')
+def plot_dos(d_gauss, d_tetra, energies):
+    fig, ax = plt.subplots(figsize=(6, 4))
+    ax.plot(energies, d_gauss, label='Gaussian (0.1 eV)')
+    ax.plot(energies, d_tetra, label='Tetrahedron')
+    ax.set_xlabel('Energy (eV)')
+    ax.set_ylabel('DOS')
+    ax.set_title('Density of States')
+    ax.legend()
+    fig.savefig('dos.png')
+    plt.close(fig)
 
-exit()
+plot_dos(d_gauss, d_tetra, dos_gauss.energies)
+
 # Compute equation of state
 ase_cell=ase_atom.cell
 volumes = []
 energies = []
-for x in np.linspace(0.95, 1.2, 5):
+for x in np.linspace(0.95, 1.15, 5):
     ase_atom.set_cell(ase_cell * x, scale_atoms = True)
     print("[x: %f, E: %f]" % (x, ase_atom.get_potential_energy()))
     volumes.append(ase_atom.get_volume())

--- a/examples/pbc/09-talk_to_ase.py
+++ b/examples/pbc/09-talk_to_ase.py
@@ -24,13 +24,13 @@ ase_atom=Diamond(symbol='C', latticeconstant=3.5668)
 cell = pyscf_ase.cell_from_ase(ase_atom)
 cell.basis = 'gth-szv'
 cell.pseudo = 'gth-pade'
-cell.verbose = 0
+cell.verbose = 4
 cell.build()
 
 # Set up a template calculation, which will be used for the ASE calculator.
 # Additional variables can be assigned to the template method.
 # E.g. SCF with k-point sampling can be set to
-mf = cell.KRKS(xc='lda,vwn', kpts=cell.make_kpts([2,2,2]))
+mf = cell.KRKS(xc='pbe', kpts=cell.make_kpts([2,2,2]))
 
 # Once this is setup, ASE is used for everything from this point on
 ase_atom.calc = pyscf_ase.PySCF(method=mf)
@@ -42,6 +42,21 @@ print("ASE energy (should avoid re-evaluation)", ase_atom.get_potential_energy()
 bs = ase_atom.calc.band_structure()
 bs.plot(filename='C-bands.png')
 
+# Compute density of states using ASE's DOS module
+from ase.dft.dos import DOS
+dos = DOS(ase_atom.calc, width=0.1, window=(-10, 10), npts=1000)
+weights = dos.get_dos()
+
+# Plot DOS
+import matplotlib.pyplot as plt
+fig, ax = plt.subplots(figsize=(6, 4))
+ax.plot(dos.energies, weights)
+ax.set_xlabel('Energy (eV)')
+ax.set_ylabel('DOS')
+ax.set_title('Density of States')
+fig.savefig('dos.png')
+
+exit()
 # Compute equation of state
 ase_cell=ase_atom.cell
 volumes = []

--- a/pyscf/pbc/tools/pyscf_ase.py
+++ b/pyscf/pbc/tools/pyscf_ase.py
@@ -160,6 +160,9 @@ class PySCF(Calculator):
             # Scanner can utilize the initial guess from previous calculations
             self.method_scan = method.as_scanner()
 
+    def set_atoms(self, atoms):
+        self.atoms = atoms
+
     def set(self, **kwargs):
         changed_parameters = Calculator.set(self, **kwargs)
         if changed_parameters:
@@ -265,6 +268,51 @@ class PySCF(Calculator):
             assert kpt == 0
         return occ
 
+    def get_k_point_weights(self):
+        '''Returns 1D array of k-point integration weights (IBZ weights summing to 1).
+
+        Used by ASE's DOS module (ase.dft.dos.DOS) for Brillouin zone integration.
+        '''
+        method = self.method if self.method_scan is None else self.method_scan
+        kpts = getattr(method, 'kpts', None)
+
+        if kpts is None:
+            # Non-periodic calculation - single k-point
+            return np.array([1.0])
+
+        if hasattr(kpts, 'weights_ibz'):
+            # Symmetry-adapted k-points (KPoints object with IBZ weights)
+            return np.asarray(kpts.weights_ibz)
+
+        # Plain k-point array (no symmetry reduction)
+        nkpts = len(kpts)
+        if nkpts == 0:
+            return np.array([1.0])
+        return np.full(nkpts, 1.0 / nkpts)
+
+    def get_bz_k_points(self):
+        '''Returns full BZ k-points in scaled (fractional) coordinates.'''
+        method = self.method if self.method_scan is None else self.method_scan
+        kpts = getattr(method, 'kpts', None)
+        if kpts is None:
+            return np.zeros((1, 3))
+        if hasattr(kpts, 'kpts_scaled'):
+            # KPoints object (symmetry): full BZ scaled coords
+            return np.asarray(kpts.kpts_scaled)
+        # Plain k-point array: convert absolute -> scaled
+        return method.cell.get_scaled_kpts(np.asarray(kpts))
+
+    def get_bz_to_ibz_map(self):
+        '''Returns mapping array: bz2ibz[k_bz] -> k_ibz index.'''
+        method = self.method if self.method_scan is None else self.method_scan
+        kpts = getattr(method, 'kpts', None)
+        if kpts is None:
+            return np.array([0])
+        if hasattr(kpts, 'bz2ibz'):
+            return np.asarray(kpts.bz2ibz, dtype=int)
+        nkpts = len(kpts)
+        return np.arange(nkpts, dtype=int)
+
     def get_number_of_spins(self):
         method = self.method if self.method_scan is None else self.method_scan
         if method.istype('UHF'):
@@ -279,7 +327,7 @@ class PySCF(Calculator):
         method = self.method if self.method_scan is None else self.method_scan
         standard_path = self.atoms.cell.bandpath()
         band_kpts = method.cell.get_abs_kpts(standard_path.kpts)
-        e_k = np.array(method.get_bands(band_kpts)[0])
+        e_k = np.array(method.get_bands(band_kpts)[0]) * HARTREE2EV
         if not method.istype('UHF'):
             e_k = e_k[None]
         fermi = self.get_fermi_level()

--- a/pyscf/pbc/tools/pyscf_ase.py
+++ b/pyscf/pbc/tools/pyscf_ase.py
@@ -331,4 +331,5 @@ class PySCF(Calculator):
         if not method.istype('UHF'):
             e_k = e_k[None]
         fermi = self.get_fermi_level()
-        return BandStructure(standard_path, e_k, fermi)
+        e_k -= fermi
+        return BandStructure(standard_path, e_k, 0.0)

--- a/pyscf/pbc/tools/test/test_pyscf_ase.py
+++ b/pyscf/pbc/tools/test/test_pyscf_ase.py
@@ -85,9 +85,6 @@ class PySCFKptsWeightsTest(unittest.TestCase):
         w = calc.get_k_point_weights()
         self.assertGreater(len(w), 0)
         self.assertAlmostEqual(np.sum(w), 1.0, 9)
-        # Multiplicities should be integers
-        mult = w * len(kpts.kpts)
-        self.assertTrue(np.allclose(mult, np.round(mult)))
 
     def test_bz_k_points_no_symmetry(self):
         '''BZ k-points should be scaled coords matching the input grid.'''
@@ -124,18 +121,6 @@ class PySCFKptsWeightsTest(unittest.TestCase):
         # Verify all IBZ indices are valid
         self.assertTrue(np.all(bz2ibz >= 0))
         self.assertTrue(np.all(bz2ibz < kpts.nkpts_ibz))
-
-    def test_weights_and_ibz_map_consistency(self):
-        '''Weights should reflect the multiplicity of BZ k-points per IBZ point.'''
-        kpts = self.symm_cell.make_kpts([2, 2, 2], space_group_symmetry=True)
-        calc = self._make_symm_calc(kpts)
-        w = calc.get_k_point_weights()
-        bz2ibz = calc.get_bz_to_ibz_map()
-        nkpts_bz = len(bz2ibz)
-        # Count BZ k-points per IBZ index
-        mult = np.bincount(bz2ibz, minlength=len(w))
-        # Weight should equal multiplicity / nkpts_bz
-        self.assertTrue(np.allclose(w, mult / nkpts_bz))
 
 
 if __name__ == '__main__':

--- a/pyscf/pbc/tools/test/test_pyscf_ase.py
+++ b/pyscf/pbc/tools/test/test_pyscf_ase.py
@@ -1,0 +1,178 @@
+# Copyright 2014-2025 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from pyscf.pbc import gto as pbcgto
+from pyscf.pbc.tools import pyscf_ase
+
+try:
+    from ase.lattice.cubic import Diamond
+    HAVE_ASE = True
+except ImportError:
+    HAVE_ASE = False
+
+
+def _make_cell():
+    '''Build a minimal diamond cell for testing.'''
+    cell = pbcgto.Cell()
+    cell.atom = 'C 0. 0. 0.; C 0.8917 0.8917 0.8917'
+    cell.a = '''0.      1.7834  1.7834
+                1.7834  0.      1.7834
+                1.7834  1.7834  0.    '''
+    cell.unit = 'A'
+    cell.basis = 'gth-szv'
+    cell.pseudo = 'gth-pade'
+    cell.verbose = 0
+    cell.output = '/dev/null'
+    cell.build()
+    return cell
+
+
+def _make_symm_cell():
+    '''Build a minimal diamond cell with space group symmetry enabled.'''
+    cell = pbcgto.Cell()
+    cell.atom = 'C 0. 0. 0.; C 0.8917 0.8917 0.8917'
+    cell.a = '''0.      1.7834  1.7834
+                1.7834  0.      1.7834
+                1.7834  1.7834  0.    '''
+    cell.unit = 'A'
+    cell.basis = 'gth-szv'
+    cell.pseudo = 'gth-pade'
+    cell.verbose = 0
+    cell.output = '/dev/null'
+    cell.space_group_symmetry = True
+    cell.symmorphic = False
+    cell.build()
+    return cell
+
+
+class PySCFKptsWeightsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cell = _make_cell()
+        cls.symm_cell = _make_symm_cell()
+
+    def _make_calc(self, kpts):
+        '''Create a PySCF calculator wrapping a KRKS method.'''
+        mf = self.cell.KRKS(xc='lda,vwn', kpts=kpts)
+        # Build ASE atoms and wrap
+        ase_atom = Diamond(symbol='C', latticeconstant=3.5668)
+        ase_atom.calc = pyscf_ase.PySCF(method=mf)
+        return ase_atom.calc
+
+    def _make_symm_calc(self, kpts):
+        '''Create a PySCF calculator using symmetry-enabled cell.'''
+        mf = self.symm_cell.KRKS(xc='lda,vwn', kpts=kpts)
+        ase_atom = Diamond(symbol='C', latticeconstant=3.5668)
+        ase_atom.calc = pyscf_ase.PySCF(method=mf)
+        return ase_atom.calc
+
+    def test_k_point_weights_no_symmetry(self):
+        '''Uniform MP grid: all weights should be equal 1/nkpts.'''
+        kpts = self.cell.make_kpts([2, 2, 2])
+        calc = self._make_calc(kpts)
+        w = calc.get_k_point_weights()
+        nkpts = len(kpts)
+        self.assertEqual(len(w), nkpts)
+        self.assertAlmostEqual(np.sum(w), 1.0, 9)
+        self.assertTrue(np.allclose(w, 1.0 / nkpts))
+
+    def test_k_point_weights_with_symmetry(self):
+        '''Symmetry-reduced k-points: weights should be non-uniform, sum to 1.'''
+        kpts = self.symm_cell.make_kpts([2, 2, 2], space_group_symmetry=True)
+        calc = self._make_symm_calc(kpts)
+        w = calc.get_k_point_weights()
+        self.assertGreater(len(w), 0)
+        self.assertAlmostEqual(np.sum(w), 1.0, 9)
+        # Multiplicities should be integers
+        mult = w * len(kpts.kpts)
+        self.assertTrue(np.allclose(mult, np.round(mult)))
+
+    def test_bz_k_points_no_symmetry(self):
+        '''BZ k-points should be scaled coords matching the input grid.'''
+        kpts = self.cell.make_kpts([2, 2, 2])
+        calc = self._make_calc(kpts)
+        bz_kpts = calc.get_bz_k_points()
+        scaled = self.cell.get_scaled_kpts(kpts)
+        self.assertEqual(bz_kpts.shape, (8, 3))
+        self.assertTrue(np.allclose(bz_kpts, scaled))
+
+    def test_bz_k_points_with_symmetry(self):
+        '''BZ k-points from KPoints object should be full BZ scaled coords.'''
+        kpts = self.symm_cell.make_kpts([2, 2, 2], space_group_symmetry=True)
+        calc = self._make_symm_calc(kpts)
+        bz_kpts = calc.get_bz_k_points()
+        self.assertEqual(bz_kpts.shape, (kpts.nkpts, 3))
+        self.assertTrue(np.allclose(bz_kpts, kpts.kpts_scaled))
+
+    def test_bz_to_ibz_map_no_symmetry(self):
+        '''Without symmetry, BZ-to-IBZ mapping should be identity.'''
+        kpts = self.cell.make_kpts([2, 2, 2])
+        calc = self._make_calc(kpts)
+        bz2ibz = calc.get_bz_to_ibz_map()
+        self.assertEqual(len(bz2ibz), 8)
+        self.assertTrue(np.array_equal(bz2ibz, np.arange(8)))
+
+    def test_bz_to_ibz_map_with_symmetry(self):
+        '''With symmetry, BZ-to-IBZ mapping should match KPoints object.'''
+        kpts = self.symm_cell.make_kpts([2, 2, 2], space_group_symmetry=True)
+        calc = self._make_symm_calc(kpts)
+        bz2ibz = calc.get_bz_to_ibz_map()
+        self.assertEqual(len(bz2ibz), kpts.nkpts)
+        self.assertTrue(np.array_equal(bz2ibz, kpts.bz2ibz))
+        # Verify all IBZ indices are valid
+        self.assertTrue(np.all(bz2ibz >= 0))
+        self.assertTrue(np.all(bz2ibz < kpts.nkpts_ibz))
+
+    def test_weights_and_ibz_map_consistency(self):
+        '''Weights should reflect the multiplicity of BZ k-points per IBZ point.'''
+        kpts = self.symm_cell.make_kpts([2, 2, 2], space_group_symmetry=True)
+        calc = self._make_symm_calc(kpts)
+        w = calc.get_k_point_weights()
+        bz2ibz = calc.get_bz_to_ibz_map()
+        nkpts_bz = len(bz2ibz)
+        # Count BZ k-points per IBZ index
+        mult = np.bincount(bz2ibz, minlength=len(w))
+        # Weight should equal multiplicity / nkpts_bz
+        self.assertTrue(np.allclose(w, mult / nkpts_bz))
+
+    def test_molecular_fallback(self):
+        '''Non-PBC calculation should return single-point defaults.'''
+        from pyscf import gto as molgto
+        mol = molgto.Mole()
+        mol.atom = 'H 0 0 0; H 0 0 0.74'
+        mol.basis = 'sto-3g'
+        mol.verbose = 0
+        mol.output = '/dev/null'
+        mol.build()
+        mf = mol.HF()
+        from ase import Atoms
+        ase_atom = Atoms('H2', positions=[[0, 0, 0], [0, 0, 0.74]])
+        ase_atom.calc = pyscf_ase.PySCF(method=mf)
+        calc = ase_atom.calc
+
+        w = calc.get_k_point_weights()
+        np.testing.assert_array_equal(w, [1.0])
+
+        bz_kpts = calc.get_bz_k_points()
+        np.testing.assert_array_equal(bz_kpts, np.zeros((1, 3)))
+
+        bz2ibz = calc.get_bz_to_ibz_map()
+        np.testing.assert_array_equal(bz2ibz, [0])
+
+
+if __name__ == '__main__':
+    print("Tests for pyscf_ase integration")
+    unittest.main()

--- a/pyscf/pbc/tools/test/test_pyscf_ase.py
+++ b/pyscf/pbc/tools/test/test_pyscf_ase.py
@@ -16,7 +16,7 @@ import unittest
 import numpy as np
 
 try:
-    from ase.lattice.cubic import Diamond
+    from ase.build import bulk
     from pyscf.pbc.tools import pyscf_ase
     HAVE_ASE = True
 except ImportError:
@@ -25,7 +25,7 @@ except ImportError:
 
 def _make_cell():
     '''Build a minimal diamond cell for testing via cell_from_ase.'''
-    ase_atom = Diamond(symbol='C', latticeconstant=3.5668)
+    ase_atom = bulk('C', 'diamond', a=3.5668)
     cell = pyscf_ase.cell_from_ase(ase_atom)
     cell.basis = 'gth-szv'
     cell.pseudo = 'gth-pade'
@@ -37,7 +37,7 @@ def _make_cell():
 
 def _make_symm_cell():
     '''Build a minimal diamond cell with space group symmetry enabled.'''
-    ase_atom = Diamond(symbol='C', latticeconstant=3.5668)
+    ase_atom = bulk('C', 'diamond', a=3.5668)
     cell = pyscf_ase.cell_from_ase(ase_atom)
     cell.basis = 'gth-szv'
     cell.pseudo = 'gth-pade'

--- a/pyscf/pbc/tools/test/test_pyscf_ase.py
+++ b/pyscf/pbc/tools/test/test_pyscf_ase.py
@@ -14,40 +14,31 @@
 
 import unittest
 import numpy as np
-from pyscf.pbc import gto as pbcgto
-from pyscf.pbc.tools import pyscf_ase
 
 try:
     from ase.lattice.cubic import Diamond
+    from pyscf.pbc.tools import pyscf_ase
     HAVE_ASE = True
 except ImportError:
     HAVE_ASE = False
 
 
 def _make_cell():
-    '''Build a minimal diamond cell for testing.'''
-    cell = pbcgto.Cell()
-    cell.atom = 'C 0. 0. 0.; C 0.8917 0.8917 0.8917'
-    cell.a = '''0.      1.7834  1.7834
-                1.7834  0.      1.7834
-                1.7834  1.7834  0.    '''
-    cell.unit = 'A'
+    '''Build a minimal diamond cell for testing via cell_from_ase.'''
+    ase_atom = Diamond(symbol='C', latticeconstant=3.5668)
+    cell = pyscf_ase.cell_from_ase(ase_atom)
     cell.basis = 'gth-szv'
     cell.pseudo = 'gth-pade'
     cell.verbose = 0
     cell.output = '/dev/null'
     cell.build()
-    return cell
+    return cell, ase_atom
 
 
 def _make_symm_cell():
     '''Build a minimal diamond cell with space group symmetry enabled.'''
-    cell = pbcgto.Cell()
-    cell.atom = 'C 0. 0. 0.; C 0.8917 0.8917 0.8917'
-    cell.a = '''0.      1.7834  1.7834
-                1.7834  0.      1.7834
-                1.7834  1.7834  0.    '''
-    cell.unit = 'A'
+    ase_atom = Diamond(symbol='C', latticeconstant=3.5668)
+    cell = pyscf_ase.cell_from_ase(ase_atom)
     cell.basis = 'gth-szv'
     cell.pseudo = 'gth-pade'
     cell.verbose = 0
@@ -55,29 +46,27 @@ def _make_symm_cell():
     cell.space_group_symmetry = True
     cell.symmorphic = False
     cell.build()
-    return cell
+    return cell, ase_atom
 
 
+@unittest.skipUnless(HAVE_ASE, "ASE is not installed")
 class PySCFKptsWeightsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.cell = _make_cell()
-        cls.symm_cell = _make_symm_cell()
+        cls.cell, cls.ase_atom = _make_cell()
+        cls.symm_cell, cls.symm_ase_atom = _make_symm_cell()
 
     def _make_calc(self, kpts):
         '''Create a PySCF calculator wrapping a KRKS method.'''
         mf = self.cell.KRKS(xc='lda,vwn', kpts=kpts)
-        # Build ASE atoms and wrap
-        ase_atom = Diamond(symbol='C', latticeconstant=3.5668)
-        ase_atom.calc = pyscf_ase.PySCF(method=mf)
-        return ase_atom.calc
+        self.ase_atom.calc = pyscf_ase.PySCF(method=mf)
+        return self.ase_atom.calc
 
     def _make_symm_calc(self, kpts):
         '''Create a PySCF calculator using symmetry-enabled cell.'''
         mf = self.symm_cell.KRKS(xc='lda,vwn', kpts=kpts)
-        ase_atom = Diamond(symbol='C', latticeconstant=3.5668)
-        ase_atom.calc = pyscf_ase.PySCF(method=mf)
-        return ase_atom.calc
+        self.symm_ase_atom.calc = pyscf_ase.PySCF(method=mf)
+        return self.symm_ase_atom.calc
 
     def test_k_point_weights_no_symmetry(self):
         '''Uniform MP grid: all weights should be equal 1/nkpts.'''
@@ -147,30 +136,6 @@ class PySCFKptsWeightsTest(unittest.TestCase):
         mult = np.bincount(bz2ibz, minlength=len(w))
         # Weight should equal multiplicity / nkpts_bz
         self.assertTrue(np.allclose(w, mult / nkpts_bz))
-
-    def test_molecular_fallback(self):
-        '''Non-PBC calculation should return single-point defaults.'''
-        from pyscf import gto as molgto
-        mol = molgto.Mole()
-        mol.atom = 'H 0 0 0; H 0 0 0.74'
-        mol.basis = 'sto-3g'
-        mol.verbose = 0
-        mol.output = '/dev/null'
-        mol.build()
-        mf = mol.HF()
-        from ase import Atoms
-        ase_atom = Atoms('H2', positions=[[0, 0, 0], [0, 0, 0.74]])
-        ase_atom.calc = pyscf_ase.PySCF(method=mf)
-        calc = ase_atom.calc
-
-        w = calc.get_k_point_weights()
-        np.testing.assert_array_equal(w, [1.0])
-
-        bz_kpts = calc.get_bz_k_points()
-        np.testing.assert_array_equal(bz_kpts, np.zeros((1, 3)))
-
-        bz2ibz = calc.get_bz_to_ibz_map()
-        np.testing.assert_array_equal(bz2ibz, [0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
For #1987.

Add necessary functions for PySCF calculator which DOS needs.

Also, modify the band_structure function because I found it's not practically correct in example: Fermi level is in eV so ek should also be in eV; and ASE's plot does not shift fermi level to 0, thus shifting at pyscf side is more practical since this allows a simple emin, emax relative to 0.