### PR TITLE
Publish Windows wheels to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -182,3 +182,93 @@ jobs:
           #cache-to: type=local,dest=/tmp/.buildx-cache
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+
+  # Windows wheel publishing (follow-up to #3328). A single py3-none-win_amd64
+  # wheel is built once, smoke-installed on several Python versions, then
+  # uploaded. There is no per-version build matrix: the C libraries are loaded
+  # via ctypes, so one wheel serves every Python 3.x.
+  release-pypi-windows-build:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Set up MSYS2 UCRT64
+        id: msys2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-openblas
+      - name: Install build dependencies
+        run: python -m pip install build wheel setuptools "cmake<4" ninja
+      - name: Build wheel
+        run: >-
+          ./.github/workflows/ci_windows/build_wheel.ps1
+          -RuntimeDllDir "${{ steps.msys2.outputs.msys2-location }}\ucrt64\bin"
+      - name: List built wheel
+        run: Get-ChildItem dist
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: windows-wheel
+          if-no-files-found: error
+          path: dist/*.whl
+
+  release-pypi-windows-smoke:
+    needs: release-pypi-windows-build
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.11", "3.13"]
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: windows-wheel
+          path: dist
+      - name: Install the built wheel
+        run: |
+          $wheel = (Get-ChildItem dist/*.whl)[0].FullName
+          python -m pip install --upgrade pip
+          python -m pip install "$wheel"
+      - name: Import and run a minimal RHF
+        run: >-
+          python -c "import pyscf; m = pyscf.M(atom='H 0 0 0; H 0 0 0.74', basis='sto-3g'); mf = m.RHF().run(); assert mf.converged and mf.e_tot < 0; print('smoke OK', pyscf.__version__, mf.e_tot)"
+
+  release-pypi-windows:
+    needs: release-pypi-windows-smoke
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: windows-wheel
+          path: dist
+      - name: Publish to PyPI
+        run: |
+          python -m pip install twine==6.0.1
+          $env:TWINE_USERNAME = "__token__"
+          $env:TWINE_PASSWORD = "${{ secrets.PYPI_API_TOKEN }}"
+          twine upload --verbose dist/*.whl


### PR DESCRIPTION
Follows #3328 and the discussion in #3411. Adds three jobs to `publish.yml` so a Windows wheel ships with each PyPI release.

How it works:

- `release-pypi-windows-build` builds one wheel with the `ci_windows` tooling from #3328 (MSYS2 UCRT64 + `build_wheel.ps1`, which vendors the dependency DLLs into the wheel) and uploads it as an artifact.
- `release-pypi-windows-smoke` installs that same wheel on Python 3.8, 3.11, and 3.13 and runs a minimal RHF. This is the gate before upload.
- `release-pypi-windows` uploads the wheel to PyPI.

The wheel is tagged `py3-none-win_amd64`, so one build covers every Python 3.x; the smoke matrix only reinstalls the same file. There is no per-version compilation.

Notes:

- The wheel is about 91 MB (bundled MinGW runtime, OpenBLAS, libcint/libxc/xcfun).
- Smoke versions are 3.8/3.11/3.13 (floor, middle, current) and are easy to widen or narrow.
- Marked draft until the questions in #3411 are settled (Python floor, and whether to keep the `build_wheel.ps1` path or move to cibuildwheel).
