### PR TITLE
Add density matrix keyword to response functions

### DIFF
--- a/pyscf/hessian/rks.py
+++ b/pyscf/hessian/rks.py
@@ -1838,17 +1838,6 @@ def _get_vnlc_deriv1(hessobj, mo_coeff, mo_occ, max_memory):
     return vmat
 
 def get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1s, max_memory):
-    """
-        Equation notation follows:
-        Liang J, Feng X, Liu X, Head-Gordon M. Analytical harmonic vibrational frequencies with
-        VV10-containing density functionals: Theory, efficient implementation, and
-        benchmark assessments. J Chem Phys. 2023 May 28;158(20):204109. doi: 10.1063/5.0152838.
-
-        mo_coeff, mo_occ are 0-th order
-        dm1s is first order
-
-        TODO: check the effect of different grid, using mf.nlcgrids right now
-    """
     if isinstance(mo_coeff, numpy.ndarray) and mo_coeff.ndim == 2:
         mocc = mo_coeff[:,mo_occ>0]
         mo_occ = mo_occ[mo_occ > 0]
@@ -1862,6 +1851,21 @@ def get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1s, max_memory):
         mo_occ_a = mo_occ[0][mo_occ[0] > 0]
         mo_occ_b = mo_occ[1][mo_occ[1] > 0]
         dm0 = (mocc_a * mo_occ_a) @ mocc_a.T + (mocc_b * mo_occ_b) @ mocc_b.T
+
+    return get_vnlc_resp1(mf, mol, dm0, dm1s, max_memory)
+
+def get_vnlc_resp1(mf, mol, dm0, dm1s, max_memory):
+    """
+        Equation notation follows:
+        Liang J, Feng X, Liu X, Head-Gordon M. Analytical harmonic vibrational frequencies with
+        VV10-containing density functionals: Theory, efficient implementation, and
+        benchmark assessments. J Chem Phys. 2023 May 28;158(20):204109. doi: 10.1063/5.0152838.
+
+        mo_coeff, mo_occ are 0-th order
+        dm1s is first order
+
+        TODO: check the effect of different grid, using mf.nlcgrids right now
+    """
     dm0 = numpy.asarray(dm0.real, order='C')
 
     output_in_2d = False

--- a/pyscf/scf/_response_functions.py
+++ b/pyscf/scf/_response_functions.py
@@ -78,7 +78,8 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None, dm0=None,
                     v1 = ni.nr_rks_fxc(mol, mf.grids, mf.xc, dm0, dm1, 0, hermi,
                                        rho0, vxc, fxc, max_memory=max_memory)
                     if with_nlc and mf.do_nlc():
-                        from pyscf.hessian.rks import get_vnlc_resp, get_vnlc_resp1 # Cannot import at top due to circular dependency
+                        # Cannot import at top due to circular dependency
+                        from pyscf.hessian.rks import get_vnlc_resp, get_vnlc_resp1
                         if mo_coeff is not None and mo_occ is not None:
                             v1 += get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1, max_memory)
                         else:
@@ -117,7 +118,8 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None, dm0=None,
                     v1 = ni.nr_rks_fxc_st(mol, mf.grids, mf.xc, dm0, dm1, hermi, True,
                                           rho0, vxc, fxc, max_memory=max_memory)
                     if with_nlc and mf.do_nlc():
-                        from pyscf.hessian.rks import get_vnlc_resp, get_vnlc_resp1 # Cannot import at top due to circular dependency
+                        # Cannot import at top due to circular dependency
+                        from pyscf.hessian.rks import get_vnlc_resp, get_vnlc_resp1
                         if mo_coeff is not None and mo_occ is not None:
                             v1 += get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1, max_memory)
                         else:
@@ -218,7 +220,8 @@ def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None, dm0=None,
                 v1 = ni.nr_uks_fxc(mol, mf.grids, mf.xc, dm0, dm1, 0, hermi,
                                    rho0, vxc, fxc, max_memory=max_memory)
                 if with_nlc and mf.do_nlc():
