### PR TITLE
Define APIs in NumInt class to simplify XC customization

### DIFF
--- a/pyscf/df/grad/rks.py
+++ b/pyscf/df/grad/rks.py
@@ -47,7 +47,7 @@ def get_veff(ks_grad, mol=None, dm=None):
             ni, mol, grids, mf.xc, dm,
             max_memory=max_memory, verbose=ks_grad.verbose)
         if mf.do_nlc():
-            if ni.libxc.is_nlc(mf.xc):
+            if ni.is_nlc(mf.xc):
                 xc = mf.xc
             else:
                 xc = mf.nlc
@@ -62,7 +62,7 @@ def get_veff(ks_grad, mol=None, dm=None):
             ni, mol, grids, mf.xc, dm,
             max_memory=max_memory, verbose=ks_grad.verbose)
         if mf.do_nlc():
-            if ni.libxc.is_nlc(mf.xc):
+            if ni.is_nlc(mf.xc):
                 xc = mf.xc
             else:
                 xc = mf.nlc
@@ -72,7 +72,7 @@ def get_veff(ks_grad, mol=None, dm=None):
             vxc += vnlc
     t0 = logger.timer(ks_grad, 'vxc', *t0)
 
-    if not ni.libxc.is_hybrid_xc(mf.xc):
+    if not ni.is_hybrid_xc(mf.xc):
         vj = ks_grad.get_j(mol, dm)
         vxc += vj
         if ks_grad.auxbasis_response:

--- a/pyscf/df/grad/uks.py
+++ b/pyscf/df/grad/uks.py
@@ -49,7 +49,7 @@ def get_veff(ks_grad, mol=None, dm=None):
                 ni, mol, grids, mf.xc, dm,
                 max_memory=max_memory, verbose=ks_grad.verbose)
         if mf.do_nlc():
-            if ni.libxc.is_nlc(mf.xc):
+            if ni.is_nlc(mf.xc):
                 xc = mf.xc
             else:
                 xc = mf.nlc
@@ -64,7 +64,7 @@ def get_veff(ks_grad, mol=None, dm=None):
                 ni, mol, grids, mf.xc, dm,
                 max_memory=max_memory, verbose=ks_grad.verbose)
         if mf.do_nlc():
-            if ni.libxc.is_nlc(mf.xc):
+            if ni.is_nlc(mf.xc):
                 xc = mf.xc
             else:
                 xc = mf.nlc
@@ -74,7 +74,7 @@ def get_veff(ks_grad, mol=None, dm=None):
             vxc += vnlc
     t0 = logger.timer(ks_grad, 'vxc', *t0)
 
-    if not ni.libxc.is_hybrid_xc(mf.xc):
+    if not ni.is_hybrid_xc(mf.xc):
         vj = ks_grad.get_j(mol, dm)
         vxc += vj[0] + vj[1]
         if ks_grad.auxbasis_response:

--- a/pyscf/df/hessian/rks.py
+++ b/pyscf/df/hessian/rks.py
@@ -53,7 +53,7 @@ def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
     dm0 = numpy.dot(mocc, mocc.T) * 2
 
     omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=mol.spin)
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
     de2, ej, ek = df_rhf_hess._partial_hess_ejk(hessobj, mo_energy, mo_coeff, mo_occ,
                                                 atmlst, max_memory, verbose,
                                                 with_k=hybrid)
@@ -92,9 +92,8 @@ def make_h1(hessobj, mo_coeff, mo_occ, chkfile=None, atmlst=None, verbose=None):
     mol = hessobj.mol
     mf = hessobj.base
     ni = mf._numint
-    ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
     omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=mol.spin)
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
 
     mem_now = lib.current_memory()[0]
     max_memory = max(2000, mf.max_memory*.9-mem_now)

--- a/pyscf/df/hessian/uks.py
+++ b/pyscf/df/hessian/uks.py
@@ -57,7 +57,7 @@ def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
     dm0b = numpy.dot(moccb, moccb.T)
 
     omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=mol.spin)
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
     de2, ej, ek = df_uhf_hess._partial_hess_ejk(hessobj, mo_energy, mo_coeff, mo_occ,
                                                 atmlst, max_memory, verbose,
                                                 with_k=hybrid)
@@ -97,9 +97,8 @@ def make_h1(hessobj, mo_coeff, mo_occ, chkfile=None, atmlst=None, verbose=None):
     mol = hessobj.mol
     mf = hessobj.base
     ni = mf._numint
-    ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
     omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=mol.spin)
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
 
     mem_now = lib.current_memory()[0]
     max_memory = max(2000, mf.max_memory*.9-mem_now)

--- a/pyscf/dft/gks.py
+++ b/pyscf/dft/gks.py
@@ -78,10 +78,10 @@ def get_veff(ks, mol=None, dm=None, dm_last=None, vhf_last=None, hermi=1):
                                  hermi=hermi, max_memory=max_memory)
         logger.debug(ks, 'nelec by numeric integration = %s', n)
         if ks.do_nlc():
-            if ni.libxc.is_nlc(ks.xc):
+            if ni.is_nlc(ks.xc):
                 xc = ks.xc
             else:
-                assert ni.libxc.is_nlc(ks.nlc)
+                assert ni.is_nlc(ks.nlc)
                 xc = ks.nlc
             n, enlc, vnlc = ni.nr_nlc_vxc(mol, ks.nlcgrids, xc, dm,
                                           hermi=hermi, max_memory=max_memory)
@@ -97,7 +97,7 @@ def get_veff(ks, mol=None, dm=None, dm_last=None, vhf_last=None, hermi=1):
         _dm = numpy.asarray(dm) - numpy.asarray(dm_last)
     else:
         _dm = dm
-    if not ni.libxc.is_hybrid_xc(ks.xc):
+    if not ni.is_hybrid_xc(ks.xc):
         vk = None
         vj = ks.get_j(mol, _dm, hermi)
         if incremental_jk:

--- a/pyscf/dft/libxc.py
+++ b/pyscf/dft/libxc.py
@@ -329,16 +329,11 @@ def is_lda(xc_code):
 def is_hybrid_xc(xc_code):
     if xc_code is None:
         return False
