### PR TITLE
Use e_free for conv check for smear scf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ OneRDM*
 
 # Memoization and caching
 tmp/
+.cortexkit/
 
 # IDEs
 .idea/

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -2073,9 +2073,7 @@ This is the Gaussian fit version as described in doi:10.1063/5.0004046.''')
     # to check_convergence can overwrite the default convergence criteria
     check_convergence = None
     # A hook for overloading the convergence criteria of the extra (conv_check)
-    # cycle.  The envs dict carries the relaxed convergence tolerances
-    # (conv_tol*10, conv_tol_grad*3).  If set, it takes precedence over
-    # check_convergence for the extra cycle.
+    # cycle.
     check_extra_convergence = None
 
     def scf(self, dm0=None, **kwargs):

--- a/pyscf/scf/hf.py
+++ b/pyscf/scf/hf.py
@@ -224,7 +224,9 @@ Keyword argument "init_dm" is replaced by "dm0"''')
 
         conv_tol = conv_tol * 10
         conv_tol_grad = conv_tol_grad * 3
-        if callable(mf.check_convergence):
+        if callable(mf.check_extra_convergence):
+            scf_conv = mf.check_extra_convergence(locals())
+        elif callable(mf.check_convergence):
             scf_conv = mf.check_convergence(locals())
         elif abs(e_tot-last_hf_e) < conv_tol or norm_gorb < conv_tol_grad:
             scf_conv = True
@@ -1709,6 +1711,11 @@ class SCF(lib.StreamObject):
             An extra cycle to check convergence after SCF iterations.
         check_convergence : function(envs) => bool
             A hook for overloading convergence criteria in SCF iterations.
+        check_extra_convergence : function(envs) => bool
+            A hook for overloading the convergence criteria of the extra
+            (conv_check) cycle.  The envs dict carries the relaxed tolerances
+            (conv_tol*10, conv_tol_grad*3).  If set, it takes precedence over
+            check_convergence for the extra cycle.
 
     Saved results:
 
@@ -2065,6 +2072,11 @@ This is the Gaussian fit version as described in doi:10.1063/5.0004046.''')
     #   f(envs) => bool
     # to check_convergence can overwrite the default convergence criteria
     check_convergence = None
+    # A hook for overloading the convergence criteria of the extra (conv_check)
+    # cycle.  The envs dict carries the relaxed convergence tolerances
+    # (conv_tol*10, conv_tol_grad*3).  If set, it takes precedence over
+    # check_convergence for the extra cycle.
+    check_extra_convergence = None
 
     def scf(self, dm0=None, **kwargs):
         '''SCF main driver

--- a/pyscf/scf/smearing.py
+++ b/pyscf/scf/smearing.py
@@ -133,6 +133,7 @@ class _SmearingSCF:
         self.entropy = None
         self.e_free = None
         self.e_zero = None
+        self._e_free_prev = None
 
     def undo_smearing(self):
         obj = lib.view(self, lib.drop_class(self.__class__, _SmearingSCF))
@@ -143,6 +144,25 @@ class _SmearingSCF:
         del obj.e_free
         del obj.e_zero
         return obj
