### PR TITLE
Add opt-in agent recipes

### DIFF
--- a/agent-recipes/README.md
+++ b/agent-recipes/README.md
@@ -1,0 +1,4 @@
+# Agent Recipes
+
+Opt-in templates and guidance for PySCF development activities.
+

--- a/agent-recipes/agents/AGENTS.md
+++ b/agent-recipes/agents/AGENTS.md
@@ -24,7 +24,6 @@ Reusable guidance for PySCF development. Paths below are relative to the reposit
 - Set `PYSCF_TMPDIR` or `TMPDIR` to a writable scratch directory.
 - `uv` is supported for developing PySCF alone. Prefer `virtualenv` when also developing namespace packages such as PySCF extensions or `pyscf-forge`; that combination has not been tested with `uv`.
 - To develop or debug C extensions, configure a native build with `cmake -S pyscf/lib -B pyscf/lib/build`, then compile with `cmake --build pyscf/lib/build`. Reuse an existing configured build and its dependency options where possible.
-- Do not create pull requests against the upstream repository unless explicitly asked.
 
 ## Code Style
 
@@ -39,6 +38,15 @@ Reusable guidance for PySCF development. Paths below are relative to the reposit
 * Prefer lightweight, deterministic tests, with minimal mocking.
 - Run the smallest relevant test selection. Documentation-only changes do not require numerical tests.
 - Investigate failures near numerical tolerances. Do not substantially relax tolerances or replace reference values merely to make tests pass.
+
+## AI Disclosure
+
+- When preparing a pull request or issue with AI assistance, include a `Notes`
+  section briefly describing how AI was used. Mention the AI tool or agent and
+  the nature of its assistance, such as code generation, testing, debugging, or
+  drafting.
+- Do not create pull requests against the upstream repository unless explicitly
+  asked.
 
 ## Skills
 

--- a/agent-recipes/agents/AGENTS.md
+++ b/agent-recipes/agents/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+Reusable guidance for PySCF development. Paths below are relative to the repository root.
+
+## Repository
+
+- PySCF is primarily written in Python, with C extensions for computational hotspots.
+- Codebase layout:
+  - `pyscf/lib/`: shared utilities and compiled C extensions. The CMake entry point is `pyscf/lib/CMakeLists.txt`.
+  - `pyscf/data/`: common data and physical constants.
+  - `pyscf/__config__.py`: global configuration defaults.
+  - `pyscf/pbc/`: periodic implementations.
+  - Other method packages under `pyscf/`: molecular implementations.
+- Tests generally live in `pyscf/<module>/test/`, including nested packages.
+- Runnable examples live in `examples/`, grouped by package.
+- Documentation is maintained separately at https://github.com/pyscf/github.pyscf.io. The local `doc/` directory is legacy and can be ignored unless the task explicitly concerns it.
+- Consult `pyproject.toml` for supported Python versions and dependencies, `pytest.ini` for test selection, and `.github/workflows/` for CI behavior.
+- Do not add mandatory dependencies to the core package. Declare optional dependencies in `pyproject.toml` and import them only in modules that need them.
+
+## Development Environment
+
+- Develop with any supported Python version, but keep syntax and standard-library usage compatible with the minimum version in `pyproject.toml`.
+- Prefer serial BLAS libraries: BLAS functions may be called from within OpenMP threads. When using multithreaded OpenBLAS or MKL, configure their thread counts to one, for example with `OPENBLAS_NUM_THREADS=1` or `MKL_NUM_THREADS=1`. Avoid nested multithreading.
+- Set `PYSCF_TMPDIR` or `TMPDIR` to a writable scratch directory.
+- `uv` is supported for developing PySCF alone. Prefer `virtualenv` when also developing namespace packages such as PySCF extensions or `pyscf-forge`; that combination has not been tested with `uv`.
+- To develop or debug C extensions, configure a native build with `cmake -S pyscf/lib -B pyscf/lib/build`, then compile with `cmake --build pyscf/lib/build`. Reuse an existing configured build and its dependency options where possible.
+- Do not create pull requests against the upstream repository unless explicitly asked.
+
+## Code Style
+
+- Keep method-specific logic in the corresponding package and reusable infrastructure in the existing shared modules.
+- Make small, complete changes. Follow nearby code and existing APIs before introducing abstractions or dependencies.
+- Preserve unrelated tracked changes, untracked experiments, calculation outputs, checkpoints, and local configuration.
+- Follow the existing formatting and lint configuration. Avoid unrelated reformatting and preserve license notices.
+
+## Validation
+
+* Prefer focused regression tests for bug fixes and numerical changes, using small systems and nearby test conventions.
+* Prefer lightweight, deterministic tests, with minimal mocking.
+- Run the smallest relevant test selection. Documentation-only changes do not require numerical tests.
+- Investigate failures near numerical tolerances. Do not substantially relax tolerances or replace reference values merely to make tests pass.
+
+## Skills
+
+- When a task explicitly selects a skill, read the corresponding template in `agent-recipes/skills/` or the user's customized version before applying it.

--- a/agent-recipes/skills/pyscf-coding-style.template.md
+++ b/agent-recipes/skills/pyscf-coding-style.template.md
@@ -1,0 +1,46 @@
+# PySCF Python coding style
+
+Load this template when writing, modifying, or reviewing Python code in PySCF.
+Customize as needed.
+
+## Implementation
+
+- PySCF favors compact scientific code. Keep implementations concise while
+  making algorithmic steps and numerical assumptions clear.
+- Follow nearby code when conventions differ, unless changing the style is
+  part of the task.
+- Make the smallest complete change that solves the problem. Avoid unrelated
+  cleanup, renaming, or reformatting.
+- Do not substantially refactor, rewrite, or reorganize existing helper
+  functions unless the task clearly requires it. If substantial refactoring is
+  necessary, explain why the localized approach is insufficient.
+- Reuse existing PySCF utilities before adding equivalent third-party helpers.
+- Use PySCF's logger for diagnostic output rather than Python's standard
+  `logging` module or `print` statements.
+- Import hierarchy: `data`, `gto`, `lib`, and `tools` are foundational modules.
+  Prefer dependencies from higher-level modules toward these foundations, and
+  avoid introducing reverse dependencies.
+- Prefer module-scope imports. When circular imports arise, resolve them
+  through appropriate dependency boundaries or localized imports rather than
+  adding eager imports to package `__init__.py` files. Only expose new
+  submodules through `__init__.py` when required by the public API.
+- Prefer side-effect-free implementations. Do not rely on mutations of shared
+  objects to make other objects behave correctly. When modifying an object,
+  prefer creating a new instance unless in-place updates are
+  performance-critical or required by the API. Use the returned object
+  explicitly, even when the operation mutates in place.
+
+## Formatting and linting
+
+- Follow the repository's formatting and lint configuration, which permits
+  compact conventions. Do not mechanically apply generic PEP 8 formatting.
+- Break long numerical calls and Boolean expressions at logical boundaries,
+  matching the surrounding continuation-line indentation.
+
+## Documentation
+
+- Document non-obvious assumptions.
+- For functions outside the public API, a short docstring explaining their
+  purpose is sufficient.
+- Update documentation when changing parameters, return values, supported
+  shapes, symmetry, units, or public behavior.


### PR DESCRIPTION
## Summary

Predefined agent instructions and skills that PySCF developers can optionally reference from their local coding agents.

See also #3283 

## Notes

Developers and users are welcome to contribute improvements to the agent guidance and skills. New recipes, and refinements based on practical experience are encouraged.

--
GPT-6 was used to create and revise the AGENTS and skill templates.
