### PR TITLE
Modify two KRPA mean-field driver

### DIFF
--- a/pyscf/pbc/gw/krpa.py
+++ b/pyscf/pbc/gw/krpa.py
@@ -83,8 +83,8 @@ def kernel(rpa, mo_energy, mo_coeff, nw=None, with_e_hf=None):
         rhf.with_df = rpa._scf.with_df
         with temporary_env(rpa.with_df, verbose=0), temporary_env(rhf.mol, verbose=0):
             dm = rpa._scf.make_rdm1()
-            e_1e = 1.0 / len(rpa.kpts) * lib.einsum('kij,kji', dm, rhf.get_hcore()).real
-            e_j = 0.5 / len(rpa.kpts) * lib.einsum('kij,kji', dm, rhf.get_j(rhf.cell, dm)).real
+            e_1e = 1.0 / len(rpa.kpts) * lib.einsum('kij,kji', dm, rpa._scf.get_hcore()).real
+            e_j = 0.5 / len(rpa.kpts) * lib.einsum('kij,kji', dm, rpa._scf.get_j(rhf.cell, dm)).real
             e_x = get_rpa_exx(rpa, acfd=rpa.acfd_exx, correction_only=False)
             e_nuc = rpa._scf.energy_nuc()
             e_hf = e_1e + e_j + e_x + e_nuc

--- a/pyscf/pbc/gw/kurpa.py
+++ b/pyscf/pbc/gw/kurpa.py
@@ -81,9 +81,9 @@ def kernel(rpa, mo_energy, mo_coeff, nw=None, with_e_hf=None):
         uhf.with_df = rpa._scf.with_df
         with temporary_env(rpa.with_df, verbose=0), temporary_env(rpa.mol, verbose=0):
             dm = rpa._scf.make_rdm1()
-            vj = uhf.get_j(uhf.cell, dm)
+            vj = rpa._scf.get_j(uhf.cell, dm)
             vj_tot = vj[0] + vj[1]
-            e_1e = 1.0 / len(rpa.kpts) * lib.einsum('kij,kji', dm[0] + dm[1], uhf.get_hcore()).real
+            e_1e = 1.0 / len(rpa.kpts) * lib.einsum('kij,kji', dm[0] + dm[1], rpa._scf.get_hcore()).real
             e_j = 0.5 / len(rpa.kpts) * lib.einsum('kij,kji', dm[0] + dm[1], vj_tot).real
             e_x = get_rpa_exx(rpa, acfd=rpa.acfd_exx, correction_only=False)
             e_nuc = rpa._scf.energy_nuc()


### PR DESCRIPTION
For KRPA calculations, this PR replaced rhf.get_hcore and get_j with rpa._scf.get_hcore and get_j (same for KURPA).

This is useful when the rpa._scf has a modified hcore definition. For example, with x2c Hamiltonian, the old implementation failed to reproduce the exact X2C-HF energy.