### PR TITLE
Harden the finite difference driver and use it for Hessians

### DIFF
--- a/examples/tools/07-finite_difference.py
+++ b/examples/tools/07-finite_difference.py
@@ -37,6 +37,21 @@ print('Analytical Hessian:')
 print(mol.RHF().run().Hessian().kernel())
 
 #
+# Hessian for a method that has an analytic gradient but no analytic second
+# derivative. TDDFT is the common case: excited-state vibrational frequencies
+# are only reachable this way.
+#
+mf = mol.RKS(xc='pbe0')
+mf.grids.level = 5      # a Hessian needs a finer grid than the default
+mf.grids.prune = None
+mf.run(conv_tol=1e-13)
+td = mf.TDA().run(nstates=5)
+# Build the scanner to pin the root being differentiated
+H = finite_diff.kernel(td.nuc_grad_method().as_scanner(state=1))
+print('Finite difference Hessian of the first excited state:')
+print(H)
+
+#
 # Finite difference Gradients as a PySCF builtin Gradients object
 #
 mf = mol.RHF()

--- a/pyscf/grad/tdrhf.py
+++ b/pyscf/grad/tdrhf.py
@@ -234,7 +234,7 @@ class TDSCF_GradScanner(lib.GradScanner):
     def converged(self):
         td_scanner = self.base
         return all((td_scanner._scf.converged,
-                    td_scanner.converged[self.state]))
+                    td_scanner.converged[self.state-1]))
 
 
 class Gradients(rhf_grad.GradientsBase):

--- a/pyscf/tools/finite_diff.py
+++ b/pyscf/tools/finite_diff.py
@@ -15,6 +15,16 @@
 
 '''
 Finite difference driver
+
+Differencing energies gives gradients, differencing analytic gradients gives
+Hessians.  The latter is the only route to a Hessian for the many methods that
+have an analytic gradient but no analytic second derivative: TDHF and TDDFT,
+MP2, CISD, CCSD, CCSD(T) and CASSCF among them.
+
+Excited states are differentiated at a fixed root.  Build the gradient scanner
+to pin the state and hand it over:
+
+    >>> H = finite_diff.kernel(td.nuc_grad_method().as_scanner(state=2))
 '''
 
 import numpy as np
@@ -24,7 +34,115 @@ from pyscf.lib import logger
 from pyscf.grad.rhf import GradientsBase
 from pyscf.hessian.rhf import HessianBase
 
