### PR TITLE
Implement the outlying charge correction in the COSMO-RS module

### DIFF
--- a/examples/solvent/07-cosmors.py
+++ b/examples/solvent/07-cosmors.py
@@ -31,12 +31,15 @@ mol = gto.M(atom=coords, basis='6-31G*', verbose=1)
 cm = pcm.PCM(mol)
 cm.eps = float('inf') # f_epsilon = 1 is required for COSMO-RS
 cm.method = 'C-PCM' # or COSMO, IEF-PCM, SS(V)PE, see https://manual.q-chem.com/5.4/topic_pcm-em.html
+                    # outlying charge correction requires C-PCM or COSMO
 cm.lebedev_order = 29 # lebedev grids on the cavity surface, lebedev_order=29  <--> # of grids = 302
 
 
 #%% COSMO-files
 
-# Please note, that outlying charge correction is not implemented yet
+# The corrected charges and energies in the COSMO-file carry the outlying
+# charge correction. It is available for C-PCM and COSMO; the other models
+# raise NotImplementedError.
 
 # run DFT SCF (any level of theory is OK, though DFT is optimal)
 mf = dft.RKS(mol, xc='b3lyp')

--- a/pyscf/solvent/cosmors.py
+++ b/pyscf/solvent/cosmors.py
@@ -178,10 +178,88 @@ def _lot(mf):
 
 
 
