### PR TITLE
Use libwignernj for Clebsch-Gordan coefficients and the real Y_lm basis

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   'numpy>=1.13,!=1.16,!=1.17',
   'scipy>=1.6.0',
   'h5py>=2.7',
+  'wignernj>=0.7',
   'setuptools',
   "psutil; sys_platform == 'win32'"
 ]

--- a/pyscf/symm/cg.py
+++ b/pyscf/symm/cg.py
@@ -13,24 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy
+from fractions import Fraction
+
+import wignernj
 
 def cg_spin(l, jdouble, mjdouble, spin):
-    '''Clebsch Gordon coefficient of <l,m,1/2,spin|j,mj>'''
-    ll1 = 2 * l + 1
-    if jdouble == 2*l+1:
-        if spin > 0:
-            c = numpy.sqrt(.5*(ll1+mjdouble)/ll1)
-        else:
-            c = numpy.sqrt(.5*(ll1-mjdouble)/ll1)
-    elif jdouble == 2*l-1:
-        if spin > 0:
-            c =-numpy.sqrt(.5*(ll1-mjdouble)/ll1)
-        else:
-            c = numpy.sqrt(.5*(ll1+mjdouble)/ll1)
-    else:
-        c = 0
-    return c
+    '''Clebsch Gordon coefficient of <l,m,1/2,spin|j,mj>
+
+    The angular momenta j and mj are given as twice their value, so that
+    half-integers are represented exactly; spin is +1 for alpha and -1 for
+    beta, i.e. twice the value of ms.  m is fixed by mj = m + ms.
+
+    Evaluated exactly with libwignernj (S. Lehtola, Comput. Phys. Commun.
+    329, 110342 (2026), doi:10.1016/j.cpc.2026.110342).
+    '''
+    return wignernj.clebsch_gordan(Fraction(l), Fraction(mjdouble - spin, 2),
+                                   Fraction(1, 2), Fraction(spin, 2),
+                                   Fraction(jdouble, 2), Fraction(mjdouble, 2))
 
 
 if __name__ == '__main__':

--- a/pyscf/symm/sph.py
+++ b/pyscf/symm/sph.py
@@ -19,6 +19,7 @@ Spherical harmonics
 
 import numpy
 import scipy.linalg
+import wignernj
 from pyscf.symm.cg import cg_spin
 
 def real_sph_vec(r, lmax, reorder_p=False):
@@ -115,37 +116,22 @@ def sph_pure2real(l, reorder_p=True):
     O(-1) = i/\sqrt(2){Y(-1) + Y(1)};   O(1) = 1/\sqrt(2){Y(-1) - Y(1)}
     O(-2) = i/\sqrt(2){Y(-2) - Y(2)};   O(2) = 1/\sqrt(2){Y(-2) + Y(2)}
 
+    The transformation is obtained from libwignernj (S. Lehtola, Comput. Phys.
+    Commun. 329, 110342 (2026), doi:10.1016/j.cpc.2026.110342), which returns
+    the basis-vector matrix C of O_m = \sum_m' C(m,m') Y_m'; U is its
+    transpose.  Both use the Condon-Shortley phase convention.
+
     Kwargs:
         reorder_p (bool): Whether the p functions are in the (x,y,z) order.
 
     Returns:
         2D array U_{complex,real}
     '''
-    n = 2 * l + 1
-    u = numpy.zeros((n,n), dtype=complex)
-    sqrthfr = numpy.sqrt(.5)
-    sqrthfi = numpy.sqrt(.5)*1j
-
+    c = numpy.array(wignernj.real_ylm_in_complex_ylm(l), dtype=numpy.complex128)
     if reorder_p and l == 1:
-        u[1,2] = 1
-        u[0,1] =  sqrthfi
-        u[2,1] =  sqrthfi
-        u[0,0] =  sqrthfr
-        u[2,0] = -sqrthfr
-    else:
-        u[l,l] = 1
-        for m in range(1, l+1, 2):
-            u[l-m,l-m] =  sqrthfi
-            u[l+m,l-m] =  sqrthfi
-            u[l-m,l+m] =  sqrthfr
-            u[l+m,l+m] = -sqrthfr
-        for m in range(2, l+1, 2):
-            u[l-m,l-m] =  sqrthfi
-            u[l+m,l-m] = -sqrthfi
-            u[l-m,l+m] =  sqrthfr
-            u[l+m,l+m] =  sqrthfr
-
-    return u
+        # (y,z,x) -> (x,y,z)
+        c = c[[2,0,1]]
+    return c.T
 
 def sph_real2pure(l, reorder_p=True):
     '''


