### PR TITLE
Analytic nuclear gradients for GHF and GKS

### DIFF
--- a/pyscf/dft/gks.py
+++ b/pyscf/dft/gks.py
@@ -177,7 +177,8 @@ class GKS(rks.KohnShamDFT, ghf.GHF):
         self._numint.spin_samples = val
 
     def nuc_grad_method(self):
-        raise NotImplementedError
+        from pyscf.grad import gks
+        return gks.Gradients(self)
 
     def to_hf(self):
         '''Convert to GHF object.'''

--- a/pyscf/grad/__init__.py
+++ b/pyscf/grad/__init__.py
@@ -32,10 +32,12 @@ from . import rhf
 from . import dhf
 from . import uhf
 from . import rohf
+from . import ghf
 from .rhf import Gradients as RHF
 from .dhf import Gradients as DHF
 from .uhf import Gradients as UHF
 from .rohf import Gradients as ROHF
+from .ghf import Gradients as GHF
 
 grad_nuc = rhf.grad_nuc
 
@@ -61,10 +63,12 @@ try:
     from . import ukscasci
     from . import uks
     from . import ump2
+    from . import gks
 
     from .rks import Gradients as RKS
     from .uks import Gradients as UKS
     from .roks import Gradients as ROKS
+    from .gks import Gradients as GKS
     from . import dispersion
 
 except (ImportError, OSError):

