### PR TITLE
Normalize the initial CIAH trial vector; match sa4 conv_tol to its assertion

### DIFF
--- a/pyscf/mcscf/test/test_h2o.py
+++ b/pyscf/mcscf/test/test_h2o.py
@@ -69,6 +69,12 @@ def tearDownModule():
 class KnownValues(unittest.TestCase):
     def test_nosymm_sa4_newton (self):
         mc = mcscf.CASSCF (m, 4, 4).state_average_([0.25,]*4).newton ()
+        # The eight-place total-energy assertion requires the converged-energy
+        # scatter to stay below 0.5e-8.  With the default conv_tol=1e-7 the
+        # gradient threshold sqrt(conv_tol)~3.2e-4 permits a legitimate energy
+        # spread of ~g^2 ~ 1e-8, so the default tolerance cannot guarantee the
+        # asserted precision.
+        mc.conv_tol = 1e-8
         mo = mc.sort_mo([4,5,6,10], base=1)
         mc.kernel(mo)
         self.assertAlmostEqual (mc.e_tot, mc_ref.e_tot, 8)

--- a/pyscf/soscf/ciah.py
+++ b/pyscf/soscf/ciah.py
@@ -263,6 +263,22 @@ def davidson_cc(h_op, g_op, precond, x0, tol=1e-10, xs=[], ax=[],
     heff = numpy.zeros((max_cycle+nx+1,max_cycle+nx+1), dtype=x0.dtype)
     ovlp = numpy.eye(max_cycle+nx+1, dtype=x0.dtype)
     if nx == 0:
+        # The initial trial vector is often recycled from the last (possibly
+        # tiny) micro step of the previous macro iteration.  Feeding it
+        # unnormalized makes the subspace metric singular
+        # (seig ~ |x0|^2 < lindep), so safe_eigh discards the only expansion
+        # direction: the solver then returns an exact zero step and
+        # terminates on its first iteration before any useful direction can
+        # be added.  Normalization removes the scale pathology while keeping
+        # the direction; the generalized subspace problem is invariant to
+        # the scaling of a basis vector.
+        norm_x0 = numpy.linalg.norm(x0)
+        if norm_x0 == 0:
+            # No direction information at all; start from the gradient.
+            x0 = g_op()
+            norm_x0 = numpy.linalg.norm(x0)
+        if norm_x0 > 0:
+            x0 = x0 / norm_x0
         xs.append(x0)
         ax.append(h_op(x0))
     else:

--- a/pyscf/soscf/test/test_newton_ah.py
+++ b/pyscf/soscf/test/test_newton_ah.py
@@ -21,6 +21,7 @@ import numpy
 import scipy.linalg
 import tempfile
 from pyscf import gto
+from pyscf.soscf import ciah
 from pyscf import scf
 from pyscf import dft
 
@@ -388,6 +389,30 @@ class KnownValues(unittest.TestCase):
         mol = gto.M(atom='He', basis='sto3g')
         mf = mol.RHF().newton().run()
         self.assertAlmostEqual(mf.e_tot, -2.80778395753997, 9)
+
+
+class KnownValuesCIAH(unittest.TestCase):
+    def test_davidson_cc_tiny_initial_guess(self):
+        # A recycled initial trial vector with norm ~1e-14 must not collapse
+        # the subspace metric: the solver has to take a genuine step and
+        # reduce the residual instead of returning an exact zero step on its
+        # first iteration.
+        numpy.random.seed(1)
+        n = 8
+        a = numpy.random.rand(n, n)
+        h = a.T.dot(a) + numpy.eye(n) * 2
+        g = numpy.random.rand(n)
+        h_op = lambda x: h.dot(x)
+        g_op = lambda: g
+        precond = lambda dx, w: dx
+        x0 = numpy.random.rand(n) * 1e-14
+        xtrial = None
+        for conv, itr, w, xtrial, hx, dx, seig in ciah.davidson_cc(
+                h_op, g_op, precond, x0, tol=1e-12):
+            if conv:
+                break
+        self.assertTrue(numpy.linalg.norm(xtrial) > 1e-6)
+        self.assertTrue(numpy.linalg.norm(dx) < 1e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`test_h2o.py::KnownValues::test_nosymm_sa4_newton` fails intermittently at the
unchanged eight-place SA-total-energy assertion. Reproduction on unmodified
master (`ubuntu-latest`, Python 3.12, `omp4-blas4`, 200 fresh-process
attempts): **1/200**, energy `7.5e-8` above the reference
([run 31956718807](https://github.com/psiQAQ/pyscf/actions/runs/31956718807)).
The historical instance recorded in the #3319 discussion stalled with
`|g| = 1.57e-4` while every micro iteration reported
`|dxi| = 0, seig = 1.6e-28` until `max_cycle_macro` ran out.

## Root cause - two layers

**1. A solver deadlock in `davidson_cc` (fixed here).** The macro loop of
`newton_casscf` recycles the last micro step as the next Davidson initial
guess. `davidson_cc` is the only place where a trial vector enters the
subspace *unnormalized*: when the previous macro iteration ends on a tiny
step (norm ~1e-14), the subspace metric becomes singular -
`seig = |x0|^2` falls below `ah_lindep`, `safe_eigh` discards the only
expansion direction, and the solver returns an exact zero step and terminates
on its **first** iteration, before any useful direction can be added. The
zero step is accepted, the zero vector is recycled, and the macro loop is
deadlocked with a finite gradient. The historical fingerprint
`seig = 1.6e-28 = (1.3e-14)^2` is precisely the square of an unnormalized
tiny guess. Normalizing the initial trial vector removes the scale pathology
while keeping its direction - the generalized subspace problem is invariant
to the scaling of a basis vector, so well-conditioned paths are unchanged.
An exactly zero guess falls back to the gradient direction. This is the
root-cause counterpart of #3319 (closed as a symptom-level fix), and follows
the degenerate-path-hardening precedent of #3315/#3317.

**2. A tolerance/assertion mismatch in the test (also addressed).** With the
deadlock fixed, rare shallow misses remained (2/200, energies `1.4e-8` and
`3.8e-8` above the reference,
[run 31958114826](https://github.com/psiQAQ/pyscf/actions/runs/31958114826)):
the default `conv_tol = 1e-7` implies a gradient threshold
`sqrt(conv_tol) ~ 3.2e-4`, which legitimately permits a converged-energy
spread of `~g^2 ~ 1e-8` - wider than the `0.5e-8` the assertion demands.
The test now sets `conv_tol = 1e-8` so the convergence guarantee matches the
asserted precision. The assertions themselves are unchanged.

## Verification

- solver-level regression (added): feeding `davidson_cc` a tiny recycled
  guess must produce a genuine step and a reduced residual instead of a
  zero step - fails on the old code deterministically;
- fix only, original test settings: solver regression 200/200; sa4 failures
  move from the deadlock signature (`7.5e-8`) to the shallow
  tolerance-window misses above;
- fix + tightened `conv_tol`, plus a converged-flag probe variant:
  **200/200 and 200/200**
  ([run 31959226283](https://github.com/psiQAQ/pyscf/actions/runs/31959226283));
- all runs carry per-attempt logs, records.jsonl and environment capture.
