### PR TITLE
Fix: use per-root shift in the Davidson preconditioner

### DIFF
--- a/pyscf/lib/linalg_helper.py
+++ b/pyscf/lib/linalg_helper.py
@@ -526,7 +526,7 @@ def davidson1(aop, x0, precond, tol=1e-12, max_cycle=50, max_space=12,
         # remove subspace linear dependency
         for k, ek in enumerate(e):
             if (not conv[k]) and dx_norm[k]**2 > lindep:
-                xt[k] = precond(xt[k], e[0], x0[k])
+                xt[k] = precond(xt[k], e[k], x0[k])
                 xt[k] *= dot(xt[k].conj(), xt[k]).real ** -.5
             elif not conv[k]:
                 # Remove linearly dependent vector


### PR DESCRIPTION
The preconditioner shift must be the eigenvalue estimate of the root currently being corrected (`e[k]`), not a fixed reference like the ground-state energy (`e[0]`). The diagonal preconditioner approximates the correction equation `(H - e_k) t = -r_k` for root `k`, so the shift is intrinsically tied to that root's own eigenvalue, not a free parameter. This PR corrects `precond(xt[k], e[0], x0[k])` to `precond(xt[k], e[k], x0[k])` so each root is corrected using its own shift.