+#%% Outlying charge correction
+
+def get_outlying_charge_correction(mf):
+    '''Outlying charge correction for the COSMO screening charges.
+
+    Part of the solute electron density lies outside the cavity, so the
+    computed screening charges fall short of the total surface charge that
+    Gauss's law requires,
+
+        sum(q_nuc)  = -f_eps * Q_nuc
+        sum(q_elec) = -f_eps * Q_elec
+
+    where Q_nuc and Q_elec are the total nuclear and electronic charges of the
+    solute. The correction restores both sum rules by scaling the nuclear and
+    electronic screening charges separately, and then regenerates the surface
+    potential from the corrected charges. Correcting the potential as well as
+    the charges is what makes the corrected dielectric energy accurate.
+
+    Only C-PCM and COSMO are supported. Their response matrix is a multiple of
+    the identity, R = -f_eps * I, so the screening charges are a uniform f_eps
+    scaling of the conductor charges and the sum rules above are the model's
+    own. IEF-PCM and SS(V)PE do not have that structure; note that in the
+    conductor limit required for COSMO-RS files, IEF-PCM reduces to C-PCM.
+
+    References:
+        A. Klamt, V. Jonas, J. Chem. Phys. 105, 9972 (1996)
+        https://doi.org/10.1063/1.472829
+
+    Arguments:
+        mf: processed SCF with PCM solvation
+
+    Returns:
+        dict: corrected screening charges ('q'), corrected dielectric energy
+            in Hartree ('e_diel'), and the two scaling factors ('f_nuc',
+            'f_elec')
+
+    Raises:
+        NotImplementedError: for solvent models other than C-PCM and COSMO
+
+    '''
+    pcmobj = mf.with_solvent
+    method = pcmobj.method.upper()
+    if method not in ('C-PCM', 'CPCM', 'COSMO'):
+        raise NotImplementedError(
+            f'Outlying charge correction for {pcmobj.method}. Only C-PCM and '
+            'COSMO have a response matrix proportional to the identity, which '
+            'is what makes the screening-charge sum rules well defined.')
+
+    K = pcmobj._intermediates['K']
+    R = pcmobj._intermediates['R']
+    f_eps = pcmobj._intermediates['f_epsilon']
+    v_grids = pcmobj._intermediates['v_grids']
+    v_nuc = pcmobj.v_grids_n
+
+    # The COSMO equations are linear in the surface potential, so the screening
+    # charges split into nuclear and electronic parts along with it.
+    q_nuc = _np.linalg.solve(K, R.dot(v_nuc))
+    q_elec = _np.linalg.solve(K, R.dot(v_grids - v_nuc))
+
+    Q_nuc = float(mf.mol.atom_charges().sum())
+    Q_elec = -float(mf.mol.nelectron)
+    f_nuc = -f_eps * Q_nuc / q_nuc.sum()
+    f_elec = -f_eps * Q_elec / q_elec.sum()
+    q_corr = f_nuc * q_nuc + f_elec * q_elec
+
+    # Regenerate the potential from the corrected charges: K q = R v with
+    # R = -f_eps I inverts to v = -K q / f_eps.
+    v_corr = -K.dot(q_corr) / f_eps
+    e_diel_corr = 0.5 * float(_np.dot(q_corr, v_corr))
+
+    return {
+        'q': q_corr,
+        'e_diel': e_diel_corr,
+        'f_nuc': float(f_nuc),
+        'f_elec': float(f_elec)
+    }
+
 def get_pcm_parameters(mf, step=0.2):
     '''Returns a dictionary containing the main PCM computation parameters.
-    All physical parameters are expressed in atomic units (a.u.).
-    Please also note, that outlying charge correction is not implemented yet.
+    All physical parameters are expressed in atomic units (a.u.). The corrected
+    quantities carry the outlying charge correction, see
+    :func:`get_outlying_charge_correction`.
 
     Arguments:
         mf: processed SCF with PCM solvation
@@ -218,6 +296,12 @@ def get_pcm_parameters(mf, step=0.2):
     areas = mf.with_solvent.surface['area']
     potentials = mf.with_solvent._intermediates['v_grids']
 
+    # outlying charge correction
+    occ = get_outlying_charge_correction(mf)
+    charges_corr = occ['q']
+    E_diel_corr = occ['e_diel']
+    E_tot_corr = E_tot - E_diel + E_diel_corr
+
     # output
     params = {
         'pyscf_version': __version__,
@@ -230,14 +314,14 @@ def get_pcm_parameters(mf, step=0.2):
         },
         'screening_charge': {
             'cosmo': float(sum(charges)),
-            'correction': 0.0,
-            'total': float(sum(charges))
+            'correction': float(sum(charges_corr) - sum(charges)),
+            'total': float(sum(charges_corr))
         },
         'energies': {
             'e_tot': float(E_tot),
-            'e_tot_corr': float(E_tot), # TODO: implement OCC
+            'e_tot_corr': float(E_tot_corr),
             'e_diel': float(E_diel),
-            'e_diel_corr': float(E_diel) # TODO: implement OCC
+            'e_diel_corr': float(E_diel_corr)
         },
         'atoms': {
             'atom_index': atom_idxs,
@@ -254,10 +338,10 @@ def get_pcm_parameters(mf, step=0.2):
             'y': s_ys,
             'z': s_zs,
             'charge': charges.tolist(),
-            'charge_corr': charges.tolist(), # TODO: implement OCC
+            'charge_corr': charges_corr.tolist(),
             'area': areas.tolist(),
             'sigma': (charges / areas).tolist(),
-            'sigma_corr': (charges / areas).tolist(), # TODO: implement OCC
+            'sigma_corr': (charges_corr / areas).tolist(),
             'potential': potentials.tolist(),
         }
     }
@@ -267,8 +351,9 @@ def get_pcm_parameters(mf, step=0.2):
 
 
 def write_cosmo_file(fout, mf, step=0.2, volume=None):
-    '''Saves COSMO file in Turbomole format. Please note, that outlying charge
-    correction is not implemented yet
+    '''Saves COSMO file in Turbomole format. The corrected charges and energies
+    carry the outlying charge correction, see
+    :func:`get_outlying_charge_correction`.
 
     Arguments:
         fout: writable file object

--- a/pyscf/solvent/test/test_cosmors.py
+++ b/pyscf/solvent/test/test_cosmors.py
@@ -18,7 +18,8 @@
 
 import unittest
 import io, re
-from pyscf import gto, dft
+import numpy
+from pyscf import gto, scf, dft
 from pyscf.solvent import pcm, cosmors
 from pyscf.data.nist import BOHR as _BOHR
 
@@ -82,6 +83,70 @@ class TestCosmoRS(unittest.TestCase):
         self.assertAlmostEqual(ps['energies']['e_tot'], -112.953044138, 5)
         self.assertAlmostEqual(ps['energies']['e_diel'], -0.0023256022, 5)
         self.assertAlmostEqual(ps['pcm_data']['area'] * _BOHR**2, 64.848604, 2)
+
+    def test_occ_charge_split_is_exact(self):
+        # The COSMO equations are linear in the surface potential, so the
+        # nuclear and electronic charges must add back up to the full solution.
+        smod = mf0.with_solvent
+        K = smod._intermediates['K']
+        R = smod._intermediates['R']
+        v = smod._intermediates['v_grids']
+        v_nuc = smod.v_grids_n
+        q_nuc = numpy.linalg.solve(K, R.dot(v_nuc))
+        q_elec = numpy.linalg.solve(K, R.dot(v - v_nuc))
+        self.assertAlmostEqual(
+            abs(q_nuc + q_elec - smod._intermediates['q']).max(), 0, 10)
+
+    def test_occ_sum_rule(self):
+        # After the correction the total screening charge must equal the exact
+        # Gauss value -f_eps * Q, for neutral and charged solutes alike.
+        for charge, spin, atom in ((0, 0, 'O 0 0 0; H 0 -0.757 0.587; H 0 0.757 0.587'),
+                                   (-1, 0, 'O 0 0 0; H 0 0 0.97')):
+            m = gto.M(atom=atom, basis='6-31g', charge=charge, spin=spin,
+                      verbose=0, output='/dev/null')
+            cm = pcm.PCM(m)
+            cm.eps = float('inf')
+            cm.method = 'C-PCM'
+            cm.lebedev_order = 29
+            cm.verbose = 0
+            mf = scf.RHF(m).PCM(cm)
+            mf.kernel()
+            ps = cosmors.get_pcm_parameters(mf)
+            f_eps = ps['pcm_data']['f_eps']
+            self.assertAlmostEqual(ps['screening_charge']['total'],
+                                   -f_eps * charge, 9)
+            # the uncorrected sum misses it, so the test is not vacuous
+            self.assertTrue(abs(ps['screening_charge']['correction']) > 1e-4)
+            m.stdout.close()
+
+    def test_occ_values(self):
+        occ = cosmors.get_outlying_charge_correction(mf0)
+        self.assertAlmostEqual(occ['f_nuc'], 1.0016847551, 6)
+        self.assertAlmostEqual(occ['f_elec'], 1.0019332410, 6)
+        ps = cosmors.get_pcm_parameters(mf0)
+        self.assertAlmostEqual(ps['energies']['e_diel_corr'], -0.0023399469, 7)
+        self.assertAlmostEqual(ps['energies']['e_tot_corr'], -112.9530584825, 5)
+        # the correction shifts the segment charges without being a no-op
+        seg = ps['segments']
+        self.assertTrue(
+            abs(numpy.array(seg['charge_corr']) - numpy.array(seg['charge'])).max() > 1e-8)
+        self.assertAlmostEqual(
+            abs(numpy.array(seg['sigma_corr']) * numpy.array(seg['area'])
+                - numpy.array(seg['charge_corr'])).max(), 0, 12)
+
+    def test_occ_unsupported_model(self):
+        # Only C-PCM and COSMO have R proportional to the identity. The others
+        # must refuse rather than report a wrong correction.
+        for method in ('IEF-PCM', 'SS(V)PE'):
+            cm = pcm.PCM(mol)
+            cm.eps = float('inf')
+            cm.method = method
+            cm.lebedev_order = 29
+            cm.verbose = 0
+            mf = dft.RKS(mol, xc='b3lyp').PCM(cm)
+            mf.kernel()
+            self.assertRaises(NotImplementedError,
+                              cosmors.get_outlying_charge_correction, mf)
 
     def test_sas_volume(self):
         V1 = cosmors.get_sas_volume(mf0.with_solvent.surface, step = 0.2) * _BOHR**3


### PR DESCRIPTION
## The problem

Every corrected field in `cosmors.py` is currently a copy of the uncorrected value:

```
cosmors.py:238  'e_tot_corr':  float(E_tot),               # TODO: implement OCC
cosmors.py:240  'e_diel_corr': float(E_diel)               # TODO: implement OCC
cosmors.py:257  'charge_corr': charges.tolist(),           # TODO: implement OCC
cosmors.py:260  'sigma_corr':  (charges / areas).tolist(), # TODO: implement OCC
```

plus `screening_charge['correction']` hardcoded to `0.0`.

`write_cosmo_file` writes those into the `$screening_charge` and `$cosmo_energy` blocks and uses `charge_corr` for the per-segment charges. So a COSMO file produced by PySCF tells COSMOtherm, ORCA's reader, and anything else consuming the format that uncorrected charges have been corrected. The docstrings did note the correction was missing, but a file parser does not read docstrings. This is closer to a correctness bug than a missing feature, which is why I picked it up.

## The correction

Part of the solute electron density lies outside the cavity, so the screening charges fall short of the total surface charge Gauss's law requires. `get_outlying_charge_correction` restores the two sum rules

```
sum(q_nuc)  = -f_eps * Q_nuc
sum(q_elec) = -f_eps * Q_elec
```

by scaling the nuclear and electronic screening charges separately, then regenerating the surface potential from the corrected charges. Correcting the potential and not only the charges is what makes the corrected dielectric energy accurate; see Klamt and Jonas, J. Chem. Phys. 105, 9972 (1996), and the recent discussion in the NWChem COSMO paper (J. Chem. Theory Comput., 2026).

The COSMO equations are linear in the surface potential, so the split into nuclear and electronic charges is exact and comes straight from `v_grids` and `v_grids_n`.

I did not implement the Klamt-Jonas double-cavity variant. It projects only the contact spherical portions of the surface, leaves the reentrant portion uncorrected, and has been criticised for producing arbitrary changes in the multipole moments of the surface charge distribution. The scaling form is better defined and is what NWChem moved to.

## Scope

Restricted to C-PCM and COSMO. Their response matrix is a multiple of the identity, `R = -f_eps * I`, so the screening charges are a uniform `f_eps` scaling of the conductor charges and the sum rules above are the model's own. IEF-PCM and SS(V)PE raise `NotImplementedError` rather than report a wrong correction. That is not much of a restriction in practice: `write_cosmo_file` already requires `f_eps = 1`, and in that conductor limit IEF-PCM reduces to C-PCM exactly (verified numerically, the two agree to machine precision).

## It is not cosmetic

| system | sum(q) before | sum(q) after | exact | dE_diel |
| --- | --- | --- | --- | --- |
| H2O / 6-31G* | -0.002846 | 0.000000 | 0 | -0.030 kcal/mol |
| H2O / aug-cc-pVTZ | -0.009265 | 0.000000 | 0 | -0.042 kcal/mol |
| NH4+ / 6-31G* | -1.002679 | -1.000000 | -1 | +0.444 kcal/mol |
| OH- / aug-cc-pVDZ | +0.963934 | +1.000000 | +1 | **-6.425 kcal/mol** |

The anion in a diffuse basis is the case that matters: its density leaks badly, the uncorrected screening charge is off by 3.6%, and the dielectric energy moves by 6.4 kcal/mol. The correction also scales with basis diffuseness, as it should.

## Validation

* the nuclear/electronic charge split reproduces the full solution to 1e-15;
* the corrected total screening charge equals `-f_eps * Q` to 1e-15 for neutral, anionic and cationic solutes;
* the regenerated potential reproduces PySCF's own `e_solvent` **exactly** (difference 0.0) when the scaling factors are set to one, which confirms the energy expression is PySCF's own relation rather than a reimplementation;
* the scaling factors come out at 1.0013 (nuclear) and 1.0016 (electronic) for H2O/6-31G*. The nuclear factor is the pure cavity-discretisation deficit, since point nuclei are strictly inside the cavity; the extra amount on the electronic factor is the genuine outlying charge. Scaling them separately is what separates the two.

Four tests added to `test_cosmors.py`, which now runs 8 tests in under 4 seconds. The four existing tests assert only uncorrected quantities and are unaffected.

## Notes

* `cosmors.py` has CRLF line endings; the diff preserves them, so it stays at 95 insertions rather than a whole-file rewrite.
* The stale "not implemented yet" note in `examples/solvent/07-cosmors.py` is updated.
* This unblocks #2925 (sigma-profiles and sigma-potentials), where the profile is a histogram over `segments['sigma']` and now has corrected charges to work from.
* Lint is clean under all four checks the Lint workflow runs.