-                    from pyscf.hessian.rks import get_vnlc_resp, get_vnlc_resp1 # Cannot import at top due to circular dependency
+                    # Cannot import at top due to circular dependency
+                    from pyscf.hessian.rks import get_vnlc_resp, get_vnlc_resp1
                     if mo_coeff is not None and mo_occ is not None:
                         v1 += get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1, max_memory)
                     else:

--- a/pyscf/scf/_response_functions.py
+++ b/pyscf/scf/_response_functions.py
@@ -26,7 +26,7 @@ from pyscf import lib
 from pyscf.lib import logger
 from pyscf.scf import hf, rohf, uhf, ghf, dhf
 
-def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
+def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None, dm0=None,
                       singlet=None, hermi=0, max_memory=None, with_nlc=True):
     '''Generate a function to compute the product of RHF response function and
     RHF density matrices.
@@ -40,8 +40,9 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
     '''
     assert isinstance(mf, hf.RHF) and not isinstance(mf, (uhf.UHF, rohf.ROHF))
 
-    if mo_coeff is None: mo_coeff = mf.mo_coeff
-    if mo_occ is None: mo_occ = mf.mo_occ
+    if dm0 is None:
+        if mo_coeff is None: mo_coeff = mf.mo_coeff
+        if mo_occ is None: mo_occ = mf.mo_occ
     mol = mf.mol
     if isinstance(mf, hf.KohnShamDFT):
         ni = mf._numint
@@ -53,9 +54,12 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
             spin = 0
         else:
             spin = 1
-        rho0, vxc, fxc = ni.cache_xc_kernel(mol, mf.grids, mf.xc,
-                                            mo_coeff, mo_occ, spin)
-        dm0 = None
+        if mo_coeff is not None and mo_occ is not None:
+            rho0, vxc, fxc = ni.cache_xc_kernel(mol, mf.grids, mf.xc,
+                                                mo_coeff, mo_occ, spin)
+        else:
+            rho0, vxc, fxc = ni.cache_xc_kernel1(mol, mf.grids, mf.xc,
+                                                 dm0, spin)
 
         if max_memory is None:
             mem_now = lib.current_memory()[0]
@@ -74,8 +78,11 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
                     v1 = ni.nr_rks_fxc(mol, mf.grids, mf.xc, dm0, dm1, 0, hermi,
                                        rho0, vxc, fxc, max_memory=max_memory)
                     if with_nlc and mf.do_nlc():
-                        from pyscf.hessian.rks import get_vnlc_resp # Cannot import at top due to circular dependency
-                        v1 += get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1, max_memory)
+                        from pyscf.hessian.rks import get_vnlc_resp, get_vnlc_resp1 # Cannot import at top due to circular dependency
+                        if mo_coeff is not None and mo_occ is not None:
+                            v1 += get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1, max_memory)
+                        else:
+                            v1 += get_vnlc_resp1(mf, mol, dm0, dm1, max_memory)
                 if hybrid:
                     if omega == 0:
                         vj, vk = mf.get_jk(mol, dm1, hermi)
@@ -110,8 +117,11 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
                     v1 = ni.nr_rks_fxc_st(mol, mf.grids, mf.xc, dm0, dm1, hermi, True,
                                           rho0, vxc, fxc, max_memory=max_memory)
                     if with_nlc and mf.do_nlc():
-                        from pyscf.hessian.rks import get_vnlc_resp # Cannot import at top due to circular dependency
-                        v1 += get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1, max_memory)
+                        from pyscf.hessian.rks import get_vnlc_resp, get_vnlc_resp1 # Cannot import at top due to circular dependency
+                        if mo_coeff is not None and mo_occ is not None:
+                            v1 += get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1, max_memory)
+                        else:
+                            v1 += get_vnlc_resp1(mf, mol, dm0, dm1, max_memory)
                 if hybrid:
                     if omega == 0:
                         vj, vk = mf.get_jk(mol, dm1, hermi)
@@ -171,14 +181,15 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
     return vind
 
 
