### PR TITLE
Fixing a few bugs for k-point RPA

### DIFF
--- a/pyscf/pbc/gw/krpa.py
+++ b/pyscf/pbc/gw/krpa.py
@@ -706,10 +706,9 @@ def get_rpa_exx(rpa, acfd=False, correction_only=False):
     ex : double
         exchange energy
     """
-    mo_coeff = np.array(_mo_frozen(rpa, rpa._scf.mo_coeff))
-    mo_occ = np.array(_mo_occ_frozen(rpa, rpa._scf.mo_occ))
+    mo_coeff = np.asarray(rpa._scf.mo_coeff)
+    mo_occ = np.asarray(rpa._scf.mo_occ)
 
-    nocc = rpa.nocc
     nao = rpa._scf.mo_coeff[0].shape[0]
     nkpts = rpa.nkpts
     kpts = rpa.kpts
@@ -771,9 +770,13 @@ def get_rpa_exx(rpa, acfd=False, correction_only=False):
                 # ex -= np.einsum('Lij,Lij->', Lij_occ.reshape(-1, nocc, nocc), Lij.reshape(-1, nocc, nocc).conj())
                 ex -= blas.zdotc(Lij_occ.ravel(), Lij.ravel())
             else:
-                moij, ijslice = _conc_mos(mo_coeff[km][:, :nocc], mo_coeff[kn][:, :nocc])[2:]
+                nocc_i = np.count_nonzero(mo_occ[km])
+                nocc_j = np.count_nonzero(mo_occ[kn])
+                moij, ijslice = _conc_mos(
+                    mo_coeff[km][:, :nocc_i],
+                    mo_coeff[kn][:, :nocc_j],
+                )[2:]
                 Lij = r_e2(Lpq_ao, moij, ijslice, tao=[], ao_loc=None, out=Lij)
-                # ex -= np.einsum('Lij,Lij->', Lij.reshape(-1, nocc, nocc), Lij.reshape(-1, nocc, nocc).conj())
                 ex -= blas.zdotc(Lij.ravel(), Lij.ravel())
 
     ex = ex.real

--- a/pyscf/pbc/gw/krpa.py
+++ b/pyscf/pbc/gw/krpa.py
@@ -805,6 +805,10 @@ def get_kconserv_ria_efficient(cell, kpts, tol=1e-12):
 
         (k(m) - k(n) - k(kshift)) \dot a = 2n\pi
     """
+    # The conservation table is built for momentum transfers, which are invariant
+    # under a uniform shift of all k-points.
+    kpts = kpts - kpts[0]
+
     nkpts = kpts.shape[0]
     a = cell.lattice_vectors() / (2 * np.pi)
 

