### PR TITLE
tighten tol in uhf smearing test

### DIFF
--- a/pyscf/scf/test/test_addons.py
+++ b/pyscf/scf/test/test_addons.py
@@ -490,11 +490,11 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(myhf_s.e_tot, -244.9873314, 5)
         self.assertAlmostEqual(myhf_s.entropy, 0, 3)
 
-        myhf_s = scf.UHF(mol)
+        myhf_s = scf.UHF(mol.set(verbose=4))
         myhf_s = addons.smearing_(myhf_s, sigma=0.01, method='fermi', fix_spin=True)
         myhf_s.sigma = 0.1
         myhf_s.fix_spin = False
-        myhf_s.conv_tol = 1e-7
+        myhf_s.conv_tol = 1e-8
         myhf_s.kernel()
         self.assertAlmostEqual(myhf_s.e_tot, -243.086989253, 5)
         self.assertAlmostEqual(myhf_s.entropy, 17.11431, 4)


### PR DESCRIPTION
With tol=1e-7 the uhf smearing test will fall into a wrong scf solution (although very rare, <1% rate, see report in #3331). Changing to 1e-8 the test does not fail in my local 600 times run.