-    elif isinstance(xc_code, str):
-        if 'HF' in xc_code:
-            return True
-        xc = _get_xc(xc_code)
-        return _is_hybrid_xc(xc.xc_objs, xc.hyb, xc.facs, xc_code)
-    elif numpy.issubdtype(type(xc_code), numpy.integer):
-        xc = _get_xc(xc_code)
-        return _is_hybrid_xc(xc.xc_objs, xc.hyb, xc.facs, xc_code)
-    else:
-        return any((is_hybrid_xc(x) for x in xc_code))
+    if rsh_coeff(xc_code) != (0, 0, 0):
+        return True
+    if hybrid_coeff(xc_code) != 0:
+        return True
+    return False
 
 def _is_hybrid_xc(xc_objs, hyb, facs, xc_code):
     if _hybrid_coeff(xc_objs, hyb, facs) != 0:

--- a/pyscf/dft/numint.py
+++ b/pyscf/dft/numint.py
@@ -2737,6 +2737,18 @@ class LibXCMixin:
     def rsh_coeff(self, xc_code):
         return self.libxc.rsh_coeff(xc_code)
 
+    def is_hybrid_xc(self, xc_code):
+        if xc_code is None:
+            return False
+        if self.rsh_coeff(xc_code) != (0, 0, 0):
+            return True
+        if self.hybrid_coeff(xc_code) != 0:
+            return True
+        return False
+
+    def is_nlc(self, xc_code):
+        return self.libxc.is_nlc(xc_code)
+
     @lib.with_doc(libxc.eval_xc.__doc__)
     def eval_xc(self, xc_code, rho, spin=0, relativity=0, deriv=1, omega=None,
                 verbose=None):

--- a/pyscf/dft/rks.py
+++ b/pyscf/dft/rks.py
@@ -81,10 +81,10 @@ def get_veff(ks, mol=None, dm=None, dm_last=None, vhf_last=None, hermi=1):
         n, exc, vxc = ni.nr_rks(mol, ks.grids, ks.xc, dm, max_memory=max_memory)
         logger.debug(ks, 'nelec by numeric integration = %s', n)
         if ks.do_nlc():
-            if ni.libxc.is_nlc(ks.xc):
+            if ni.is_nlc(ks.xc):
                 xc = ks.xc
             else:
-                assert ni.libxc.is_nlc(ks.nlc)
+                assert ni.is_nlc(ks.nlc)
                 xc = ks.nlc
             n, enlc, vnlc = ni.nr_nlc_vxc(mol, ks.nlcgrids, xc, dm,
                                           max_memory=max_memory)
@@ -100,7 +100,7 @@ def get_veff(ks, mol=None, dm=None, dm_last=None, vhf_last=None, hermi=1):
         _dm = numpy.asarray(dm) - numpy.asarray(dm_last)
     else:
         _dm = dm
-    if not ni.libxc.is_hybrid_xc(ks.xc):
+    if not ni.is_hybrid_xc(ks.xc):
         vk = None
         vj = ks.get_j(mol, _dm, hermi)
         if incremental_jk:
@@ -400,7 +400,7 @@ class KohnShamDFT:
         if self.nlc == 0:
             return False
 
-        xc_has_nlc = self._numint.libxc.is_nlc(xc)
+        xc_has_nlc = self._numint.is_nlc(xc)
         return self.nlc == 'vv10' or xc_has_nlc
 
     def to_rhf(self):
@@ -489,7 +489,7 @@ class KohnShamDFT:
 
     def check_sanity(self):
         out = super().check_sanity()
-        if self.do_nlc() and self.do_disp() and self._numint.libxc.is_nlc(self.xc):
+        if self.do_nlc() and self.do_disp() and self._numint.is_nlc(self.xc):
             import warnings
             warnings.warn(
                 f'nlc-type xc {self.xc} and disp {self.disp} may lead to'

--- a/pyscf/dft/uks.py
+++ b/pyscf/dft/uks.py
@@ -53,10 +53,10 @@ def get_veff(ks, mol=None, dm=None, dm_last=None, vhf_last=None, hermi=1):
         n, exc, vxc = ni.nr_uks(mol, ks.grids, ks.xc, dm, max_memory=max_memory)
         logger.debug(ks, 'nelec by numeric integration = %s', n)
         if ks.do_nlc():
-            if ni.libxc.is_nlc(ks.xc):
+            if ni.is_nlc(ks.xc):
                 xc = ks.xc
             else:
-                assert ni.libxc.is_nlc(ks.nlc)
+                assert ni.is_nlc(ks.nlc)
                 xc = ks.nlc
             n, enlc, vnlc = ni.nr_nlc_vxc(mol, ks.nlcgrids, xc, dm[0]+dm[1],
                                           max_memory=max_memory)
@@ -75,7 +75,7 @@ def get_veff(ks, mol=None, dm=None, dm_last=None, vhf_last=None, hermi=1):
         _dm = dm - dm_last
     else:
         _dm = dm
-    if not ni.libxc.is_hybrid_xc(ks.xc):
+    if not ni.is_hybrid_xc(ks.xc):
         vk = None
         vj = ks.get_j(mol, _dm[0]+_dm[1], hermi)
         if incremental_jk:

--- a/pyscf/eph/rks.py
+++ b/pyscf/eph/rks.py
@@ -103,9 +103,8 @@ def get_eph(ephobj, mo1, omega, vec, mo_rep):
     mol = ephobj.mol
     mf = ephobj.base
     ni = mf._numint
-    ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
     omg, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=mol.spin)
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
 
     vnuc_deriv = ephobj.vnuc_generator(mol)
     aoslices = mol.aoslice_by_atom()

--- a/pyscf/eph/uks.py
+++ b/pyscf/eph/uks.py
@@ -127,9 +127,8 @@ def get_eph(ephobj, mo1, omega, vec, mo_rep):
     mol = ephobj.mol
     mf = ephobj.base
     ni = mf._numint
-    ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
     omg, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=mol.spin)
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
 
     vnuc_deriv = ephobj.vnuc_generator(mol)
     aoslices = mol.aoslice_by_atom()

--- a/pyscf/grad/rks.py
+++ b/pyscf/grad/rks.py
@@ -52,7 +52,7 @@ def get_veff(ks_grad, mol=None, dm=None):
                                          max_memory=max_memory,
                                          verbose=ks_grad.verbose)
         if mf.do_nlc():
