### PR TITLE
Use the optical dielectric constant of the solvent in non-equilibrium TDDFT

### DIFF
--- a/examples/solvent/21-tddft_equilibrium_solvation.py
+++ b/examples/solvent/21-tddft_equilibrium_solvation.py
@@ -42,3 +42,16 @@ td.kernel()
 #
 td.with_solvent.equilibrium_solvation = False
 td.kernel()
+
+#
+# Non-equilibrium solvation is governed by the optical dielectric constant of
+# the solvent, the square of its refractive index. Unless .eps_optical is
+# assigned, the value of water (1.78) is assumed. The SMD model derives
+# .eps_optical from its solvent database automatically.
+#
+mf = mol.RHF().ddCOSMO()
+mf.with_solvent.eps = 7.4257           # tetrahydrofuran
+mf.with_solvent.eps_optical = 1.405**2
+mf.run()
+td = mf.TDA()
+td.kernel()

--- a/pyscf/solvent/_attach_solvent.py
+++ b/pyscf/solvent/_attach_solvent.py
@@ -671,10 +671,12 @@ def _for_tdscf(method, solvent_obj=None, dm=None, equilibrium_solvation=False):
         solvent_obj.equilibrium_solvation = equilibrium_solvation
         if not equilibrium_solvation:
             # The vertical excitation is a fast process, applying non-equilibrium
-            # solvation with optical dielectric constant eps=1.78
+            # solvation with the optical dielectric constant of the solvent
             # TODO: reset() can be skipped. Most intermeidates can be reused.
+            eps_optical = solvent_obj.get_eps_optical()
             solvent_obj.reset()
-            solvent_obj.eps = 1.78
+            solvent_obj.eps_optical = eps_optical
+            solvent_obj.eps = eps_optical
             solvent_obj.build()
 
     if isinstance(method, _Solvation):
@@ -756,7 +758,8 @@ class TDSCFWithSolvent(_Solvation):
         # The redistributed surface charge is computed by solving
         #     K^{-1} R (dm_response)
         # using a different dielectric constant. The optical dielectric constant
-        # (eps=1.78, see QChem manual) is a suitable choice for the excited state.
+        # of the solvent (see QChem manual) is a suitable choice for the
+        # excited state.
         if not self.with_solvent.equilibrium_solvation:
             # Solvent with optical dielectric constant, for evaluating the
             # response of the fast solvent part

--- a/pyscf/solvent/ddcosmo.py
+++ b/pyscf/solvent/ddcosmo.py
@@ -241,6 +241,13 @@ from pyscf.symm import sph
 
 from pyscf.solvent import _attach_solvent
 
+# Static (zero-frequency) dielectric constant of water at 298 K
+EPS_WATER = 78.3553
+
+# Optical (high-frequency) dielectric constant of water, roughly the square of
+# its refractive index. See the QChem manual, the non-equilibrium PCM section.
+EPS_OPTICAL_WATER = 1.78
+
 @lib.with_doc(_attach_solvent._for_scf.__doc__)
 def ddcosmo_for_scf(mf, solvent_obj=None, dm=None):
     if solvent_obj is None:
@@ -612,8 +619,8 @@ def atoms_with_vdw_overlap(atm_id, atom_coords, r_vdw):
 class ddCOSMO(lib.StreamObject):
     _keys = {
         'mol', 'radii_table', 'atom_radii', 'lebedev_order', 'lmax', 'eta',
-        'eps', 'grids', 'max_cycle', 'conv_tol', 'state_id', 'frozen',
-        'equilibrium_solvation', 'e', 'v',
+        'eps', 'eps_optical', 'grids', 'max_cycle', 'conv_tol', 'state_id',
+        'frozen', 'equilibrium_solvation', 'e', 'v',
     }
 
     def __init__(self, mol):
@@ -629,7 +636,12 @@ class ddCOSMO(lib.StreamObject):
         self.lebedev_order = 17
         self.lmax = 6  # max angular momentum of spherical harmonics basis
         self.eta = .1  # regularization parameter
-        self.eps = 78.3553
+        self.eps = EPS_WATER
+
+        # Square of the refractive index of the solvent, used by the
+        # non-equilibrium solvation (see .get_eps_optical)
+        self.eps_optical = None
+
         self.grids = Grids(mol)
 
         # The maximum iterations and convergence tolerance to update solvent
@@ -697,6 +709,24 @@ class ddCOSMO(lib.StreamObject):
     def vpcm(self, val):
         self.v_solvent = val
 
