### PR TITLE
Give sa4 newton conv_tol an order-of-magnitude margin over its assertion

### DIFF
--- a/pyscf/mcscf/test/test_h2o.py
+++ b/pyscf/mcscf/test/test_h2o.py
@@ -70,11 +70,12 @@ class KnownValues(unittest.TestCase):
     def test_nosymm_sa4_newton (self):
         mc = mcscf.CASSCF (m, 4, 4).state_average_([0.25,]*4).newton ()
         # The eight-place total-energy assertion requires the converged-energy
-        # scatter to stay below 0.5e-8.  With the default conv_tol=1e-7 the
-        # gradient threshold sqrt(conv_tol)~3.2e-4 permits a legitimate energy
-        # spread of ~g^2 ~ 1e-8, so the default tolerance cannot guarantee the
-        # asserted precision.
-        mc.conv_tol = 1e-8
+        # scatter to stay below 0.5e-8.  The gradient threshold is
+        # sqrt(conv_tol), and the permitted energy spread is ~g^2 ~ conv_tol:
+        # 1e-8 sits exactly on the assertion line with no margin (observed
+        # rare 5e-9..2e-8 misses), so use 1e-9 for an order-of-magnitude
+        # margin.
+        mc.conv_tol = 1e-9
         mo = mc.sort_mo([4,5,6,10], base=1)
         mc.kernel(mo)
         self.assertAlmostEqual (mc.e_tot, mc_ref.e_tot, 8)


### PR DESCRIPTION
## Problem

Follow-up to #3406. Post-merge revalidation of `test_nosymm_sa4_newton` on
master (200 fresh-process attempts, `ubuntu-latest`, Python 3.12,
`omp4-blas4`) still shows **3/200 misses** at `5.1e-9`, `7.4e-9` and
`1.8e-8` above the reference
([run 32183973779](https://github.com/psiQAQ/pyscf/actions/runs/32183973779);
the CIAH solver regression added in #3406 passes 200/200 in the same run).

## Analysis

The permitted converged-energy spread scales as `~g^2 ~ conv_tol`. With
`conv_tol = 1e-8` the guaranteed spread (`~5e-9`) sits exactly on the
eight-place assertion line (`0.5e-8`) with no margin, so the tail of the
distribution still crosses it occasionally - the observed misses are
precisely in that window.

## Change

Tighten the test's `conv_tol` from `1e-8` to `1e-9`, putting the guaranteed
spread (`~5e-10`) an order of magnitude inside the assertion. Verified with
**1000/1000** fresh-process attempts on master + this change
([run 32185997241](https://github.com/psiQAQ/pyscf/actions/runs/32185997241)).
The scientific assertions are unchanged.