-            if ni.libxc.is_nlc(mf.xc):
+            if ni.is_nlc(mf.xc):
                 xc = mf.xc
             else:
                 xc = mf.nlc
@@ -66,7 +66,7 @@ def get_veff(ks_grad, mol=None, dm=None):
         exc, vxc = get_vxc(ni, mol, grids, mf.xc, dm,
                            max_memory=max_memory, verbose=ks_grad.verbose)
         if mf.do_nlc():
-            if ni.libxc.is_nlc(mf.xc):
+            if ni.is_nlc(mf.xc):
                 xc = mf.xc
             else:
                 xc = mf.nlc
@@ -76,7 +76,7 @@ def get_veff(ks_grad, mol=None, dm=None):
             vxc += vnlc
     t0 = logger.timer(ks_grad, 'vxc', *t0)
 
-    if not ni.libxc.is_hybrid_xc(mf.xc):
+    if not ni.is_hybrid_xc(mf.xc):
         vj = ks_grad.get_j(mol, dm)
         vxc += vj
     else:

--- a/pyscf/grad/tdrks.py
+++ b/pyscf/grad/tdrks.py
@@ -82,7 +82,7 @@ def grad_elec(td_grad, x_y, singlet=True, atmlst=None,
             _contract_xc_kernel(td_grad, mf.xc, dmxpy,
                                 dmzoo, True, True, singlet, max_memory)
 
-    if ni.libxc.is_hybrid_xc(mf.xc):
+    if ni.is_hybrid_xc(mf.xc):
         dm = (dmzoo, dmxpy+dmxpy.T, dmxmy-dmxmy.T)
         vj, vk = mf.get_jk(mol, dm, hermi=0)
         vk *= hyb
@@ -157,7 +157,7 @@ def grad_elec(td_grad, x_y, singlet=True, atmlst=None,
 
     dmz1doo = z1ao + dmzoo
     oo0 = reduce(numpy.dot, (orbo, orbo.T))
-    if ni.libxc.is_hybrid_xc(mf.xc):
+    if ni.is_hybrid_xc(mf.xc):
         dm = (oo0, dmz1doo+dmz1doo.T, dmxpy+dmxpy.T, dmxmy-dmxmy.T)
         vj, vk = td_grad.get_jk(mol, dm)
         vk *= hyb

--- a/pyscf/grad/tduks.py
+++ b/pyscf/grad/tduks.py
@@ -98,7 +98,7 @@ def grad_elec(td_grad, x_y, atmlst=None, max_memory=2000, verbose=logger.INFO):
             _contract_xc_kernel(td_grad, mf.xc, (dmxpya,dmxpyb),
                                 (dmzooa,dmzoob), True, True, max_memory)
 
-    if ni.libxc.is_hybrid_xc(mf.xc):
+    if ni.is_hybrid_xc(mf.xc):
         dm = (dmzooa, dmxpya+dmxpya.T, dmxmya-dmxmya.T,
               dmzoob, dmxpyb+dmxpyb.T, dmxmyb-dmxmyb.T)
         vj, vk = mf.get_jk(mol, dm, hermi=0)
@@ -215,7 +215,7 @@ def grad_elec(td_grad, x_y, atmlst=None, max_memory=2000, verbose=logger.INFO):
     oo0b = reduce(numpy.dot, (orbob, orbob.T))
     as_dm1 = oo0a + oo0b + (dmz1dooa + dmz1doob) * .5
 
-    if ni.libxc.is_hybrid_xc(mf.xc):
+    if ni.is_hybrid_xc(mf.xc):
         dm = (oo0a, dmz1dooa+dmz1dooa.T, dmxpya+dmxpya.T, dmxmya-dmxmya.T,
               oo0b, dmz1doob+dmz1doob.T, dmxpyb+dmxpyb.T, dmxmyb-dmxmyb.T)
         vj, vk = td_grad.get_jk(mol, dm)

--- a/pyscf/grad/uks.py
+++ b/pyscf/grad/uks.py
@@ -51,7 +51,7 @@ def get_veff(ks_grad, mol=None, dm=None):
                                          max_memory=max_memory,
                                          verbose=ks_grad.verbose)
         if mf.do_nlc():
-            if ni.libxc.is_nlc(mf.xc):
+            if ni.is_nlc(mf.xc):
                 xc = mf.xc
             else:
                 xc = mf.nlc
@@ -65,7 +65,7 @@ def get_veff(ks_grad, mol=None, dm=None):
         exc, vxc = get_vxc(ni, mol, grids, mf.xc, dm,
                            max_memory=max_memory, verbose=ks_grad.verbose)
         if mf.do_nlc():
-            if ni.libxc.is_nlc(mf.xc):
+            if ni.is_nlc(mf.xc):
                 xc = mf.xc
             else:
                 xc = mf.nlc
@@ -75,7 +75,7 @@ def get_veff(ks_grad, mol=None, dm=None):
             vxc += vnlc
     t0 = logger.timer(ks_grad, 'vxc', *t0)
 
-    if not ni.libxc.is_hybrid_xc(mf.xc):
+    if not ni.is_hybrid_xc(mf.xc):
         vj = ks_grad.get_j(mol, dm)
         vxc += vj[0] + vj[1]
     else:

--- a/pyscf/hessian/rks.py
+++ b/pyscf/hessian/rks.py
@@ -61,7 +61,7 @@ def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
     dm0 = numpy.dot(mocc, mocc.T) * 2
 
     omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=mol.spin)
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
 
     de2, ej, ek = rhf_hess._partial_hess_ejk(hessobj, mo_energy, mo_coeff, mo_occ,
                                              atmlst, max_memory, verbose,
@@ -129,9 +129,8 @@ def make_h1(hessobj, mo_coeff, mo_occ, chkfile=None, atmlst=None, verbose=None):
 
     mf = hessobj.base
     ni = mf._numint
-    ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
     omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=mol.spin)
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
 
     mem_now = lib.current_memory()[0]
     max_memory = max(2000, mf.max_memory*.9-mem_now)
@@ -475,7 +474,7 @@ def _get_enlc_deriv2_numerical(hessobj, mo_coeff, mo_occ, max_memory):
         ni = mf._numint
         _, nlcgrids = _initialize_grids(grad_obj)
 