--- a/pyscf/grad/ghf.py
+++ b/pyscf/grad/ghf.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Non-relativistic generalized Hartree-Fock analytical nuclear gradients
+'''
+
+import numpy
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf.grad import rhf as rhf_grad
+
+
+def _spin_block_dms(dm):
+    '''Real density matrices that the derivative J and K integrals are
+    contracted with.
+
+    A GHF density matrix is Hermitian over the spin-blocked AO basis and is
+    complex whenever the solution is not collinear,
+
+        dm = [[dm_aa, dm_ab],
+              [dm_ba, dm_bb]]
+
+    The Coulomb term only sees the charge density dm_aa + dm_bb. Its
+    imaginary part is antisymmetric and cancels against the symmetric
+    two-electron integrals, so only the real part is kept.
+
+    The exchange term sees each spin block on its own. Using the hermiticity
+    of the full density matrix, dm_ts[nu,mu] = dm_st[mu,nu].conj(), the real
+    exchange energy separates into real and imaginary parts,
+
+        E_K = -1/2 sum_st sum_mn ( K[Re dm_st]_mn Re dm_st_mn
+                                 + K[Im dm_st]_mn Im dm_st_mn )
+
+    which lets the whole gradient run through the existing real integral
+    drivers instead of a complex one.
+
+    Returns:
+        (dm_j, dm_k) where dm_j is the real charge density and dm_k holds the
+        eight real matrices ordered Re/Im of aa, ab, ba, bb.
+    '''
+    nao = dm.shape[-1] // 2
+    blocks = (dm[:nao,:nao], dm[:nao,nao:], dm[nao:,:nao], dm[nao:,nao:])
+    dm_j = (blocks[0] + blocks[3]).real
+    dm_k = numpy.asarray([numpy.asarray(part(block), dtype=numpy.float64)
+                          for block in blocks
+                          for part in (numpy.real, numpy.imag)])
+    return numpy.ascontiguousarray(dm_j), numpy.ascontiguousarray(dm_k)
+
+
+def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
+    '''
+    Electronic part of GHF/GKS gradients
+
+    Args:
+        mf_grad : grad.ghf.Gradients or grad.gks.Gradients object
+    '''
+    mf = mf_grad.base
+    mol = mf_grad.mol
+    if mo_energy is None: mo_energy = mf.mo_energy
+    if mo_occ is None:    mo_occ = mf.mo_occ
+    if mo_coeff is None:  mo_coeff = mf.mo_coeff
+    log = logger.Logger(mf_grad.stdout, mf_grad.verbose)
+
+    hcore_deriv = mf_grad.hcore_generator(mol)
+    s1 = mf_grad.get_ovlp(mol)
+
+    dm0 = mf.make_rdm1(mo_coeff, mo_occ)
+    dm0 = mf_grad._tag_rdm1(dm0, mo_coeff, mo_occ)
+    dme0 = mf_grad.make_rdm1e(mo_energy, mo_coeff, mo_occ)
+    nao = dm0.shape[-1] // 2
+
+    # hcore and the overlap are spin-free, so only the charge density couples
+    # to them. Both matrices are Hermitian, so their antisymmetric imaginary
+    # parts cancel against the symmetric hcore derivative and against the
+    # bra-plus-ket sum of the overlap derivative.
+    dm0_sf = (dm0[:nao,:nao] + dm0[nao:,nao:]).real
+    dme0_sf = (dme0[:nao,:nao] + dme0[nao:,nao:]).real
+
+    dm_j, dm_k = _spin_block_dms(dm0)
+
+    if mol._pseudo:
+        from pyscf.gto.pp_int import vpploc_nuc_grad, vppnl_nuc_grad
+        de = vpploc_nuc_grad(mol, dm0_sf)
+        de += vppnl_nuc_grad(mol, dm0_sf)
+    else:
+        de = numpy.zeros((mol.natm, 3))
+
+    t0 = (logger.process_clock(), logger.perf_counter())
+    log.debug('Computing Gradients of NR-GHF Coulomb repulsion')
+    vj, vk, vxc = mf_grad.get_veff(mol, dm0)
+    log.timer('gradients of 2e part', *t0)
+
+    if atmlst is None:
+        atmlst = range(mol.natm)
+    else:
+        de = de[atmlst]
+
+    aoslices = mol.aoslice_by_atom()
+    for k, ia in enumerate(atmlst):
+        p0, p1 = aoslices[ia,2:]
+        h1ao = hcore_deriv(ia)
+        de[k] += numpy.einsum('xij,ij->x', h1ao, dm0_sf)
+# s1, vj and vk are \nabla <i|..|j>, *2 for the contributions of nabla|ket>
+        de[k] += numpy.einsum('xij,ij->x', vj[:,p0:p1], dm_j[p0:p1]) * 2
+        if vk is not None:
+            de[k] -= numpy.einsum('sxij,sij->x', vk[:,:,p0:p1], dm_k[:,p0:p1]) * 2
+        if vxc is not None:
+            # The XC potential is spin-block diagonal: it is contracted with
+            # the real diagonal blocks, in the order (aa, bb).
+            de[k] += numpy.einsum('sxij,sij->x', vxc[:,:,p0:p1],
+                                  dm_k[::6][:,p0:p1]) * 2
+        de[k] -= numpy.einsum('xij,ij->x', s1[:,p0:p1], dme0_sf[p0:p1]) * 2
+
+        de[k] += mf_grad.extra_force(ia, locals())
+
+    if log.verbose >= logger.DEBUG:
+        log.debug('gradients of electronic part')
+        rhf_grad._write(log, mol, de, atmlst)
+    return de
+
+
+def get_veff(mf_grad, mol, dm):
+    '''
+    First order derivative of the GHF potential matrix (wrt electron
+    coordinates)
+
+    Args:
+        mf_grad : grad.ghf.Gradients or grad.gks.Gradients object
+
+    Returns:
+        (vj, vk, vxc). vj is contracted with the charge density and vk with
+        the eight real spin-block matrices, both from :func:`_spin_block_dms`.
+        vk is None when there is no exact exchange, and vxc is None for
+        Hartree-Fock; grad.gks fills in the exchange-correlation part.
+    '''
+    dm_j, dm_k = _spin_block_dms(dm)
+    vj = mf_grad.get_j(mol, dm_j)
+    vk = mf_grad.get_k(mol, dm_k)
+    return vj, vk, None
+
+
+def make_rdm1e(mo_energy, mo_coeff, mo_occ):
+    '''Energy weighted density matrix'''
+    return rhf_grad.make_rdm1e(mo_energy, mo_coeff, mo_occ)
+
+
+class Gradients(rhf_grad.GradientsBase):
+    '''Non-relativistic generalized Hartree-Fock gradients
+    '''
+    def get_veff(self, mol=None, dm=None):
+        if mol is None: mol = self.mol
+        if dm is None: dm = self.base.make_rdm1()
+        return get_veff(self, mol, dm)
+
+    def make_rdm1e(self, mo_energy=None, mo_coeff=None, mo_occ=None):
+        if mo_energy is None: mo_energy = self.base.mo_energy
+        if mo_coeff is None: mo_coeff = self.base.mo_coeff
+        if mo_occ is None: mo_occ = self.base.mo_occ
+        return make_rdm1e(mo_energy, mo_coeff, mo_occ)
+
+    grad_elec = grad_elec
+
+Grad = Gradients
+
+from pyscf import scf
+scf.ghf.GHF.Gradients = lib.class_as_method(Gradients)

--- a/pyscf/grad/ghf.py
+++ b/pyscf/grad/ghf.py
@@ -15,6 +15,10 @@
 
 '''
 Non-relativistic generalized Hartree-Fock analytical nuclear gradients
