### PR TITLE
Run the CI test suite in parallel worker processes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ name: CI
 #      - completed
 on: [push, pull_request]
 
+# Superseded runs on a branch are cancelled rather than left to finish; pushing
+# twice in quick succession otherwise leaves two multi-hour runs competing for
+# runners. Runs on master are always allowed to complete.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   linux-build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,29 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           token: ${{secrets.CODECOV_TOKEN}}
-  
+
+  # The job above runs every worker single threaded, which leaves the OpenMP
+  # kernels untested. This one keeps threads on so that threaded code paths are
+  # still covered, over the modules whose C extensions actually contain OpenMP
+  # pragmas, and skips the slow ones to stay well inside the main job's runtime.
+  linux-build-multithread:
+    runs-on: ubuntu-latest
+    env:
+      OMP_NUM_THREADS: 2
+      PYTEST_JOBS: 2
+      TEST_PATHS: >-
+        pyscf/lib pyscf/gto pyscf/ao2mo pyscf/scf pyscf/dft pyscf/mp
+        pyscf/cc pyscf/mcscf pyscf/agf2
+        pyscf/pbc/scf pyscf/pbc/df pyscf/pbc/dft
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install and Test
+        run: ./.github/workflows/run_ci.sh
+
   linux-build-aarch64:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci_linux/python_deps.sh
+++ b/.github/workflows/ci_linux/python_deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 python -m pip install --upgrade pip
-pip install "numpy!=1.16,!=1.17" "scipy!=1.5" h5py pytest pytest-cov pytest-timer
+pip install "numpy!=1.16,!=1.17" "scipy!=1.5" h5py pytest pytest-cov pytest-timer pytest-xdist
 pip install git+https://github.com/jhrmnn/pyberny.git@36a4be9
 pip install --no-deps pyscf-dispersion==1.5.0
 pip install geometric

--- a/.github/workflows/ci_macos/python_deps.sh
+++ b/.github/workflows/ci_macos/python_deps.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 python -m pip install --upgrade pip
-pip install "numpy!=1.16,!=1.17" scipy h5py pytest pytest-cov pytest-timer
+pip install "numpy!=1.16,!=1.17" scipy h5py pytest pytest-cov pytest-timer pytest-xdist

--- a/.github/workflows/run_tests.sh
+++ b/.github/workflows/run_tests.sh
@@ -1,18 +1,29 @@
 #!/usr/bin/env bash
-# The tests run in parallel processes (pytest-xdist), one BLAS/OpenMP thread
-# each. Most tests are too small to keep 4 BLAS threads busy, so spreading the
-# work over processes uses the runner's cores far better than threading it.
-export OMP_NUM_THREADS=1
+# By default the tests run in parallel processes (pytest-xdist), one BLAS/OpenMP
+# thread each. Most tests are too small to keep 4 BLAS threads busy, so spreading
+# the work over processes uses the runner's cores far better than threading it.
+#
+# The three knobs below let a workflow job reshape that. The multi-threaded job
+# raises OMP_NUM_THREADS so the OpenMP kernels are actually exercised with more
+# than one thread, and narrows TEST_PATHS to keep the runtime down.
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-1}
 export PYTHONPATH=$(pwd):$PYTHONPATH
 ulimit -s 20000
 
-# Number of pytest worker processes. "auto" is one per core; override to dial
-# back if the workers start competing for memory.
+# Number of pytest worker processes. "auto" is one per core, "0" disables xdist
+# entirely. Dial back if the workers start competing for memory.
 PYTEST_JOBS=${PYTEST_JOBS:-auto}
-# loadfile keeps every test in a file on the same worker. Several tests write
-# chkfiles named relative to the working directory, and a few rely on module
-# level setUpModule fixtures that are expensive to rebuild per worker.
-PARALLEL="-n $PYTEST_JOBS --dist loadfile"
+# Which tests to run.
+TEST_PATHS=${TEST_PATHS:-pyscf}
+
+if [ "$PYTEST_JOBS" = "0" ]; then
+  PARALLEL=""
+else
+  # loadfile keeps every test in a file on the same worker. Several tests write
+  # chkfiles named relative to the working directory, and a few rely on module
+  # level setUpModule fixtures that are expensive to rebuild per worker.
+  PARALLEL="-n $PYTEST_JOBS --dist loadfile"
+fi
 
 mkdir -p pyscftmpdir
 echo 'pbc_tools_pbc_fft_engine = "NUMPY+BLAS"' > .pyscf_conf.py