-        if ni.libxc.is_nlc(mf.xc):
+        if ni.is_nlc(mf.xc):
             xc = mf.xc
         else:
             xc = mf.nlc
@@ -902,7 +901,7 @@ def _get_enlc_deriv2(hessobj, mo_coeff, mo_occ, max_memory):
     if grids.coords is None:
         grids.build()
 
-    if numint.libxc.is_nlc(mf.xc):
+    if numint.is_nlc(mf.xc):
         xc_code = mf.xc
     else:
         xc_code = mf.nlc
@@ -1207,10 +1206,10 @@ def _get_vnlc_deriv1_numerical(hessobj, mo_coeff, mo_occ, max_memory):
 
     def get_nlc_vmat(mol, mf, dm):
         ni = mf._numint
-        if ni.libxc.is_nlc(mf.xc):
+        if ni.is_nlc(mf.xc):
             xc = mf.xc
         else:
-            assert ni.libxc.is_nlc(mf.nlc)
+            assert ni.is_nlc(mf.nlc)
             xc = mf.nlc
         mf.nlcgrids.build()
         _, _, vnlc = ni.nr_nlc_vxc(mol, mf.nlcgrids, xc, dm)
@@ -1302,7 +1301,7 @@ def _get_vnlc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
     if grids.coords is None:
         grids.build()
 
-    if numint.libxc.is_nlc(mf.xc):
+    if numint.is_nlc(mf.xc):
         xc_code = mf.xc
     else:
         xc_code = mf.nlc
@@ -1879,7 +1878,7 @@ def get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1s, max_memory):
 
     ni = mf._numint
 
-    if numint.libxc.is_nlc(mf.xc):
+    if numint.is_nlc(mf.xc):
         xc_code = mf.xc
     else:
         xc_code = mf.nlc

--- a/pyscf/hessian/uks.py
+++ b/pyscf/hessian/uks.py
@@ -61,7 +61,7 @@ def partial_hess_elec(hessobj, mo_energy=None, mo_coeff=None, mo_occ=None,
     dme0+= numpy.einsum('pi,qi,i->pq', moccb, moccb, mo_eb)
 
     omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=mol.spin)
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
     de2, ej, ek = uhf_hess._partial_hess_ejk(hessobj, mo_energy, mo_coeff, mo_occ,
                                              atmlst, max_memory, verbose,
                                              with_k=hybrid)
@@ -138,9 +138,8 @@ def make_h1(hessobj, mo_coeff, mo_occ, chkfile=None, atmlst=None, verbose=None):
 
     mf = hessobj.base
     ni = mf._numint
-    ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
     omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=mol.spin)
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
 
     mem_now = lib.current_memory()[0]
     max_memory = max(2000, mf.max_memory*.9-mem_now)

--- a/pyscf/pbc/dft/gks.py
+++ b/pyscf/pbc/dft/gks.py
@@ -51,7 +51,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
     if ks.do_nlc():
         raise NotImplementedError(f'NLC functional {ks.xc} + {ks.nlc}')
 
-    hybrid = ni.libxc.is_hybrid_xc(ks.xc)
+    hybrid = ni.is_hybrid_xc(ks.xc)
 
     # TODO GKS with hybrid functional
     if hybrid:

--- a/pyscf/pbc/dft/kgks.py
+++ b/pyscf/pbc/dft/kgks.py
@@ -62,10 +62,8 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
     if ks.do_nlc():
         raise NotImplementedError(f'NLC functional {ks.xc} + {ks.nlc}')
 
-    hybrid = ni.libxc.is_hybrid_xc(ks.xc)
-
     # TODO GKS with hybrid functional
-    hybrid = ks._numint.libxc.is_hybrid_xc(ks.xc)
+    hybrid = ni.is_hybrid_xc(ks.xc)
     if hybrid:
         raise NotImplementedError
 
@@ -164,7 +162,7 @@ class KGKS(rks.KohnShamDFT, kghf.KGHF):
         out = self._transfer_attrs_(scf.KGHF(self.cell, self.kpts))
 
         # Pure functionals only construct J-type integrals. Enable all integrals for KHF.
-        if (not self._numint.libxc.is_hybrid_xc(self.xc) and
+        if (not self._numint.is_hybrid_xc(self.xc) and
             len(self.kpts) > 1 and getattr(self.with_df, '_j_only', False)):
             out.with_df._j_only = False
             out.with_df.reset()

--- a/pyscf/pbc/dft/krks.py
+++ b/pyscf/pbc/dft/krks.py
@@ -73,10 +73,10 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
                             kpts, kpts_band, max_memory=max_memory)
     logger.info(ks, 'nelec by numeric integration = %s', n)
     if ks.do_nlc():
-        if ni.libxc.is_nlc(ks.xc):
+        if ni.is_nlc(ks.xc):
             xc = ks.xc
         else:
-            assert ni.libxc.is_nlc(ks.nlc)
+            assert ni.is_nlc(ks.nlc)
             xc = ks.nlc
         n, enlc, vnlc = ni.nr_nlc_vxc(cell, ks.nlcgrids, xc, dm, 0, hermi, kpts,
                                       max_memory=max_memory)
@@ -96,7 +96,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
         ecoul = None
         if ground_state:
             ecoul = np.einsum('Kij,Kji', dm, vj) * .5 * weight
-    if ni.libxc.is_hybrid_xc(ks.xc):
+    if ni.is_hybrid_xc(ks.xc):
         vxc -= .5 * vk
         if ground_state:
             exc -= np.einsum('Kij,Kji', dm, vk).real * .25 * weight
@@ -145,7 +145,7 @@ def gen_response(mf, mo_coeff=None, mo_occ=None, singlet=None, hermi=0,
     cell = mf.cell
     kpts = mf.kpts
     ni = mf._numint
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
     j_in_xc = getattr(ni, 'xc_with_j', False)
 
     if with_nlc and mf.do_nlc():
@@ -222,7 +222,7 @@ def _get_jk(mf, cell, dm, hermi, kpts, kpts_band=None, with_j=True, kshift=0):
 
     ni = mf._numint
     omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=cell.spin)
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
     if not hybrid:
         if hermi == 2 or not with_j:
             vj = 0