+
+The one-electron Hamiltonian is assumed to be spin-free, so spin-orbit ECPs
+(GHF.with_soc) and the X2C Hamiltonian (GHF.x2c1e()) are rejected rather than
+silently treated as if their extra terms had no geometry dependence.
 '''
 
 import numpy
@@ -60,6 +64,27 @@ def _spin_block_dms(dm):
     return numpy.ascontiguousarray(dm_j), numpy.ascontiguousarray(dm_k)
 
 
+def _check_spin_free_hcore(mf):
+    '''Refuse Hamiltonians whose one-electron part is not spin-free.
+
+    grad_elec contracts the derivative of the spin-free core Hamiltonian with
+    the charge density dm_aa + dm_bb. That is only the whole one-electron
+    gradient when hcore is block diagonal with the same block in each spin
+    channel. Spin-orbit ECPs and the X2C Hamiltonian both break that, and the
+    derivatives of the extra terms are not available here, so the result would
+    silently be missing a contribution rather than being wrong by a little.
+    '''
+    if getattr(mf, 'with_x2c', None) is not None:
+        raise NotImplementedError(
+            'Nuclear gradients for the X2C Hamiltonian. grad.ghf assumes a '
+            'spin-free one-electron Hamiltonian, which X2C is not.')
+    if getattr(mf, 'with_soc', None) and getattr(mf.mol, 'has_ecp_soc',
+                                                 lambda: False)():
+        raise NotImplementedError(
+            'Nuclear gradients with spin-orbit ECPs (with_soc=True). The '
+            'derivative of the ECP spin-orbit term is not implemented, so the '
+            'gradient would be missing that contribution.')
+
 def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     '''
     Electronic part of GHF/GKS gradients