### PR DESCRIPTION
This PR replaces hardcoded angular-momentum algebra in PySCF with efficient numerically exact versions from libwignernj, which is a pure C library with a native Python interface and which is pip installable.

## AI summary
`pyscf.symm` contains two hand-coded pieces of angular momentum algebra that can be replaced by an exact library implementation.

### `cg.cg_spin`

Evaluated `<l,m,1/2,s|j,mj>` from a closed form specialised to `j = l ± 1/2`, and silently returned 0 for any other `j`. It now calls `wignernj.clebsch_gordan`, with the angular momenta passed as `Fraction` so the half-integers are represented exactly. Coefficients outside the old special case are now evaluated correctly instead of as zero.

### `sph.sph_pure2real`

Built the complex-to-real spherical harmonic unitary from two hardcoded m-parity branches plus a special-cased `l = 1`. It now transposes `wignernj.real_ylm_in_complex_ylm`, which uses the same Condon–Shortley convention; only the `l = 1` `(y,z,x) -> (x,y,z)` reordering for `reorder_p` remains. `sph_real2pure` is unchanged, being the conjugate transpose.

### Numerical equivalence

Both replacements reproduce the previous results bit for bit. Loading the old and new code side by side in a single process:

```
cg_spin           max|old-new| = 0.000e+00   (l = 0..11, all j and mj)
sph_pure2real     max|old-new| = 0.000e+00   (l = 0..8, both reorder_p)
sph_real2pure     max|old-new| = 0.000e+00
sph2spinor        max|old-new| = 0.000e+00
```

Shapes and dtypes are preserved.

### Tests

| suite | result |
|---|---|
| `pyscf/symm/test` | 85 passed |
| `pyscf/scf/test/test_dhf.py`, `pyscf/x2c/test`, `pyscf/pbc/symm/test` | 59 passed |
| `pyscf/gto/test/test_mole.py`, `pyscf/symm/test/test_sph.py` | 58 passed |
| `pyscf/scf/test/test_addons.py`, `pyscf/ao2mo/test` | 44 passed |

### Dependency

`wignernj` is added to the runtime dependencies. It is on PyPI with wheels for Linux (x86_64/aarch64), macOS (arm64) and Windows (x86_64), with an sdist fallback; the compiled core is C99 with no dependencies of its own. Happy to make it an optional import with the old code retained as a fallback instead, if a new hard dependency is unwelcome — that just means keeping the code this PR removes.

libwignernj evaluates these coefficients in exact integer arithmetic via prime factorisation of the factorials, converting to floating point only at the final step: S. Lehtola, *Comput. Phys. Commun.* **329**, 110342 (2026), [doi:10.1016/j.cpc.2026.110342](https://doi.org/10.1016/j.cpc.2026.110342).

### Not included

Two other sites turned up in the same sweep and are deliberately left alone:

- `symm.Dmatrix.dmatrix` builds the Wigner small-d matrix from the Wigner formula with floating-point factorials, and loses accuracy with `l` (`max|d dᵀ − I|` grows from 4e-16 at `l=2` to 2.9e-11 at `l=24`). This is *not* a case for libwignernj: diagonalising `J_y` and exponentiating the eigenvalues is stable at ~3e-15 out to `l=512` in plain float64, needing neither exact factorials nor extended precision. Worth fixing, but separately and by that route.
- The ECP angular integrals in `pyscf/lib/gto/nr_ecp.c` (`int_unit_xyz`, `ang_nuc_in_cart`, `type2_facs_ang`, `type1_static_facs`) are real Gaunt coefficients in a Cartesian-monomial encoding, fused into the radial/angular factorisation and sitting in a hot loop. Substituting `gaunt_real` there is a rewrite rather than a replacement; the cheap win would be using it as an independent oracle in the ECP tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UqYTmsopK5a6cfuohsBwoT