@@ -277,7 +277,7 @@ class KRKS(rks.KohnShamDFT, khf.KRHF):
         from pyscf.pbc import scf, df
         out = self._transfer_attrs_(scf.KRHF(self.cell, self.kpts))
         # Pure functionals only construct J-type integrals. Enable all integrals for KHF.
-        if (not self._numint.libxc.is_hybrid_xc(self.xc) and
+        if (not self._numint.is_hybrid_xc(self.xc) and
             len(self.kpts) > 1 and getattr(self.with_df, '_j_only', False)):
             out.with_df._j_only = False
             out.with_df.reset()

--- a/pyscf/pbc/dft/krks_ksymm.py
+++ b/pyscf/pbc/dft/krks_ksymm.py
@@ -55,10 +55,10 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
                             max_memory=max_memory)
     logger.info(ks, 'nelec by numeric integration = %s', n)
     if ks.do_nlc():
-        if ni.libxc.is_nlc(ks.xc):
+        if ni.is_nlc(ks.xc):
             xc = ks.xc
         else:
-            assert ni.libxc.is_nlc(ks.nlc)
+            assert ni.is_nlc(ks.nlc)
             xc = ks.nlc
         n, enlc, vnlc = ni.nr_nlc_vxc(cell, ks.nlcgrids, xc, dm,
                                       0, hermi, kpts, max_memory=max_memory)
@@ -76,7 +76,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
         ecoul = None
         if ground_state:
             ecoul = np.einsum('K,Kij,Kji->', weight, dm, vj) * .5
-    if ni.libxc.is_hybrid_xc(ks.xc):
+    if ni.is_hybrid_xc(ks.xc):
         vxc -= .5 * vk
         if ground_state:
             exc -= np.einsum('K,Kij,Kji->', weight, dm, vk).real * .25

--- a/pyscf/pbc/dft/kroks.py
+++ b/pyscf/pbc/dft/kroks.py
@@ -64,7 +64,7 @@ class KROKS(rks.KohnShamDFT, krohf.KROHF):
         from pyscf.pbc import scf, df
         out = self._transfer_attrs_(scf.KROHF(self.cell, self.kpts))
         # Pure functionals only construct J-type integrals. Enable all integrals for KHF.
-        if (not self._numint.libxc.is_hybrid_xc(self.xc) and
+        if (not self._numint.is_hybrid_xc(self.xc) and
             len(self.kpts) > 1 and getattr(self.with_df, '_j_only', False)):
             out.with_df._j_only = False
             out.with_df.reset()

--- a/pyscf/pbc/dft/kuks.py
+++ b/pyscf/pbc/dft/kuks.py
@@ -59,10 +59,10 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
                             kpts, kpts_band, max_memory=max_memory)
     logger.info(ks, 'nelec by numeric integration = %s', n)
     if ks.do_nlc():
-        if ni.libxc.is_nlc(ks.xc):
+        if ni.is_nlc(ks.xc):
             xc = ks.xc
         else:
-            assert ni.libxc.is_nlc(ks.nlc)
+            assert ni.is_nlc(ks.nlc)
             xc = ks.nlc
         n, enlc, vnlc = ni.nr_nlc_vxc(cell, ks.nlcgrids, xc, dm[0]+dm[1],
                                       0, hermi, kpts, max_memory=max_memory)
@@ -83,7 +83,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
         ecoul = None
         if ground_state:
             ecoul = np.einsum('nKij,Kji->', dm, vj).real * .5 * weight
-    if ni.libxc.is_hybrid_xc(ks.xc):
+    if ni.is_hybrid_xc(ks.xc):
         vxc -= vk
         if ground_state:
             exc -= np.einsum('nKij,nKji->', dm, vk).real * .5 * weight
@@ -121,7 +121,7 @@ def gen_response(mf, mo_coeff=None, mo_occ=None,
     cell = mf.cell
     kpts = mf.kpts
     ni = mf._numint
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
     j_in_xc = getattr(ni, 'xc_with_j', False)
 
     if with_nlc and mf.do_nlc():
@@ -180,7 +180,7 @@ class KUKS(rks.KohnShamDFT, kuhf.KUHF):
         from pyscf.pbc import scf, df
         out = self._transfer_attrs_(scf.KUHF(self.cell, self.kpts))
         # Pure functionals only construct J-type integrals. Enable all integrals for KHF.
-        if (not self._numint.libxc.is_hybrid_xc(self.xc) and
+        if (not self._numint.is_hybrid_xc(self.xc) and
             len(self.kpts) > 1 and getattr(self.with_df, '_j_only', False)):
             out.with_df._j_only = False
             out.with_df.reset()

--- a/pyscf/pbc/dft/kuks_ksymm.py
+++ b/pyscf/pbc/dft/kuks_ksymm.py
@@ -55,10 +55,10 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
                             max_memory=max_memory)
     logger.info(ks, 'nelec by numeric integration = %s', n)
     if ks.do_nlc():
-        if ni.libxc.is_nlc(ks.xc):
+        if ni.is_nlc(ks.xc):
             xc = ks.xc
         else:
-            assert ni.libxc.is_nlc(ks.nlc)
+            assert ni.is_nlc(ks.nlc)
             xc = ks.nlc
         n, enlc, vnlc = ni.nr_nlc_vxc(cell, ks.nlcgrids, xc, dm[0]+dm[1],
                                       0, hermi, kpts, max_memory=max_memory)
@@ -77,7 +77,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
         ecoul = None
         if ground_state:
             ecoul = np.einsum('K,nKij,Kji->', weight, dm, vj) * .5
-    if ni.libxc.is_hybrid_xc(ks.xc):
+    if ni.is_hybrid_xc(ks.xc):
         vxc -= vk
         if ground_state:
             exc -= np.einsum('K,nKij,nKji->', weight, dm, vk).real * .5

--- a/pyscf/pbc/dft/rks.py
+++ b/pyscf/pbc/dft/rks.py
@@ -78,10 +78,10 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
                             kpt, kpts_band, max_memory=max_memory)
     logger.info(ks, 'nelec by numeric integration = %s', n)
     if ks.do_nlc():