--- a/pyscf/pbc/gw/krpa.py
+++ b/pyscf/pbc/gw/krpa.py
@@ -139,9 +139,15 @@ def get_idx_metal(mo_occ, threshold=1.0e-6):
     idx_vir : list
         list of virtual orbital indexes
     """
-    idx_occ = np.where(mo_occ > 2.0 - threshold)[0]
-    idx_vir = np.where(mo_occ < threshold)[0]
-    idx_frac = list(range(idx_occ[-1] + 1, idx_vir[0]))
+    mo_occ = np.asarray(mo_occ)
+
+    mask_occ = mo_occ > 2.0 - threshold
+    mask_vir = mo_occ < threshold
+    mask_frac = ~(mask_occ | mask_vir)
+
+    idx_occ = np.where(mask_occ)[0]
+    idx_frac = np.where(mask_frac)[0]
+    idx_vir = np.where(mask_vir)[0]
 
     return idx_occ, idx_frac, idx_vir
 
@@ -183,14 +189,20 @@ def get_rho_response_metal(omega, mo_energy, mo_occ, Lpq, kidx):
     for i in range(nkpts):
         # Find ka that conserves with ki and kL (-ki+ka+kL=G)
         a = kidx[i]
-        idx_occ_i, _, idx_vir_i = get_idx_metal(mo_occ[i])
-        idx_occ_a, idx_frac_a, idx_vir_a = get_idx_metal(mo_occ[a])
 
-        # merge index
-        idx_i = slice(idx_occ_i[0], idx_vir_i[0])
-        idx_a = slice(idx_occ_a[-1] + 1, idx_vir_a[-1] + 1)
+        idx_occ_i, idx_frac_i, _ = get_idx_metal(mo_occ[i])
+        idx_occ_a, idx_frac_a, _ = get_idx_metal(mo_occ[a])
+
         nocc_i = len(idx_occ_i)
+        nfrac_i = len(idx_frac_i)
+        nocc_a = len(idx_occ_a)
         nfrac_a = len(idx_frac_a)
+
+        # occupied + fractional
+        idx_i = slice(0, nocc_i + nfrac_i)
+
+        # fractional + virtual
+        idx_a = slice(nocc_a, len(mo_occ[a]))
 
         eia = mo_energy[i, idx_i, None] - mo_energy[a, None, idx_a]
         fia = (mo_occ[i][idx_i, None] - mo_occ[a][None, idx_a]) / 2.0

--- a/pyscf/pbc/gw/kurpa.py
+++ b/pyscf/pbc/gw/kurpa.py
@@ -533,7 +533,6 @@ def get_rpa_exx(rpa, acfd=False, correction_only=False):
     mo_coeff = np.asarray(rpa._scf.mo_coeff)
     mo_occ = np.asarray(rpa._scf.mo_occ)
 
-    nocc = rpa.nocc
     nspin, _, nao, _ = mo_coeff.shape
     nkpts = rpa.nkpts
     kpts = rpa.kpts
@@ -596,9 +595,13 @@ def get_rpa_exx(rpa, acfd=False, correction_only=False):
                     # ex -= np.einsum('Lij,Lij->', Lij_occ.reshape(-1, nocc, nocc), Lij.reshape(-1, nocc, nocc).conj())
                     ex -= blas.zdotc(Lij_occ.ravel(), Lij.ravel())
                 else:
-                    moij, ijslice = _conc_mos(mo_coeff[s][km][:, :nocc[s]], mo_coeff[s][kn][:, :nocc[s]])[2:]
+                    nocc_i = np.count_nonzero(mo_occ[s][km])
+                    nocc_j = np.count_nonzero(mo_occ[s][kn])
+                    moij, ijslice = _conc_mos(
+                        mo_coeff[s][km][:, :nocc_i],
+                        mo_coeff[s][kn][:, :nocc_j],
+                    )[2:]
                     Lij = _ao2mo.r_e2(Lpq_ao, moij, ijslice, tao=[], ao_loc=None, out=Lij)
-                    # ex -= np.einsum('Lij,Lij->', Lij.reshape(-1, nocc, nocc), Lij.reshape(-1, nocc, nocc).conj())
                     ex -= blas.zdotc(Lij.ravel(), Lij.ravel())
 
     ex = ex.real
@@ -646,7 +649,11 @@ class KURPA(KRPA):
     @property
     def nocc(self):
         mo_occ = self._scf.mo_occ
-        return (int(np.sum(mo_occ[0][0])), int(np.sum(mo_occ[1][0])))
+        nocc_a, nocc_b = [
+            int(np.rint(np.sum(mo_occ[s]) / self.nkpts))
+            for s in range(2)
+        ]
+        return nocc_a, nocc_b
 
     @nocc.setter
     def nocc(self, n):

--- a/pyscf/pbc/gw/kurpa.py
+++ b/pyscf/pbc/gw/kurpa.py
@@ -139,9 +139,15 @@ def get_idx_metal(mo_occ, threshold=1.0e-6):
     idx_vir : list
         list of virtual orbital indexes
     """
-    idx_occ = np.where(mo_occ > 1.0 - threshold)[0]
-    idx_vir = np.where(mo_occ < threshold)[0]
-    idx_frac = list(range(idx_occ[-1] + 1, idx_vir[0]))
+    mo_occ = np.asarray(mo_occ)
+
+    mask_occ = mo_occ > 1.0 - threshold
+    mask_vir = mo_occ < threshold
+    mask_frac = ~(mask_occ | mask_vir)
+
+    idx_occ = np.where(mask_occ)[0]
+    idx_frac = np.where(mask_frac)[0]
+    idx_vir = np.where(mask_vir)[0]
 
     return idx_occ, idx_frac, idx_vir
 

