### PR TITLE
Use the per-root eigenvalue as the Davidson preconditioner shift

### DIFF
--- a/pyscf/lib/linalg_helper.py
+++ b/pyscf/lib/linalg_helper.py
@@ -526,7 +526,7 @@ def davidson1(aop, x0, precond, tol=1e-12, max_cycle=50, max_space=12,
         # remove subspace linear dependency
         for k, ek in enumerate(e):
             if (not conv[k]) and dx_norm[k]**2 > lindep:
-                xt[k] = precond(xt[k], e[0], x0[k])
+                xt[k] = precond(xt[k], ek, x0[k])
                 xt[k] *= dot(xt[k].conj(), xt[k]).real ** -.5
             elif not conv[k]:
                 # Remove linearly dependent vector
@@ -887,7 +887,7 @@ def davidson_nosym1(aop, x0, precond, tol=1e-12, max_cycle=50, max_space=20,
         # remove subspace linear dependency
         for k, ek in enumerate(e):
             if (not conv[k]) and dx_norm[k]**2 > lindep:
-                xt[k] = precond(xt[k], e[0], x0[k])
+                xt[k] = precond(xt[k], ek, x0[k])
                 xt[k] *= dot(xt[k].conj(), xt[k]).real ** -.5
             elif not conv[k]:
                 # Remove linearly dependent vector
@@ -1187,6 +1187,10 @@ def dgeev1(abop, x0, precond, type=1, tol=1e-12, max_cycle=50, max_space=12,
         # remove subspace linear dependency
         for k, ek in enumerate(e):
             if dx_norm[k]**2 > lindep:
+                # Unlike davidson1, the shift stays at e[0] here. The diagonal
+                # preconditioner models diag(A) - e, while the residual of the
+                # generalized problem is A x_k - e_k B x_k. Shifting per root
+                # amplifies that mismatch and costs convergence for type=2.
                 xt[k] = precond(xt[k], e[0], x0[k])
                 xt[k] *= dot(xt[k].conj(), xt[k]).real ** -.5
             else:

--- a/pyscf/lib/test/test_linalg_helper.py
+++ b/pyscf/lib/test/test_linalg_helper.py
@@ -73,6 +73,44 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(e0[:3] - eref[:3]).max(), 0, 8)
         self.assertAlmostEqual(abs(numpy.abs(x0[:3]) - abs(u[:,:3].T)).max(), 0, 5)
 
+    def test_davidson_precond_shift(self):
+        # Each root has to be corrected with its own eigenvalue estimate,
+        # (H - e_k) t_k = -r_k, not with the shift of the lowest root.
+        numpy.random.seed(12)
+        n = 100
+        nroots = 3
+        a = numpy.random.rand(n,n) * .1
+        a = a + a.conj().T + numpy.diag(numpy.arange(n)*1.)
+        eref = scipy.linalg.eigh(a)[0][:nroots]
+
+        shifts = []
+        def precond(dx, e, x0):
+            shifts.append(e)
+            diagd = a.diagonal() - (e - 1e-3)
+            diagd[abs(diagd)<1e-8] = 1e-8
+            return dx/diagd
+
+        checked = [False]
+        def check_shifts(envs):
+            e = envs['e']
+            for shift in shifts:
+                self.assertTrue(numpy.any(abs(e - shift) < 1e-14))
+            if len(shifts) > 1:
+                # Every root corrected in this cycle must have been given a
+                # different shift. Preconditioning them all with e[0] would
+                # collapse these to a single value.
+                self.assertEqual(len(set(shifts)), len(shifts))
+                checked[0] = True
+            shifts.clear()
+
+        def aop(x):
+            return numpy.dot(a, numpy.asarray(x).T).T
+        x0 = numpy.eye(n)[:nroots]
+        e0 = linalg_helper.davidson1(aop, x0, precond, nroots=nroots,
+                                     max_cycle=100, callback=check_shifts)[1]
+        self.assertAlmostEqual(abs(e0 - eref).max(), 0, 8)
+        self.assertTrue(checked[0])
+
     def test_davidson_diag_matrix(self):
         numpy.random.seed(12)
         n = 100


### PR DESCRIPTION
Fixes #3398.

The diagonal preconditioner approximates the correction equation `(H - e_k) t_k = -r_k` for root k, so the shift is tied to the root being corrected. `davidson1` and `davidson_nosym1` passed `e[0]` instead, which preconditions every root with the lowest root's shift. Both call sites now pass `ek`, the loop variable already bound by the enclosing `for k, ek in enumerate(e)`.

This is a convergence-rate defect rather than a wrong-answer defect. Eigenvalues come out the same, they just cost more matrix-vector products to reach. I compared the two variants built from the same source, differing only in that one line:

| test set | `e[0]` | `e[k]` |
| --- | --- | --- |
| 36 symmetric problems, 4 to 12 roots, well separated spectra | 2181 products | 1258 products, faster in 36/36 |
| 36 symmetric problems, near-degenerate and strongly coupled | 11524 products, 2 unconverged | 11182 products, 1 unconverged, faster in 25/36 |
| 20 non-symmetric problems via `davidson_nosym1` | 641 products | 410 products, faster in 20/20 |
| FCI N2/STO-3G, 4 roots | 123 contractions | 105 contractions |
| EOM-EE-CCSD and EOM-IP-CCSD, 4 roots | 36 and 27 products | 35 and 26 products |

No accuracy regressions in any of those runs, and the `nroots=1` callers (SOSCF, CIAH, Newton-CASSCF) are unaffected by construction since `e[0]` and `e[k]` coincide there.

`dgeev1` carries the same `e[0]` pattern and is deliberately left alone, with a comment recording why. It solves the generalized problem `A c = e B c`, but the preconditioner it builds is `diag(A) - e`, which models `A - e*I` rather than `A - e_k*B`. Feeding each root its own shift amplifies that mismatch instead of correcting it: over 20 random generalized problems at `max_cycle=300`, type=1 stayed at 20/20 converged but type=2 fell from 18/20 to 12/20, and the existing `test_dgeev` problem stopped converging at its usual cycle count. Making `dgeev1` per-root really means fixing its preconditioner to shift by `diag(A) - e_k*diag(B)`, which is a separate change and is not attempted here.

`test_davidson_precond_shift` is new. It records the shift handed to the preconditioner on every call, asserts each one is one of the current eigenvalue estimates, and asserts that when several roots are corrected in the same cycle they all receive different shifts, which is what collapses to a single value under the old behavior. It fails on master and passes with this change. No existing test needed modification.

Test suites run locally: `pyscf/lib` 15 passed, `pyscf/fci` and `pyscf/ci` 162 passed, `pyscf/tdscf` 82 passed, EOM-CC 67 passed, SCF stability with CASCI and Newton-CASSCF 28 passed.