-def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None,
+def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None, dm0=None,
                       with_j=True, hermi=0, max_memory=None, with_nlc=True):
     '''Generate a function to compute the product of UHF response function and
     UHF density matrices.
     '''
     assert isinstance(mf, (uhf.UHF, rohf.ROHF))
-    if mo_coeff is None: mo_coeff = mf.mo_coeff
-    if mo_occ is None: mo_occ = mf.mo_occ
+    if dm0 is None:
+        if mo_coeff is None: mo_coeff = mf.mo_coeff
+        if mo_occ is None: mo_occ = mf.mo_occ
     mol = mf.mol
     if isinstance(mf, hf.KohnShamDFT):
         ni = mf._numint
@@ -186,9 +197,12 @@ def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None,
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
         hybrid = ni.libxc.is_hybrid_xc(mf.xc)
 
-        rho0, vxc, fxc = ni.cache_xc_kernel(mol, mf.grids, mf.xc,
-                                            mo_coeff, mo_occ, 1)
-        dm0 = None
+        if mo_coeff is not None and mo_occ is not None:
+            rho0, vxc, fxc = ni.cache_xc_kernel(mol, mf.grids, mf.xc,
+                                                mo_coeff, mo_occ, 1)
+        else:
+            rho0, vxc, fxc = ni.cache_xc_kernel1(mol, mf.grids, mf.xc,
+                                                 dm0, 1)
 
         if max_memory is None:
             mem_now = lib.current_memory()[0]
@@ -204,8 +218,11 @@ def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None,
                 v1 = ni.nr_uks_fxc(mol, mf.grids, mf.xc, dm0, dm1, 0, hermi,
                                    rho0, vxc, fxc, max_memory=max_memory)
                 if with_nlc and mf.do_nlc():
-                    from pyscf.hessian.rks import get_vnlc_resp # Cannot import at top due to circular dependency
-                    v1 += get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1[0] + dm1[1], max_memory)
+                    from pyscf.hessian.rks import get_vnlc_resp, get_vnlc_resp1 # Cannot import at top due to circular dependency
+                    if mo_coeff is not None and mo_occ is not None:
+                        v1 += get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1, max_memory)
+                    else:
+                        v1 += get_vnlc_resp1(mf, mol, dm0[0] + dm0[1], dm1[0] + dm1[1], max_memory)
             if not hybrid:
                 if with_j:
                     vj = mf.get_j(mol, dm1, hermi=hermi)

--- a/pyscf/scf/_response_functions.py
+++ b/pyscf/scf/_response_functions.py
@@ -223,7 +223,7 @@ def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None, dm0=None,
                     # Cannot import at top due to circular dependency
                     from pyscf.hessian.rks import get_vnlc_resp, get_vnlc_resp1
                     if mo_coeff is not None and mo_occ is not None:
-                        v1 += get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1, max_memory)
+                        v1 += get_vnlc_resp(mf, mol, mo_coeff, mo_occ, dm1[0] + dm1[1], max_memory)
                     else:
                         v1 += get_vnlc_resp1(mf, mol, dm0[0] + dm0[1], dm1[0] + dm1[1], max_memory)
             if not hybrid:
@@ -267,13 +267,14 @@ def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None, dm0=None,
     return vind
 
 