+    def get_eps_optical(self):
+        '''The optical (high-frequency) dielectric constant of the solvent.
+
+        Only the fast, electronic part of the solvent polarization follows a
+        vertical excitation. Its response is governed by the optical dielectric
+        constant rather than the static one (see .equilibrium_solvation).
+        '''
+        if self.eps_optical is not None:
+            return self.eps_optical
+        # .eps is None in the SMD model when eps is taken from solvent_db
+        if self.eps is not None and abs(self.eps - EPS_WATER) > 1e-6:
+            logger.warn(self, 'eps_optical was not specified for eps=%g. The '
+                        'optical dielectric constant of water (%g) is applied '
+                        'in the non-equilibrium solvation. Please set '
+                        '.eps_optical to the square of the refractive index of '
+                        'the solvent in use.', self.eps, EPS_OPTICAL_WATER)
+        return EPS_OPTICAL_WATER
+
     def __setattr__(self, key, val):
         if key in ('radii_table', 'atom_radii', 'lebedev_order', 'lmax',
                    'eta', 'eps', 'grids'):
@@ -710,6 +740,7 @@ class ddCOSMO(lib.StreamObject):
         logger.info(self, 'lmax = %s'         , self.lmax)
         logger.info(self, 'eta = %s'          , self.eta)
         logger.info(self, 'eps = %s'          , self.eps)
+        logger.info(self, 'eps_optical = %s'  , self.eps_optical)
         logger.info(self, 'frozen = %s'       , self.frozen)
         logger.info(self, 'equilibrium_solvation = %s', self.equilibrium_solvation)
         logger.debug2(self, 'radii_table %s', self.radii_table)

--- a/pyscf/solvent/ddpcm.py
+++ b/pyscf/solvent/ddpcm.py
@@ -204,6 +204,7 @@ class ddPCM(ddcosmo.DDCOSMO):
         logger.info(self, 'lmax = %s'         , self.lmax)
         logger.info(self, 'eta = %s'          , self.eta)
         logger.info(self, 'eps = %s'          , self.eps)
+        logger.info(self, 'eps_optical = %s'  , self.eps_optical)
         logger.info(self, 'frozen = %s'       , self.frozen)
         logger.info(self, 'equilibrium_solvation = %s', self.equilibrium_solvation)
         logger.debug2(self, 'radii_table %s', self.radii_table)

--- a/pyscf/solvent/pcm.py
+++ b/pyscf/solvent/pcm.py
@@ -287,6 +287,13 @@ class PCM(lib.StreamObject):
         The dielectric constant of the solvent. Default is 78.3553, the dielectric constant
         for water.
 
+    eps_optical : float
+        The optical (high-frequency) dielectric constant of the solvent, i.e. the square of
+        its refractive index. It is only used by the non-equilibrium solvation of excited
+        states (see `equilibrium_solvation`). If left unset, the value of water
+        (eps_optical=1.78) is applied and a warning is issued whenever `eps` indicates a
+        solvent other than water. Default is None.
+
     frozen : bool
         Whether to freeze the potential produced by the solvent during SCF iterations or
         other convergence processes. When frozen=True is set, the solvent is
@@ -303,9 +310,8 @@ class PCM(lib.StreamObject):
         Affects TDDFT and other excited state computations. Controls whether the solvent
         relaxes rapidly with respect to the electron density of the excited state.
         For vertical excitations, it is recommended to set this to False, as the solvent
-        typically does not fully relax. In some software packages (e.g., Q-Chem),
-        non-equilibrium solvation is applied with an optical dielectric constant of
-        eps=1.78. Default is False.
+        typically does not fully relax. The non-equilibrium solvation is then applied with
+        the optical dielectric constant `eps_optical`. Default is False.
 
     state_id : int
         Specifies the target state in excited state calculations.
@@ -342,12 +348,13 @@ class PCM(lib.StreamObject):
     _keys = {
         'method', 'vdw_scale', 'surface', 'r_probe',
         'mol', 'radii_table', 'lebedev_order',
-        'eps', 'max_cycle', 'conv_tol', 'state_id', 'frozen',
+        'eps', 'eps_optical', 'max_cycle', 'conv_tol', 'state_id', 'frozen',
         'equilibrium_solvation', 'e', 'v', 'v_grids_n',
         'surface_discretization_method',
     }
 
     kernel = ddcosmo.DDCOSMO.kernel
+    get_eps_optical = ddcosmo.DDCOSMO.get_eps_optical
 
     def __init__(self, mol):
         self.mol = mol
@@ -360,7 +367,8 @@ class PCM(lib.StreamObject):
         self.r_probe = 0.0
         self.radii_table = None
         self.lebedev_order = 29
-        self.eps = 78.3553
+        self.eps = ddcosmo.EPS_WATER
+        self.eps_optical = None
         self.surface_discretization_method = "SWIG"
 
         self.max_cycle = 20
