### PR TITLE
update multi thread ci test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,9 @@ jobs:
       OMP_NUM_THREADS: 2
       PYTEST_JOBS: 2
       TEST_PATHS: >-
-        pyscf/lib pyscf/gto pyscf/ao2mo pyscf/scf pyscf/dft pyscf/mp
-        pyscf/cc pyscf/mcscf pyscf/agf2
-        pyscf/pbc/scf pyscf/pbc/df pyscf/pbc/dft
+        pyscf/agf2 pyscf/ao2mo pyscf/cc pyscf/dft pyscf/gto pyscf/lib
+        pyscf/mcpdft pyscf/mcscf pyscf/mp pyscf/scf pyscf/tdscf
+        pyscf/pbc/df pyscf/pbc/dft pyscf/pbc/scf
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python


### PR DESCRIPTION
Add mcpdft and tdscf to this test, since they have generally more failing risk according to #3245 #3312.