### PR TITLE
Fix the mixed-spin dvvVV block of the UCCSD(T) response density

### DIFF
--- a/pyscf/cc/uccsd_t_rdm.py
+++ b/pyscf/cc/uccsd_t_rdm.py
@@ -250,6 +250,7 @@ def _gamma2_intermediates(mycc, t1, t2, l1, l2, eris=None,
         dvvvv *= .5
         dvvVV = dvvVV + dvvVV.transpose(1,0,2,3)
         dvvVV = lib.take_2d(dvvVV.reshape(nvira**2,nvirb**2), idxa, idxb)
+        dvvVV *= .5
         dVVVV = dVVVV + dVVVV.transpose(1,0,2,3)
         dVVVV = lib.take_2d(dVVVV.reshape(nvirb**2,nvirb**2), idxb, idxb)
         dVVVV *= .5

--- a/pyscf/grad/test/test_uccsd_t.py
+++ b/pyscf/grad/test/test_uccsd_t.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# Copyright 2014-2018 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy
+from pyscf import gto, lib
+from pyscf import scf
+from pyscf import cc
+from pyscf.cc import uccsd_t_lambda
+from pyscf.grad import uccsd_t as uccsd_t_grad
+
+def setUpModule():
+    global mol, mf
+    mol = gto.Mole()
+    mol.verbose = 7
+    mol.output = '/dev/null'
+    mol.atom = [
+        [8 , (0. , 0.     , 0.)],
+        [1 , (0. , -0.757 , 0.587)],
+        [1 , (0. , 0.757  , 0.587)]]
+    mol.spin = 2
+    mol.basis = '631g'
+    mol.build()
+    mf = scf.UHF(mol)
+    mf.conv_tol_grad = 1e-8
+    mf.kernel()
+
+def tearDownModule():
+    global mol, mf
+    mol.stdout.close()
+    del mol, mf
+
+
+def _fd_z(mycc, delta=0.001):
+    '''Central finite difference of the CCSD(T) energy along the z coordinate
+    of the first atom.'''
+    myccs = mycc.as_scanner()
+    atom0 = mol.atom[0]
+    try:
+        mol.atom[0] = ["O", (0., 0., delta)]
+        mol.build(0, 0)
+        e1 = myccs(mol)
+        e1 += myccs.ccsd_t()
+        mol.atom[0] = ["O", (0., 0., -delta)]
+        mol.build(0, 0)
+        e2 = myccs(mol)
+        e2 += myccs.ccsd_t()
+    finally:
+        mol.atom[0] = atom0
+        mol.build(0, 0)
+    return (e1 - e2) / (2 * delta) * lib.param.BOHR
+
+
+class KnownValues(unittest.TestCase):
+    def test_uccsd_t_grad(self):
+        mycc = cc.uccsd.UCCSD(mf)
+        mycc.conv_tol = 1e-10
+        mycc.conv_tol_normt = 1e-8
+        eris = mycc.ao2mo()
+        ecc, t1, t2 = mycc.kernel(eris=eris)
+        conv, l1, l2 = uccsd_t_lambda.kernel(mycc, eris, t1, t2)
+        g1 = uccsd_t_grad.Gradients(mycc).kernel(t1, t2, l1, l2, eris=eris)
+#[[ 0.            0.            0.14809395]
+# [ 0.            0.11228921   -0.07404698]
+# [ 0.           -0.11228921   -0.07404698]]
+        self.assertAlmostEqual(lib.fp(g1), -0.22991153901988648, 7)
+        self.assertAlmostEqual(g1[0,2], _fd_z(mycc), 5)
+
+    def test_uccsd_t_grad_frozen(self):
+        mycc = cc.uccsd.UCCSD(mf, frozen=1)
+        mycc.conv_tol = 1e-10
+        mycc.conv_tol_normt = 1e-8
+        eris = mycc.ao2mo()
+        ecc, t1, t2 = mycc.kernel(eris=eris)
+        conv, l1, l2 = uccsd_t_lambda.kernel(mycc, eris, t1, t2)
+        g1 = uccsd_t_grad.Gradients(mycc).kernel(t1, t2, l1, l2, eris=eris)
+        self.assertAlmostEqual(lib.fp(g1), -0.22995398197034367, 7)
+        self.assertAlmostEqual(g1[0,2], _fd_z(mycc), 5)
+
+    def test_uccsd_t_grad_vs_rccsd_t(self):
+        '''On a closed-shell molecule the UHF reference reduces to the RHF one,
+        so both gradient codes must agree. This is the regression guard for the
+        mixed-spin dvvVV compression bug of issue #3305, which affected only
+        the UHF path.
+        '''
+        from pyscf.cc import ccsd_t_lambda
+        from pyscf.grad import ccsd_t as ccsd_t_grad
+        pmol = gto.M(atom=mol.atom, basis='631g', spin=0, verbose=0)
+
+        rmf = scf.RHF(pmol).run(conv_tol=1e-12)
+        rcc = cc.ccsd.CCSD(rmf)
+        rcc.conv_tol = 1e-10
+        rcc.conv_tol_normt = 1e-8
+        reris = rcc.ao2mo()
+        rcc.kernel(eris=reris)
+        conv, rl1, rl2 = ccsd_t_lambda.kernel(rcc, reris, rcc.t1, rcc.t2)
+        gr = ccsd_t_grad.Gradients(rcc).kernel(rcc.t1, rcc.t2, rl1, rl2, eris=reris)
+
+        umf = scf.UHF(pmol).run(conv_tol=1e-12)
+        ucc = cc.uccsd.UCCSD(umf)
+        ucc.conv_tol = 1e-10
+        ucc.conv_tol_normt = 1e-8
+        ueris = ucc.ao2mo()
+        ucc.kernel(eris=ueris)
+        conv, ul1, ul2 = uccsd_t_lambda.kernel(ucc, ueris, ucc.t1, ucc.t2)
+        gu = uccsd_t_grad.Gradients(ucc).kernel(ucc.t1, ucc.t2, ul1, ul2, eris=ueris)
+
+        self.assertAlmostEqual(abs(gu - gr).max(), 0, 7)
+
+if __name__ == "__main__":
+    print("Tests for UCCSD(T) gradients")
+    unittest.main()

--- a/pyscf/grad/uccsd_t.py
+++ b/pyscf/grad/uccsd_t.py
@@ -133,7 +133,6 @@ H          0.96345360     1.30488291    -0.10782263
     mol.build(0, 0)
     e2 = myccs(mol)
     e2 += myccs.ccsd_t()
-    # FIXME: disagreements between analytical value and finite difference value
     print(g1[0,0], (e1-e2)/0.002)
 #CCSD
 #H   0.0113620114            0.0664344363            0.0029855587


### PR DESCRIPTION
Fixes #3305.

`uccsd_t_rdm._gamma2_intermediates` omits the `*= .5` rescaling of the mixed-spin `dvvVV` block when `compress_vvvv=True`. The block enters the gradient at twice its correct weight, which is the source of the analytic/finite-difference disagreement.

```python
        dvvVV = dvvVV + dvvVV.transpose(1,0,2,3)
        dvvVV = lib.take_2d(dvvVV.reshape(nvira**2,nvirb**2), idxa, idxb)
        dvvVV *= .5                                    # this line was missing
```

The same-spin `dvvvv` and `dVVVV` blocks immediately above and below already had it, and so does the corresponding block of `uccsd_rdm._gamma2_intermediates`, which is why plain UCCSD gradients were unaffected.

### Why the factor is needed

`compress_vvvv` stores only the lower triangle of each virtual pair index, since `(ab|cd)` is symmetric under `a <-> b`. Discarding the `a < b` half requires folding its weight into the surviving element first, which is what the `+ transpose(1,0,2,3)` step does. Because the integrals are symmetric, the quantity that must be stored is the symmetric part `(G_ab + G_ba)/2`, not the sum. The transpose step builds twice that, so the `.5` restores the correct normalisation. Without it the whole alpha-beta `vvvv` block is uniformly a factor of two too large.

### Why it went unnoticed

* `make_rdm1`/`make_rdm2` call `_gamma2_intermediates` with the default `compress_vvvv=False`, so the compression branch never runs on the density matrix path. Properties computed from the RDMs are correct, and `Tr(h.D1) + Tr(eri.D2)/2` reproduces the CCSD(T) energy to 3.8e-12.
* Only `grad/uccsd_t.py` requests `compress_vvvv=True`, so the gradient is the sole consumer of the faulty branch.
* The block is mixed alpha-beta. RHF has no such block, so `grad/ccsd_t.py` was never affected.
* `pyscf/grad/test/` contained `test_ccsd_t.py` but no `test_uccsd_t.py`, so nothing exercised the path.

The (T) energy, the `uccsd_t_lambda` amplitudes and the CCSD(T) response density were all verified correct before and after the change, so they are untouched here.

### Verification

Central finite differences, SCF `conv_tol=1e-14`, CC `conv_tol=1e-12`, step 1e-4:

| case | before | after |
|---|---|---|
| NH2 radical / 6-31G / frozen=1 (issue case) | 4.10e-04 | 1.5e-08 |
| OH radical / 6-31G / frozen=1 | 3.6e-05 | 1.3e-08 |
| OH radical / 6-31G / frozen=None | 3.6e-05 | 1.5e-08 |
| H2O closed shell through UHF / 6-31G | 4.01e-04 | 4.7e-09 |
| H2O triplet / 6-31G | 3e-04 | 1.1e-08 |
| CH3 radical / STO-3G | | 3.8e-18 |
| NH2 radical / cc-pVDZ / frozen=1 | | 1.5e-08 |

The residual is finite-difference step error, matching what `grad/ccsd_t.py` achieves on the same systems.

On a closed-shell molecule the UHF reference reduces to the RHF one, so the two gradient codes must agree. Before the change they differed by 4.01e-04, after it by 4.60e-10.

The `H4` example in the `__main__` block of `grad/uccsd_t.py` now reproduces its own documented reference values and agrees with finite differences to 2.3e-08, so the `FIXME` recording the disagreement is removed.

### Tests

Adds the missing `pyscf/grad/test/test_uccsd_t.py`, covering the open-shell gradient with and without a frozen core, and a closed-shell UCCSD(T) against RCCSD(T) cross-check that would have caught this directly. All three fail on master and pass with the change.