--- a/pyscf/pbc/gw/test/test_krpa.py
+++ b/pyscf/pbc/gw/test/test_krpa.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import numpy as np
 import pytest
 
 from pyscf.pbc import df, gto, scf
@@ -86,3 +87,32 @@ def test_krpa_with_fc_outcore(diamond_krhf):
 
     assert rpa.e_corr == pytest.approx(-0.20723389722097715, abs=1e-6)
     assert rpa.e_tot == pytest.approx(-10.716348738655793, abs=1e-6)
+
+
+def test_krpa_get_idx_metal():
+    from pyscf.pbc.gw.krpa import get_idx_metal
+    cases = [
+        ([2.0, 1.5, 0.5, 0.0], ([0], [1, 2], [3])),
+        ([1.9, 0.7, 0.0], ([], [0, 1], [2])),
+        ([2.0, 1.2, 0.1], ([0], [1, 2], [])),
+        ([1.9, 1.0, 0.1], ([], [0, 1, 2], [])),
+    ]
+    for mo_occ, expected in cases:
+        result = tuple(list(idx) for idx in get_idx_metal(np.asarray(mo_occ)))
+        assert result == expected
+
+
+def test_krpa_get_rho_response_metal_all_fractional():
+    from pyscf.pbc.gw.krpa import get_rho_response_metal
+    omega = 0.7
+    mo_energy = np.array([[-1.0, -0.2, 0.8]])
+    mo_occ = np.array([[1.8, 1.0, 0.2]])
+    Lpq = [np.arange(18).reshape(2, 3, 3).astype(np.complex128) / 20]
+
+    eia = mo_energy[0, :, None] - mo_energy[0, None, :]
+    fia = mo_occ[0, :, None] - mo_occ[0, None, :]
+    weight = eia * fia / (omega**2 + eia**2)
+    expected = np.einsum("Pia,ia,Qia->PQ", Lpq[0], weight, Lpq[0].conj())
+
+    result = get_rho_response_metal(omega, mo_energy, mo_occ, Lpq, [0])
+    np.testing.assert_allclose(result, expected)

--- a/pyscf/pbc/gw/test/test_krpa.py
+++ b/pyscf/pbc/gw/test/test_krpa.py
@@ -118,6 +118,31 @@ def test_krpa_get_rho_response_metal_all_fractional():
     np.testing.assert_allclose(result, expected)
 
 
+def test_krpa_kconserv_shifted_kmesh():
+    ''' This test checks if the kconserv table constructed by `get_kconserv_ria_efficient`
+        remains invariant to a rigid shift of a given k-mesh.
+    '''
+    from pyscf.pbc.gw.krpa import get_kconserv_ria_efficient
+
+    cell = gto.Cell()
+    cell.build(
+        a=np.eye(3) * 3,
+        atom="H 0 0 0",
+        basis="sto-3g",
+        spin=1,
+        verbose=0,
+    )
+    kmesh = [2, 2, 2]
+    kpts = cell.make_kpts(kmesh, scaled_center=[0, 0, 0])
+    shifted_kpts = cell.make_kpts(
+        kmesh, scaled_center=[0.6223 / 2, 0.2953 / 2, 0]
+    )
+
+    reference = get_kconserv_ria_efficient(cell, kpts)
+    result = get_kconserv_ria_efficient(cell, shifted_kpts)
+    np.testing.assert_array_equal(result, reference)
+
+
 @pytest.fixture(scope="module")
 def water_krhf():
     cell = gto.Cell()

--- a/pyscf/pbc/gw/test/test_krpa.py
+++ b/pyscf/pbc/gw/test/test_krpa.py
@@ -116,3 +116,62 @@ def test_krpa_get_rho_response_metal_all_fractional():
 
     result = get_rho_response_metal(omega, mo_energy, mo_occ, Lpq, [0])
     np.testing.assert_allclose(result, expected)
