### PR TITLE
Bug fix and update `pbc.tools.precompute_exx`

### DIFF
--- a/examples/pbc/50-band_vcut.py
+++ b/examples/pbc/50-band_vcut.py
@@ -1,0 +1,116 @@
+''' This example uses `get_bands` for HF band structure calculations using `vcut_sph/ws` potentials.
+'''
+
+
+import numpy as np
+
+from pyscf.pbc import gto, scf
+
+from pyscf.data.nist import BOHR
+from ase.dft.kpoints import sc_special_points as special_points, get_bandpath
+
+
+atom = '''
+Si    0.0000000000    0.0000000000    0.0000000000
+Si    1.3577500000    1.3577500000    1.3577500000
+'''
+a = '''
+2.7155000000 2.7155000000 0.0000000000
+0.0000000000 2.7155000000 2.7155000000
+2.7155000000 0.0000000000 2.7155000000
+'''
+basis = '''
+Si  S
+    1.271038   -2.675576e-01
+    0.307669    3.996909e-01
+    0.141794    5.784306e-01
+Si  S
+    0.062460    1.000000e+00
+Si  P
+    1.610683   -2.629981e-02
+    0.384570    3.047784e-01
+    0.148473    5.453783e-01
+Si  P
+    0.055964    1.000000e+00
+Si  D
+    0.285590    1.000000e+00
+'''
+pseudo = 'gth-hf-rev'
+
+cell = gto.M(atom=atom, a=a, basis=basis, pseudo=pseudo).set(verbose=4)
+cell.mesh = [23,23,23]
+nocc = cell.nelectron // 2
+
+kpts = cell.make_kpts([2,2,2])
+
+mf = scf.KRHF(cell, kpts, exxdiv='vcut_ws')
+mf.kernel()
+
+# ASE preparation
+lat_symm = 'fcc'
+sp_points_name = 'LGXWKG'
+npoints = 50
+latvec = cell.lattice_vectors() * BOHR
+points = special_points[lat_symm]
+sp_points_ase = [points[s] for s in sp_points_name]
+kpts_band, kpath, sp_points = get_bandpath(sp_points_ase, latvec, npoints=npoints)
+kpts_band = cell.get_abs_kpts(kpts_band)
+
+# vcut_ws bands
+en_vs_k_all = {}
+for exxdiv in ['ewald', 'vcut_ws', 'vcut_sph']:
+    mf1 = scf.KRHF(cell, kpts, exxdiv=exxdiv)
+    for k in ['mo_coeff','mo_occ','mo_energy']:
+        setattr(mf1, k, getattr(mf, k))
+    mf1.converged = True
+
+    band_energy = mf1.get_bands(kpts_band)[0]
+    en_vs_k = np.asarray(band_energy, order='C').T  # nband,nkpts
+    en_vs_k_all[exxdiv] = (en_vs_k - en_vs_k[nocc-1].max()) * 27.211399
+
+
+''' Plot band
+'''
+from matplotlib import pyplot as plt
+
+figsize = (3, 3.5)
+fig = plt.figure(figsize=figsize)
+ax = fig.gca()
+
+emin = -20
+emax = 40
+zorder0 = 10
+
+def plot1(en_vs_k, lstyls, label):
+    for i,band in enumerate(en_vs_k):
+        label1 = label if i == 0 else None
+        ax.plot(kpath, band, **lstyls, label=label1)
+
+lstyls = [
+    {'ls':'-', 'lw':3, 'color':'#CBCBCD', 'zorder':zorder0+1},
+    {'ls':'--', 'lw':1.5, 'color':'#597DAD', 'zorder':zorder0+3},
+    {'ls':'--', 'lw':1, 'color':'#CB8680', 'zorder':zorder0+2},
+]
+
+for i,exxdiv in enumerate(['ewald', 'vcut_ws', 'vcut_sph']):
+    plot1(en_vs_k_all[exxdiv], lstyls[i], exxdiv)
+
+leg = ax.legend(frameon=True, loc='upper right')
+leg.set_zorder(zorder0+100)
+
+ax.axhline(0, ls='--', lw=0.7, color='k', zorder=zorder0)
+for y in sp_points:
+    ax.axvline(y, ls='-', lw=0.7, color='k', zorder=zorder0)
+
+ax.set_xticks(sp_points)
+ax.set_xticklabels([r'$\Gamma$' if x == 'G' else r'$%s$'%(x) for x in sp_points_name])
+
+ax.set_xlim((kpath[0], kpath[-1]))
+
+ax.set_ylim([emin, emax])
+ax.set_ylabel('Band energy (eV)')
+
+plt.tight_layout()
+
+plt.savefig('band.pdf')
+plt.close(fig)

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -486,65 +486,186 @@ def get_coulG(cell, k=np.zeros(3), exx=False, mf=None, mesh=None, Gv=None,
             coulG[G0_idx] += Nk*cell.vol*madelung(cell, kpts, omega=0)
     return coulG
 
-def precompute_exx(cell, kpts=None):
+
+def precompute_exx(cell, kpts=None, precision=None, precision_fft=None, nimgs=None):
+    '''Precompute the Wigner-Seitz truncated EXX kernel.
+
+    The long-range part of the kernel is constructed with the minimum-image
+    convention and range separation of Eq. (A4) in Phys. Rev. B 87, 165122
+    (2013). The short-range part is evaluated analytically in :func:`get_coulG`.
+
+    Args:
+        cell : :class:`pyscf.pbc.gto.Cell`
+            Primitive cell.
+        kpts : (nkpts, 3) array_like
+            Complete regular k-point mesh. Defaults to the Gamma point.
+        precision : float
+            Accuracy threshold used to set the range-separation parameter ``alpha``.
+            Defaults to ``min(cell.precision, 1e-11)``, where the default value
+            1e-11 follows the PRB paper above.
+        precision_fft : float
+            Accuracy threshold used to set the FFT mesh for the numerical
+            long-range kernel. Defaults to ``__config__.pbc_tools_pbc_vcut_ws_precision_fft``
+            if set, and to ``precision`` otherwise. Smaller values produce denser FFT
+            meshes without changing ``alpha``.
+        nimgs : (3,) array_like of int
+            Number of lattice images searched in each direction on both sides
+            of the Born-von Karman cell. Defaults to [3,3,3], which can be overwritten
+            by setting the `__config__` attribute "pbc_tools_pbc_vcut_ws_nimgs".
+
+    Returns:
+        dict
+            Range-separation parameter, Born-von Karman cell, reciprocal
+            vectors, and the numerical long-range kernel.
+    '''
     from pyscf.pbc import gto as pbcgto
-    from pyscf.pbc.dft import gen_grid
+    from pyscf.pbc.lo.base import get_kmesh
+
     log = lib.logger.Logger(cell.stdout, cell.verbose)
-    log.debug("# Precomputing Wigner-Seitz EXX kernel")
-    Nk = get_monkhorst_pack_size(cell, kpts)
-    log.debug("# Nk = %s", Nk)
+    log.debug('# Precomputing Wigner-Seitz EXX kernel')
+
+    if kpts is None: kpts = np.zeros((1, 3))
+    kpts = np.reshape(kpts, (-1, 3))
+    kmesh = np.asarray(get_kmesh(cell, kpts), dtype=int)
+    scaled_kpts = cell.get_scaled_kpts(kpts - kpts[0])
+    scaled_kpts = np.rint(scaled_kpts * kmesh).astype(int) % kmesh
+    if len(np.unique(scaled_kpts, axis=0)) != len(kpts):
+        raise RuntimeError('Input k-points do not form a complete regular mesh')
+    log.debug('# kmesh = %s', kmesh)
+
+    if precision is None:
+        precision = min(cell.precision, 1e-11)
+    else:
+        precision = float(precision)
+    assert 0 < precision < 1
+
+    if precision_fft is None:
+        precision_fft = getattr(__config__, 'pbc_tools_pbc_vcut_ws_precision_fft', None)
+        if precision_fft is None:
+            precision_fft = precision
+    precision_fft = float(precision_fft)
+    assert 0 < precision_fft < 1
+
+    if nimgs is None:
+        nimgs = getattr(__config__, 'pbc_tools_pbc_vcut_ws_nimgs', [3, 3, 3])
+    nimgs = np.asarray(nimgs, dtype=int)
+    assert nimgs.shape == (3,)
+    assert np.all(nimgs > 0)
 
     kcell = pbcgto.Cell()
     kcell.atom = 'H 0. 0. 0.'
     kcell.spin = 1
     kcell.unit = 'B'
     kcell.verbose = 0
-    kcell.a = cell.lattice_vectors() * Nk
-    Lc = 1.0/lib.norm(np.linalg.inv(kcell.a), axis=0)
-    log.debug("# Lc = %s", Lc)
-    Rin = Lc.min() / 2.0
-    log.debug("# Rin = %s", Rin)
-    # ASE:
-    alpha = 5./Rin # sqrt(-ln eps) / Rc, eps ~ 10^{-11}
-    log.info("WS alpha = %s", alpha)
-    kcell.mesh = np.array([4*int(L*alpha*3.0) for L in Lc])  # ~ [120,120,120]
-    # QE:
-    #alpha = 3./Rin * np.sqrt(0.5)
-    #kcell.mesh = (4*alpha*np.linalg.norm(kcell.a,axis=1)).astype(int)
-    log.debug("# kcell.mesh FFT = %s", kcell.mesh)
+    kcell.a = np.einsum('xi,x->xi', cell.lattice_vectors(), kmesh)
+
+    Rin = get_ws_inradius(cell.lattice_vectors(), kmesh)
+    log.debug('# Rin = %s', Rin)
+
+    log_precision = -np.log(precision)
+    alpha = np.sqrt(log_precision) / Rin
+    log.info('WS alpha = %s', alpha)
+
+    log_precision_fft = -np.log(precision_fft)
+    Gmax = 2 * alpha * np.sqrt(log_precision_fft)
+    kcell.mesh = cutoff_to_mesh(kcell.a, Gmax**2 * 0.5)
+    log.debug('# kcell.mesh FFT = %s', kcell.mesh)
+
     rs = kcell.get_uniform_grids(wrap_around=False)
     kngs = len(rs)
-    log.debug("# kcell kngs = %d", kngs)
-    corners_coord = lib.cartesian_prod(([0, 1], [0, 1], [0, 1]))
-    corners = np.dot(corners_coord, kcell.a)
-    #vR = np.empty(kngs)
-    #for i, rv in enumerate(rs):
-    #    # Minimum image convention to corners of kcell parallelepiped
-    #    r = lib.norm(rv-corners, axis=1).min()
-    #    if np.isclose(r, 0.):
-    #        vR[i] = 2*alpha / np.sqrt(np.pi)
-    #    else:
-    #        vR[i] = scipy.special.erf(alpha*r) / r
-    r = np.min([lib.norm(rs-c, axis=1) for c in corners], axis=0)
+    log.debug('# kcell kngs = %d', kngs)
+
+    images_coord = lib.cartesian_prod([
+        range(-n, n + 1) for n in nimgs
+    ])
+    images = np.dot(images_coord, kcell.a)
+    r = np.full(kngs, np.inf)
+    for image in images:
+        np.minimum(r, lib.norm(rs - image, axis=1), out=r)
+
+    # Check the image search against a range guaranteed to be exhaustive.
+    Lc = 1. / lib.norm(np.linalg.inv(kcell.a), axis=0)
+    nimgs_ref = np.floor(r.max() / Lc).astype(int) + 1
+    nimgs_ref = np.maximum(nimgs, nimgs_ref)
+    images_ref_coord = lib.cartesian_prod([
+        range(-n, n + 1) for n in nimgs_ref
+    ])
+    r_ref = r.copy()
+    for image_coord in images_ref_coord:
+        if np.all(abs(image_coord) <= nimgs):
+            continue
+        image = np.dot(image_coord, kcell.a)
+        np.minimum(r_ref, lib.norm(rs - image, axis=1), out=r_ref)
+    if np.max(r - r_ref) > 1e-10:
+        raise RuntimeError(
+            f'nimgs={nimgs} is not large enough for the minimum image '
+            f'convention; a sufficient value is {nimgs_ref}')
+
     vR = scipy.special.erf(alpha*r) / (r+1e-200)
     vR[r<1e-9] = 2*alpha / np.sqrt(np.pi)
     vG = (kcell.vol/kngs) * fft(vR, kcell.mesh)
 
     if abs(vG.imag).max() > 1e-6:
-        # vG should be real in regular lattice. If imaginary part is observed,
-        # this probably means a ws cell was built from a unconventional
-        # lattice. The SR potential erfc(alpha*r) for the charge in the center
-        # of ws cell decays to the region out of ws cell. The Ewald-sum based
-        # on the minimum image convention cannot be used to build the kernel
-        # Eq (12) of PRB 87, 165122
         raise RuntimeError('Unconventional lattice was found')
 
     ws_exx = {'alpha': alpha,
               'kcell': kcell,
               'q'    : kcell.Gv,
               'vq'   : vG.real.copy()}
-    log.debug("# Finished precomputing")
+    log.debug('# Finished precomputing')
     return ws_exx
+
+
+def get_ws_inradius(a, kmesh):
+    ''' Wigner-Seitz inradius of the BvK superlattice.
+
+    Parameters
+    ----------
+    a : (3, 3) array_like
+        Primitive lattice vectors stored by rows.
+    kmesh : (3,) array_like of int
+        k-point mesh, e.g. (3, 3, 1).
+
+    Returns
+    -------
+    Rin : float
+        Inradius of the BvK Wigner-Seitz cell, in the same
+        length unit as `a`.
+    '''
+    from itertools import product
+
+    a = np.asarray(a, dtype=float)
+    kmesh = np.asarray(kmesh, dtype=int)
+
+    # BvK lattice vectors, stored by rows
+    A = kmesh[:, None] * a
+
+    # Metric in lattice-coordinate space:
+    # |m @ A|^2 = m @ G @ m
+    G = A @ A.T
+
+    # The shortest lattice vector cannot be longer than
+    # the shortest generating vector.
+    best2 = np.min(np.diag(G))
+
+    # If lambda_min is the smallest eigenvalue of G,
+    # m @ G @ m >= lambda_min * |m|^2.
+    # Therefore any vector shorter than our current upper
+    # bound must satisfy |m| <= sqrt(best2/lambda_min).
+    lam_min = np.linalg.eigvalsh(G)[0]
+    mmax = int(np.ceil(np.sqrt(best2 / lam_min)))
+
+    for m in product(range(-mmax, mmax + 1), repeat=3):
+        if m == (0, 0, 0):
+            continue
+
+        m = np.asarray(m)
+        r2 = m @ G @ m
+
+        if r2 < best2:
+            best2 = r2
+
+    return 0.5 * np.sqrt(best2)
 
 
 def madelung(cell, kpts=None, omega=None):

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -524,6 +524,8 @@ def precompute_exx(cell, kpts=None, precision=None, precision_fft=None, nimgs=No
     log = lib.logger.Logger(cell.stdout, cell.verbose)
     log.debug('# Precomputing Wigner-Seitz EXX kernel')
 
+    cput0 = log.init_timer()
+
     if kpts is None: kpts = np.zeros((1, 3))
     kpts = np.reshape(kpts, (-1, 3))
     kmesh = np.asarray(get_kmesh(cell, kpts), dtype=int)
@@ -539,6 +541,8 @@ def precompute_exx(cell, kpts=None, precision=None, precision_fft=None, nimgs=No
         precision = float(precision)
     assert 0 < precision < 1
 
+    log.debug('# precision = %.15g', precision)
+
     if precision_fft is None:
         precision_fft = getattr(__config__, 'pbc_tools_pbc_vcut_ws_precision_fft', None)
         if precision_fft is None:
@@ -546,11 +550,15 @@ def precompute_exx(cell, kpts=None, precision=None, precision_fft=None, nimgs=No
     precision_fft = float(precision_fft)
     assert 0 < precision_fft < 1
 
+    log.debug('# precision_fft = %.15g', precision_fft)
+
     if nimgs is None:
         nimgs = getattr(__config__, 'pbc_tools_pbc_vcut_ws_nimgs', [3, 3, 3])
     nimgs = np.asarray(nimgs, dtype=int)
     assert nimgs.shape == (3,)
     assert np.all(nimgs > 0)
+
+    log.debug('# nimgs = %s', nimgs)
 
     kcell = pbcgto.Cell()
     kcell.atom = 'H 0. 0. 0.'
@@ -564,7 +572,7 @@ def precompute_exx(cell, kpts=None, precision=None, precision_fft=None, nimgs=No
 
     log_precision = -np.log(precision)
     alpha = np.sqrt(log_precision) / Rin
-    log.info('WS alpha = %s', alpha)
+    log.debug('# WS alpha = %s', alpha)
 
     log_precision_fft = -np.log(precision_fft)
     Gmax = 2 * alpha * np.sqrt(log_precision_fft)
@@ -613,6 +621,9 @@ def precompute_exx(cell, kpts=None, precision=None, precision_fft=None, nimgs=No
               'q'    : kcell.Gv,
               'vq'   : vG.real.copy()}
     log.debug('# Finished precomputing')
+
+    log.timer('Wigner-Seitz EXX precomputing', *cput0)
+
     return ws_exx
 
 

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -388,21 +388,38 @@ def get_coulG(cell, k=np.zeros(3), exx=False, mf=None, mesh=None, Gv=None,
             mf._ws_exx = precompute_exx(cell, kpts)
         exx_alpha = mf._ws_exx['alpha']
         exx_kcell = mf._ws_exx['kcell']
-        exx_q = mf._ws_exx['q']
-        exx_vq = mf._ws_exx['vq']
 
         with np.errstate(divide='ignore',invalid='ignore'):
             coulG = 4*np.pi/absG2*(1.0 - np.exp(-absG2/(4*exx_alpha**2)))
         coulG[absG2==0] = np.pi / exx_alpha**2
         # Index k+Gv into the precomputed vq and add on
         gxyz = np.dot(kG, exx_kcell.lattice_vectors().T)/(2*np.pi)
-        gxyz = gxyz.round(decimals=6).astype(int)
+        shift = (gxyz[0] + .5) % 1 - .5
+        gxyz_int = np.rint(gxyz - shift).astype(int)
+        if abs(gxyz - gxyz_int - shift).max() > 1e-6:
+            raise RuntimeError('k+G vectors are incompatible with the FFT mesh')
+
+        no_shift = abs(shift).max() < 1e-9
+        if no_shift:
+            exx_vq = mf._ws_exx['vq']
+        else:
+            key = tuple(np.round(shift, 12))
+            cache = mf._ws_exx['vq_cache']
+            if key not in cache:
+                delta = np.dot(shift, exx_kcell.reciprocal_vectors())
+                phase = np.exp(-1j * np.dot(mf._ws_exx['r_mic'], delta))
+                vG = (exx_kcell.vol / len(phase)) * fftk(
+                    mf._ws_exx['vR'], exx_kcell.mesh, phase)
+                cache[key] = vG.real.copy()
+            exx_vq = cache[key]
+
         mesh = np.asarray(exx_kcell.mesh)
-        gxyz = (gxyz + mesh)%mesh
+        gxyz = (gxyz_int + mesh)%mesh
         qidx = (gxyz[:,0]*mesh[1] + gxyz[:,1])*mesh[2] + gxyz[:,2]
-        #qidx = [np.linalg.norm(exx_q-kGi,axis=1).argmin() for kGi in kG]
-        maxqv = abs(exx_q).max(axis=0)
-        is_lt_maxqv = (abs(kG) <= maxqv).all(axis=1)
+        lower = -(mesh // 2)
+        upper = (mesh - 1) // 2
+        is_lt_maxqv = ((gxyz_int >= lower) &
+                       (gxyz_int <= upper)).all(axis=1)
         coulG = coulG.astype(exx_vq.dtype)
         coulG[is_lt_maxqv] += exx_vq[qidx[is_lt_maxqv]]
 
@@ -588,8 +605,13 @@ def precompute_exx(cell, kpts=None, precision=None, precision_fft=None, nimgs=No
     ])
     images = np.dot(images_coord, kcell.a)
     r = np.full(kngs, np.inf)
+    r_mic = np.empty_like(rs)
     for image in images:
-        np.minimum(r, lib.norm(rs - image, axis=1), out=r)
+        dr = rs - image
+        r1 = lib.norm(dr, axis=1)
+        mask = r1 < r
+        r[mask] = r1[mask]
+        r_mic[mask] = dr[mask]
 
     # Check the image search against a range guaranteed to be exhaustive.
     Lc = 1. / lib.norm(np.linalg.inv(kcell.a), axis=0)
@@ -619,7 +641,10 @@ def precompute_exx(cell, kpts=None, precision=None, precision_fft=None, nimgs=No
     ws_exx = {'alpha': alpha,
               'kcell': kcell,
               'q'    : kcell.Gv,
-              'vq'   : vG.real.copy()}
+              'vq'   : vG.real.copy(),
+              'vR'   : vR,
+              'r_mic': r_mic,
+              'vq_cache': {}}
     log.debug('# Finished precomputing')
 
     log.timer('Wigner-Seitz EXX precomputing', *cput0)

--- a/pyscf/pbc/tools/pbc.py
+++ b/pyscf/pbc/tools/pbc.py
@@ -406,6 +406,13 @@ def get_coulG(cell, k=np.zeros(3), exx=False, mf=None, mesh=None, Gv=None,
             key = tuple(np.round(shift, 12))
             cache = mf._ws_exx['vq_cache']
             if key not in cache:
+                ''' Note: A grid point on the WS boundary can have multiple degenerate r_mic.
+                    The current implementation in `precompute_exx` selects only one of them
+                    deterministically. These boundary points have zero measure in the continuous
+                    integral, so their contribution vanishes as the FFT mesh is refined. Future
+                    implementation may want to collect all degenerate r_mic's and average their
+                    phases (i.e., similar to how Wannier interpolation handles boundary images).
+                '''
                 delta = np.dot(shift, exx_kcell.reciprocal_vectors())
                 phase = np.exp(-1j * np.dot(mf._ws_exx['r_mic'], delta))
                 vG = (exx_kcell.vol / len(phase)) * fftk(
@@ -504,7 +511,7 @@ def get_coulG(cell, k=np.zeros(3), exx=False, mf=None, mesh=None, Gv=None,
     return coulG
 
 
-def precompute_exx(cell, kpts=None, precision=None, precision_fft=None, nimgs=None):
+def precompute_exx(cell, kpts=None, precision=None, nimgs=None):
     '''Precompute the Wigner-Seitz truncated EXX kernel.
 
     The long-range part of the kernel is constructed with the minimum-image
@@ -520,15 +527,12 @@ def precompute_exx(cell, kpts=None, precision=None, precision_fft=None, nimgs=No
             Accuracy threshold used to set the range-separation parameter ``alpha``.
             Defaults to ``min(cell.precision, 1e-11)``, where the default value
             1e-11 follows the PRB paper above.
-        precision_fft : float
-            Accuracy threshold used to set the FFT mesh for the numerical
-            long-range kernel. Defaults to ``__config__.pbc_tools_pbc_vcut_ws_precision_fft``
-            if set, and to ``precision`` otherwise. Smaller values produce denser FFT
-            meshes without changing ``alpha``.
         nimgs : (3,) array_like of int
-            Number of lattice images searched in each direction on both sides
-            of the Born-von Karman cell. Defaults to [3,3,3], which can be overwritten
-            by setting the `__config__` attribute "pbc_tools_pbc_vcut_ws_nimgs".
+            Initial number of lattice images searched in each direction on
+            both sides of the Born-von Karman cell. The search range is
+            automatically enlarged when needed. Defaults to [3,3,3], which
+            can be overwritten by setting the `__config__` attribute
+            "pbc_tools_pbc_vcut_ws_nimgs".
 
     Returns:
         dict
@@ -560,15 +564,6 @@ def precompute_exx(cell, kpts=None, precision=None, precision_fft=None, nimgs=No
 
     log.debug('# precision = %.15g', precision)
 
-    if precision_fft is None:
-        precision_fft = getattr(__config__, 'pbc_tools_pbc_vcut_ws_precision_fft', None)
-        if precision_fft is None:
-            precision_fft = precision
-    precision_fft = float(precision_fft)
-    assert 0 < precision_fft < 1
-
-    log.debug('# precision_fft = %.15g', precision_fft)
-
     if nimgs is None:
         nimgs = getattr(__config__, 'pbc_tools_pbc_vcut_ws_nimgs', [3, 3, 3])
     nimgs = np.asarray(nimgs, dtype=int)
@@ -591,8 +586,7 @@ def precompute_exx(cell, kpts=None, precision=None, precision_fft=None, nimgs=No
     alpha = np.sqrt(log_precision) / Rin
     log.debug('# WS alpha = %s', alpha)
 
-    log_precision_fft = -np.log(precision_fft)
-    Gmax = 2 * alpha * np.sqrt(log_precision_fft)
+    Gmax = 2 * alpha * np.sqrt(log_precision)
     kcell.mesh = cutoff_to_mesh(kcell.a, Gmax**2 * 0.5)
     log.debug('# kcell.mesh FFT = %s', kcell.mesh)
 
@@ -605,31 +599,26 @@ def precompute_exx(cell, kpts=None, precision=None, precision_fft=None, nimgs=No
     ])
     images = np.dot(images_coord, kcell.a)
     r = np.full(kngs, np.inf)
-    r_mic = np.empty_like(rs)
     for image in images:
+        np.minimum(r, lib.norm(rs - image, axis=1), out=r)
+
+    # Determine an image search range guaranteed to be exhaustive.
+    Lc = 1. / lib.norm(np.linalg.inv(kcell.a), axis=0)
+    nimgs_ref = np.floor(r.max() / Lc).astype(int) + 1
+    log.debug('# nimgs_ref = %s', nimgs_ref)
+
+    images_ref_coord = lib.cartesian_prod([
+        range(-n, n + 1) for n in nimgs_ref
+    ])
+    r.fill(np.inf)
+    r_mic = np.empty_like(rs)
+    for image_coord in images_ref_coord:
+        image = np.dot(image_coord, kcell.a)
         dr = rs - image
         r1 = lib.norm(dr, axis=1)
         mask = r1 < r
         r[mask] = r1[mask]
         r_mic[mask] = dr[mask]
-
-    # Check the image search against a range guaranteed to be exhaustive.
-    Lc = 1. / lib.norm(np.linalg.inv(kcell.a), axis=0)
-    nimgs_ref = np.floor(r.max() / Lc).astype(int) + 1
-    nimgs_ref = np.maximum(nimgs, nimgs_ref)
-    images_ref_coord = lib.cartesian_prod([
-        range(-n, n + 1) for n in nimgs_ref
-    ])
-    r_ref = r.copy()
-    for image_coord in images_ref_coord:
-        if np.all(abs(image_coord) <= nimgs):
-            continue
-        image = np.dot(image_coord, kcell.a)
-        np.minimum(r_ref, lib.norm(rs - image, axis=1), out=r_ref)
-    if np.max(r - r_ref) > 1e-10:
-        raise RuntimeError(
-            f'nimgs={nimgs} is not large enough for the minimum image '
-            f'convention; a sufficient value is {nimgs_ref}')
 
     vR = scipy.special.erf(alpha*r) / (r+1e-200)
     vR[r<1e-9] = 2*alpha / np.sqrt(np.pi)

--- a/pyscf/pbc/tools/test/test_pbc.py
+++ b/pyscf/pbc/tools/test/test_pbc.py
@@ -55,6 +55,39 @@ class KnownValues(unittest.TestCase):
         coulG[:,5,:] = 0
         self.assertAlmostEqual(lib.fp(coulG), -15.809448382668005+0j, 9)
 
+        # reciprocal vector outside the WS FFT mesh
+        ws_exx = mf._ws_exx
+        alpha = ws_exx['alpha']
+        mesh = np.asarray(ws_exx['kcell'].mesh)
+        Gv = mesh[0] * ws_exx['kcell'].reciprocal_vectors()[[0]]
+        coulG = tools.get_coulG(
+            cell, exx=True, mf=mf, Gv=Gv, wrap_around=False)
+
+        q2 = np.dot(Gv[0], Gv[0])
+        ref = 4*np.pi/q2 * (1 - np.exp(-q2/(4*alpha**2)))
+        self.assertAlmostEqual(coulG[0], ref, 12)
+
+        # arbitrary band k-point
+        mf._ws_exx = None
+        mf.kpts = cell.make_kpts([2,2,2])
+        kpt_band = cell.get_abs_kpts([.12, .23, .34])
+        Gv = np.zeros((1,3))
+
+        for kpt in mf.kpts:
+            q = kpt - kpt_band
+            coulG = tools.get_coulG(
+                cell, q, True, mf, Gv=Gv, wrap_around=False)
+
+            ws_exx = mf._ws_exx
+            q2 = np.dot(q, q)
+            alpha = ws_exx['alpha']
+            ref = 4*np.pi/q2 * (1 - np.exp(-q2/(4*alpha**2)))
+            ref += ws_exx['kcell'].vol / len(ws_exx['vR']) * np.dot(
+                ws_exx['vR'], np.cos(np.dot(ws_exx['r_mic'], q)))
+            self.assertAlmostEqual(coulG[0], ref, 10)
+
+        self.assertEqual(len(ws_exx['vq_cache']), 1)
+
     def test_unconventional_ws_cell(self):
         cell = pbcgto.Cell()
         cell.atom = 'He'

--- a/pyscf/pbc/tools/test/test_pbc.py
+++ b/pyscf/pbc/tools/test/test_pbc.py
@@ -39,11 +39,21 @@ class KnownValues(unittest.TestCase):
         cell.output = '/dev/null'
         cell.build()
         mf = khf.KRHF(cell, exxdiv='vcut_ws')
+
+        # isotropic k-mesh
         mf.kpts = cell.make_kpts([2,2,2])
         coulG = tools.get_coulG(cell, mf.kpts[2], True, mf, gs=[5,5,5])
         coulG = coulG.reshape([11]*3)
         coulG[:,5,:] = 0
-        self.assertAlmostEqual(lib.fp(coulG), 1.3245365170998518+0j, 9)
+        self.assertAlmostEqual(lib.fp(coulG), 1.3415512608007418+0j, 9)
+
+        # anisotropic k-mesh
+        mf._ws_exx = None   # remove precomputing
+        mf.kpts = cell.make_kpts([1,2,3])
+        coulG = tools.get_coulG(cell, mf.kpts[2], True, mf, gs=[5,5,5])
+        coulG = coulG.reshape([11]*3)
+        coulG[:,5,:] = 0
+        self.assertAlmostEqual(lib.fp(coulG), -15.809448382668005+0j, 9)
 
     def test_unconventional_ws_cell(self):
         cell = pbcgto.Cell()
@@ -54,7 +64,23 @@ class KnownValues(unittest.TestCase):
                     0.5, 0  , 1.8'''
         cell.build()
         kpts = cell.make_kpts([1,1,1])
-        self.assertRaises(RuntimeError, tools.precompute_exx, cell, kpts)
+
+        # assert that using a small nimgs raise RuntimeError
+        self.assertRaises(RuntimeError, tools.precompute_exx, cell, kpts, nimgs=[1,1,1])
+
+        # but using the new default nimgs=[3,3,3] gives no error
+        res = tools.precompute_exx(cell, kpts)
+        self.assertAlmostEqual(lib.fp(res['vq']), 44.672318849250274+0j, 9)
+
+    def test_ws_inradius(self):
+        a = np.array([[2.0, 0.0, 0.0],
+                      [1.2, 1.0, 0.0],
+                      [0.0, 0.0, 3.0]])
+        ref = 0.5 * np.linalg.norm(a[0] - a[1])
+        self.assertAlmostEqual(tools.get_ws_inradius(a, [1,1,1]), ref, 12)
+
+        a = np.diag([2.0, 3.0, 4.0])
+        self.assertAlmostEqual(tools.get_ws_inradius(a, [2,1,3]), 1.5, 12)
 
     def test_coulG(self):
         numpy.random.seed(19)

--- a/pyscf/pbc/tools/test/test_pbc.py
+++ b/pyscf/pbc/tools/test/test_pbc.py
@@ -98,9 +98,6 @@ class KnownValues(unittest.TestCase):
         cell.build()
         kpts = cell.make_kpts([1,1,1])
 
-        # assert that using a small nimgs raise RuntimeError
-        self.assertRaises(RuntimeError, tools.precompute_exx, cell, kpts, nimgs=[1,1,1])
-
         # but using the new default nimgs=[3,3,3] gives no error
         res = tools.precompute_exx(cell, kpts)
         self.assertAlmostEqual(lib.fp(res['vq']), 44.672318849250274+0j, 9)


### PR DESCRIPTION
This PR fixes several bugs in `precompute_exx` for periodic HF calculations with `exxdiv="vcut_ws"` and updates the implementation to more closely follow Sundararaman and Arias, Phys. Rev. B 87, 165122 (2013). In particular:

- The old implementation constructs the BvK lattice using `kcell.a = cell.lattice_vectors() * Nk`, which scales the *columns* of the lattice-vector matrix, whereas the k-mesh should scale its *rows*. The new implementation fixes this. This fix does not affect isotropic k-meshes but now correctly handles anisotropic k-meshes.
- The old minimum-image search considers only the eight translations in `[0, 1]^3`, which is insufficient for some anisotropic or skewed BvK supercells. The new implementation searches `[-nimgs, nimgs]` in each direction, with a default `nimgs=[3, 3, 3]`, and checks whether the supplied range is sufficient. Expert users can change the default through `__config__` as documented in the docstring.
- `Rin` is now the exact inradius of the BvK Wigner-Seitz cell, i.e. half the length of the shortest nonzero BvK lattice vector.
- `alpha` is determined from an accuracy threshold `precision`, which defaults to `min(cell.precision, 1e-11)`, following the criterion in the paper but also allows refinement with tightened `cell.precision`.
- The FFT mesh is determined from the Nyquist-frequency criterion in the paper. A separate `precision_fft` can be set through either the function argument or `__config__` to tune the FFT mesh without changing `alpha`.

Old tests in `pbc/tools/test/test_pbc.py` related to "vcut_ws" are updated. One new test regarding the `Rin` construction is added.


### A scientific note

The new FFT mesh is substantially smaller than the old default. For very small k-meshes, this introduces a small difference from the old, much denser numerical construction because of the quadrature error associated with the Wigner-Seitz boundary. The difference decreases rapidly as the k-mesh, and therefore the BvK supercell, increases. This was also noted by Sundararaman and Arias in their original implementation (see the end of Appendix 1):

> The cusps in the periodic repetition of the integrand at the boundaries of the Wigner-Seitz cell cause an additional error in the kernel, but this error does not contribute in the Coulomb energy of charge distributions that are confined to the half-sized Wigner-Seitz cell and are resolvable on the chosen Fourier grid.

The following table compares the HF exchange energies of diamond (2-atom primitive cell) in the GTH-cc-pVDZ basis set with the GTH-HF-rev pseudopotential. `cell.precision` is set to `1e-12`. The old FFT mesh is `[120,120,120]` while the new one is `[35,35,35]`. One can see that the difference between the new and old implementations becomes physically negligible for anything but very small k-meshes.

| k-mesh | New exchange energy (Ha) | Old exchange energy (Ha) | Error (microhartree) |
|:------:|--------------------:|--------------------:|---------------------:|
| 1x1x1  | -3.4252007880 | -3.4252832174 | 82.4 |
| 2x2x2  | -3.2658658746 | -3.2658693694 | 3.5 |
| 3x3x3  | -3.2386490504 | -3.2386495625 | 0.5 |
| 4x4x4 | -3.2307226222 | -3.2307225656 | 0.06 |


### Update (08/21)

The original implementation assumes that the input k-points form a (possibly twisted) uniform mesh. In `get_bands`, however, `q = kpti - band_kptj` generally does not lie on the reciprocal BvK lattice. The original code rounds `q` to the nearest reciprocal BvK grid point, resulting in unphysical band structures.

There are two possible solutions:

1. Calculate `vq` independently for every `kpti - band_kptj` pair, requiring up to `Nk * Nk_band` additional FFTs but no extra memory.
2. For each unique band-k-point shift, calculate `vq` once and cache it. This requires up to `Nk_band` additional FFTs and cached `vq` arrays.

For a fixed band k-point, all sampled k-points have the same fractional shift on the reciprocal BvK grid. This PR therefore uses the second approach. The additional memory is modest with the substantially reduced FFT mesh size. For example, a diamond calculation with a 6x6x6 SCF k-mesh and 100 band k-points requires about 40 MB for the cache (with default `1e-11` precision). The resulting `vcut_ws` band structure is now physical and agrees with `vcut_sph`, as illustrated below for silicon. An example for HF band-structure calculation using `vcut_ws` or `vcut_sph` is added in `examples/pbc/50-band_vcut.py`.

A related aliasing bug was also found in the reciprocal-grid bounds check. For a nonorthogonal lattice, a reciprocal vector can lie inside the Cartesian bounding box of the precomputed grid while its integer BvK coordinates lie outside the FFT index range. The subsequent modulo indexing,
```python
gxyz = (gxyz + mesh) % mesh
```
can then alias a high-q vector accidentally onto an unrelated low-q vector, causing sizable energy errors for large k-meshes. The new implementation checks the integer BvK coordinates directly against the FFT bounds before applying the modulo indexing.

Simple tests have been added to `test_pbc.py` for both bugs.

<img width="300" height="350" alt="band" src="https://github.com/user-attachments/assets/67bd1200-06f8-4839-87fa-693ad52c70a9" />