@@ -386,6 +394,7 @@ class PCM(lib.StreamObject):
         logger.info(self, 'lebedev_order = %s (%d grids per sphere)',
                     self.lebedev_order, gen_grid.LEBEDEV_ORDER[self.lebedev_order])
         logger.info(self, 'eps = %s'          , self.eps)
+        logger.info(self, 'eps_optical = %s'  , self.eps_optical)
         logger.info(self, 'frozen = %s'       , self.frozen)
         #logger.info(self, 'equilibrium_solvation = %s', self.equilibrium_solvation)
         return self

--- a/pyscf/solvent/smd.py
+++ b/pyscf/solvent/smd.py
@@ -350,9 +350,14 @@ class SMD(pcm.PCM):
         Affects TDDFT and other excited state computations. Controls whether the solvent
         relaxes rapidly with respect to the electron density of the excited state.
         For vertical excitations, it is recommended to set this to False, as the solvent
-        typically does not fully relax. In some software packages (e.g., Q-Chem),
-        non-equilibrium solvation is applied with an optical dielectric constant of
-        eps=1.78. Default is False.
+        typically does not fully relax. The non-equilibrium solvation is then applied with
+        the optical dielectric constant `eps_optical`. Default is False.
+
+    eps_optical : float
+        The optical (high-frequency) dielectric constant of the solvent, i.e. the square of
+        its refractive index. It is only used by the non-equilibrium solvation of excited
+        states (see `equilibrium_solvation`). If left unset, it is derived from the
+        refractive index of `solvent` in the SMD solvent database. Default is None.
 
     state_id : int
         Specifies the target state in excited state calculations.