-def _gen_ghf_response(mf, mo_coeff=None, mo_occ=None,
+def _gen_ghf_response(mf, mo_coeff=None, mo_occ=None, dm0=None,
                       with_j=True, hermi=0, max_memory=None, with_nlc=True):
     '''Generate a function to compute the product of GHF response function and
     GHF density matrices.
     '''
-    if mo_coeff is None: mo_coeff = mf.mo_coeff
-    if mo_occ is None: mo_occ = mf.mo_occ
+    if dm0 is None:
+        if mo_coeff is None: mo_coeff = mf.mo_coeff
+        if mo_occ is None: mo_occ = mf.mo_occ
     mol = mf.mol
     if isinstance(mf, hf.KohnShamDFT):
         from pyscf.dft import numint2c, r_numint
@@ -283,8 +284,10 @@ def _gen_ghf_response(mf, mo_coeff=None, mo_occ=None,
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
         hybrid = ni.libxc.is_hybrid_xc(mf.xc)
 
-        rho0, vxc, fxc = ni.cache_xc_kernel(mol, mf.grids, mf.xc, mo_coeff, mo_occ, 1)
-        dm0 = None
+        if mo_coeff is not None and mo_occ is not None:
+            rho0, vxc, fxc = ni.cache_xc_kernel(mol, mf.grids, mf.xc, mo_coeff, mo_occ, 1)
+        else:
+            rho0, vxc, fxc = ni.cache_xc_kernel1(mol, mf.grids, mf.xc, dm0, 1)
 
         if max_memory is None:
             mem_now = lib.current_memory()[0]
@@ -300,19 +303,27 @@ def _gen_ghf_response(mf, mo_coeff=None, mo_occ=None,
                 v1 = ni.get_fxc(mol, mf.grids, mf.xc, dm0, dm1, 0, 0, hermi,
                                 rho0, vxc, fxc, max_memory=max_memory)
                 if with_nlc and mf.do_nlc():
-                    from pyscf.hessian.rks import get_vnlc_resp
-                    nao = mo_coeff.shape[0] // 2
-                    dm1_sf = dm1[...,:nao,:nao] + dm1[...,nao:,nao:]
-                    mo_uks = [mo_coeff[:nao], mo_coeff[nao:]]
-                    mo_occ_uks = [mo_occ, mo_occ]
-                    # The get_vnlc_resp function uses mf._numint and explicitly
-                    # calls the NumInt functions for mf._numint
+                    from pyscf.hessian.rks import get_vnlc_resp, get_vnlc_resp1
+                    # The get_vnlc_resp/get_vnlc_resp1 functions use mf._numint
+                    # and explicitly call the NumInt functions for mf._numint
                     ni1c = mf._numint._to_numint1c()
-                    with lib.temporary_env(mf, _numint=ni1c):
-                        vxc_nlc = get_vnlc_resp(mf, mol, mo_uks, mo_occ_uks,
-                                                dm1_sf.real, max_memory)
-                        v1[...,:nao,:nao] += vxc_nlc
-                        v1[...,nao:,nao:] += vxc_nlc
+                    if mo_coeff is not None and mo_occ is not None:
+                        nao = mo_coeff.shape[0] // 2
+                        dm1_sf = dm1[...,:nao,:nao] + dm1[...,nao:,nao:]
+                        mo_uks = [mo_coeff[:nao], mo_coeff[nao:]]
+                        mo_occ_uks = [mo_occ, mo_occ]
+                        with lib.temporary_env(mf, _numint=ni1c):
+                            vxc_nlc = get_vnlc_resp(mf, mol, mo_uks, mo_occ_uks,
+                                                    dm1_sf.real, max_memory)
+                    else:
+                        nao = dm0.shape[0] // 2
+                        dm1_sf = dm1[...,:nao,:nao] + dm1[...,nao:,nao:]
+                        dm0_sf = dm0[:nao,:nao] + dm0[nao:,nao:]
+                        with lib.temporary_env(mf, _numint=ni1c):
+                            vxc_nlc = get_vnlc_resp1(mf, mol, dm0_sf,
+                                                     dm1_sf.real, max_memory)
+                    v1[...,:nao,:nao] += vxc_nlc
+                    v1[...,nao:,nao:] += vxc_nlc
             if not hybrid:
                 if with_j:
                     vj = mf.get_j(mol, dm1, hermi=hermi)
@@ -353,12 +364,12 @@ def _gen_ghf_response(mf, mo_coeff=None, mo_occ=None,
     return vind
 
 
-def _gen_dhf_response(mf, mo_coeff=None, mo_occ=None,
+def _gen_dhf_response(mf, mo_coeff=None, mo_occ=None, dm0=None,
                       with_j=True, hermi=0, max_memory=None, with_nlc=True):
     '''Generate a function to compute the product of DHF response function and
     DHF density matrices.
     '''
-    return _gen_ghf_response(mf, mo_coeff, mo_occ, with_j, hermi, max_memory)
+    return _gen_ghf_response(mf, mo_coeff, mo_occ, dm0, with_j, hermi, max_memory)
 
 
 hf.RHF.gen_response = _gen_rhf_response

--- a/pyscf/scf/test/test_response_function.py
+++ b/pyscf/scf/test/test_response_function.py
@@ -47,6 +47,93 @@ class KnownValues(unittest.TestCase):
         v = vind(scipy.linalg.block_diag(*dm1))
         self.assertAlmostEqual(abs(v - ref).max(), 0, 12)
 
+    def _check_dm0_response(self, mf, dm1, with_nlc):
+        dm0 = mf.make_rdm1()
+        vind_mo = mf.gen_response(mf.mo_coeff, mf.mo_occ, with_nlc=with_nlc)
+        vind_dm0 = mf.gen_response(dm0=dm0, with_nlc=with_nlc)
+        self.assertAlmostEqual(abs(vind_mo(dm1) - vind_dm0(dm1)).max(), 0, 10)
+
+    def test_rhf_response_dm0(self):
+        mol = gto.M(
+            verbose = 0,
+            atom = [
+            ["O" , (0. , 0.     , 0.)],
+            [1   , (0. , -0.757 , 0.587)],
+            [1   , (0. , 0.757  , 0.587)]],
+            basis = '631g')
+        nao = mol.nao
+        dm1 = np.random.rand(nao, nao)
+        dm1 = dm1 + dm1.T
+
+        mf = mol.RHF().run()
+        self._check_dm0_response(mf, dm1, with_nlc=True)
+
+        mf = mol.RKS(xc='wb97mv').run()
+        mf.nlcgrids.level = 0
+        self._check_dm0_response(mf, dm1, with_nlc=True)
+
+    def test_uhf_response_dm0(self):
+        mol = gto.M(
+            verbose = 0,
+            atom = [
+            ["O" , (0. , 0.     , 0.)],
+            [1   , (0. , -0.757 , 0.587)],
+            [1   , (0. , 0.757  , 0.587)]],
+            charge = 1,
+            spin = 1,
+            basis = '631g')
+        nao = mol.nao
+        dm1 = np.random.rand(2, nao, nao)
+        dm1 = dm1 + dm1.transpose(0, 2, 1)
+
+        mf = mol.UHF().run()
+        self._check_dm0_response(mf, dm1, with_nlc=True)
+
+        mf = mol.UKS(xc='wb97mv').run()
+        mf.nlcgrids.level = 0
+        self._check_dm0_response(mf, dm1, with_nlc=True)
+
+    def test_ghf_response_dm0(self):
+        mol = gto.M(
+            verbose = 0,
+            atom = [
+            ["O" , (0. , 0.     , 0.)],
+            [1   , (0. , -0.757 , 0.587)],
+            [1   , (0. , 0.757  , 0.587)]],
+            charge = 1,
+            spin = 1,
+            basis = '631g')
+
+        mf = mol.GHF().run()
+        n2c = mf.mo_coeff.shape[0]
+        dm1 = np.random.rand(n2c, n2c)
+        dm1 = dm1 + dm1.T
+        self._check_dm0_response(mf, dm1, with_nlc=True)
+
+        mf = mol.GKS(xc='wb97mv').run()
+        mf.nlcgrids.level = 0
+        n2c = mf.mo_coeff.shape[0]
+        dm1 = np.random.rand(n2c, n2c)
+        dm1 = dm1 + dm1.T
+        self._check_dm0_response(mf, dm1, with_nlc=True)
+
+    def test_dhf_response_dm0(self):
+        mol = gto.M(
+            verbose = 0,
+            atom = [
+            ["O" , (0. , 0.     , 0.)],
+            [1   , (0. , -0.757 , 0.587)],
+            [1   , (0. , 0.757  , 0.587)]],
+            charge = 1,
+            spin = 1,
+            basis = '631g')
+
+        mf = mol.DHF().run()
+        n4c = mf.mo_coeff.shape[0]
+        dm1 = np.random.rand(n4c, n4c) + 1j * np.random.rand(n4c, n4c)
+        dm1 = dm1 + dm1.conj().T
+        self._check_dm0_response(mf, dm1, with_nlc=True)
+
 if __name__ == "__main__":
     print("Full Tests for response_functions")
     unittest.main()

--- a/pyscf/x2c/_response_functions.py
+++ b/pyscf/x2c/_response_functions.py
@@ -20,12 +20,12 @@ Generate X2C-SCF response functions
 from pyscf.x2c import x2c
 from pyscf.scf._response_functions import _gen_ghf_response
 
-def _gen_x2chf_response(mf, mo_coeff=None, mo_occ=None,
+def _gen_x2chf_response(mf, mo_coeff=None, mo_occ=None, dm0=None,
                         with_j=True, hermi=0, max_memory=None, with_nlc=True):
     '''Generate a function to compute the product of X2C-HF response function
     and density matrices.
     '''
-    return _gen_ghf_response(mf, mo_coeff, mo_occ, with_j, hermi, max_memory,
+    return _gen_ghf_response(mf, mo_coeff, mo_occ, dm0, with_j, hermi, max_memory,
                              with_nlc=with_nlc)
 
 x2c.UHF.gen_response = _gen_x2chf_response

--- a/pyscf/x2c/test/test_response_function.py
+++ b/pyscf/x2c/test/test_response_function.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# Copyright 2025 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from pyscf import gto
+from pyscf.x2c import x2c, dft
+from pyscf.x2c import _response_functions  # noqa
+
+class KnownValues(unittest.TestCase):
+    def _check_dm0_response(self, mf, dm1, with_nlc):
+        dm0 = mf.make_rdm1()
+        vind_mo = mf.gen_response(mf.mo_coeff, mf.mo_occ, with_nlc=with_nlc)
+        vind_dm0 = mf.gen_response(dm0=dm0, with_nlc=with_nlc)
+        self.assertAlmostEqual(abs(vind_mo(dm1) - vind_dm0(dm1)).max(), 0, 10)
+
+    def test_x2chf_response_dm0(self):
+        mol = gto.M(
+            verbose = 0,
+            atom = [
+            ["O" , (0. , 0.     , 0.)],
+            [1   , (0. , -0.757 , 0.587)],
+            [1   , (0. , 0.757  , 0.587)]],
+            charge = 1,
+            spin = 1,
+            basis = '631g')
+
+        mf = x2c.UHF(mol).run()
+        n2c = mf.mo_coeff.shape[0]
+        dm1 = np.random.rand(n2c, n2c)
+        dm1 = dm1 + dm1.T
+        self._check_dm0_response(mf, dm1, with_nlc=True)
+
+        mf = dft.UKS(mol, xc='pbe').run()
+        n2c = mf.mo_coeff.shape[0]
+        dm1 = np.random.rand(n2c, n2c)
+        dm1 = dm1 + dm1.T
+        self._check_dm0_response(mf, dm1, with_nlc=False)
+
+if __name__ == "__main__":
+    print("Full Tests for x2c response_functions")
+    unittest.main()


### PR DESCRIPTION
This PR adds a `dm0` keyword to the `_gen_response` functions (for RHF/UHF/GHF/DHF/X2C-HF) so the response function can be built directly from a density matrix instead of requiring `mo_coeff` and `mo_occ`. This is useful for callers that only have a density matrix on hand and would otherwise have to diagonalize it back into an MO basis just to call this function. Internally this reuses the existing `cache_xc_kernel1` helper (already in `numint.py`) instead of `cache_xc_kernel` when `dm0` is passed. For the NLC contribution, `get_vnlc_resp` in `pyscf/hessian/rks.py `is split into `get_vnlc_resp` (which builds `dm0` from `mo_coeff/mo_occ`) and a new `get_vnlc_resp1` function (which takes dm0 directly), so the `dm0` path can call the latter. No new numerical machinery is introduced. I also added tests for the equivalence of the implementations employing `mo_coeff` vs. `dm0` for RHF/UHF/GHF/DHF/X2C-HF.