### PR TITLE
Fix slow ksymm RSH DF-JK: use the optimized AFT path when kpts_band is a subset of kpts

### DIFF
--- a/pyscf/pbc/df/aft_jk.py
+++ b/pyscf/pbc/df/aft_jk.py
@@ -34,13 +34,35 @@ from pyscf.pbc.df import ft_ao
 from pyscf.pbc.df.df_jk import (_format_dms, _format_kpts_band, _format_jks,
                                 _ewald_exxdiv_for_G0)
 from pyscf.pbc.lib.kpts_helper import (is_zero, group_by_conj_pairs,
-                                       kk_adapted_iter)
+                                       kk_adapted_iter, KPT_DIFF_TOL)
 from pyscf.pbc.tools import k2gamma
 from pyscf.pbc.df.incore import libpbc
 
+def _sub_kpts_idx(kpts, kpts_band):
+    '''Indices of kpts_band within kpts, if every band k-point is also a member
+    of kpts. Returns None otherwise.
+
+    The k-point symmetry adapted SCF drivers call get_jk with kpts_band set to
+    the IBZ k-points, which are a subset of the full BZ mesh. Detecting this
+    lets the optimized *_kpts algorithms be used instead of the generic (and
+    much slower) band code.
+    '''
+    if kpts_band is None:
+        return None
+    kpts = numpy.reshape(kpts, (-1,3))
+    band = numpy.reshape(kpts_band, (-1,3))
+    dk = abs(band[:,None,:] - kpts).max(axis=2)
+    idx = dk.argmin(axis=1)
+    if dk[numpy.arange(len(band)),idx].max() > KPT_DIFF_TOL:
+        return None
+    return idx
+
 def get_j_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None):
+    band_idx = None
     if kpts_band is not None:
-        return get_j_for_bands(mydf, dm_kpts, hermi, kpts, kpts_band)
+        band_idx = _sub_kpts_idx(kpts, kpts_band)
+        if band_idx is None:
+            return get_j_for_bands(mydf, dm_kpts, hermi, kpts, kpts_band)
 
     dm_kpts = lib.asarray(dm_kpts, order='C')
     dms = _format_dms(dm_kpts, kpts)
@@ -58,6 +80,8 @@ def get_j_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None):
 
     if is_zero(kpts):
         vj_kpts = vj_kpts.real.copy()
+    if band_idx is not None:
+        vj_kpts = vj_kpts[:,band_idx]
     return _format_jks(vj_kpts, dm_kpts, kpts_band, kpts)
 
 def _update_vj_(vj_kpts, Gpq, dms, coulG, weight=None):
@@ -134,8 +158,11 @@ def get_j_for_bands(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=N
 
 def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None,
                exxdiv=None):
+    band_idx = None
     if kpts_band is not None:
-        return get_k_for_bands(mydf, dm_kpts, hermi, kpts, kpts_band, exxdiv)
+        band_idx = _sub_kpts_idx(kpts, kpts_band)
+        if band_idx is None:
+            return get_k_for_bands(mydf, dm_kpts, hermi, kpts, kpts_band, exxdiv)
 
     cpu0 = cpu1 = logger.process_clock(), logger.perf_counter()
     log = logger.new_logger(mydf)