@@ -378,7 +383,7 @@ class SMD(pcm.PCM):
     _keys = {
         'method', 'vdw_scale', 'sasa_ng',
         'mol', 'radii_table', 'lebedev_order', 'lmax', 'eta',
-        'solvent', 'eps', 'max_cycle', 'conv_tol', 'state_id', 'frozen',
+        'solvent', 'eps', 'eps_optical', 'max_cycle', 'conv_tol', 'state_id', 'frozen',
         'frozen_dm0_for_finite_difference_without_response',
         'equilibrium_solvation', 'solvent_descriptors',
         'surface', 'intopt', 'e', 'v', 'v_grids_n', 'e_cds',
@@ -400,6 +405,7 @@ class SMD(pcm.PCM):
         self.solvent_descriptors = None
         self.radii_table = None
         self.eps = None
+        self.eps_optical = None
         self.surface_discretization_method = "SWIG"
         self.max_cycle = 20
         self.conv_tol = 1e-7
@@ -460,6 +466,20 @@ class SMD(pcm.PCM):
         self.v_grids_n = np.dot(atom_charges, v_ng)
         return self
 
+    def get_eps_optical(self):
+        '''The optical (high-frequency) dielectric constant of the solvent.
+
+        Unless .eps_optical is set explicitly, it is evaluated as n**2 from the
+        refractive index n of the solvent (see .sol_desc).
+        '''
+        if self.eps_optical is not None:
+            return self.eps_optical
+        n = (self.solvent_descriptors or solvent_db[self.solvent])[0]
+        if not n:
+            # Neither .solvent nor .sol_desc was specified. n is unknown.
+            return pcm.PCM.get_eps_optical(self)
+        return n**2
+
     @property
     def sol_desc(self):
         return self.solvent_descriptors
@@ -489,6 +509,7 @@ class SMD(pcm.PCM):
         logger.info(self, '******** %s ********', self.__class__)
         logger.info(self, 'sasa_ng = %s', self.sasa_ng)
         logger.info(self, 'eps = %s'   , self.eps or eps)
+        logger.info(self, 'eps_optical = %s', self.eps_optical)
         logger.info(self, 'frozen = %s', self.frozen)
         logger.info(self, '---------- SMD solvent descriptors -------')
         logger.info(self, f'n     = {n}')

--- a/pyscf/solvent/test/test_pcm_tdscf.py
+++ b/pyscf/solvent/test/test_pcm_tdscf.py
@@ -255,6 +255,42 @@ class KnownValues(unittest.TestCase):
         #es_get_ab = diagonalize_u(a, b)[0]
         #assert np.linalg.norm(es_get_ab - es) < 1e-10
 
+    def test_eps_optical_default(self):
+        # eps_optical defaults to the value of water
+        mf = self.mf
+        td = mf.TDA(equilibrium_solvation=False)
+        self.assertAlmostEqual(td.with_solvent.eps, 1.78, 12)
+        # The ground state solvent must not be modified
+        self.assertAlmostEqual(mf.with_solvent.eps, 78, 12)
+        self.assertIsNone(mf.with_solvent.eps_optical)
+
+    def test_eps_optical(self):
+        # issue #3372
+        mf = self.mf
+        eps_optical = 1.4961**2 # toluene
+        with lib.temporary_env(mf.with_solvent, eps_optical=eps_optical):
+            td = mf.TDA(equilibrium_solvation=False)
+        self.assertAlmostEqual(td.with_solvent.eps, eps_optical, 12)
+        es = td.kernel(nstates=5)[0]
+
+        # Equivalent to overriding the excited state eps by hand
+        td_ref = mf.TDA(equilibrium_solvation=False)
+        td_ref.with_solvent.reset()
+        td_ref.with_solvent.eps = eps_optical
+        td_ref.with_solvent.build()
+        es_ref = td_ref.kernel(nstates=5)[0]
+        self.assertAlmostEqual(abs(es - es_ref).max(), 0, 9)
+
+        es_water = mf.TDA(equilibrium_solvation=False).kernel(nstates=5)[0]
+        self.assertTrue(abs(es - es_water).max() > 1e-5)
+
+    def test_eps_optical_equilibrium_solvation(self):
+        # Equilibrium solvation is governed by the static eps
+        mf = self.mf
+        with lib.temporary_env(mf.with_solvent, eps_optical=1.4961**2):
+            td = mf.TDA(equilibrium_solvation=True)
+        self.assertAlmostEqual(td.with_solvent.eps, 78, 12)
+
 
 if __name__ == "__main__":
     print("Full Tests for PCM TDDFT")

--- a/pyscf/solvent/test/test_smd.py
+++ b/pyscf/solvent/test/test_smd.py
@@ -227,6 +227,30 @@ H -0.595 -0.476 -0.824
         _check_smd(atom, 2.1279, solvent='water')
         _check_smd(atom, -0.9778, solvent='toluene')
 
+class OpticalDielectric(unittest.TestCase):
+    def test_eps_optical_from_solvent_db(self):
+        # issue #3372
+        for solvent in ('water', 'toluene', 'methanol', 'tetrahydrofuran'):
+            smdobj = smd.SMD(mol, solvent=solvent)
+            n = smd.solvent_db[solvent][0]
+            self.assertAlmostEqual(smdobj.get_eps_optical(), n**2, 12)
+
+    def test_eps_optical_from_sol_desc(self):
+        smdobj = smd.SMD(mol)
+        smdobj.sol_desc = smd.solvent_db['toluene']
+        self.assertAlmostEqual(smdobj.get_eps_optical(), 1.4961**2, 12)
+
+    def test_eps_optical_overwrite(self):
+        smdobj = smd.SMD(mol, solvent='toluene')
+        smdobj.eps_optical = 1.78
+        self.assertAlmostEqual(smdobj.get_eps_optical(), 1.78, 12)
+
+    def test_eps_optical_unknown_solvent(self):
+        # n is unknown. The value of water is assumed.
+        smdobj = smd.SMD(mol)
+        smdobj.eps = 2.3741
+        self.assertAlmostEqual(smdobj.get_eps_optical(), 1.78, 12)
+
 if __name__ == "__main__":
     print("Full Tests for SMDs")
     unittest.main()


### PR DESCRIPTION
Fixes #3372.

`_for_tdscf` overwrote the dielectric constant of the excited state solvent with hardcoded `1.78`, the optical dielectric constant of water, regardless of the solvent the user had configured. The value the calculation actually used was neither configurable nor reported.

### Changes

* New `eps_optical` attribute on `ddCOSMO`, `ddPCM`, `PCM` and `SMD`, the optical (high-frequency) dielectric constant of the solvent, i.e. the square of its refractive index. `_for_tdscf` now applies it to the non-equilibrium solvation through the new `get_eps_optical` method.
* `SMD` derives `eps_optical` from the refractive index of its solvent database, so a named solvent no longer silently gets the value of water (toluene: 2.238 instead of 1.78).
* `ddCOSMO`/`ddPCM`/`PCM` cannot infer the refractive index from `eps` alone. They keep 1.78 as the fallback, but now warn when `eps` indicates a solvent other than water and `eps_optical` was left unset.
* `eps_optical` is recorded on the excited state solvent object and reported by `dump_flags`, so the value in use can be inspected as `td.with_solvent.eps_optical`.

Equilibrium solvation is unaffected: it is governed by the static dielectric constant of the ground state solvent. Gradients are unaffected as well, since they require `equilibrium_solvation=True`.

### Backward compatibility

Results are unchanged for `ddCOSMO`, `ddPCM` and `PCM` unless `eps_optical` is set explicitly. Non-equilibrium `SMD` TDDFT excitation energies change for solvents other than water, which is the bug being fixed.

### Tests

Added `test_eps_optical*` in `test_pcm_tdscf.py` and an `OpticalDielectric` case in `test_smd.py`. The full `pyscf/solvent/test` suite passes, with the pre-existing reference values in `test_pcm_tdscf.py` unchanged.