+
+    def pre_kernel(self, envs):
+        self._e_free_prev = self.e_free
+
+    def check_extra_convergence(self, envs):
+        '''Convergence check of the extra (conv_check) cycle.
+
+        The envs dict carries the relaxed tolerances (conv_tol*10,
+        conv_tol_grad*3).  Smearing minimizes the free energy
+        e_free = E - sigma*S, so the extra cycle certifies convergence on
+        e_free instead of the plain energy (issue #3379).  When smearing is
+        inactive the default OR logic is replicated.
+        '''
+        if (self.sigma and self.smearing_method
+                and self.e_free is not None and self._e_free_prev is not None):
+            return (abs(self.e_free - self._e_free_prev) < envs['conv_tol']
+                    and envs['norm_gorb'] < envs['conv_tol_grad'])
+        return (abs(envs['e_tot'] - envs['last_hf_e']) < envs['conv_tol']
+                or envs['norm_gorb'] < envs['conv_tol_grad'])
 
     def get_occ(self, mo_energy=None, mo_coeff=None):
         '''Label the occupancies for each orbital
@@ -256,6 +276,7 @@ class _SmearingSCF:
     def energy_tot(self, dm=None, h1e=None, vhf=None):
         e_tot = self.energy_elec(dm, h1e, vhf)[0] + self.energy_nuc()
         if self.sigma and self.smearing_method and self.entropy is not None:
+            self._e_free_prev = self.e_free
             self.e_free = e_tot - self.sigma * self.entropy
             self.e_zero = e_tot - self.sigma * self.entropy * .5
             logger.info(self, '    Total E(T) = %.15g  Free energy = %.15g  E0 = %.15g',

--- a/pyscf/scf/smearing.py
+++ b/pyscf/scf/smearing.py
@@ -148,6 +148,22 @@ class _SmearingSCF:
     def pre_kernel(self, envs):
         self._e_free_prev = self.e_free
 
+    def check_convergence(self, envs):
+        '''Convergence check of the main SCF loop.
+
+        Smearing minimizes the free energy e_free = E - sigma*S, so the main
+        loop requires both the plain energy and the free energy to be
+        converged (issue #3379).
+        '''
+        if (self.sigma and self.smearing_method
+                and self.e_free is not None and self._e_free_prev is not None):
+            dE = abs(envs['e_tot'] - envs['last_hf_e'])
+            dF = abs(self.e_free - self._e_free_prev)
+            return (dE < envs['conv_tol'] and dF < envs['conv_tol']
+                    and envs['norm_gorb'] < envs['conv_tol_grad'])
+        return (abs(envs['e_tot'] - envs['last_hf_e']) < envs['conv_tol']
+                and envs['norm_gorb'] < envs['conv_tol_grad'])
+
     def check_extra_convergence(self, envs):
         '''Convergence check of the extra (conv_check) cycle.
 

--- a/pyscf/scf/smearing.py
+++ b/pyscf/scf/smearing.py
@@ -152,14 +152,13 @@ class _SmearingSCF:
         '''Convergence check of the main SCF loop.
 
         Smearing minimizes the free energy e_free = E - sigma*S, so the main
-        loop requires both the plain energy and the free energy to be
-        converged (issue #3379).
+        loop converges on e_free (issue #3379). A tight conv_tol is suggested to
+        reach the stationary point on flat free-energy surfaces.
         '''
         if (self.sigma and self.smearing_method
                 and self.e_free is not None and self._e_free_prev is not None):
-            dE = abs(envs['e_tot'] - envs['last_hf_e'])
             dF = abs(self.e_free - self._e_free_prev)
-            return (dE < envs['conv_tol'] and dF < envs['conv_tol']
+            return (dF < envs['conv_tol']
                     and envs['norm_gorb'] < envs['conv_tol_grad'])
         return (abs(envs['e_tot'] - envs['last_hf_e']) < envs['conv_tol']
                 and envs['norm_gorb'] < envs['conv_tol_grad'])
@@ -168,15 +167,12 @@ class _SmearingSCF:
         '''Convergence check of the extra (conv_check) cycle.
 
         The envs dict carries the relaxed tolerances (conv_tol*10,
-        conv_tol_grad*3).  Smearing minimizes the free energy
-        e_free = E - sigma*S, so the extra cycle certifies convergence on
-        e_free instead of the plain energy (issue #3379).  When smearing is
-        inactive the default OR logic is replicated.
+        conv_tol_grad*3).
         '''
         if (self.sigma and self.smearing_method
                 and self.e_free is not None and self._e_free_prev is not None):
             return (abs(self.e_free - self._e_free_prev) < envs['conv_tol']
-                    and envs['norm_gorb'] < envs['conv_tol_grad'])
+                    or envs['norm_gorb'] < envs['conv_tol_grad'])
         return (abs(envs['e_tot'] - envs['last_hf_e']) < envs['conv_tol']
                 or envs['norm_gorb'] < envs['conv_tol_grad'])
 

--- a/pyscf/scf/test/test_addons.py
+++ b/pyscf/scf/test/test_addons.py
@@ -497,11 +497,9 @@ class KnownValues(unittest.TestCase):
         myhf_s.conv_tol = 1e-9
         myhf_s.kernel()
         # With sigma=0.1 the near-degenerate 3d manifold makes the plain
-        # energy E vary by ~7e-6 across (free-energy-degenerate) thread-noise
-        # solutions, while e_free = E - sigma*S is pinned to ~1e-8 (see
-        # issue #3379). Assert e_free tightly and E/entropy loosely.  The
-        # extra cycle certifies convergence on e_free, so converged is
-        # reliable.  
+        # energy E vary a lot (free-energy-degenerate), while 
+        # e_free = E - sigma*S is more stable (see
+        # issue #3379). Assert e_free tightly and E/entropy loosely.
         self.assertAlmostEqual(myhf_s.e_free, -244.7984202573, 7)
         self.assertAlmostEqual(myhf_s.e_tot, -243.086989253, 4)
         self.assertAlmostEqual(myhf_s.entropy, 17.11431, 3)

--- a/pyscf/scf/test/test_addons.py
+++ b/pyscf/scf/test/test_addons.py
@@ -496,14 +496,20 @@ class KnownValues(unittest.TestCase):
         myhf_s.fix_spin = False
         myhf_s.conv_tol = 1e-7
         myhf_s.kernel()
-        self.assertAlmostEqual(myhf_s.e_tot, -243.086989253, 5)
-        self.assertAlmostEqual(myhf_s.entropy, 17.11431, 4)
+        # With sigma=0.1 the near-degenerate 3d manifold makes the plain
+        # energy E vary by ~7e-6 across (free-energy-degenerate) thread-noise
+        # solutions, while e_free = E - sigma*S is pinned to ~1e-8.
+        # Assert e_free tightly and E/entropy loosely. 
+        self.assertAlmostEqual(myhf_s.e_free, -244.7984202573, 7)
+        self.assertAlmostEqual(myhf_s.e_tot, -243.086989253, 4)
+        self.assertAlmostEqual(myhf_s.entropy, 17.11431, 3)
         self.assertTrue(myhf_s.converged)
 
         myhf_s.mu = -0.2482816
         myhf_s.kernel(dm0=myhf_s.make_rdm1())
-        self.assertAlmostEqual(myhf_s.e_tot, -243.086989253, 5)
-        self.assertAlmostEqual(myhf_s.entropy, 17.11431, 4)
+        self.assertAlmostEqual(myhf_s.e_free, -244.7984202573, 7)
+        self.assertAlmostEqual(myhf_s.e_tot, -243.086989253, 4)
+        self.assertAlmostEqual(myhf_s.entropy, 17.11431, 3)
 
     def test_rhf_smearing_nelec(self):
         mol = gto.Mole()

--- a/pyscf/scf/test/test_addons.py
+++ b/pyscf/scf/test/test_addons.py
@@ -498,18 +498,14 @@ class KnownValues(unittest.TestCase):
         myhf_s.kernel()
         # With sigma=0.1 the near-degenerate 3d manifold makes the plain
         # energy E vary by ~7e-6 across (free-energy-degenerate) thread-noise
-        # solutions, while e_free = E - sigma*S is pinned to ~1e-8.
-        # Assert e_free tightly and E/entropy loosely. 
+        # solutions, while e_free = E - sigma*S is pinned to ~1e-8 (see
+        # issue #3379). Assert e_free tightly and E/entropy loosely.  The
+        # extra cycle certifies convergence on e_free, so converged is
+        # reliable.  
         self.assertAlmostEqual(myhf_s.e_free, -244.7984202573, 7)
         self.assertAlmostEqual(myhf_s.e_tot, -243.086989253, 4)
         self.assertAlmostEqual(myhf_s.entropy, 17.11431, 3)
         self.assertTrue(myhf_s.converged)
-
-        myhf_s.mu = -0.2482816
-        myhf_s.kernel(dm0=myhf_s.make_rdm1())
-        self.assertAlmostEqual(myhf_s.e_free, -244.7984202573, 7)
-        self.assertAlmostEqual(myhf_s.e_tot, -243.086989253, 4)
-        self.assertAlmostEqual(myhf_s.entropy, 17.11431, 3)
 
     def test_rhf_smearing_nelec(self):
         mol = gto.Mole()

--- a/pyscf/scf/test/test_addons.py
+++ b/pyscf/scf/test/test_addons.py
@@ -475,7 +475,7 @@ class KnownValues(unittest.TestCase):
         mf = addons.smearing(mf, sigma=0.1)
         mf.kernel()
         self.assertAlmostEqual(mf.mo_occ.sum(), 15, 8)
-        self.assertAlmostEqual(mf.e_tot, -106.9310800402, 8)
+        self.assertAlmostEqual(mf.e_tot, -106.9310800142, 8)
 
     def test_uhf_smearing(self):
         mol = gto.M(
@@ -494,7 +494,7 @@ class KnownValues(unittest.TestCase):
         myhf_s = addons.smearing_(myhf_s, sigma=0.01, method='fermi', fix_spin=True)
         myhf_s.sigma = 0.1
         myhf_s.fix_spin = False
-        myhf_s.conv_tol = 1e-7
+        myhf_s.conv_tol = 1e-9
         myhf_s.kernel()
         # With sigma=0.1 the near-degenerate 3d manifold makes the plain
         # energy E vary by ~7e-6 across (free-energy-degenerate) thread-noise

--- a/pyscf/scf/test/test_addons.py
+++ b/pyscf/scf/test/test_addons.py
@@ -475,7 +475,8 @@ class KnownValues(unittest.TestCase):
         mf = addons.smearing(mf, sigma=0.1)
         mf.kernel()
         self.assertAlmostEqual(mf.mo_occ.sum(), 15, 8)
-        self.assertAlmostEqual(mf.e_tot, -106.9310800142, 8)
+        self.assertAlmostEqual(mf.e_free, -107.22209716, 8)
+        self.assertAlmostEqual(mf.e_tot, -106.9310800142, 5)
 
     def test_uhf_smearing(self):
         mol = gto.M(


### PR DESCRIPTION
This was originally for debugging #3331 and I found it finally partly address #3379.

The Fe2 smeared UHF in #3331 has a free-energy-degenerate solution family: E_tot varies around 7e-6 across runs, while e_free is pinned to 1e-8 -- the well-defined quantity.

So I made smearing SCF to check e_free for convergence, and now the test unconvergence rate is 0/1000.

Notes for changes in this PR:
- Because the previous extra-cycle conv-check is inlined, I turned it into a hook function for cleaner code. The new check_extra_convergence function is used like check_convergence.
- The second run changing `mu` in the test looks like no-op so I removed it. The smearing SCF has no `mu` but only `mu0`.

For #3331: the e_tot -243.086994 state still occurs, but in the new scheme it is considered as correct since its e_free does not violate test assert. The assertion of e_tot is still kept, but with a looser criteria, to let this condition pass.

For #3379: the request of changing e_tot definition is not considered here, because I think this is backward compatibility breaking and needs more discussion.