### PR TITLE
Gauge-invariant EOM-GCCSD star contraction for degenerate roots

### DIFF
--- a/pyscf/cc/eom_gccsd.py
+++ b/pyscf/cc/eom_gccsd.py
@@ -114,6 +114,51 @@ def ipccsd_diag(eom, imds=None):
     vector = eom.amplitudes_to_vector(Hr1, Hr2)
     return vector
 
+def _biorthonormalize_degenerate_left_evecs(eom, evals, evecs, levecs,
+                                            nmo, nocc, deg_tol=1e-6):
+    """Rotate left eigenvectors within each degenerate cluster so that the
+    left/right amplitude overlap matrix becomes the identity.
+
+    The left and right eigenvectors come from two independent Davidson
+    solves.  Within a degenerate cluster each solve returns an arbitrary
+    basis of the same subspace, so the index-wise overlap <l_i|r_i> used by
+    the star contraction is not well defined and can become arbitrarily
+    small, amplifying the residual error of the Davidson vectors.  Solving
+    L' = S^{-1} L with S_ij = <l_i|r_j> gives <l'_i|r_j> = delta_ij, which
+    makes the per-root contraction independent of the arbitrary bases (for
+    symmetry-induced degeneracies the star correction is proportional to
+    the identity within the cluster).  Non-degenerate roots are returned
+    unchanged.
+    """
+    evals = np.atleast_1d(np.asarray(evals))
+    evecs = np.atleast_2d(np.asarray(evecs))
+    levecs = np.atleast_2d(np.asarray(levecs)).copy()
+    nroots = len(evals)
+
+    def overlap(lvec, rvec):
+        l1, l2 = eom.vector_to_amplitudes(lvec, nmo, nocc)
+        r1, r2 = eom.vector_to_amplitudes(rvec, nmo, nocc)
+        return np.dot(l1.ravel(), r1.ravel()) + 0.5 * np.dot(l2.ravel(), r2.ravel())
+
+    i0 = 0
+    while i0 < nroots:
+        i1 = i0 + 1
+        while i1 < nroots and abs(evals[i1] - evals[i1-1]) < deg_tol:
+            i1 += 1
+        if i1 - i0 > 1:
+            cluster = range(i0, i1)
+            ovlp = np.array([[overlap(levecs[i], evecs[j]) for j in cluster]
+                             for i in cluster])
+            if 1. / np.linalg.cond(ovlp) < 1e-10:
+                raise ValueError(
+                    'Left and right eigenvectors of the degenerate cluster '
+                    f'{list(cluster)} have a near-singular overlap matrix; '
+                    'the star correction is not defined for this input.')
+            levecs[i0:i1] = np.linalg.solve(ovlp, levecs[i0:i1])
+        i0 = i1
+    return levecs
+
+
 def ipccsd_star_contract(eom, ipccsd_evals, ipccsd_evecs, lipccsd_evecs, imds=None):
     """
     Returns:
@@ -177,6 +222,10 @@ def ipccsd_star_contract(eom, ipccsd_evals, ipccsd_evecs, lipccsd_evecs, imds=No
     e_star = []
     ipccsd_evecs, lipccsd_evecs = [np.atleast_2d(x) for x in [ipccsd_evecs, lipccsd_evecs]]
     ipccsd_evals = np.atleast_1d(ipccsd_evals)
+    ipccsd_evals = np.atleast_1d(ipccsd_evals)
+    ipccsd_evecs = np.atleast_2d(ipccsd_evecs)
+    lipccsd_evecs = _biorthonormalize_degenerate_left_evecs(
+        eom, ipccsd_evals, ipccsd_evecs, lipccsd_evecs, nmo, nocc)
     for ip_eval, ip_evec, ip_levec in zip(ipccsd_evals, ipccsd_evecs, lipccsd_evecs):
         # Enforcing <L|R> = 1
         l1, l2 = eom.vector_to_amplitudes(ip_levec, nmo, nocc)
@@ -402,6 +451,8 @@ def eaccsd_star_contract(eom, eaccsd_evals, eaccsd_evecs, leaccsd_evecs, imds=No
     e_star = []
     eaccsd_evecs, leaccsd_evecs = [np.atleast_2d(x) for x in [eaccsd_evecs, leaccsd_evecs]]
     eaccsd_evals = np.atleast_1d(eaccsd_evals)
+    leaccsd_evecs = _biorthonormalize_degenerate_left_evecs(
+        eom, eaccsd_evals, eaccsd_evecs, leaccsd_evecs, nmo, nocc)
     for ea_eval, ea_evec, ea_levec in zip(eaccsd_evals, eaccsd_evecs, leaccsd_evecs):
         # Enforcing <L|R> = 1
         l1, l2 = eom.vector_to_amplitudes(ea_levec, nmo, nocc)

--- a/pyscf/cc/test/test_eom_gccsd.py
+++ b/pyscf/cc/test/test_eom_gccsd.py
@@ -121,6 +121,21 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(e[2], 0.50226873136932748, 5)
 
 
+    def test_ipccsd_star_degenerate_left_gauge(self):
+        # The degenerate pair spans a two-dimensional subspace in which two
+        # independent Davidson solves may return any basis.  Swapping the two
+        # left vectors emulates the worst such gauge; the star correction must
+        # stay at its reference value instead of dividing by a near-zero
+        # left/right overlap.
+        myeom = eom_gccsd.EOMIP(mycc)
+        e, v = myeom.ipccsd(nroots=3)
+        el, lv = myeom.ipccsd(nroots=3, left=True)
+        lv = numpy.asarray(lv).copy()
+        lv[[0, 1]] = lv[[1, 0]]
+        estar = myeom.ipccsd_star_contract(e, v, lv)
+        self.assertAlmostEqual(estar[0], 0.4358615224789573, 5)
+        self.assertAlmostEqual(estar[1], 0.4358615224789594, 5)
+
     def test_eaccsd(self):
         e,v = mycc.eaccsd(nroots=1)
         self.assertAlmostEqual(e, 0.19050592141957523, 5)
@@ -145,6 +160,17 @@ class KnownValues(unittest.TestCase):
         # been observed to come out as ~1e-26 on some machines, in which case
         # the correction is numerical noise. FIXME
         #self.assertAlmostEqual(e[2], 0.2820757599337823, 5)
+
+    def test_eaccsd_star_degenerate_left_gauge(self):
+        # Same gauge-invariance guard as test_ipccsd_star_degenerate_left_gauge.
+        myeom = eom_gccsd.EOMEA(mycc)
+        e, v = myeom.eaccsd(nroots=3)
+        el, lv = myeom.eaccsd(nroots=3, left=True)
+        lv = numpy.asarray(lv).copy()
+        lv[[0, 1]] = lv[[1, 0]]
+        estar = myeom.eaccsd_star_contract(e, v, lv)
+        self.assertAlmostEqual(estar[0], 0.1894169322207168, 5)
+        self.assertAlmostEqual(estar[1], 0.1894169322207168, 5)
 
     def test_eaccsd_koopmans(self):
         e,v = mycc.eaccsd(nroots=3, koopmans=True)


### PR DESCRIPTION
## Problem

`test_ipccsd` and `test_eaccsd` fail intermittently at the unchanged five-place
star-correction assertions (`test_eom_gccsd.py:107/:140/:141`). On unmodified
master, 200 fresh-process attempts per nodeid (`ubuntu-latest`, Python 3.12,
OMP 4 / BLAS 4) measured in
[run 31793659105](https://github.com/psiQAQ/pyscf/actions/runs/31793659105):

- `test_eaccsd`: **4/200 failures**;
- `test_ipccsd`: **1/200 failures**;
- errors range from `6.3e-06` to `6.5e-03` and occur in both directions.

The same failure hit the upstream gate CI on
[run 31689089793](https://github.com/pyscf/pyscf/actions/runs/31689089793)
(linux 3.12, `1.6e-03`), and historical Windows installed-wheel runs cataloged
in #3312.

## Root cause

The star contractions pair left and right eigenvectors **by index** and
normalize by `<l_i|r_i>`. The first two roots of both tests are a degenerate
pair (spin degeneracy of the GHF representation of the RHF reference), and the
left and right eigenvectors come from two independent Davidson solves. Within
a degenerate cluster each solve returns an arbitrary basis of the same
subspace, so the index-wise overlap is gauge dependent and can become
arbitrarily small (the test comments record `~1e-26` for the third root).
Dividing by it amplifies the Davidson residual by `1/<l_i|r_i>`, which turns
`~1e-8`-level vector noise into the observed `1e-6`-to-`1e-2` energy errors -
a continuous spectrum, not a fixed wrong root.

## Fix

Biorthonormalize the left vectors within each degenerate cluster before the
per-root contraction: build the cluster overlap `S_ij = <l_i|r_j>` and solve
`L' = S^-1 L`, giving `<l'_i|r_j> = delta_ij`. For symmetry-induced
degeneracies the star correction is proportional to the identity within the
cluster, so the per-root energies become independent of whatever bases the two
Davidson runs happened to return. A near-singular cluster overlap raises
explicitly instead of silently producing numbers (same policy as the matched
wrapper path). Non-degenerate roots take the existing path unchanged; no
scientific assertion is modified.

Relation to prior work: #3316 fixed left/right root matching for the wrapper
path (`perturbed_ccsd_kernel`); the direct-contract API deliberately kept by
these tests (see the #3332 discussion) had no such protection. This change
completes it for that API. The index-wise pairing exists only in
`eom_gccsd.py` (both star contractions); `eom_rccsd`/`eom_uccsd` have no
direct-contract analogue.

## Verification

- deterministic regression (added here): swapping the two degenerate left
  vectors - the worst gauge two independent solves can return - keeps the
  star energies at their unchanged reference values; without the fix this
  divides by a near-zero overlap and fails immediately;
- RED, unmodified master: 5/400 failures
  ([run 31793659105](https://github.com/psiQAQ/pyscf/actions/runs/31793659105));
- GREEN, this fix: **800/800 pass**
  ([run 31952683745](https://github.com/psiQAQ/pyscf/actions/runs/31952683745)) -
  both original assertions and both gauge regressions, 200 attempts each on
  the same platform and threading profile (`test_eaccsd` moves from 4/200
  failures to 0/200; at its measured 2% rate, 200 clean attempts have
  P(all pass | unfixed) of about 1.8%). Artifacts carry per-attempt logs,
  records.jsonl and full environment capture.