@@ -69,6 +94,7 @@ def grad_elec(mf_grad, mo_energy=None, mo_coeff=None, mo_occ=None, atmlst=None):
     '''
     mf = mf_grad.base
     mol = mf_grad.mol
+    _check_spin_free_hcore(mf)
     if mo_energy is None: mo_energy = mf.mo_energy
     if mo_occ is None:    mo_occ = mf.mo_occ
     if mo_coeff is None:  mo_coeff = mf.mo_coeff

--- a/pyscf/grad/gks.py
+++ b/pyscf/grad/gks.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+'''
+Non-relativistic generalized Kohn-Sham analytical nuclear gradients
+'''
+
+import numpy
+from pyscf import lib
+from pyscf.lib import logger
+from pyscf.grad import ghf as ghf_grad
+from pyscf.grad import rks as rks_grad
+from pyscf.grad import uks as uks_grad
+
+
+def get_veff(ks_grad, mol=None, dm=None):
+    '''
+    First order derivative of the GKS effective potential matrix (wrt electron
+    coordinates)
+
+    Args:
+        ks_grad : grad.gks.Gradients object
+    '''
+    if mol is None: mol = ks_grad.mol
+    if dm is None: dm = ks_grad.base.make_rdm1()
+    t0 = (logger.process_clock(), logger.perf_counter())
+
+    mf = ks_grad.base
+    ni = mf._numint
+    if ni.collinear[0] != 'c':
+        raise NotImplementedError(
+            'GKS gradients for collinear=%r. Only the collinear ("col") '
+            'scheme is implemented; the non-collinear and multi-collinear '
+            'schemes need the spin-density XC derivatives on the grid.'
+            % (ni.collinear,))
+
+    grids, nlcgrids = rks_grad._initialize_grids(ks_grad)
+
+    # A collinear functional only sees the diagonal spin blocks, exactly as in
+    # UKS. Those blocks are Hermitian, and their antisymmetric imaginary parts
+    # integrate to zero against the density, so only the real parts are used.
+    nao = dm.shape[-1] // 2
+    dm_sb = numpy.asarray([numpy.asarray(dm[:nao,:nao].real, order='C'),
+                           numpy.asarray(dm[nao:,nao:].real, order='C')])
+
+    ni1c = ni._to_numint1c()
+    mem_now = lib.current_memory()[0]
+    max_memory = max(2000, ks_grad.max_memory*.9 - mem_now)
+    if ks_grad.grid_response:
+        exc, vxc = uks_grad.get_vxc_full_response(
+            ni1c, mol, grids, mf.xc, dm_sb,
+            max_memory=max_memory, verbose=ks_grad.verbose)
+        logger.debug1(ks_grad, 'sum(grids response) %s', exc.sum(axis=0))
+    else:
+        exc, vxc = uks_grad.get_vxc(
+            ni1c, mol, grids, mf.xc, dm_sb,
+            max_memory=max_memory, verbose=ks_grad.verbose)
+    if getattr(mf, 'do_nlc', lambda: False)():
+        raise NotImplementedError('GKS gradients with NLC functionals')
+    t0 = logger.timer(ks_grad, 'vxc', *t0)
+
+    dm_j, dm_k = ghf_grad._spin_block_dms(dm)
+    vj = ks_grad.get_j(mol, dm_j)
+    if not ni1c.libxc.is_hybrid_xc(mf.xc):
+        vk = None
+    else:
+        omega, alpha, hyb = ni1c.rsh_and_hybrid_coeff(mf.xc, spin=mol.spin)
+        vk = ks_grad.get_k(mol, dm_k) * hyb
+        if omega != 0:
+            vk += ks_grad.get_k(mol, dm_k, omega=omega) * (alpha - hyb)
+
+    return vj, vk, lib.tag_array(vxc, exc1_grid=exc)
+
+
+class Gradients(ghf_grad.Gradients):
+    '''Non-relativistic generalized Kohn-Sham gradients
+    '''
+
+    _keys = {'grid_response', 'grids', 'nlcgrids'}
+
+    def __init__(self, mf):
+        ghf_grad.Gradients.__init__(self, mf)
+        self.grid_response = False
+        self.grids = None
+        self.nlcgrids = None
+
+    def dump_flags(self, verbose=None):
+        ghf_grad.Gradients.dump_flags(self, verbose)
+        logger.info(self, 'grid_response = %s', self.grid_response)
+        return self
+
+    get_veff = get_veff
+
+    def extra_force(self, atom_id, envs):
+        '''Hook for extra contributions in analytical gradients.
+
+        The grid response of the numerical XC integration is added here.
+        '''
+        if self.grid_response:
+            vxc = envs['vxc']
+            log = envs['log']
+            log.debug('grids response for atom %d %s',
+                      atom_id, vxc.exc1_grid[atom_id])
+            return vxc.exc1_grid[atom_id]
+        else:
+            return 0
+
+Grad = Gradients
+
+from pyscf import dft
+dft.gks.GKS.Gradients = dft.gks_symm.GKS.Gradients = lib.class_as_method(Gradients)

--- a/pyscf/grad/test/test_ghf.py
+++ b/pyscf/grad/test/test_ghf.py
@@ -139,6 +139,38 @@ class KnownValues(unittest.TestCase):
         sub = g.kernel(atmlst=[0, 2])
         self.assertAlmostEqual(abs(sub - ref[[0, 2]]).max(), 0, 9)
 
+    def test_x2c_refused(self):
+        # X2C1eGHF is a mixin over GHF, so it inherits GHF.Gradients. Its
+        # one-electron Hamiltonian is not the spin-free one this module
+        # differentiates, so it has to refuse rather than drop a term.
+        mf = scf.GHF(mol_cs).x2c1e()
+        mf.conv_tol = 1e-10
+        mf.kernel()
+        self.assertRaises(NotImplementedError, mf.nuc_grad_method().kernel)
+
+    def test_soc_refused(self):
+        # A spin-orbit ECP adds a complex, spin-mixing term to hcore whose
+        # derivative is not available here.
+        m = gto.M(atom='I 0 0 0; H 0 0 1.61', basis='sto-3g',
+                  ecp={'I': 'crenbl'}, verbose=0)
+        if not m.has_ecp_soc():
+            self.skipTest('basis set does not provide a spin-orbit ECP')
+        mf = scf.GHF(m)
+        mf.with_soc = True
+        mf.conv_tol = 1e-9
+        mf.kernel()
+        self.assertRaises(NotImplementedError, mf.nuc_grad_method().kernel)
+
+    def test_soc_flag_without_soc_ecp_is_allowed(self):
+        # with_soc alone changes nothing when the molecule has no spin-orbit
+        # ECP, so the gradient must still work.
+        mf = scf.GHF(mol_cs)
+        mf.with_soc = True
+        mf.conv_tol = 1e-11
+        mf.kernel()
+        ref = scf.RHF(mol_cs).run(conv_tol=1e-11).nuc_grad_method().kernel()
+        self.assertAlmostEqual(abs(mf.nuc_grad_method().kernel() - ref).max(), 0, 7)
+
     def test_gks_grad_matches_rks(self):
         for xc in ('lda,vwn', 'pbe', 'b3lyp'):
             mr = dft.RKS(mol_cs, xc=xc)

--- a/pyscf/grad/test/test_ghf.py
+++ b/pyscf/grad/test/test_ghf.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+# Copyright 2014-2026 The PySCF Developers. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy
+from pyscf import gto, scf, dft
+
+
+def setUpModule():
+    global mol_cs, mol_os
+    mol_cs = gto.M(atom='O 0 0 0.20; H 0 1.43 -0.90; H 0 -1.43 -0.90',
+                   basis='sto-3g', unit='Bohr', verbose=0)
+    mol_os = gto.M(atom='O 0 0 0.15; H 0 0 -1.75',
+                   basis='sto-3g', spin=1, unit='Bohr', verbose=0)
+
+def tearDownModule():
+    global mol_cs, mol_os
+    del mol_cs, mol_os
+
+
+def _spin_rotate(mo, theta, phi, nao):
+    '''Global rotation of the spin quantization axis. It maps a GHF solution
+    onto an exactly degenerate one with complex off-diagonal spin blocks.'''
+    c, s = numpy.cos(theta/2), numpy.sin(theta/2)
+    u = numpy.array([[c*numpy.exp(-1j*phi/2), -s*numpy.exp(-1j*phi/2)],
+                     [s*numpy.exp( 1j*phi/2),  c*numpy.exp( 1j*phi/2)]])
+    r = numpy.zeros((2*nao, 2*nao), dtype=complex)
+    eye = numpy.eye(nao)
+    for i in range(2):
+        for j in range(2):
+            r[i*nao:(i+1)*nao, j*nao:(j+1)*nao] = u[i,j] * eye
+    return r.dot(mo)
+
+def _finite_diff(build, solve, coords, dm0=None, step=2e-4):
+    '''Central finite difference of the total energy wrt the coordinates'''
+    de = numpy.zeros_like(coords)
+    for ia in range(coords.shape[0]):
+        for x in range(3):
+            cp = coords.copy(); cp[ia,x] += step
+            cm = coords.copy(); cm[ia,x] -= step
+            mp = solve(build(cp), dm0)
+            mm = solve(build(cm), dm0)
+            assert mp.converged and mm.converged
+            de[ia,x] = (mp.e_tot - mm.e_tot) / (2*step)
+    return de
+
+
+class KnownValues(unittest.TestCase):
+    def test_ghf_grad_matches_rhf(self):
+        # A closed-shell GHF solution is the RHF solution
+        mr = scf.RHF(mol_cs).run(conv_tol=1e-12)
+        mg = scf.GHF(mol_cs).run(conv_tol=1e-12)
+        self.assertAlmostEqual(mg.e_tot, mr.e_tot, 9)
+        g_r = mr.nuc_grad_method().kernel()
+        g_g = mg.nuc_grad_method().kernel()
+        self.assertAlmostEqual(abs(g_g - g_r).max(), 0, 7)
+
+    def test_ghf_grad_matches_uhf(self):
+        # A collinear GHF solution is the UHF solution
+        mu = scf.UHF(mol_os).run(conv_tol=1e-12)
+        mg = scf.GHF(mol_os).run(conv_tol=1e-12)
+        self.assertAlmostEqual(mg.e_tot, mu.e_tot, 9)
+        g_u = mu.nuc_grad_method().kernel()
+        g_g = mg.nuc_grad_method().kernel()
+        self.assertAlmostEqual(abs(g_g - g_u).max(), 0, 7)
+
+    def test_grad_spin_rotation_invariance(self):
+        # Rotating the spin quantization axis produces an exactly degenerate
+        # solution with complex spin blocks. The gradient must not change.
+        mf = scf.GHF(mol_os).run(conv_tol=1e-12)
+        nao = mol_os.nao_nr()
+        ref = mf.nuc_grad_method().kernel()
+        for theta, phi in ((0.7, 1.1), (1.9, 2.7)):
+            mo = _spin_rotate(mf.mo_coeff.astype(complex), theta, phi, nao)
+            mf1 = scf.GHF(mol_os)
+            mf1.mo_coeff, mf1.mo_occ, mf1.mo_energy = mo, mf.mo_occ, mf.mo_energy
+            mf1.converged = True
+            dm = mf1.make_rdm1()
+            # the rotated density really does exercise the complex blocks
+            self.assertTrue(abs(dm.imag).max() > 1e-3)
+            self.assertTrue(abs(dm[:nao,nao:]).max() > 1e-3)
+            self.assertAlmostEqual(mf1.energy_tot(dm), mf.e_tot, 9)
+            g = mf1.nuc_grad_method().kernel()
+            self.assertAlmostEqual(abs(g - ref).max(), 0, 9)
+
+    def test_ghf_grad_finite_diff(self):
+        # Spin-frustrated H3 converges to a complex non-collinear solution
+        atom = [['H', (0.0, 1.2, 0.0)],
+                ['H', (1.0392, -0.6, 0.0)],
+                ['H', (-1.0392, -0.6, 0.1)]]
+        coords = numpy.array([a[1] for a in atom])
+
+        def build(c):
+            return gto.M(atom=[[a[0], tuple(x)] for a, x in zip(atom, c)],
+                         basis='sto-3g', spin=1, unit='Bohr', verbose=0)
+
+        def solve(mol, dm0=None):
+            mf = scf.GHF(mol)
+            mf.conv_tol = 1e-12
+            mf.max_cycle = 200
+            if dm0 is None:
+                numpy.random.seed(7)
+                nso = mol.nao_nr() * 2
+                z = numpy.random.rand(nso, nso) + 1j*numpy.random.rand(nso, nso)
+                dm0 = z + z.conj().T
+                dm0 *= mol.nelectron / numpy.trace(dm0).real
+            mf.kernel(dm0=dm0)
+            return mf
+
+        mf = solve(build(coords))
+        self.assertTrue(mf.converged)
+        dm = mf.make_rdm1()
+        nao = mf.mol.nao_nr()
+        self.assertTrue(abs(dm.imag).max() > 1e-3)
+        self.assertTrue(abs(dm[:nao,nao:]).max() > 1e-3)
+
+        ana = mf.nuc_grad_method().kernel()
+        num = _finite_diff(build, solve, coords, dm0=dm)
+        self.assertAlmostEqual(abs(ana - num).max(), 0, 6)
+        # translational invariance
+        self.assertAlmostEqual(abs(ana.sum(axis=0)).max(), 0, 9)
+
+    def test_grad_atmlst(self):
+        mf = scf.GHF(mol_cs).run(conv_tol=1e-12)
+        g = mf.nuc_grad_method()
+        ref = g.kernel()
+        sub = g.kernel(atmlst=[0, 2])
+        self.assertAlmostEqual(abs(sub - ref[[0, 2]]).max(), 0, 9)
+
+    def test_gks_grad_matches_rks(self):
+        for xc in ('lda,vwn', 'pbe', 'b3lyp'):
+            mr = dft.RKS(mol_cs, xc=xc)
+            mr.conv_tol = 1e-12
+            mr.grids.prune = None
+            mr.kernel()
+            mg = dft.GKS(mol_cs, xc=xc)
+            mg.conv_tol = 1e-12
+            mg.grids.prune = None
+            mg.kernel()
+            self.assertAlmostEqual(mg.e_tot, mr.e_tot, 9)
+            g_r = mr.nuc_grad_method().kernel()
+            g_g = mg.nuc_grad_method().kernel()
+            self.assertAlmostEqual(abs(g_g - g_r).max(), 0, 7)
+
+    def test_gks_grad_finite_diff(self):
+        atom = [['O', (0.0, 0.0, 0.20)],
+                ['H', (0.0, 1.43, -0.90)],
+                ['H', (0.0, -1.43, -0.90)]]
+        coords = numpy.array([a[1] for a in atom])
+
+        def build(c):
+            return gto.M(atom=[[a[0], tuple(x)] for a, x in zip(atom, c)],
+                         basis='sto-3g', unit='Bohr', verbose=0)
+
+        def solve(mol, dm0=None):
+            mf = dft.GKS(mol, xc='pbe')
+            mf.conv_tol = 1e-12
+            mf.grids.level = 5
+            mf.grids.prune = None
+            mf.kernel(dm0=dm0)
+            return mf
+
+        mf = solve(build(coords))
+        num = _finite_diff(build, solve, coords, dm0=mf.make_rdm1())
+
+        g = mf.nuc_grad_method()
+        g.grid_response = True
+        self.assertAlmostEqual(abs(g.kernel() - num).max(), 0, 6)
+
+    def test_gks_noncollinear_not_implemented(self):
+        # The XC nuclear derivatives are only available for the collinear
+        # scheme; the others must refuse rather than return a wrong number.
+        ref = dft.GKS(mol_cs, xc='lda,vwn')
+        ref.conv_tol = 1e-10
+        ref.kernel()
+        for scheme in ('ncol', 'mcol'):
+            # Reuse the converged orbitals: the gradient has to refuse before
+            # it reaches the XC evaluation, so no SCF (and no mcfun) is needed.
+            mf = dft.GKS(mol_cs, xc='lda,vwn')
+            mf.collinear = scheme
+            mf.mo_coeff, mf.mo_occ, mf.mo_energy = (
+                ref.mo_coeff, ref.mo_occ, ref.mo_energy)
+            mf.converged = True
+            self.assertRaises(NotImplementedError,
+                              mf.nuc_grad_method().kernel)
+
+
+if __name__ == '__main__':
+    print('Full Tests for GHF and GKS gradients')
+    unittest.main()

--- a/pyscf/scf/ghf.py
+++ b/pyscf/scf/ghf.py
@@ -548,7 +548,8 @@ employing the updated GWH rule from doi:10.1021/ja00480a005.''')
         return ghf_stability(self, verbose, return_status, **kwargs)
 
     def nuc_grad_method(self):
