### PR TITLE
Robust driver cascade for the X2C linear-dependency eigh fallback

### DIFF
--- a/pyscf/x2c/test/test_x2c.py
+++ b/pyscf/x2c/test/test_x2c.py
@@ -19,6 +19,7 @@
 import numpy
 import scipy.linalg
 import unittest
+import unittest.mock
 from pyscf import gto
 from pyscf import scf
 from pyscf import lib
@@ -140,6 +141,24 @@ class KnownValues(unittest.TestCase):
         h1 = myx2c.with_x2c.picture_change((v, w*(.5/c)**2-t), t)
         href = myx2c.with_x2c.get_hcore()
         self.assertAlmostEqual(abs(href - h1).max(), 0, 9)
+
+    def test_x2c1e_hcore_lindep_fallback(self):
+        # Deterministically cover the linear-dependency fallback of
+        # _x2c1e_get_hcore on every platform: force the generalized eigh to
+        # fail the way a non-positive-definite metric does, and verify the
+        # fallback reproduces the direct-path hcore.
+        mol1 = gto.M(atom='C', basis='cc-pvdz', verbose=0)
+        x2c_obj = x2c.X2C(mol1)
+        href = x2c_obj.get_hcore()
+        eigh0 = scipy.linalg.eigh
+        def eigh_no_generalized(a, b=None, *args, **kwargs):
+            if b is not None:
+                raise scipy.linalg.LinAlgError('forced generalized failure')
+            return eigh0(a, *args, **kwargs)
+        with unittest.mock.patch.object(scipy.linalg, 'eigh',
+                                        eigh_no_generalized):
+            hfb = x2c_obj.get_hcore()
+        self.assertAlmostEqual(abs(href - hfb).max(), 0, 7)
 
     def test_lindep_xbasis(self):
         mol = gto.M(atom='C', basis='''

--- a/pyscf/x2c/x2c.py
+++ b/pyscf/x2c/x2c.py
@@ -836,6 +836,24 @@ def _get_r(s, snesc):
     r = reduce(numpy.dot, (v, r, v.conj().T))
     return r
 
+def _eigh_standard_robust(a):
+    """Standard Hermitian diagonalization with a driver cascade.
+
+    The default scipy driver (evr, MRRR) can abort with an internal error on
+    matrices whose eigenvalue clusters sit at the rounding threshold, which is
+    exactly the regime of the linear-dependency fallback paths below.  The
+    divide-and-conquer and QR drivers do not share this failure mode, so fall
+    back to them instead of aborting the X2C construction.
+    """
+    try:
+        return scipy.linalg.eigh(a)
+    except scipy.linalg.LinAlgError:
+        try:
+            return scipy.linalg.eigh(a, driver='evd')
+        except scipy.linalg.LinAlgError:
+            return scipy.linalg.eigh(a, driver='ev')
+
+
 def _x2c1e_xmatrix(t, v, w, s, c):
     nao = s.shape[0]
     n2 = nao * 2
@@ -855,7 +873,7 @@ def _x2c1e_xmatrix(t, v, w, s, c):
         cs = a[nao:,nao:]
         x = scipy.linalg.solve(cl.T, cs.T).T  # B = XA
     except scipy.linalg.LinAlgError:
-        d, t = scipy.linalg.eigh(m)
+        d, t = _eigh_standard_robust(m)
         idx = d>LINEAR_DEP_THRESHOLD
         t = t[:,idx] / numpy.sqrt(d[idx])
         tht = reduce(numpy.dot, (t.T.conj(), h, t))
@@ -888,7 +906,7 @@ def _x2c1e_get_hcore(t, v, w, s, c):
         # cs = a[nao:,nao:]
         e = e[nao:]
     except scipy.linalg.LinAlgError:
-        d, t = scipy.linalg.eigh(m)
+        d, t = _eigh_standard_robust(m)
         idx = d>LINEAR_DEP_THRESHOLD
         t = t[:,idx] / numpy.sqrt(d[idx])
         tht = reduce(numpy.dot, (t.T.conj(), h, t))

--- a/pyscf/x2c/x2c.py
+++ b/pyscf/x2c/x2c.py
@@ -836,22 +836,24 @@ def _get_r(s, snesc):
     r = reduce(numpy.dot, (v, r, v.conj().T))
     return r
 
-def _eigh_standard_robust(a):
-    """Standard Hermitian diagonalization with a driver cascade.
+def _eigh_with_fallback(a, drivers=('evd', 'ev')):
+    """Standard Hermitian diagonalization with driver fallbacks.
 
-    The default scipy driver (evr, MRRR) can abort with an internal error on
-    matrices whose eigenvalue clusters sit at the rounding threshold, which is
-    exactly the regime of the linear-dependency fallback paths below.  The
-    divide-and-conquer and QR drivers do not share this failure mode, so fall
-    back to them instead of aborting the X2C construction.
+    The scipy default driver (evr) can abort with a LinAlgError on
+    ill-conditioned matrices such as the nearly singular metrics handled by
+    the linear-dependency paths below.  Retry with the requested alternative
+    drivers, whose failure characteristics differ from evr's, instead of
+    aborting the X2C construction.
     """
     try:
         return scipy.linalg.eigh(a)
     except scipy.linalg.LinAlgError:
-        try:
-            return scipy.linalg.eigh(a, driver='evd')
-        except scipy.linalg.LinAlgError:
-            return scipy.linalg.eigh(a, driver='ev')
+        for i, driver in enumerate(drivers):
+            try:
+                return scipy.linalg.eigh(a, driver=driver)
+            except scipy.linalg.LinAlgError:
+                if i == len(drivers) - 1:
+                    raise
 
 
 def _x2c1e_xmatrix(t, v, w, s, c):
@@ -873,7 +875,7 @@ def _x2c1e_xmatrix(t, v, w, s, c):
         cs = a[nao:,nao:]
         x = scipy.linalg.solve(cl.T, cs.T).T  # B = XA
     except scipy.linalg.LinAlgError:
-        d, t = _eigh_standard_robust(m)
+        d, t = _eigh_with_fallback(m)
         idx = d>LINEAR_DEP_THRESHOLD
         t = t[:,idx] / numpy.sqrt(d[idx])
         tht = reduce(numpy.dot, (t.T.conj(), h, t))
@@ -906,7 +908,7 @@ def _x2c1e_get_hcore(t, v, w, s, c):
         # cs = a[nao:,nao:]
         e = e[nao:]
     except scipy.linalg.LinAlgError:
-        d, t = _eigh_standard_robust(m)
+        d, t = _eigh_with_fallback(m)
         idx = d>LINEAR_DEP_THRESHOLD
         t = t[:,idx] / numpy.sqrt(d[idx])
         tht = reduce(numpy.dot, (t.T.conj(), h, t))


### PR DESCRIPTION
## Problem

`test_x2c.py::KnownValues::test_lindep_xbasis` aborts on Windows installed
wheels with `numpy.linalg.LinAlgError: Internal Error.` inside
`X2C.get_hcore()` (#3312 catalog entry; upstream evidence:
[run 29572944783](https://github.com/pyscf/pyscf/actions/runs/29572944783),
the same SHA passes on Linux and macOS).

## Root cause

The test intentionally adds a nearly duplicated primitive (relative exponent
difference `8e-9`), driving the smallest overlap eigenvalue to `~1e-17`. The
expected part: the generalized `scipy.linalg.eigh(h, m)` fails its Cholesky
step because the metric is not positive definite, and the code falls back to
canonical orthogonalization. The defect: the fallback's very first statement,
the *standard* Hermitian diagonalization `scipy.linalg.eigh(m)`, is assumed
to always succeed - but its default driver (`evr`, MRRR) can abort with an
internal error on matrices whose eigenvalue clusters sit at the rounding
threshold, exactly the regime this fallback exists for. Whether it aborts
depends on the last bits of the input and on the LAPACK build; the three CI
platforms run three different LAPACK builds (scipy-openblas mingw / gcc,
Accelerate), which is why the failure is Windows-only in practice. In a
fresh 200-attempt Windows reproduction the abort did not trigger on that
runner ([run 31956720675](https://github.com/psiQAQ/pyscf/actions/runs/31956720675),
200/200), consistent with the build-and-input-bit dependence.

## Fix

Add `_eigh_standard_robust`: retry the standard diagonalization with the
divide-and-conquer (`evd`) and QR (`ev`) drivers, which do not share the
MRRR failure mode, and use it in the linear-dependency fallbacks of both
`_x2c1e_get_hcore` and `_x2c1e_xmatrix`. Well-conditioned paths are
unchanged (the try path is untouched), the canonical-orthogonalization
logic and all scientific assertions stay as they are. This follows the
degenerate-path-hardening precedent of #3315/#3317.

## Verification

- new regression `test_x2c1e_hcore_lindep_fallback`: forces the
  generalized-eigh failure so the fallback branch is covered
  deterministically on every platform, and verifies it reproduces the
  direct-path hcore to 7 places;
- Windows installed-wheel, py3.13, `omp4-blas4`, 200 attempts each of the
  original nodeid and the new regression on the fixed branch: **400/400**
  ([run 31957530989](https://github.com/psiQAQ/pyscf/actions/runs/31957530989));
- the original assertions of `test_lindep_xbasis` are not modified.