-        if ni.libxc.is_nlc(ks.xc):
+        if ni.is_nlc(ks.xc):
             xc = ks.xc
         else:
-            assert ni.libxc.is_nlc(ks.nlc)
+            assert ni.is_nlc(ks.nlc)
             xc = ks.nlc
         n, enlc, vnlc = ni.nr_nlc_vxc(cell, ks.nlcgrids, xc, dm, 0, hermi, kpt,
                                       max_memory=max_memory)
@@ -99,7 +99,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
         ecoul = None
         if ground_state:
             ecoul = numpy.einsum('ij,ji', dm, vj).real * .5
-    if ni.libxc.is_hybrid_xc(ks.xc):
+    if ni.is_hybrid_xc(ks.xc):
         vxc -= .5 * vk
         if ground_state:
             exc -= numpy.einsum('ij,ji->', dm, vk).real * .25
@@ -110,7 +110,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
 def _patch_df_beckegrids(density_fit):
     def new_df(self, auxbasis=None, with_df=None, *args, **kwargs):
         mf = density_fit(self, auxbasis, with_df, *args, **kwargs)
-        mf.with_df._j_only = not self._numint.libxc.is_hybrid_xc(self.xc)
+        mf.with_df._j_only = not self._numint.is_hybrid_xc(self.xc)
         mf.grids = gen_grid.BeckeGrids(self.cell)
         mf.grids.level = getattr(__config__, 'dft_rks_RKS_grids_level',
                                  mf.grids.level)
@@ -142,7 +142,7 @@ def gen_response(mf, mo_coeff=None, mo_occ=None,
     cell = mf.cell
     kpt = mf.kpt
     ni = mf._numint
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
     j_in_xc = getattr(ni, 'xc_with_j', False)
 
     if with_nlc and mf.do_nlc():
@@ -211,7 +211,7 @@ def _get_jk(mf, cell, dm, hermi, kpt, kpts_band=None, with_j=True):
     '''J and Exx matrix. Note, Exx here is a scaled HF K term.'''
     ni = mf._numint
     omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, spin=cell.spin)
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
     vj = vk = None
     if not hybrid:
         if hermi == 2 or not with_j:

--- a/pyscf/pbc/dft/uks.py
+++ b/pyscf/pbc/dft/uks.py
@@ -67,10 +67,10 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
                             kpt, kpts_band, max_memory=max_memory)
     logger.info(ks, 'nelec by numeric integration = %s', n)
     if ks.do_nlc():
-        if ni.libxc.is_nlc(ks.xc):
+        if ni.is_nlc(ks.xc):
             xc = ks.xc
         else:
-            assert ni.libxc.is_nlc(ks.nlc)
+            assert ni.is_nlc(ks.nlc)
             xc = ks.nlc
         n, enlc, vnlc = ni.nr_nlc_vxc(cell, ks.nlcgrids, xc, dm[0]+dm[1],
                                       0, hermi, kpt, max_memory=max_memory)