+
+
+@pytest.fixture(scope="module")
+def water_krhf():
+    cell = gto.Cell()
+    cell.build(
+        unit="angstrom",
+        atom="""
+        O          0.00000        0.00000        0.11779
+        H          0.00000        0.75545       -0.47116
+        H          0.00000       -0.75545       -0.47116
+        """,
+        a=np.eye(3) * 5,
+        verbose=0,
+        output="/dev/null",
+        pseudo=None,
+        basis="cc-pvdz",
+        precision=1e-12,
+    )
+
+    kpts = cell.make_kpts([1, 1, 1], scaled_center=[0, 0, 0])
+    gdf = df.RSGDF(cell, kpts)
+    gdf.build()
+
+    kmf = scf.KRHF(cell, kpts).rs_density_fit()
+    kmf.with_df = gdf
+    kmf.conv_tol = 1e-12
+
+    yield kmf
+
+    cell.stdout.close()
+
+
+def test_krpa_exx_with_frozen(water_krhf):
+    ''' Check that HF exchange energy calculated inside KRPA agrees with that from
+        `mf.get_jk` for both non-smeared and smeared cases and with or without frozen.
+    '''
+    kmf = water_krhf
+
+    for sigma_ev in [0., 1.]:
+        if sigma_ev > 1e-4:
+            scf.addons.smearing_(kmf, sigma=sigma_ev/27.211399, method='fermi')
+
+        kmf.kernel()
+
+        from pyscf.pbc.gw.krpa import get_rpa_exx
+        rpa = KRPA(kmf, frozen=0)
+        mf = rpa._scf
+        dm = mf.make_rdm1()
+        vk = mf.get_k(dm_kpts=dm)
+        e_x_ref = np.einsum('kij,kji->', vk, dm).real * -0.25 / len(mf.kpts)
+        e_x = get_rpa_exx(rpa)
+
+        assert e_x == pytest.approx(e_x_ref, abs=1e-6)
+
+        rpa = KRPA(kmf, frozen=2)
+        e_x = get_rpa_exx(rpa)
+
+        assert e_x == pytest.approx(e_x_ref, abs=1e-6)

--- a/pyscf/pbc/gw/test/test_kurpa.py
+++ b/pyscf/pbc/gw/test/test_kurpa.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import numpy as np
 import pytest
 
 from pyscf.pbc import df, gto, scf
@@ -83,3 +84,36 @@ def test_kurpa_with_fc_outcore(hydrogen_kuhf):
     rpa.kernel()
 
     assert rpa.e_corr == pytest.approx(-0.04295466718074476, abs=1e-6)
+
+
+def test_kurpa_get_idx_metal():
+    from pyscf.pbc.gw.kurpa import get_idx_metal
+    cases = [
+        ([1.0, 0.75, 0.25, 0.0], ([0], [1, 2], [3])),
+        ([0.9, 0.35, 0.0], ([], [0, 1], [2])),
+        ([1.0, 0.6, 0.05], ([0], [1, 2], [])),
+        ([0.9, 0.5, 0.1], ([], [0, 1, 2], [])),
+    ]
+    for mo_occ, expected in cases:
+        result = tuple(list(idx) for idx in get_idx_metal(np.asarray(mo_occ)))
+        assert result == expected
+
+
+def test_kurpa_get_rho_response_metal_all_fractional():
+    from pyscf.pbc.gw.kurpa import get_rho_response_metal
+    omega = 0.7
+    mo_energy = np.array([[[-1.0, -0.2, 0.8]], [[-0.9, 0.1, 1.0]]])
+    mo_occ = np.array([[[0.9, 0.5, 0.1]], [[0.8, 0.4, 0.2]]])
+    Lpq = np.arange(36).reshape(1, 2, 2, 3, 3).astype(np.complex128) / 20
+
+    expected = np.zeros((2, 2), dtype=np.complex128)
+    for spin in range(2):
+        eia = mo_energy[spin, 0, :, None] - mo_energy[spin, 0, None, :]
+        fia = mo_occ[spin, 0, :, None] - mo_occ[spin, 0, None, :]
+        weight = eia * fia / (omega**2 + eia**2)
+        expected += np.einsum(
+            "Pia,ia,Qia->PQ", Lpq[0, spin], weight, Lpq[0, spin].conj()
+        )
+
+    result = get_rho_response_metal(omega, mo_energy, mo_occ, Lpq, [0])
+    np.testing.assert_allclose(result, expected)