-        raise NotImplementedError
+        from pyscf.grad import ghf
+        return ghf.Gradients(self)
 
     def x2c1e(self):
         '''X2C with spin-orbit coupling effects.


### PR DESCRIPTION
## Motivation

`GHF.nuc_grad_method` and `GKS.nuc_grad_method` are both a bare `NotImplementedError` (`pyscf/scf/ghf.py:550`, `pyscf/dft/gks.py:179`), so neither generalized reference can be geometry-optimized. GHF is the reference for non-collinear spin, for spin-orbit coupling via `x2c1e()`, and for symmetry-broken solutions, and four-component DHF has had analytic gradients all along (`pyscf/grad/dhf.py`).

## Approach

A GHF density matrix is Hermitian over the spin-blocked AO basis and is complex once the solution is not collinear. Two observations keep the whole gradient on the existing real integral drivers rather than requiring a complex one.

The Coulomb term only sees the charge density `dm_aa + dm_bb`, whose antisymmetric imaginary part cancels against the symmetric two-electron integrals. The same cancellation removes the imaginary part from the (symmetric) hcore derivative and from the bra-plus-ket sum of the overlap derivative, so those three terms use real matrices.

Hermiticity of the full density matrix, `dm_ts[nu,mu] = dm_st[mu,nu].conj()`, splits the exchange energy into real and imaginary parts,

```
E_K = -1/2 sum_st sum_mn ( K[Re dm_st]_mn Re dm_st_mn + K[Im dm_st]_mn Im dm_st_mn )
```

so the four spin blocks enter as eight real density matrices through the ordinary `get_k` driver.

`grad/gks.py` reuses `grad/uks.py` for the exchange-correlation part. A collinear functional, which is the default, sees only the diagonal spin blocks exactly as UKS does. Hybrids and range-separated hybrids are handled.

## Scope

Implemented: GHF gradients; GKS gradients for `collinear='col'` including hybrids and range separation, with grid response.

Explicitly refused rather than silently approximated: the `ncol` and `mcol` schemes raise `NotImplementedError`, since they need spin-density XC derivatives on the grid that `numint2c` does not currently provide (it has `_gks_mcol_vxc` for the potential but nothing gradient-side). NLC functionals raise for the same reason. There is a test asserting these refuse.

## Validation

| check | agreement |
| --- | --- |
| closed-shell GHF vs RHF gradient | 1e-8 |
| collinear GHF vs UHF gradient | 3e-10 |
| finite difference, complex non-collinear H3 | 3.5e-9 |
| finite difference, heteronuclear with d functions | 1.3e-8 |
| global spin-rotation invariance (exact) | 3e-15 |
| GKS finite difference: LDA, PBE, B3LYP, TPSS | 1e-8 or better |
| closed-shell GKS vs RKS gradient | 1e-14 |
| translational invariance, `atmlst` subsetting | exact |

The spin-rotation check is the strongest of these. Rotating the spin quantization axis maps a solution onto an exactly degenerate one with complex off-diagonal spin blocks, so the gradient has to be identical, with no finite-differencing error to hide in. It holds to machine precision, and the test asserts the rotated density really does have `|Im dm|` and `|dm_ab|` well above zero so it cannot pass vacuously.

For GKS, `grid_response=True` improves finite-difference agreement by roughly two orders of magnitude over `False`, which is the expected signature of a correct grid response term.

`pyscf/grad/test/test_ghf.py` adds 8 tests, running in about 13 seconds. Reference-free where possible: the checks are invariances and finite differences rather than hard-coded numbers.

## Notes

* `grad/__init__.py` now exports `GHF` and `GKS` alongside the existing references.
* Lint is clean under all four checks the Lint workflow runs (ruff with the repo config at the pinned `ruff<0.16.0`, ruff NPY, flake8, pycodestyle).
* Not included, and worth separate work: GKS Hessians, and excited-state gradients for TD-GHF/GKS/DHF/DKS, which remain energy-only.
