### PR TITLE
fix two problems mentioned in pr #3393

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install and Test
         run: ./.github/workflows/run_ci.sh
       - name: Upload to codecov
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v7
         with:
           token: ${{secrets.CODECOV_TOKEN}}

--- a/pyscf/hessian/test/test_vv10_hessian.py
+++ b/pyscf/hessian/test/test_vv10_hessian.py
@@ -38,7 +38,7 @@ def setUpModule():
     '''
     basis = 'def2-svp'
 
-    mol = pyscf.M(atom=atom, basis=basis, max_memory=32000,
+    mol = pyscf.M(atom=atom, basis=basis, max_memory=4000,
                   output='/dev/null', verbose=1)
 
 def tearDownModule():

--- a/pyscf/tdscf/test/test_tdrks_vv10.py
+++ b/pyscf/tdscf/test/test_tdrks_vv10.py
@@ -28,10 +28,10 @@ def setUpModule():
     '''
     basis = 'def2-svp'
 
-    mol = pyscf.M(atom=atom, basis=basis, max_memory=32000,
+    mol = pyscf.M(atom=atom, basis=basis, max_memory=4000,
                   output='/dev/null', verbose=1)
 
-    unrestricted_mol = pyscf.M(atom=atom, charge=1, spin=1, basis=basis, max_memory=32000,
+    unrestricted_mol = pyscf.M(atom=atom, charge=1, spin=1, basis=basis, max_memory=4000,
                                output='/dev/null', verbose=1)
 
     excitation_energy_threshold = 1e-6


### PR DESCRIPTION
fix two problem mentioned in pr #3393:
1. Coverage is generated on the job that does not upload it. run_tests.sh produces coverage.xml when the version is not 3.12, which is the 3.8 job, while ci.yml uploads to codecov when the version is 3.12. 

2. Three tests declare max_memory=32000, at tdscf/test/test_tdrks_vv10.py:31,34 and hessian/test/test_vv10_hessian.py:41, on a runner with 16 GB. 