@@ -89,7 +89,7 @@ def get_veff(ks, cell=None, dm=None, dm_last=None, vhf_last=None, hermi=1,
         ecoul = None
         if ground_state:
             ecoul = numpy.einsum('nij,ji->', dm, vj).real * .5
-    if ni.libxc.is_hybrid_xc(ks.xc):
+    if ni.is_hybrid_xc(ks.xc):
         vxc -= vk
         if ground_state:
             exc -= numpy.einsum('nij,nji->', dm, vk).real * .5
@@ -104,7 +104,7 @@ def gen_response(mf, mo_coeff=None, mo_occ=None,
     cell = mf.cell
     kpt = mf.kpt
     ni = mf._numint
-    hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+    hybrid = ni.is_hybrid_xc(mf.xc)
     j_in_xc = getattr(ni, 'xc_with_j', False)
 
     if with_nlc and mf.do_nlc():

--- a/pyscf/pbc/grad/krks.py
+++ b/pyscf/pbc/grad/krks.py
@@ -51,7 +51,7 @@ def get_veff(ks_grad, dm=None, kpts=None):
         vxc = get_vxc(ni, cell, grids, mf.xc, dm, kpts,
                            max_memory=max_memory, verbose=ks_grad.verbose)
     t0 = logger.timer(ks_grad, 'vxc', *t0)
-    if not ni.libxc.is_hybrid_xc(mf.xc):
+    if not ni.is_hybrid_xc(mf.xc):
         vj = ks_grad.get_j(dm, kpts)
         vxc += vj
     else:

--- a/pyscf/pbc/grad/krks_stress.py
+++ b/pyscf/pbc/grad/krks_stress.py
@@ -286,7 +286,7 @@ def kernel(mf_grad):
     with_df = mf.with_df
     assert isinstance(with_df, FFTDF)
     ni = mf._numint
-    if ni.libxc.is_hybrid_xc(mf.xc):
+    if ni.is_hybrid_xc(mf.xc):
         raise NotImplementedError('Stress tensor for hybrid DFT')
 
     log = logger.new_logger(mf_grad)

--- a/pyscf/pbc/grad/kuks.py
+++ b/pyscf/pbc/grad/kuks.py
@@ -53,7 +53,7 @@ def get_veff(ks_grad, dm=None, kpts=None):
                        max_memory=max_memory, verbose=ks_grad.verbose)
     t0 = logger.timer(ks_grad, 'vxc', *t0)
 
-    if not ni.libxc.is_hybrid_xc(mf.xc):
+    if not ni.is_hybrid_xc(mf.xc):
         vj = ks_grad.get_j(dm, kpts)
         vxc += vj[:,0][:,None] + vj[:,1][:,None]
     else:

--- a/pyscf/pbc/grad/kuks_stress.py
+++ b/pyscf/pbc/grad/kuks_stress.py
@@ -213,7 +213,7 @@ def kernel(mf_grad):
     with_df = mf.with_df
     assert isinstance(with_df, FFTDF)
     ni = mf._numint
-    if ni.libxc.is_hybrid_xc(mf.xc):
+    if ni.is_hybrid_xc(mf.xc):
         raise NotImplementedError('Stress tensor for hybrid DFT')
 
     log = logger.new_logger(mf_grad)

--- a/pyscf/pbc/grad/rks_stress.py
+++ b/pyscf/pbc/grad/rks_stress.py
@@ -420,7 +420,7 @@ def kernel(mf_grad):
     with_df = mf.with_df
     assert isinstance(with_df, FFTDF)
     ni = mf._numint
-    if ni.libxc.is_hybrid_xc(mf.xc):
+    if ni.is_hybrid_xc(mf.xc):
         raise NotImplementedError('Stress tensor for hybrid DFT')
     if hasattr(mf, 'U_idx'):
         raise NotImplementedError('Stress tensor for DFT+U')

--- a/pyscf/pbc/grad/uks_stress.py
+++ b/pyscf/pbc/grad/uks_stress.py
@@ -205,7 +205,7 @@ def kernel(mf_grad):
     with_df = mf.with_df
     assert isinstance(with_df, FFTDF)
     ni = mf._numint
-    if ni.libxc.is_hybrid_xc(mf.xc):
+    if ni.is_hybrid_xc(mf.xc):
         raise NotImplementedError('Stress tensor for hybrid DFT')
     if hasattr(mf, 'U_idx'):
         raise NotImplementedError('Stress tensor for DFT+U')

--- a/pyscf/pbc/tdscf/rks.py
+++ b/pyscf/pbc/tdscf/rks.py
@@ -38,7 +38,7 @@ TDDFTNoHybrid = CasidaTDDFT
 def tddft(mf, frozen=None):
     '''Driver to create TDDFT or CasidaTDDFT object'''
     kpt = getattr(mf, 'kpt', None)
-    if not mf._numint.libxc.is_hybrid_xc(mf.xc) and gamma_point(kpt):
+    if not mf._numint.is_hybrid_xc(mf.xc) and gamma_point(kpt):
         return CasidaTDDFT(mf, frozen)
     else:
         return TDDFT(mf, frozen)

--- a/pyscf/pbc/tdscf/uks.py
+++ b/pyscf/pbc/tdscf/uks.py
@@ -35,7 +35,7 @@ TDDFTNoHybrid = CasidaTDDFT
 
 def tddft(mf, frozen=None):
     '''Driver to create TDDFT or CasidaTDDFT object'''
-    if mf._numint.libxc.is_hybrid_xc(mf.xc):
+    if mf._numint.is_hybrid_xc(mf.xc):
         return TDDFT(mf, frozen)
     else:
         return CasidaTDDFT(mf, frozen)

--- a/pyscf/scf/_response_functions.py
+++ b/pyscf/scf/_response_functions.py
@@ -45,9 +45,8 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
     mol = mf.mol
     if isinstance(mf, hf.KohnShamDFT):
         ni = mf._numint
-        ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
-        hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+        hybrid = ni.is_hybrid_xc(mf.xc)
 
         if singlet is None: # for ground state orbital hessian
             spin = 0
@@ -182,9 +181,8 @@ def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None,
     mol = mf.mol
     if isinstance(mf, hf.KohnShamDFT):
         ni = mf._numint
-        ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
-        hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+        hybrid = ni.is_hybrid_xc(mf.xc)
 
         rho0, vxc, fxc = ni.cache_xc_kernel(mol, mf.grids, mf.xc,
                                             mo_coeff, mo_occ, 1)
@@ -259,9 +257,8 @@ def _gen_ghf_response(mf, mo_coeff=None, mo_occ=None,
         from pyscf.dft import numint2c, r_numint
         ni = mf._numint
         assert isinstance(ni, (numint2c.NumInt2C, r_numint.RNumInt))
-        ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
-        hybrid = ni.libxc.is_hybrid_xc(mf.xc)
+        hybrid = ni.is_hybrid_xc(mf.xc)
 
         rho0, vxc, fxc = ni.cache_xc_kernel(mol, mf.grids, mf.xc, mo_coeff, mo_occ, 1)
         dm0 = None

--- a/pyscf/solvent/grad/ddcosmo_tdscf_grad.py
+++ b/pyscf/solvent/grad/ddcosmo_tdscf_grad.py
@@ -306,7 +306,7 @@ def tdrks_grad_elec(td_grad, x_y, singlet=True, atmlst=None,
             tdrks_grad._contract_xc_kernel(td_grad, mf.xc, dmxpy,
                                            dmzoo, True, True, singlet, max_memory)
 
-    if ni.libxc.is_hybrid_xc(mf.xc):
+    if ni.is_hybrid_xc(mf.xc):
         dm = (dmzoo, dmxpy+dmxpy.T, dmxmy-dmxmy.T)
         vj, vk = mf.get_jk(mol, dm, hermi=0)
         if with_solvent.equilibrium_solvation:
@@ -392,7 +392,7 @@ def tdrks_grad_elec(td_grad, x_y, singlet=True, atmlst=None,
 
     dmz1doo = z1ao + dmzoo
     oo0 = reduce(numpy.dot, (orbo, orbo.T))
-    if ni.libxc.is_hybrid_xc(mf.xc):
+    if ni.is_hybrid_xc(mf.xc):
         dm = (oo0, dmz1doo+dmz1doo.T, dmxpy+dmxpy.T, dmxmy-dmxmy.T)
         vj, vk = td_grad.get_jk(mol, dm)
         vk *= hyb
@@ -715,7 +715,7 @@ def tduks_grad_elec(td_grad, x_y, atmlst=None, max_memory=2000, verbose=logger.I
             tduks_grad._contract_xc_kernel(td_grad, mf.xc, (dmxpya,dmxpyb),
                                            (dmzooa,dmzoob), True, True, max_memory)
 
-    if ni.libxc.is_hybrid_xc(mf.xc):
+    if ni.is_hybrid_xc(mf.xc):
         dm = (dmzooa, dmxpya+dmxpya.T, dmxmya-dmxmya.T,
               dmzoob, dmxpyb+dmxpyb.T, dmxmyb-dmxmyb.T)
         vj, vk = mf.get_jk(mol, dm, hermi=0)
@@ -845,7 +845,7 @@ def tduks_grad_elec(td_grad, x_y, atmlst=None, max_memory=2000, verbose=logger.I
     oo0b = reduce(numpy.dot, (orbob, orbob.T))
     as_dm1 = oo0a + oo0b + (dmz1dooa + dmz1doob) * .5
 
-    if ni.libxc.is_hybrid_xc(mf.xc):
+    if ni.is_hybrid_xc(mf.xc):
         dm = (oo0a, dmz1dooa+dmz1dooa.T, dmxpya+dmxpya.T, dmxmya-dmxmya.T,
               oo0b, dmz1doob+dmz1doob.T, dmxpyb+dmxpyb.T, dmxmyb-dmxmyb.T)
         vj, vk = td_grad.get_jk(mol, dm)

--- a/pyscf/tdscf/dhf.py
+++ b/pyscf/tdscf/dhf.py
@@ -117,7 +117,6 @@ def get_ab(mf, mo_energy=None, mo_coeff=None, mo_occ=None):
     if isinstance(mf, scf.hf.KohnShamDFT):
         from pyscf.dft import xc_deriv
         ni = mf._numint
-        ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
         if mf.do_nlc():
             raise NotImplementedError('DKS-TDDFT for NLC functionals')
 

--- a/pyscf/tdscf/ghf.py
+++ b/pyscf/tdscf/ghf.py
@@ -172,9 +172,7 @@ def get_ab(mf, frozen=None, mo_energy=None, mo_coeff=None, mo_occ=None):
         return a, b
 
     if isinstance(mf, scf.hf.KohnShamDFT):
-        from pyscf.dft import xc_deriv
         ni = mf._numint
-        ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
         if mf.do_nlc():
             raise NotImplementedError('DKS-TDDFT NLC functional')
 

--- a/pyscf/tdscf/gks.py
+++ b/pyscf/tdscf/gks.py
@@ -101,7 +101,7 @@ class CasidaTDDFT(TDDFT, TDA):
         cpu0 = (lib.logger.process_clock(), lib.logger.perf_counter())
         mol = self.mol
         mf = self._scf
-        if mf._numint.libxc.is_hybrid_xc(mf.xc):
+        if mf._numint.is_hybrid_xc(mf.xc):
             raise RuntimeError('%s cannot be used with hybrid functional'
                                % self.__class__)
         self.check_sanity()
@@ -168,7 +168,7 @@ TDDFTNoHybrid = CasidaTDDFT
 
 def tddft(mf, frozen=None):
     '''Driver to create TDDFT or CasidaTDDFT object'''
-    if (not mf._numint.libxc.is_hybrid_xc(mf.xc) and
+    if (not mf._numint.is_hybrid_xc(mf.xc) and
         # Casida formula can be applied for real orbitals only
         mf.mo_coeff.dtype == numpy.double and mf.collinear[0] != 'm'):
         return CasidaTDDFT(mf, frozen)

--- a/pyscf/tdscf/rhf.py
+++ b/pyscf/tdscf/rhf.py
@@ -189,7 +189,6 @@ def get_ab(mf, frozen=None, mo_energy=None, mo_coeff=None, mo_occ=None):
 
     if isinstance(mf, scf.hf.KohnShamDFT):
         ni = mf._numint
-        ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
 
         add_hf_(a, b, hyb)

--- a/pyscf/tdscf/rks.py
+++ b/pyscf/tdscf/rks.py
@@ -109,7 +109,7 @@ class CasidaTDDFT(TDDFT, TDA):
         cpu0 = (lib.logger.process_clock(), lib.logger.perf_counter())
         mol = self.mol
         mf = self._scf
-        if mf._numint.libxc.is_hybrid_xc(mf.xc):
+        if mf._numint.is_hybrid_xc(mf.xc):
             raise RuntimeError('%s cannot be used with hybrid functional'
                                % self.__class__)
         self.check_sanity()
@@ -200,7 +200,7 @@ class dTDA(TDA):
 
 def tddft(mf, frozen=None):
     '''Driver to create TDDFT or CasidaTDDFT object'''
-    if mf._numint.libxc.is_hybrid_xc(mf.xc):
+    if mf._numint.is_hybrid_xc(mf.xc):
         return TDDFT(mf, frozen)
     else:
         return CasidaTDDFT(mf, frozen)

--- a/pyscf/tdscf/uhf.py
+++ b/pyscf/tdscf/uhf.py
@@ -245,9 +245,7 @@ def get_ab(mf, frozen=None,  mo_energy=None, mo_coeff=None, mo_occ=None):
         b_ab += numpy.einsum('iajb->iajb', eri_ab[:nocc_a,nocc_a:,:nocc_b,nocc_b:])
 
     if isinstance(mf, scf.hf.KohnShamDFT):
-        from pyscf.dft import xc_deriv
         ni = mf._numint
-        ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
 
         add_hf_(a, b, hyb)

--- a/pyscf/tdscf/uks.py
+++ b/pyscf/tdscf/uks.py
@@ -123,7 +123,7 @@ class CasidaTDDFT(TDDFT, TDA):
         cpu0 = (logger.process_clock(), logger.perf_counter())
         mol = self.mol
         mf = self._scf
-        if mf._numint.libxc.is_hybrid_xc(mf.xc):
+        if mf._numint.is_hybrid_xc(mf.xc):
             raise RuntimeError('%s cannot be used with hybrid functional'
                                % self.__class__)
         self.check_sanity()
@@ -225,7 +225,7 @@ class dTDA(TDA):
 
 def tddft(mf, frozen=None):
     '''Driver to create TDDFT or CasidaTDDFT object'''
-    if mf._numint.libxc.is_hybrid_xc(mf.xc):
+    if mf._numint.is_hybrid_xc(mf.xc):
         return TDDFT(mf, frozen)
     else:
         return CasidaTDDFT(mf, frozen)

--- a/pyscf/x2c/tdscf.py
+++ b/pyscf/x2c/tdscf.py
@@ -71,9 +71,7 @@ def get_ab(mf, mo_energy=None, mo_coeff=None, mo_occ=None):
         return a, b
 
     if isinstance(mf, dft.KohnShamDFT):
-        from pyscf.dft import xc_deriv
         ni = mf._numint
-        ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
         if mf.do_nlc():
             raise NotImplementedError('X2C-TDDFT for NLC functionals')
 


### PR DESCRIPTION
New APIs in NumInt class (is_hybrid_xc, is_nlc) is introduced to hide the access to the libxc attribute. This change removes the need of modifying the libxc attribute when customizing XC functionals