@@ -290,6 +317,8 @@ def get_k_kpts(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None,
             if k != k_conj:
                 vk_kpts[:,k_conj] = vk_kpts[:,k].conj()
     log.timer_debug1('get_k_kpts', *cpu0)
+    if band_idx is not None:
+        return _format_jks(vk_kpts[:,band_idx], dm_kpts, kpts_band, kpts)
     return vk_kpts.reshape(dm_kpts.shape)
 
 def get_k_for_bands(mydf, dm_kpts, hermi=1, kpts=numpy.zeros((1,3)), kpts_band=None,

--- a/pyscf/pbc/df/test/test_aft_jk.py
+++ b/pyscf/pbc/df/test/test_aft_jk.py
@@ -244,6 +244,54 @@ class KnownValues(unittest.TestCase):
         ref = FFTDF(cell, kpts=kpts).get_jk(dm, kpts=kpts)[1]
         self.assertAlmostEqual(abs(ref-vk).max(), 0, 7)
 
+    def test_jk_kpts_band_subset(self):
+        # Issue #3391. The k-point symmetry adapted SCF asks for J/K at the IBZ
+        # k-points, i.e. kpts_band is a subset of kpts. That must not fall back
+        # to the generic (and much slower) band code.
+        kpts = cell.make_kpts([2,2,2])
+        numpy.random.seed(1)
+        nao = cell.nao_nr()
+        dm = numpy.random.random((len(kpts),nao,nao))
+        dm = dm + dm.transpose(0,2,1)
+        mydf = aft.AFTDF(cell, kpts)
+        mydf.mesh = [11]*3
+
+        band_idx = [0, 3, 5]
+        kpts_band = kpts[band_idx]
+        self.assertEqual(list(aft_jk._sub_kpts_idx(kpts, kpts_band)), band_idx)
+
+        vj_ref = aft_jk.get_j_kpts(mydf, dm, 1, kpts)[band_idx]
+        vk_ref = aft_jk.get_k_kpts(mydf, dm, 1, kpts, exxdiv='ewald')[band_idx]
+        vj = aft_jk.get_j_kpts(mydf, dm, 1, kpts, kpts_band)
+        vk = aft_jk.get_k_kpts(mydf, dm, 1, kpts, kpts_band, exxdiv='ewald')
+        self.assertEqual(vj.shape, vj_ref.shape)
+        self.assertEqual(vk.shape, vk_ref.shape)
+        self.assertAlmostEqual(abs(vj-vj_ref).max(), 0, 12)
+        self.assertAlmostEqual(abs(vk-vk_ref).max(), 0, 12)
+
+        # A single band k-point may be given with shape (3,)
+        vk = aft_jk.get_k_kpts(mydf, dm, 1, kpts, kpts[3])
+        vk_ref = aft_jk.get_k_kpts(mydf, dm, 1, kpts)[3]
+        self.assertEqual(vk.shape, vk_ref.shape)
+        self.assertAlmostEqual(abs(vk-vk_ref).max(), 0, 12)
+
+        # Two sets of density matrices
+        dms = numpy.array([dm, dm*.5])
+        vk = aft_jk.get_k_kpts(mydf, dms, 1, kpts, kpts_band)
+        vk_ref = aft_jk.get_k_kpts(mydf, dms, 1, kpts)[:,band_idx]
+        self.assertEqual(vk.shape, vk_ref.shape)
+        self.assertAlmostEqual(abs(vk-vk_ref).max(), 0, 12)
+
+        # Genuine band k-points still go through the band code
+        kpts_band = numpy.array([[.1, .2, .3], [0., 0., 0.]])
+        self.assertIs(aft_jk._sub_kpts_idx(kpts, kpts_band), None)
+        vj = aft_jk.get_j_kpts(mydf, dm, 1, kpts, kpts_band)
+        vk = aft_jk.get_k_kpts(mydf, dm, 1, kpts, kpts_band)
+        vj_ref = aft_jk.get_j_for_bands(mydf, dm, 1, kpts, kpts_band)
+        vk_ref = aft_jk.get_k_for_bands(mydf, dm, 1, kpts, kpts_band)
+        self.assertAlmostEqual(abs(vj-vj_ref).max(), 0, 12)
+        self.assertAlmostEqual(abs(vk-vk_ref).max(), 0, 12)
+
     def test_update_vk(self):
         L = 5.
         cell = gto.Cell()


### PR DESCRIPTION
Fixes #3391.

### Cause

`khf_ksymm.KsymAdaptedKSCF.get_jk` always passes a non-`None` `kpts_band`:

```python
if kpts_band is None: kpts_band = kpts.kpts_ibz
```

For the long-range part of an RSH functional, `GDF.get_jk` routes the work to an `AFTDF` object, and `aft_jk.get_j_kpts`/`get_k_kpts` divert *any* non-`None` `kpts_band` to `get_j_for_bands`/`get_k_for_bands`. Those generic routines drive `ft_loop` once per k-point difference, and `ft_loop` rebuilds the `ExtendedMole` and regenerates the FT kernel on every call:

```python
supmol = ft_ao.ExtendedMole.from_cell(cell, bvk_kmesh, rcut.max())
supmol = supmol.strip_basis(rcut)
ft_kern = supmol.gen_ft_kernel(...)
```

The optimized algorithm in `get_k_kpts` builds them once. `strip_basis` is what emits the repeated `Set ft_ao cutoff to` debug lines reported in the issue. Plain J/K is unaffected because the full-range part stays in `df_jk.get_k_kpts`, which handles `kpts_band` properly.

### Fix

The IBZ k-points are a *subset* of the full mesh, not genuine band k-points, so the optimized algorithm applies directly; it already computes all of `kpts`, and the requested rows can simply be selected from its result. `_sub_kpts_idx` detects the subset case; only genuine band k-points still fall back to the band code.

### Verification

Diamond, gth-szv/gth-pade, camb3lyp, GDF, 3×3×3 mesh (27 k-points → 6 IBZ). One RSH J/K build:

| | before | after |
|---|---|---|
| RSH J/K wall time | 45.5 s | 3.6 s |

`max|ΔJ| = 1.3e-16` (‖J‖ = 6.9e-02), `max|ΔK| = 7.8e-12` (‖K‖ = 5.5e-01) against the previous code path, and the converged ksymm SCF energy is bit-identical to master.

For FCC diamond with the same settings, ksymm and no-symm now agree as expected:

```
nosym  nk=27  E = -11.3226305592
symm   nk= 4  E = -11.3226305373
```

New test `test_jk_kpts_band_subset` in `pyscf/pbc/df/test/test_aft_jk.py` covers J and K, `exxdiv='ewald'`, a single band k-point given with shape `(3,)`, two sets of density matrices, and the fallback to the band code for k-points not in the mesh.

### Note

This restores parity with the no-symmetry path. A further optimization is possible (restricting `k_to_compute` to the IBZ k-points so the contraction is skipped for the k-points that are not requested) but that interacts with the time-reversal pairing inside the C kernels, so I left it out of this change.