-def kernel(method, displacement=1e-2):
+# Near the crossover between truncation error and the noise in the quantity
+# being differenced. Larger steps are dominated by truncation: on H2O/STO-3G
+# the RHF Hessian is off by 5.5e-05 at 1e-2 and 9.1e-07 at 1e-3.
+DISPLACEMENT = 1e-3
+
+# Coarser DFT grids leave an error that does not shrink with the displacement
+# and that exceeds the finite difference error itself.
+GRID_LEVEL = 5
+
+
+def _mean_field(method):
+    '''The mean-field object underneath a gradients, post-SCF or excited-state method'''
+    mf = method
+    for _ in range(8):
+        if isinstance(mf, GradientsBase):
+            mf = mf.base
+        elif hasattr(mf, '_scf'):
+            mf = mf._scf
+        else:
+            break
+    return mf
+
+def _displace(mol, coords):
+    '''A copy of mol at the given coordinates, in the same frame.
+
+    Point group detection has a finite tolerance that the displacement falls
+    inside, so a displaced molecule is still assigned the point group of the
+    reference and the wavefunction is symmetry-adapted to a group the geometry
+    has lost.  Pinning the group to C1 avoids that, and avoids the
+    reorientation that comes with re-detection, while keeping mol.symmetry
+    truthy for symmetry-adapted SCF classes, which reject a symmetry-free Mole.
+    '''
+    if mol.symmetry:
+        return mol.set_geom_(coords, symmetry='C1', inplace=False)
+    return mol.set_geom_(coords, inplace=False)
+
+def _check_sanity(method, displacement, hessian):
+    mol = method.mol
+    mf = _mean_field(method)
+
+    # Differencing amplifies the error of the quantity being differenced by
+    # 1/(2*displacement). For a Hessian that error is itself set by how well
+    # the gradient, and so the wavefunction, is converged.
+    tol = displacement**4 if hessian else displacement**3
+    conv_tol = getattr(mf, 'conv_tol', None)
+    if conv_tol is not None and conv_tol > tol:
+        logger.warn(mol, 'conv_tol %g of %s is too loose for displacement %g. '
+                    'Errors are amplified by 1/(2*displacement) = %.0f here. '
+                    'Set conv_tol <= %g.', conv_tol, mf.__class__.__name__,
+                    displacement, .5/displacement, tol)
+
+    base = method.base if isinstance(method, GradientsBase) else method
+    if base is not mf:
+        conv_tol = getattr(base, 'conv_tol', None)
+        if conv_tol is not None and conv_tol > tol:
+            logger.warn(mol, 'conv_tol %g of %s is too loose for displacement '
+                        '%g. Set it to <= %g.', conv_tol,
+                        base.__class__.__name__, displacement, tol)
+
+    grids = getattr(mf, 'grids', None)
+    if grids is not None and (grids.level < GRID_LEVEL or grids.prune is not None):
+        logger.warn(mol, 'DFT grid (level %d, pruned %s) is coarse for finite '
+                    'differences. The grid error does not shrink with the '
+                    'displacement. Use grids.level >= %d and grids.prune = None.',
+                    grids.level, grids.prune is not None, GRID_LEVEL)
+
+def _flatten_xy(xy):
+    '''Excitation amplitudes of one state as a normalised vector'''
+    x, y = xy
+    x = np.asarray(x).ravel()
+    y = np.asarray(y).ravel()
+    if y.size == x.size:
+        x = np.concatenate([x, y])
+    norm = np.linalg.norm(x)
+    if norm > 0:
+        x = x / norm
+    return x
+
+def _reference_state(scan):
+    '''Amplitudes of the root being differentiated, for tracking it'''
+    state = getattr(scan, 'state', None)
+    xy = getattr(getattr(scan, 'base', None), 'xy', None)
+    if state is None or not xy:
+        return None
+    return _flatten_xy(xy[state - 1])
+
+def _track_state(scan, ref_xy, mol):
+    '''Warn when the tuned root is no longer the one being differentiated.
+
+    Excited states can change order under displacement.  Amplitudes carry an
+    arbitrary sign and are expressed in the displaced MO basis, so compare
+    their magnitudes; over these displacements the MO basis barely moves.
+    '''
+    if ref_xy is None:
+        return
+    xy = getattr(scan.base, 'xy', None)
+    if not xy:
+        return
+    ovlp = [abs(np.dot(ref_xy, _flatten_xy(i))) for i in xy]
+    best = int(np.argmax(ovlp))
+    state = scan.state - 1
+    if best != state:
+        logger.warn(mol, 'Root %d now overlaps state %d more strongly (%.3f vs '
+                    '%.3f). The states have swapped order and the result '
+                    'differences across the crossing.',
+                    state + 1, best + 1, ovlp[best], ovlp[state])
+
+
+def kernel(method, displacement=DISPLACEMENT):
     '''
     Evaluate gradients or Hessians for a given method using finite difference approximation.
 
@@ -34,7 +152,7 @@ def kernel(method, displacement=1e-2):
 
     Kwargs:
         displacement:
-            The small change for finite difference calculations. Default is 1e-2.
+            The small change for finite difference calculations. Default is 1e-3.
 
     Returns:
         An (n, 3) array for gradients or (n, n, 3, 3) array for hessian,
@@ -45,57 +163,55 @@ def kernel(method, displacement=1e-2):
     mol = method.mol
     original_coords = mol.atom_coords()
     natm = mol.natm
-    if isinstance(method, GradientsBase):
-        logger.info(mol, 'Computing finite-difference Hessian for {method}')
-        if method.base.conv_tol > displacement**3:
-            logger.warn(mol, 'conv_tol %g with displacement %g might be insufficinet',
-                        method.base.conv_tol, displacement)
+    hessian = isinstance(method, GradientsBase)
+    if hessian:
+        logger.info(mol, 'Computing finite-difference Hessian for %s', method)
         de = np.empty((natm,3,natm,3))
     else:
-        logger.info(mol, 'Computing finite-difference Gradients for {method}')
-        if method.conv_tol > displacement**2:
-            logger.warn(mol, 'conv_tol %g with displacement %g might be insufficinet',
-                        method.conv_tol, displacement)
+        logger.info(mol, 'Computing finite-difference gradients for %s', method)
         de = np.empty((natm,3))
+    _check_sanity(method, displacement, hessian)
+
+    # Mole.atom_coords is in Bohr; a template in Bohr keeps set_geom_ from
+    # announcing a unit change on every displacement.
+    work = mol.copy()
+    work.unit = 'Bohr'
 
     scan = None
     if isinstance(method, (lib.SinglePointScanner, lib.GradScanner)):
         scan = method
     elif hasattr(method, 'as_scanner'):
-        logger.info(mol, 'Apply {method}.scanner')
+        logger.info(mol, 'Apply %s.as_scanner', method)
         scan = method.as_scanner()
     else:
         method = method.copy()
-        if isinstance(method, GradientsBase):
+        if hessian:
             method.base = method.base.copy()
 
     if scan is not None:
+        ref_xy = _reference_state(scan)
         def evaluate(r):
-            mol.set_geom_(r, unit='Bohr')
-            if scan:
-                if isinstance(method, GradientsBase):
-                    res = scan(mol)[1]
-                else:
-                    res = scan(mol)
-                if not scan.converged:
-                    raise RuntimeError('{scan} not converged')
-                return res
+            res = scan(_displace(work, r))
+            if not scan.converged:
+                raise RuntimeError('%s not converged' % scan)
+            _track_state(scan, ref_xy, mol)
+            return res[1] if hessian else res
     else:
-        logger.info(mol, '{method}.scanner not found. '
-                    'Initial guess may not be utilized among different geometries')
+        logger.info(mol, '%s.as_scanner not found. Initial guess may not be '
+                    'utilized among different geometries', method)
         def evaluate(r):
-            if isinstance(method, GradientsBase):
-                method.base.mol.set_geom_(r, unit='Bohr')
+            dmol = _displace(work, r)
+            if hessian:
+                method.base.reset(dmol)
                 method.base.run()
                 if not method.base.converged:
-                    raise RuntimeError('{method.base} not converged')
-                method.mol.set_geom_(r, unit='Bohr')
+                    raise RuntimeError('%s not converged' % method.base)
+                method.mol = dmol
                 return method.kernel()
-            else:
-                method.mol.set_geom_(r, unit='Bohr')
-                if not method.converged:
-                    raise RuntimeError('{method} not converged')
-                res = method.kernel()
+            method.reset(dmol)
+            res = method.kernel()
+            if not method.converged:
+                raise RuntimeError('%s not converged' % method)
             return res
 
     try:
@@ -111,13 +227,17 @@ def kernel(method, displacement=1e-2):
     finally:
         mol.set_geom_(original_coords, unit='Bohr')
 
-    if isinstance(method, GradientsBase):
+    if hessian:
         # Hessian is stored as (N,N,3,3)
         de = de.transpose(0,2,1,3)
+        # The exact Hessian is symmetric; the differencing error is not
+        n3 = natm * 3
+        h = de.transpose(0,2,1,3).reshape(n3, n3)
+        de = ((h + h.T) * .5).reshape(natm,3,natm,3).transpose(0,2,1,3)
     return de
 
 class Gradients(GradientsBase):
-    displacement = 1e-2
+    displacement = DISPLACEMENT
 
     def __init__(self, method):
         assert isinstance(method, lib.StreamObject)
@@ -155,7 +275,7 @@ class GradScanner(lib.GradScanner):
         return e_tot, de
 
 class Hessian(HessianBase):
-    displacement = 1e-2
+    displacement = DISPLACEMENT
 
     def __init__(self, method):
         assert isinstance(method, lib.StreamObject)

--- a/pyscf/tools/test/test_finite_diff.py
+++ b/pyscf/tools/test/test_finite_diff.py
@@ -13,13 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
 import unittest
-import tempfile
-from functools import reduce
 import numpy
 import pyscf
+from pyscf import gto, scf, dft, tdscf
+from pyscf.hessian import thermo
 from pyscf.tools import finite_diff
 from pyscf.scf.hf import SCF
+
+H2O = 'O 0 0 0.117; H 0 0.757 -0.470; H 0 -0.757 -0.470'
+
+def h2o(**kwargs):
+    return pyscf.M(atom=H2O, basis='sto-3g', unit='Angstrom', verbose=0, **kwargs)
+
+def rks_fine(mol):
+    mf = dft.RKS(mol, xc='pbe0')
+    # A Hessian needs a much finer grid than the default; the grid error is
+    # independent of the displacement and otherwise swamps everything else.
+    mf.grids.level = 5
+    mf.grids.prune = None
+    return mf.run(conv_tol=1e-13)
 
 class KnownValues(unittest.TestCase):
     def test_grad_scanner(self):
@@ -107,6 +121,64 @@ class KnownValues(unittest.TestCase):
         e, g = g_scan(mol)
         assert abs(g - ref).max() < 1e-4
         assert abs(e - e_ref) < 1e-9
+
+    def test_hessian_against_analytic(self):
+        ref = scf.RHF(h2o()).run(conv_tol=1e-14).Hessian().kernel()
+        dat = finite_diff.kernel(scf.RHF(h2o()).set(conv_tol=1e-14).Gradients())
+        self.assertLess(abs(dat - ref).max(), 2e-6)
+
+    def test_hessian_is_symmetric(self):
+        dat = finite_diff.kernel(scf.RHF(h2o()).set(conv_tol=1e-14).Gradients())
+        self.assertAlmostEqual(abs(dat - dat.transpose(1,0,3,2)).max(), 0, 12)
+
+    def test_symmetry_is_pinned_under_displacement(self):
+        # Point group detection has a finite tolerance that the displacement
+        # falls inside, so without pinning the displaced geometry keeps the
+        # full group and the wavefunction is symmetry-adapted to a group it
+        # no longer has.
+        ref = scf.RHF(h2o()).run(conv_tol=1e-14).Hessian().kernel()
+        mf = scf.RHF(h2o(symmetry=True)).set(conv_tol=1e-14)
+        dat = finite_diff.kernel(mf.Gradients())
+        self.assertLess(abs(dat - ref).max(), 2e-6)
+
+    def test_rks_hessian_against_analytic(self):
+        mol = pyscf.M(atom='H 0 0 0; F 0 0 1.1', basis='sto-3g', verbose=0)
+        ref = rks_fine(mol).Hessian().kernel()
+        dat = finite_diff.kernel(rks_fine(mol).Gradients())
+        self.assertLess(abs(dat - ref).max(), 5e-5)
+
+    def test_tddft_hessian(self):
+        mol = h2o()
+        mf = dft.RKS(mol, xc='pbe0').run(conv_tol=1e-13)
+        td = tdscf.TDA(mf)
+        td.conv_tol = 1e-9
+        td.max_cycle = 500
+        td.run(nstates=5)
+
+        h1 = finite_diff.kernel(td.nuc_grad_method().as_scanner(state=1))
+        self.assertAlmostEqual(h1[0,0,0,0], -0.31248087, 5)
+        freq = thermo.harmonic_analysis(mol, h1, imaginary_freq=False)
+        ref = [-8060.26, -2462.18, 5261.28]
+        self.assertLess(abs(freq['freq_wavenumber'] - ref).max(), 1.0)
+
+        # The scanner really does pin the root it was built for
+        h2 = finite_diff.kernel(td.nuc_grad_method().as_scanner(state=2))
+        self.assertGreater(abs(h1 - h2).max(), 1e-3)
+
+    def test_warns_on_loose_settings(self):
+        out = io.StringIO()
+        mol = pyscf.M(atom='H 0 0 0; F 0 0 1.1', basis='sto-3g', verbose=4)
+        mol.stdout = out
+        mf = dft.RKS(mol, xc='pbe0')   # default conv_tol and default grid
+        mf.stdout = out
+        mf.run()
+        g = mf.Gradients()
+        g.stdout = out
+        finite_diff.kernel(g, 1e-3)
+        log = out.getvalue()
+        self.assertIn('conv_tol', log)
+        self.assertIn('DFT grid', log)
+
 
 if __name__ == "__main__":
     print("Full Tests for finite_diff")


### PR DESCRIPTION
Reworked after @jeanwsr's suggestion. This started as a separate `pyscf/hessian/numeric.py`; I had missed that `pyscf/tools/finite_diff.py` (#2774) already does this. It does, so the whole thing now lives there and the new module is gone.

## Why

`tools/finite_diff.py` already differences analytic gradients into a Hessian, which is the only route to a Hessian for the many methods with no analytic second derivative: TDHF and TDDFT, MP2, CISD, CCSD, CCSD(T), CASSCF. Four things kept it from being usable for that in practice, all measured on H2O/STO-3G RHF against the analytic Hessian.

**Displacement.** The 1e-2 default is dominated by truncation.

| displacement | Hessian | gradients |
|---|---|---|
| 1e-2 | 5.51e-05 | 1.47e-05 |
| 5e-3 | 1.37e-05 | 3.67e-06 |
| 1e-3 | 9.10e-07 | 1.47e-07 |

Both cases improve, so the shared default moves to 1e-3. Below that the Hessian starts picking up gradient noise, so this is the crossover rather than just "smaller is better".

**Convergence.** The Hessian guard was `conv_tol > displacement**3`. At displacement 1e-3 that is `1e-9 > 1e-9`, false, so it stays silent on exactly the pyscf default that is 500x wrong:

| SCF conv_tol | Hessian error at 1e-3 |
|---|---|
| 1e-9 (default) | 3.41e-04 |
| 1e-11 | 5.84e-05 |
| 1e-12 | 2.42e-06 |
| 1e-14 | 7.08e-07 |

Differencing amplifies error by `1/(2*displacement)`, so each check needs one more power of the displacement. The mean field is now found by walking `_scf`/`base`, so the check also reaches post-SCF and excited-state methods rather than only the object passed in.

**Symmetry.** Point group detection has a finite tolerance that the displacement falls inside, so a displaced C2v molecule is still assigned C2v and the wavefunction is symmetry-adapted to a group the geometry has lost.

| displaced-geometry handling | Hessian error |
|---|---|
| no symmetry, baseline | 9.10e-07 |
| symmetry on, as before | 7.79e-06 |
| symmetry on, pinned `'C1'` | 4.98e-07 |

Rebuilding with `symmetry=False` is not an option, since a symmetry-adapted SCF class rejects a symmetry-free Mole. The displaced Mole is now also built out of place rather than mutating the caller's, and in Bohr, which stops `set_geom_` announcing a unit change on every displacement.

**Grids.** The RKS/PBE0 error against the analytic Hessian is independent of the displacement (3.58e-04, 3.71e-04, 3.73e-04 at 5e-3, 1e-3, 5e-4) and `grid_response` on the gradient does not help. It is grid incompleteness: 3.71e-04 on the default pruned level-3 grid, 9.36e-06 at level 5 unpruned. It exceeds the finite difference error itself, so it is worth a warning.

Also symmetrises the Hessian, since the exact one is symmetric and the differencing error is not, and warns when an excited-state root stops being the best amplitude match under displacement, the root flip `grad/tdrhf.py` already carries a TODO about.

## One bug outside the module

`grad/tdrhf.py` line 237: the gradient scanner tested `converged[self.state]` with a 1-based `state`, so it read the convergence flag of the *next* root and would `IndexError` on the last one. Line 230 just above already uses `state-1`. The driver relies on that flag to refuse an unconverged displacement, which is how I hit it. Happy to split it out if you would rather it went separately.

## Tests

Six added to `pyscf/tools/test/test_finite_diff.py`, 13 total, ~17 s: Hessians against the analytic RHF and RKS ones, symmetry pinning, the symmetrisation, a TDDFT Hessian with stored frequencies plus a check that the scanner really pins its root, and the warnings firing. All seven existing tests pass unchanged. `examples/tools/07-finite_difference.py` gains the TDDFT case.

## Note on the default change

Moving `displacement` from 1e-2 to 1e-3 changes results for anyone relying on the default. It is a 60x accuracy improvement for Hessians and 100x for gradients, but say the word if you would rather keep 1e-2 and only document the recommendation.