### PR TITLE
Relax rccsd update_amps t1 fingerprint assertion to six places

### DIFF
--- a/pyscf/cc/test/test_rccsd.py
+++ b/pyscf/cc/test/test_rccsd.py
@@ -285,13 +285,13 @@ class KnownValues(unittest.TestCase):
 
         mycc1.cc2 = False
         t1a, t2a = rccsd.update_amps(mycc1, t1, t2, eris1)
-        self.assertAlmostEqual(lib.fp(t1a), -106360.5276951083, 7)
+        self.assertAlmostEqual(lib.fp(t1a), -106360.5276951083, 6)
         self.assertAlmostEqual(lib.fp(t2a), 66540.100267798145, 6)
         self.assertAlmostEqual(abs(t1a-t1b).max(), 0, 6)
         self.assertAlmostEqual(abs(t2a-t2b).max(), 0, 6)
         mycc1.cc2 = True
         t1a, t2a = rccsd.update_amps(mycc1, t1, t2, eris1)
-        self.assertAlmostEqual(lib.fp(t1a), -106360.5276951083, 7)
+        self.assertAlmostEqual(lib.fp(t1a), -106360.5276951083, 6)
         self.assertAlmostEqual(lib.fp(t2a), -1517.9391800662809, 7)
 
         mol = gto.Mole()


### PR DESCRIPTION
## Problem

`test_rccsd.py::KnownValues::test_update_amps` fails intermittently on
Windows installed wheels at the seven-place `lib.fp(t1a)` assertion:
3/200 fresh-process attempts, differences `5.04e-8` / `5.34e-8` / `6.05e-8` -
each just above the `5e-8` threshold
([run 31956720675](https://github.com/psiQAQ/pyscf/actions/runs/31956720675));
historical sample `5.03e-8`
([run 29572944783](https://github.com/pyscf/pyscf/actions/runs/29572944783)).
Five same-day CI Windows runs with bit-identical `pyscf/cc` sources went
pass/fail/pass under fixed 4/4 threads.

## Analysis

The test is a fixed-seed random-tensor construction, so its inputs are
bit-identical on every platform. `lib.fp(t1a)` has magnitude `~1.06e5`, so
seven places demand a `4.7e-13` relative match (about 2100x double eps) from
a fingerprint accumulated through the veff/ao2mo/T1 contraction chain.
Legitimate floating-point summation-order differences across BLAS engines
(bundled OpenBLAS `DYNAMIC_ARCH` micro-kernels on heterogeneous Windows
runners; pytblis on Linux) reach exactly this scale, so the assertion sits on
a portability boundary rather than exposing a defect in `update_amps`.
Full analysis and data in the
[#3312 discussion](https://github.com/pyscf/pyscf/issues/3312#issuecomment-5308434897);
maintainer approval to proceed in the reply.

## Change

Relax the `lib.fp(t1a)` assertion from seven to six places - the precision
already used for the same fingerprint in the `ccsd` branch of this test and
for the adjacent `t2` assertion. Both occurrences (cc2=False and cc2=True
paths) assert the same value and are relaxed together. No production code is
touched; all other assertions are unchanged.
