### PR TITLE
Fix operator precedence in pbc SCF energy_nuc for the RSJK builder

### DIFF
--- a/pyscf/pbc/scf/hf.py
+++ b/pyscf/pbc/scf/hf.py
@@ -766,7 +766,7 @@ class SCF(mol_hf.SCF):
             # When computing CDERI for GDF (also RSJK), the LR part is not
             # evaluated. CDERI is constructed with full-range Coulomb directly.
             # Nuclear repulsion should be computed the same way.
-            isinstance(self.with_df, df.GDF) or self.rsjk is not None):
+            (isinstance(self.with_df, df.GDF) or self.rsjk is not None)):
             from pyscf.gto.mole import classical_coulomb_energy
             return classical_coulomb_energy(cell)
         return cell.enuc

--- a/pyscf/pbc/scf/test/test_rsjk.py
+++ b/pyscf/pbc/scf/test/test_rsjk.py
@@ -17,6 +17,7 @@ import unittest
 import numpy as np
 import scipy.linalg
 from pyscf import lib
+from pyscf.gto.mole import classical_coulomb_energy
 from pyscf.pbc.gto import Cell
 from pyscf.pbc.df import FFTDF
 from pyscf.pbc.tools import k2gamma
@@ -331,6 +332,54 @@ class KnownValues(unittest.TestCase):
         )
         kmf = cell.RHF().jk_method('RS')
         kmf.run()
+
+    def test_energy_nuc(self):
+        '''Periodic systems must use the Ewald lattice sum for the nuclear
+        repulsion when the RSJK builder is enabled (issue #3371). Only a 0D
+        cell uses the real-space Coulomb energy.
+        '''
+        cell = Cell().build(
+             a = np.eye(3)*1.8,
+             atom = '''He     0.      0.      0.
+                       He     0.4917  0.4917  0.4917''',
+             basis = {'He': [[0, [2.5, 1]]]},
+             precision = 1e-9,
+             verbose = 0,
+        )
+        self.assertAlmostEqual(cell.enuc, -3.743066102133448, 9)
+        mf = cell.RHF().jk_method('RS')
+        self.assertAlmostEqual(mf.energy_nuc(), cell.enuc, 9)
+        kmf = cell.KRHF(kpts=cell.make_kpts([2,1,1])).jk_method('RS')
+        self.assertAlmostEqual(kmf.energy_nuc(), cell.enuc, 9)
+
+        cell0 = Cell().build(
+             a = np.eye(3)*8,
+             atom = 'He 0. 0. 0.; He 0. 0. 1.5',
+             basis = {'He': [[0, [2.5, 1]]]},
+             dimension = 0,
+             precision = 1e-9,
+             verbose = 0,
+        )
+        mf0 = cell0.RHF().jk_method('RS')
+        self.assertAlmostEqual(mf0.energy_nuc(),
+                               classical_coulomb_energy(cell0), 9)
+
+    def test_rhf_rsjk_vs_fftdf(self):
+        '''RSJK must reproduce the total energy of the default JK builder
+        (issue #3371).
+        '''
+        cell = Cell().build(
+             a = np.eye(3)*1.8,
+             atom = '''He     0.      0.      0.
+                       He     0.4917  0.4917  0.4917''',
+             basis = {'He': [[0, [2.5, 1]]]},
+             precision = 1e-9,
+             verbose = 0,
+        )
+        e_rs = cell.RHF().jk_method('RS').run().e_tot
+        e_ref = cell.RHF().run().e_tot
+        self.assertAlmostEqual(e_rs, e_ref, 7)
+        self.assertAlmostEqual(e_rs, -1.642545959039, 7)
 
 if __name__ == '__main__':
     print("Full Tests for rsjk")


### PR DESCRIPTION
Fixes #3371.

`SCF.energy_nuc` is missing a pair of parentheses, so the `cell.dimension == 0` guard is bypassed whenever the RSJK builder is active:

```python
        if (cell.dimension == 0 and
            isinstance(self.with_df, df.GDF) or self.rsjk is not None):
```

`and` binds tighter than `or`, so this evaluates as

```python
        if ((cell.dimension == 0 and isinstance(self.with_df, df.GDF))
            or (self.rsjk is not None)):
```

Every periodic calculation using `jk_method('RS')` therefore takes the 0D branch and returns `classical_coulomb_energy(cell)`, the bare molecular nuclear repulsion, instead of the Ewald lattice sum `cell.enuc`. The difference propagates directly into the total energy.

The intent of the condition is unchanged by this PR. A 0D cell with GDF or RSJK still uses the real-space Coulomb energy, which is what the surrounding comment describes. Only the guard is restored.

`pbc.scf.khf.KSCF` inherits this method, so k-point RSJK calculations are affected as well as gamma-point ones.

### Effect

For the cell in the issue, a H2 molecule in a 30 Angstrom box:

```
classical_coulomb_energy = 0.715104339081
cell.enuc (Ewald)        = 0.615031293022
difference               = 0.100073046059
```

which accounts for the reported error to every published digit:

| | E_tot |
|---|---|
| PySCF 2.9.0 | -1.15984707865944 |
| PySCF 2.10.0, 2.11.0, master | -1.05977403260022 |
| master with this change | -1.15984707878253 |
| isolated molecule reference | -1.15984708122961 |

I confirmed the window by running the reporter's script against the released wheels: 2.9.0 is correct, 2.10.0 is the first bad release, and the error persists through master.

The error scales as the Madelung constant, so it decays only as 1/L and comes to dominate in large cells, which is why the reported symptom was a failure to recover the isolated-molecule limit. Measured at three box sizes, the error divided by `N_elec * v_Madelung` is 0.9995, 0.9998 and 0.9999 at L = 20, 30 and 40 Angstrom.

The magnitude is not always small. On the dense He cell used in `pbc/scf/test/test_rsjk.py`, `energy_nuc` returns +2.4854 instead of -3.7431, and the RSJK total energy differs from the FFTDF result by 6.23 Hartree.

### Tests

The existing RSJK tests call `run()` without asserting on the result, which is why this went unnoticed across four releases. Two tests are added to `pbc/scf/test/test_rsjk.py`:

* `test_energy_nuc` asserts that a periodic cell uses `cell.enuc` for both RHF and KRHF with RSJK, and that a 0D cell still uses `classical_coulomb_energy`.
* `test_rhf_rsjk_vs_fftdf` asserts that RSJK reproduces the default JK builder's total energy.

Both fail on master and pass with the change.