@@ -25,9 +36,10 @@ version=$(python -c 'import sys; print("{0}.{1}".format(*sys.version_info[:2]))'
 if [ "$RUNNER_OS" == "Linux" ] && [ $version != "3.12" ]; then
   pytest -s -c pytest.ini $PARALLEL \
     --durations=20 \
-    --cov-report xml --cov-report term --cov-config .coveragerc --cov pyscf
+    --cov-report xml --cov-report term --cov-config .coveragerc --cov pyscf \
+    $TEST_PATHS
 else
-  pytest -s -c pytest.ini $PARALLEL --durations=20 pyscf
+  pytest -s -c pytest.ini $PARALLEL --durations=20 $TEST_PATHS
 fi
 
 pytest_status=$?

--- a/.github/workflows/run_tests.sh
+++ b/.github/workflows/run_tests.sh
@@ -1,7 +1,18 @@
 #!/usr/bin/env bash
-export OMP_NUM_THREADS=4
-export PYTHONPATH=$(pwd):$PYTHONPATH 
+# The tests run in parallel processes (pytest-xdist), one BLAS/OpenMP thread
+# each. Most tests are too small to keep 4 BLAS threads busy, so spreading the
+# work over processes uses the runner's cores far better than threading it.
+export OMP_NUM_THREADS=1
+export PYTHONPATH=$(pwd):$PYTHONPATH
 ulimit -s 20000
+
+# Number of pytest worker processes. "auto" is one per core; override to dial
+# back if the workers start competing for memory.
+PYTEST_JOBS=${PYTEST_JOBS:-auto}
+# loadfile keeps every test in a file on the same worker. Several tests write
+# chkfiles named relative to the working directory, and a few rely on module
+# level setUpModule fixtures that are expensive to rebuild per worker.
+PARALLEL="-n $PYTEST_JOBS --dist loadfile"
 
 mkdir -p pyscftmpdir
 echo 'pbc_tools_pbc_fft_engine = "NUMPY+BLAS"' > .pyscf_conf.py
@@ -12,11 +23,11 @@ echo 'TMPDIR = "./pyscftmpdir"' >> .pyscf_conf.py
 version=$(python -c 'import sys; print("{0}.{1}".format(*sys.version_info[:2]))')
 # pytest-cov on Python 3.12 consumes huge memory
 if [ "$RUNNER_OS" == "Linux" ] && [ $version != "3.12" ]; then
-  pytest -s -c pytest.ini \
+  pytest -s -c pytest.ini $PARALLEL \
     --durations=20 \
     --cov-report xml --cov-report term --cov-config .coveragerc --cov pyscf
 else
-  pytest -s -c pytest.ini pyscf
+  pytest -s -c pytest.ini $PARALLEL --durations=20 pyscf
 fi
 
 pytest_status=$?

--- a/pyscf/lib/__init__.py
+++ b/pyscf/lib/__init__.py
@@ -21,6 +21,10 @@ C extensions and helper functions
 
 from pyscf.lib import parameters
 param = parameters
+# Bind the submodule here rather than relying on pyscf.gto.mole importing it.
+# Code such as pyscf.fci.direct_spin1_symm reaches for lib.exceptions, which
+# only resolved because some other module happened to have imported it first.
+from pyscf.lib import exceptions
 from pyscf.lib import numpy_helper
 from pyscf.lib import linalg_helper
 from pyscf.lib import scipy_helper

--- a/pyscf/lib/test/test_misc.py
+++ b/pyscf/lib/test/test_misc.py
@@ -94,6 +94,18 @@ class KnownValues(unittest.TestCase):
         mf = mol.GKS(xc='pbe')
         pickle.loads(pickle.dumps(mf))
 
+    def test_exceptions_bound_by_package(self):
+        # lib.exceptions must be bound by pyscf/lib/__init__.py itself. It used
+        # to resolve only because pyscf.gto.mole imports it, so a freshly
+        # executed pyscf.lib lacked the attribute and code doing
+        # "raise lib.exceptions.WfnSymmetryError" raised AttributeError instead.
+        # pytest --import-mode=importlib re-imports the package that way.
+        import importlib
+        spec = importlib.util.find_spec('pyscf.lib')
+        fresh = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(fresh)
+        self.assertTrue(hasattr(fresh, 'exceptions'))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The test suite runs serially with `OMP_NUM_THREADS=4`. Most tests are far too small to keep four BLAS threads busy, so the runner sits partly idle for most of the job. This runs the suite in parallel worker processes instead, giving each worker a single thread, which uses the same four cores much better.

### Current job times

Taken from run 31269316904 on master:

| job | wall time | tests |
|---|---|---|
| linux 3.12 | 3 h 31 m | 3325 passed |
| linux 3.8 | 1 h 58 m | 3320 passed |
| macos 3.14 | 49 m | |

Overhead is not the problem. On the 3.8 job pytest itself accounts for 6941 s of roughly 7050 s of wall time, so essentially all of it is test execution.

### Measurements

Both configurations were held to the same four core budget, so this measures utilisation rather than extra hardware. Serial `OMP_NUM_THREADS=4` uses at most four cores, and `-n 4` with `OMP_NUM_THREADS=1` also uses at most four.

| subset | serial | `-n 4 --dist loadfile` | speedup |
|---|---|---|---|
| `adc/test_radc` + `cc/test`, 369 tests | 105 s | 46 s | 2.30x |
| `scf, dft, fci, mcscf, df, x2c`, 749 tests | 140 s | 93 s | 1.50x |

Every configuration produced identical pass counts and left zero leftover temporary files, so the existing leftover file check in `run_tests.sh` still holds.

The spread between the two subsets is what you would expect. The modules that dominate CI time are made of long, coarse grained tests that parallelise well. The 1.50x subset is the worst case, dominated by short tests where per test overhead does not shrink.

Weighting the two measured ratios by the per module times reported by the 3.8 job projects roughly 1.8x for the full suite, which would put 3.8 near 1 h 05 and 3.12 near 1 h 55. That is an extrapolation from two subsets rather than a full suite run, so treat it as an estimate. The real number will come from this PR's own CI.

`-n 8` on an 8 core machine gave exactly the same 93 s as `-n 4` on the second subset, so more workers than cores does not help.

### Why `--dist loadfile`

Six test files write chkfiles under bare relative names into the working directory, including `pbc/scf/test/test_khf_ksym.py`, `pbc/dft/test/test_krks_ksym.py`, `cc/test/test_momgfccsd.py` and `tools/test/test_qcschema.py`. Keeping every test in a file on one worker stops two workers from writing the same file. Granularity is not a concern, since the longest single file in the suite is 249 s against an ideal four way time of about 1570 s, so the tail does not bind.

`PYTEST_JOBS` overrides the worker count without editing the script, in case the workers turn out to compete for memory on the job that also collects coverage.

### Second commit

Adding a concurrency group so that superseded runs on a branch are cancelled instead of left to finish. Pushing twice in quick succession currently leaves two multi hour runs competing for runners, and one branch accumulated four concurrent runs in a single day. Runs on master are excluded from cancellation so the default branch always produces a complete result.

### Risk

Dropping `OMP_NUM_THREADS` to 1 is not numerically inert. Eight code paths branch on `lib.num_threads()`, and two of them select between different contraction kernels rather than just sizing buffers: `pbc/df/aft_jk.py:192,237` and `pbc/scf/rsjk.py:875,911` test `>= 2 * lib.num_threads()`, so the threshold moves from 8 to 2 and the threaded C kernel is chosen far more often. That changes floating point accumulation order, as does single threaded BLAS.

Several tests tracked in #3245 fail at exactly the 1e-12 level this perturbs, so this could flip a borderline test in either direction. It may well reduce flakiness, since single threaded BLAS has a deterministic reduction order and removes one source of run to run variation, but that is a prediction and not a measurement. This PR's CI run is the test.

I confirmed that `pytest-timer` still works under xdist and that `-s` remains compatible, so no existing diagnostics are lost. I also added `--durations=20` to the non coverage invocation, which previously had no timing summary at all.

### Two related things not changed here

Coverage is generated on the job that does not upload it. `run_tests.sh` produces `coverage.xml` when the version is not 3.12, which is the 3.8 job, while `ci.yml` uploads to codecov when the version is 3.12. The upload step completes in one second because there is nothing to upload. So the 3.8 job pays the `pytest-cov` cost for a report nobody sees, and this PR now runs that coverage across four workers. The fix is one line, but which direction to fix it in is a maintainer call, so I left it alone. Happy to follow up.

Three tests declare `max_memory=32000`, at `tdscf/test/test_tdrks_vv10.py:31,34` and `hessian/test/test_vv10_hessian.py:41`, on a runner with 16 GB. That was already wrong, but four concurrent workers each believing they have 32 GB is a hazard this PR introduces. `--dist loadfile` limits it to at most two workers holding those files and the systems involved are small, so I expect it is theoretical, but I have not measured peak memory.


---

## Measured result

The projection above has now been replaced by real numbers from this branch:

| job | before | after | speedup |
|---|---|---|---|
| linux 3.12 | 3 h 31 m | 53 m 33 s | 3.91x |
| linux 3.8 | 1 h 58 m | 47 m 44 s | 2.42x |
| macos 3.14 | 49 m | 22 m 15 s | 2.20x |

3.8 came in above the 1.8x I projected. 3.12 gained more than parallelism alone accounts for, which is consistent with #3373: the gap between the two Linux jobs was 12576/6941 = 1.81 before and is 3213/2864 = 1.12 now.

## Multi-threaded job

Running every worker single threaded means no OpenMP kernel is exercised with more than one thread, so a race or a bad reduction clause would go unnoticed. Raised by @jeanwsr in review, and addressed by a new `linux-build-multithread` job.

`run_tests.sh` grows three environment knobs so a job can reshape the run without a second script, with the defaults unchanged: `OMP_NUM_THREADS`, `PYTEST_JOBS` (where `0` disables xdist entirely) and `TEST_PATHS`.

The job uses `OMP_NUM_THREADS=2` with two xdist workers, keeping four threads on a four core runner without oversubscribing. The module list comes from counting files containing a `#pragma omp` in each C library directory (pbc 14, dft 11, vhf 9, np_helper 8, gto 8, mcscf 6, cc 5, ao2mo 4, ccsdt 3, agf2 2, pdft 1, mp 1), skipping adc, grad, hessian, tdscf, solvent and mcpdft as slow and driven by einsum rather than by threaded kernels of their own. It ran in 21 minutes, comfortably inside the main jobs. Please retune the list if something important is missing.

## A latent bug this exposed

The first run of that job failed two tests in `pyscf/mcscf/test/test_n2.py` with `AttributeError: module 'pyscf.lib' has no attribute 'exceptions'`. That turned out to be a real defect rather than anything to do with threading, and the last commit fixes it.

`pyscf/lib/__init__.py` never imported the `exceptions` submodule. The attribute existed only because `pyscf/gto/mole.py` does `from pyscf.lib.exceptions import ...`, so it was an accident of import order. Any freshly executed `pyscf.lib` lacks it, and `--import-mode=importlib` re-imports the package that way when collecting a file under `pyscf/lib/test`.

This bites the library, not only the tests. `direct_spin1_symm.py` and `direct_spin0_symm.py` raise `lib.exceptions.WfnSymmetryError` in eight places, and without the binding the raise itself fails with `AttributeError`, hiding the diagnostic. It reproduces in about a second on unmodified library code:

```
pytest pyscf/lib/test/test_misc.py pyscf/mcscf/test/test_n2.py
```

The narrowed `TEST_PATHS` only changed which files share a worker. The full suite avoids it by luck of worker assignment and can hit it intermittently, so this may be one of the unexplained failures behind #3245. Fix is a one line import plus a test that executes a fresh `pyscf.lib` from its spec and asserts the attribute is present; it fails without the import and passes with it.