--- a/pyscf/pbc/gw/test/test_kurpa.py
+++ b/pyscf/pbc/gw/test/test_kurpa.py
@@ -117,3 +117,66 @@ def test_kurpa_get_rho_response_metal_all_fractional():
 
     result = get_rho_response_metal(omega, mo_energy, mo_occ, Lpq, [0])
     np.testing.assert_allclose(result, expected)
+
+
+@pytest.fixture(scope="module")
+def water_kuhf():
+    cell = gto.Cell()
+    cell.build(
+        unit="angstrom",
+        atom="""
+        O          0.00000        0.00000        0.11779
+        H          0.00000        0.75545       -0.47116
+        H          0.00000       -0.75545       -0.47116
+        """,
+        a=np.eye(3) * 5,
+        verbose=0,
+        output="/dev/null",
+        pseudo=None,
+        basis="cc-pvdz",
+        precision=1e-12,
+    )
+
+    kpts = cell.make_kpts([1, 1, 1], scaled_center=[0, 0, 0])
+    gdf = df.RSGDF(cell, kpts)
+    gdf.build()
+
+    kmf = scf.KUHF(cell, kpts).rs_density_fit()
+    kmf.with_df = gdf
+    kmf.conv_tol = 1e-12
+
+    yield kmf
+
+    cell.stdout.close()
+
+
+def test_kurpa_exx_with_frozen(water_kuhf):
+    ''' Check that HF exchange energy calculated inside KURPA agrees with that from
+        `mf.get_jk` for both non-smeared and smeared cases and with or without frozen.
+
+        NOTE: KURPA currently ignores the `frozen` attribute, so this test does not
+        test frozen-orbital behavior at the moment. Any future implementation of
+        frozen-orbital support in KURPA should ensure that this test continues to pass.
+    '''
+    kmf = water_kuhf
+
+    for sigma_ev in [0., 1.]:
+        if sigma_ev > 1e-4:
+            scf.addons.smearing_(kmf, sigma=sigma_ev/27.211399, method='fermi')
+
+        kmf.kernel()
+
+        from pyscf.pbc.gw.kurpa import get_rpa_exx
+        rpa = KURPA(kmf, frozen=0)
+        mf = rpa._scf
+        dm = mf.make_rdm1()
+        vk = mf.get_k(dm_kpts=dm)
+        e_x_ref = np.einsum('skij,skji->', vk, dm).real * -0.5 / len(mf.kpts)
+        e_x = get_rpa_exx(rpa)
+
+        assert e_x == pytest.approx(e_x_ref, abs=1e-6)
+
+        rpa = KURPA(kmf, frozen=2)
+        e_x = get_rpa_exx(rpa)
+
+        assert e_x == pytest.approx(e_x_ref, abs=1e-6)


### PR DESCRIPTION
This PR fixes the following bugs in the current KRPA/KURPA implementations:
1. When all orbitals are fractionally occupied, `idx_occ` and/or `idx_vir` can be empty. Accessing elements such as `idx_occ[0]` or `idx_occ[-1]` then raises an error.
2. `get_rpa_exx` uses only the active (i.e., non-frozen) orbitals when calculating the HF exchange energy.
3. `KURPA.nocc` (a) uses `mo_occ` only at k-point 0 and (b) can suffer from rounding errors because of the use of int.
4. [Updated] The k-conserv table should be constructed for the momentum transfer, `kpts-kpts[0]` but was constructed for the original `kpts`. This bug is fixed by forcing `get_kconserv_ria_efficient` to work on `kpts-kpts[0]` internally.

Tests for these cases are added.

Note: `frozen` is currently not supported by `KURPA`. Therefore the test added for KURPA regarding HF exchange energy with `frozen` is not effectively testing its behavior when `frozen` is non-zero. I kept this test so that future implementation of `frozen` in `KURPA` should pass it.