### PR TITLE
ci(windows): run the installed-wheel tests in parallel

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -22,13 +22,14 @@ concurrency:
 jobs:
   windows-wheel:
     runs-on: windows-latest
-    timeout-minutes: 300
+    timeout-minutes: 120
     defaults:
       run:
         shell: pwsh
     env:
-      OMP_NUM_THREADS: "4"
-      OPENBLAS_NUM_THREADS: "4"
+      # One thread per pytest worker process; OpenMP is covered by the Linux job.
+      OMP_NUM_THREADS: "1"
+      OPENBLAS_NUM_THREADS: "1"
       PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
 
     steps:

--- a/.github/workflows/ci_windows/verify_installed_wheel.ps1
+++ b/.github/workflows/ci_windows/verify_installed_wheel.ps1
@@ -38,7 +38,7 @@ try {
     if ($wheels.Count -ne 1) {
         throw "Expected exactly one wheel, found $($wheels.Count)"
     }
-    & $python -m pip install $wheels[0].FullName 'pytest<9' geometric spglib 'git+https://github.com/jhrmnn/pyberny.git@36a4be9' 2>&1 |
+    & $python -m pip install $wheels[0].FullName 'pytest<9' pytest-xdist geometric spglib 'git+https://github.com/jhrmnn/pyberny.git@36a4be9' 2>&1 |
         Tee-Object -FilePath (Join-Path $reportDir 'install.log')
     if ($LASTEXITCODE -ne 0) {
         throw 'Installed-wheel test environment setup failed'
@@ -91,13 +91,23 @@ try {
     & $python -VV 2>&1 | Set-Content -LiteralPath (Join-Path $reportDir 'environment.txt') -Encoding utf8
     & $python -m pip freeze | Add-Content -LiteralPath (Join-Path $reportDir 'environment.txt') -Encoding utf8
 
+    # PYTEST_JOBS: "auto" is one worker per core, "0" runs serially. loadfile
+    # keeps a file's tests on one worker, for the chkfiles some of them write
+    # relative to cwd. The job disables plugin autoload, so -p xdist is needed.
+    $pytestJobs = if ($env:PYTEST_JOBS) { $env:PYTEST_JOBS } else { 'auto' }
+    $parallelArgs = @()
+    if ($pytestJobs -ne '0') {
+        $parallelArgs = @('-p', 'xdist', '-n', $pytestJobs, '--dist', 'loadfile')
+    }
+
     $junitPath = Join-Path $reportDir 'pytest-results.xml'
     $pytestArgs = @(
         'pyscf',
         '-s',
         '-c', $pytestConfig,
         '--rootdir', '.',
-        '--import-mode=prepend',
+        '--import-mode=prepend'
+    ) + $parallelArgs + @(
         '--durations=20',
         "--junitxml=$junitPath"
     )


### PR DESCRIPTION
The Windows installed-wheel job added in #3328 runs its tests in a single serial pytest process. On the most recent master run that step took 73.5 minutes (4362s for 3329 tests) out of 82 minutes total, against 7 minutes to build the wheel.

The Linux and macOS jobs already avoid this: `run_tests.sh` runs pytest under `-n auto --dist loadfile` with one thread per worker, since most PySCF tests are too small to keep several BLAS/OpenMP threads busy. This applies the same approach to Windows.

* Install `pytest-xdist` and run the staged tests with `-n auto --dist loadfile`, behind a `PYTEST_JOBS` knob (`0` restores a serial run) matching the one in `run_tests.sh`.
* Load xdist with `-p xdist`, since the job sets `PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"`.
* Drop `OMP_NUM_THREADS` and `OPENBLAS_NUM_THREADS` to 1, as four workers times four threads oversubscribes a four core runner. Threaded paths stay covered by `linux-build-multithread`.
* Lower `timeout-minutes` from 300 to 120.

`--dist loadfile` is kept for the reasons documented in `run_tests.sh`: some tests write chkfiles relative to the working directory, and some use expensive `setUpModule` fixtures.

The slowest single test is 150s, so this should bring the test step to roughly 50 minutes. Test selection, the evidence artifact, the JUnit XML, and the summary are unchanged.
