### PR TITLE
Fix analytic gradients and Hessians of X2C with finite nucleus models

### DIFF
--- a/pyscf/x2c/sfx2c1e_grad.py
+++ b/pyscf/x2c/sfx2c1e_grad.py
@@ -108,7 +108,7 @@ def _gen_h1_s1(mol):
         h1 = numpy.zeros((3,n2,n2), dtype=v1.dtype)
         m1 = numpy.zeros((3,n2,n2), dtype=v1.dtype)
         ish0, ish1, i0, i1 = aoslices[ia]
-        with mol.with_rinv_origin(mol.atom_coord(ia)):
+        with mol.with_rinv_at_nucleus(ia):
             z = mol.atom_charge(ia)
             rinv1   = -z*mol.intor('int1e_iprinv', comp=3)
             prinvp1 = -z*mol.intor('int1e_ipprinvp', comp=3)

--- a/pyscf/x2c/sfx2c1e_hess.py
+++ b/pyscf/x2c/sfx2c1e_hess.py
@@ -111,7 +111,7 @@ def gen_sf_hfw(mol, approx='1E'):
         v2cc = numpy.zeros_like(s2aa)
         w2cc = numpy.zeros_like(s2aa)
         if ia == ja:
-            with mol.with_rinv_origin(mol.atom_coord(ia)):
+            with mol.with_rinv_at_nucleus(ia):
                 z = mol.atom_charge(ia)
                 rinv2aa = z*mol.intor('int1e_ipiprinv', comp=9).reshape(3,3,nao,nao)
                 rinv2ab = z*mol.intor('int1e_iprinvip', comp=9).reshape(3,3,nao,nao)

--- a/pyscf/x2c/test/test_x2c_grad.py
+++ b/pyscf/x2c/test/test_x2c_grad.py
@@ -121,7 +121,7 @@ def get_h1_s1(mol, ia):
     t1 = mol.intor('int1e_ipkin', comp=3)
     v1 = mol.intor('int1e_ipnuc', comp=3)
     w1 = mol.intor('int1e_ipspnucsp', comp=12).reshape(3,4,nao,nao)[:,3]
-    with mol.with_rinv_origin(mol.atom_coord(ia)):
+    with mol.with_rinv_at_nucleus(ia):
         rinv1 = -8*mol.intor('int1e_iprinv', comp=3)
         prinvp1 = -8*mol.intor('int1e_ipsprinvsp', comp=12).reshape(3,4,nao,nao)[:,3]
     n2 = nao * 2

--- a/pyscf/x2c/test/test_x2c_hess.py
+++ b/pyscf/x2c/test/test_x2c_hess.py
@@ -112,7 +112,7 @@ def get_h1_s1(mol, ia):
     t1 = mol.intor('int1e_ipkin', comp=3)
     v1 = mol.intor('int1e_ipnuc', comp=3)
     w1 = mol.intor('int1e_ipspnucsp', comp=12).reshape(3,4,nao,nao)[:,3]
-    with mol.with_rinv_origin(mol.atom_coord(ia)):
+    with mol.with_rinv_at_nucleus(ia):
         z = -mol.atom_charge(ia)
         rinv1 = z*mol.intor('int1e_iprinv', comp=3)
         prinvp1 = z*mol.intor('int1e_ipsprinvsp', comp=12).reshape(3,4,nao,nao)[:,3]
@@ -162,7 +162,7 @@ def get_h2_s2(mol, ia, ja):
     v2ao = numpy.zeros_like(s2aa)
     w2ao = numpy.zeros_like(s2aa)
     if ia == ja:
-        with mol.with_rinv_origin(mol.atom_coord(ia)):
+        with mol.with_rinv_at_nucleus(ia):
             z = mol.atom_charge(ia)
             rinv2aa = z*mol.intor('int1e_ipiprinv', comp=9).reshape(3,3,nao,nao)
             rinv2ab = z*mol.intor('int1e_iprinvip', comp=9).reshape(3,3,nao,nao)


### PR DESCRIPTION
## Summary
In `sfx2c1e_grad` and `sfx2c1e_hessian`, the gradients of 1e integrals are calculated with `1/r` operator when finite nucleus models with Gaussian charge distributions are applied, leading to disagreements between analytic and numerical gradients.

## Fix
```
# with mol.with_rinv_origin(mol.atom_coord(ia)):
with mol.with_rinv_at_nucleus(ia):
    z = mol.atom_charge(ia)
    rinv1   = -z*mol.intor('int1e_iprinv', comp=3)
    prinvp1 = -z*mol.intor('int1e_ipprinvp', comp=3)
```
The finite nucleus models are now taken into account. The `with_rinv_at_nucleus` function regresses to `with_rinv_origin` when point charge nucleus models are applied.