### PR TITLE
Secondary grids for SCF response functions 

### DIFF
--- a/pyscf/dft/gen_grid.py
+++ b/pyscf/dft/gen_grid.py
@@ -747,8 +747,6 @@ class Grids(lib.StreamObject):
 def sg1_grids(mol, atom_grid=(50, 194)):
     '''SG1 grids for SCF linear response functions (cf. pyscf#2520).
 
-    A coarser SG1 standard grid which is often sufficiently accurate for the
-    occupied-virtual orbital pair transitions of linear response functions.
     It can be assigned to mf.second_grids:
 
     >>> mf.second_grids = dft.gen_grid.sg1_grids(mol)

--- a/pyscf/dft/gen_grid.py
+++ b/pyscf/dft/gen_grid.py
@@ -744,6 +744,29 @@ class Grids(lib.StreamObject):
     to_gpu = lib.to_gpu
 
 
+def sg1_grids(mol, atom_grid=(50, 194)):
+    '''SG1 grids for SCF linear response functions (cf. pyscf#2520).
+
+    A coarser SG1 standard grid which is often sufficiently accurate for the
+    occupied-virtual orbital pair transitions of linear response functions.
+    It can be assigned to mf.second_grids:
+
+    >>> mf.second_grids = dft.gen_grid.sg1_grids(mol)
+
+    Kwargs:
+        atom_grid : tuple (radial, angular)
+            (radial, angular) grids for all atoms.
+
+    Returns:
+        An unbuilt Grids object. It is built automatically when response
+        functions use it.
+    '''
+    grids = Grids(mol)
+    grids.prune = sg1_prune
+    grids.atom_grid = atom_grid
+    return grids
+
+
 def _default_rad(nuc, level=3):
     '''Number of radial grids '''
     tab   = numpy.array( (2 , 10, 18, 36, 54, 86, 118))

--- a/pyscf/dft/rks.py
+++ b/pyscf/dft/rks.py
@@ -328,9 +328,7 @@ class KohnShamDFT:
 
             >>> mol = gto.M(atom='H 0 0 0; H 0 0 1.2')
             >>> mf = dft.RKS(mol).run()
-            >>> mf.second_grids = dft.gen_grid.Grids(mol)
-            >>> mf.second_grids.prune = dft.gen_grid.sg1_prune
-            >>> mf.second_grids.atom_grid = (50, 194)
+            >>> mf.second_grids = dft.gen_grid.sg1_grids(mol)
 
     Examples:
 

--- a/pyscf/dft/rks.py
+++ b/pyscf/dft/rks.py
@@ -318,6 +318,20 @@ class KohnShamDFT:
             Drop grids if their contribution to total electrons smaller than
             this cutoff value.  Default is 1e-7.
 
+        second_grids : Grids object
+            Secondary grids for SCF linear response functions (CPHF, TDDFT,
+            second-order SCF solvers, stability analysis, etc). If set, it is
+            used by ``mf.gen_response`` in place of ``self.grids``. A coarser
+            grid is often sufficiently accurate for the occupied-virtual
+            orbital pair transitions in linear response calculations.
+            Default is None (response functions use ``self.grids``).
+
+            >>> mol = gto.M(atom='H 0 0 0; H 0 0 1.2')
+            >>> mf = dft.RKS(mol).run()
+            >>> mf.second_grids = dft.gen_grid.Grids(mol)
+            >>> mf.second_grids.prune = dft.gen_grid.sg1_prune
+            >>> mf.second_grids.atom_grid = (50, 194)
+
     Examples:
 
     >>> mol = gto.M(atom='O 0 0 0; H 0 0 1; H 0 1 0', basis='ccpvdz', verbose=0)
@@ -327,7 +341,8 @@ class KohnShamDFT:
     -76.415443079840458
     '''
 
-    _keys = {'xc', 'nlc', 'grids', 'disp', 'nlcgrids', 'small_rho_cutoff'}
+    _keys = {'xc', 'nlc', 'grids', 'disp', 'nlcgrids', 'small_rho_cutoff',
+             'second_grids'}
 
     # Use rho to filter grids
     small_rho_cutoff = getattr(__config__, 'dft_rks_RKS_small_rho_cutoff', 0)
@@ -343,6 +358,7 @@ class KohnShamDFT:
         self.nlcgrids = gen_grid.Grids(self.mol)
         self.nlcgrids.level = getattr(
             __config__, 'dft_rks_RKS_nlcgrids_level', self.nlcgrids.level)
+        self.second_grids = None
 ##################################################
 # don't modify the following attributes, they are not input options
         self._numint = numint.NumInt()
@@ -377,6 +393,10 @@ class KohnShamDFT:
             self.nlcgrids.dump_flags(verbose)
 
         log.info('small_rho_cutoff = %g', self.small_rho_cutoff)
+
+        if self.second_grids is not None:
+            log.info('** Following is secondary grids for response functions **')
+            self.second_grids.dump_flags(verbose)
         return self
 
     define_xc_ = define_xc_
@@ -485,6 +505,8 @@ class KohnShamDFT:
         hf.SCF.reset(self, mol)
         self.grids.reset(mol)
         self.nlcgrids.reset(mol)
+        if self.second_grids is not None:
+            self.second_grids.reset(mol)
         return self
 
     def check_sanity(self):

--- a/pyscf/dft/rks.py
+++ b/pyscf/dft/rks.py
@@ -325,10 +325,13 @@ class KohnShamDFT:
             grid is often sufficiently accurate for the occupied-virtual
             orbital pair transitions in linear response calculations.
             Default is None (response functions use ``self.grids``).
+            Easiest to assign with the helper method
+            ``mf.set_second_grids`` (level 1 by default; 'sg1' for the SG1
+            standard grid, Z <= 18 only).
 
             >>> mol = gto.M(atom='H 0 0 0; H 0 0 1.2')
             >>> mf = dft.RKS(mol).run()
-            >>> mf.second_grids = dft.gen_grid.sg1_grids(mol)
+            >>> mf.set_second_grids(1)
 
     Examples:
 
@@ -505,6 +508,43 @@ class KohnShamDFT:
         self.nlcgrids.reset(mol)
         if self.second_grids is not None:
             self.second_grids.reset(mol)
+        return self
+
+    def set_second_grids(self, level=1):
+        '''Assign the secondary grids for SCF linear response functions.
+
+        The secondary grids are used to evaluate the XC response kernels
+        of linear response properties (TDDFT, CPHF, Hessian, second-order
+        SCF solver, etc.). A coarser grid than the ground-state default
+        (level 3) is usually sufficiently accurate for the occupied-virtual
+        orbital pair transitions.
+
+        Args:
+            level : int or str or gen_grid.Grids
+                An int builds a gen_grid.Grids of the given level.
+                Useful values are 1 (recommended, supported for all
+                elements) and 2 (finer, closer to the ground-state grid).
+                'sg1' builds the SG1 standard grid (prune=sg1_prune,
+                atom_grid=(50,194)); SG1 radii are tabulated for Z <= 18
+                only. Other level numbers are allowed but generally do not
+                make much sense. A pre-built Grids object is used as-is.
+
+        Examples:
+
+        >>> mol = gto.M(atom='H 0 0 0; H 0 0 1.2')
+        >>> mf = dft.RKS(mol).run()
+        >>> mf.set_second_grids(1)   # or mf.set_second_grids('sg1')
+        '''
+        if isinstance(level, str):
+            if level.lower() != 'sg1':
+                raise ValueError(f'Unknown second_grids scheme {level!r}.')
+            self.second_grids = gen_grid.sg1_grids(self.mol)
+        elif isinstance(level, gen_grid.Grids):
+            self.second_grids = level
+        else:
+            grids = gen_grid.Grids(self.mol)
+            grids.level = int(level)
+            self.second_grids = grids
         return self
 
     def check_sanity(self):

--- a/pyscf/dft/rks.py
+++ b/pyscf/dft/rks.py
@@ -322,12 +322,10 @@ class KohnShamDFT:
             Secondary grids for SCF linear response functions (CPHF, TDDFT,
             second-order SCF solvers, stability analysis, etc). If set, it is
             used by ``mf.gen_response`` in place of ``self.grids``. A coarser
-            grid is often sufficiently accurate for the occupied-virtual
-            orbital pair transitions in linear response calculations.
+            grid like level 1 is often sufficiently accurate.
             Default is None (response functions use ``self.grids``).
-            Easiest to assign with the helper method
-            ``mf.set_second_grids`` (level 1 by default; 'sg1' for the SG1
-            standard grid, Z <= 18 only).
+            Easy to assign with the helper method ``mf.set_second_grids``
+            (level 1 by default; 'sg1' for the SG1 standard grid).
 
             >>> mol = gto.M(atom='H 0 0 0; H 0 0 1.2')
             >>> mf = dft.RKS(mol).run()
@@ -396,7 +394,7 @@ class KohnShamDFT:
         log.info('small_rho_cutoff = %g', self.small_rho_cutoff)
 
         if self.second_grids is not None:
-            log.info('** Following is secondary grids for response functions **')
+            log.info('** Secondary grids for response functions **')
             self.second_grids.dump_flags(verbose)
         return self
 
@@ -516,8 +514,7 @@ class KohnShamDFT:
         The secondary grids are used to evaluate the XC response kernels
         of linear response properties (TDDFT, CPHF, Hessian, second-order
         SCF solver, etc.). A coarser grid than the ground-state default
-        (level 3) is usually sufficiently accurate for the occupied-virtual
-        orbital pair transitions.
+        (level 3) is usually sufficiently accurate.
 
         Args:
             level : int or str or gen_grid.Grids

--- a/pyscf/grad/test/test_tdrks_grad.py
+++ b/pyscf/grad/test/test_tdrks_grad.py
@@ -164,6 +164,27 @@ class KnownValues(unittest.TestCase):
         g1 = tdg.kernel(state=3)
         self.assertAlmostEqual(g1[0,2], -1.55778110e-01, 6)
 
+    def test_second_grids_tda_grad(self):
+        mf = dft.RKS(mol).set(xc='b3lyp', conv_tol=1e-11)
+        mf.kernel()
+        td = tdscf.TDA(mf).run(nstates=nstates)
+        g0 = td.nuc_grad_method().kernel(state=1)
+
+        # second_grids equal to mf.grids reproduces the default gradient
+        mf.second_grids = mf.grids
+        td = tdscf.TDA(mf).run(nstates=nstates)
+        g1 = td.nuc_grad_method().kernel(state=1)
+        self.assertAlmostEqual(abs(g1 - g0).max(), 0, 7)
+        mf.second_grids = None
+
+        # A level-1 secondary grid gives a very similar gradient
+        mf.set_second_grids(1)
+        td = tdscf.TDA(mf).run(nstates=nstates)
+        g2 = td.nuc_grad_method().kernel(state=1)
+        self.assertTrue(mf.second_grids.coords.shape[0] < mf.grids.coords.shape[0])
+        self.assertAlmostEqual(abs(g2 - g0).max(), 0, 5)
+        mf.second_grids = None
+
     def test_range_separated_high_cost(self):
         if not hasattr(dft, 'xcfun'):
             raise unittest.SkipTest('PySCF not built with XCFun.')

--- a/pyscf/hessian/test/test_rks.py
+++ b/pyscf/hessian/test/test_rks.py
@@ -127,6 +127,28 @@ class KnownValues(unittest.TestCase):
         #FIXME: errors seems too big
         self.assertAlmostEqual(abs(hess[0,:,2] - (e1-e2)/2e-4*lib.param.BOHR).max(), 0, 3)
 
+    def test_second_grids_hess(self):
+        mf = dft.RKS(mol)
+        mf.xc = 'b3lyp5'
+        mf.conv_tol = 1e-14
+        mf.kernel()
+        hess = mf.Hessian().kernel()
+
+        # second_grids == grids reproduces the default hessian
+        mf.second_grids = mf.grids
+        hess1 = mf.Hessian().kernel()
+        self.assertAlmostEqual(abs(hess - hess1).max(), 0, 7)
+        mf.second_grids = None
+
+        # A coarse (SG1) secondary grid changes the CPHF response only
+        second_grids = dft.gen_grid.Grids(mol)
+        second_grids.prune = dft.gen_grid.sg1_prune
+        second_grids.atom_grid = (50, 194)
+        mf.second_grids = second_grids
+        hess2 = mf.Hessian().kernel()
+        self.assertAlmostEqual(abs(hess - hess2).max(), 0, 4)
+        mf.second_grids = None
+
     def test_finite_diff_b3lyp_hess(self):
         mf = dft.RKS(mol)
         mf.conv_tol = 1e-14

--- a/pyscf/hessian/test/test_rks.py
+++ b/pyscf/hessian/test/test_rks.py
@@ -142,7 +142,6 @@ class KnownValues(unittest.TestCase):
 
         # A coarse (SG1) secondary grid changes the CPHF response only
         second_grids = dft.gen_grid.sg1_grids(mol)
-        second_grids.build(with_non0tab=True)
         mf.second_grids = second_grids
         hess2 = mf.Hessian().kernel()
         self.assertAlmostEqual(abs(hess - hess2).max(), 0, 4)

--- a/pyscf/hessian/test/test_rks.py
+++ b/pyscf/hessian/test/test_rks.py
@@ -140,7 +140,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(hess - hess1).max(), 0, 7)
         mf.second_grids = None
 
-        # A coarse (SG1) secondary grid changes the CPHF response only
+        # A coarse (level-1) secondary grid changes the CPHF response only
         mf.set_second_grids(1)
         hess2 = mf.Hessian().kernel()
         self.assertAlmostEqual(abs(hess - hess2).max(), 0, 4)

--- a/pyscf/hessian/test/test_rks.py
+++ b/pyscf/hessian/test/test_rks.py
@@ -141,8 +141,7 @@ class KnownValues(unittest.TestCase):
         mf.second_grids = None
 
         # A coarse (SG1) secondary grid changes the CPHF response only
-        second_grids = dft.gen_grid.sg1_grids(mol)
-        mf.second_grids = second_grids
+        mf.set_second_grids(1)
         hess2 = mf.Hessian().kernel()
         self.assertAlmostEqual(abs(hess - hess2).max(), 0, 4)
         mf.second_grids = None

--- a/pyscf/hessian/test/test_rks.py
+++ b/pyscf/hessian/test/test_rks.py
@@ -141,9 +141,8 @@ class KnownValues(unittest.TestCase):
         mf.second_grids = None
 
         # A coarse (SG1) secondary grid changes the CPHF response only
-        second_grids = dft.gen_grid.Grids(mol)
-        second_grids.prune = dft.gen_grid.sg1_prune
-        second_grids.atom_grid = (50, 194)
+        second_grids = dft.gen_grid.sg1_grids(mol)
+        second_grids.build(with_non0tab=True)
         mf.second_grids = second_grids
         hess2 = mf.Hessian().kernel()
         self.assertAlmostEqual(abs(hess - hess2).max(), 0, 4)

--- a/pyscf/scf/_response_functions.py
+++ b/pyscf/scf/_response_functions.py
@@ -27,7 +27,8 @@ from pyscf.lib import logger
 from pyscf.scf import hf, rohf, uhf, ghf, dhf
 
 def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
-                      singlet=None, hermi=0, max_memory=None, with_nlc=True):
+                      singlet=None, hermi=0, max_memory=None, with_nlc=True,
+                      grids=None):
     '''Generate a function to compute the product of RHF response function and
     RHF density matrices.
 
@@ -37,6 +38,9 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
             it is used in TDDFT response kernel.
         with_nlc (boolean) : NLC contribution is typically very small. This flag
         allows to skip NLC contribution.
+        grids (Grids object) : Grids for the XC response kernel of DFT
+            functionals. If not specified, the secondary grid
+            ``mf.second_grids`` is used if available, otherwise ``mf.grids``.
     '''
     assert isinstance(mf, hf.RHF) and not isinstance(mf, (uhf.UHF, rohf.ROHF))
 
@@ -45,6 +49,12 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
     mol = mf.mol
     if isinstance(mf, hf.KohnShamDFT):
         ni = mf._numint
+        if grids is None:
+            grids = getattr(mf, 'second_grids', None)
+        if grids is None:
+            grids = mf.grids
+        if grids.coords is None:
+            grids.build(with_non0tab=True)
         ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
         hybrid = ni.libxc.is_hybrid_xc(mf.xc)
@@ -53,7 +63,7 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
             spin = 0
         else:
             spin = 1
-        rho0, vxc, fxc = ni.cache_xc_kernel(mol, mf.grids, mf.xc,
+        rho0, vxc, fxc = ni.cache_xc_kernel(mol, grids, mf.xc,
                                             mo_coeff, mo_occ, spin)
         dm0 = None
 
@@ -71,7 +81,7 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
                 if hermi == 2:
                     v1 = numpy.zeros_like(dm1)
                 else:
-                    v1 = ni.nr_rks_fxc(mol, mf.grids, mf.xc, dm0, dm1, 0, hermi,
+                    v1 = ni.nr_rks_fxc(mol, grids, mf.xc, dm0, dm1, 0, hermi,
                                        rho0, vxc, fxc, max_memory=max_memory)
                     if with_nlc and mf.do_nlc():
                         from pyscf.hessian.rks import get_vnlc_resp # Cannot import at top due to circular dependency
@@ -107,7 +117,7 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
                     v1 = numpy.zeros_like(dm1)
                 else:
                     # nr_rks_fxc_st requires alpha of dm1, dm1*.5 should be scaled
-                    v1 = ni.nr_rks_fxc_st(mol, mf.grids, mf.xc, dm0, dm1, hermi, True,
+                    v1 = ni.nr_rks_fxc_st(mol, grids, mf.xc, dm0, dm1, hermi, True,
                                           rho0, vxc, fxc, max_memory=max_memory)
                     if with_nlc and mf.do_nlc():
                         from pyscf.hessian.rks import get_vnlc_resp # Cannot import at top due to circular dependency
@@ -142,7 +152,7 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
                     v1 = numpy.zeros_like(dm1)
                 else:
                     # nr_rks_fxc_st requires alpha of dm1, dm1*.5 should be scaled
-                    v1 = ni.nr_rks_fxc_st(mol, mf.grids, mf.xc, dm0, dm1, hermi, False,
+                    v1 = ni.nr_rks_fxc_st(mol, grids, mf.xc, dm0, dm1, hermi, False,
                                           rho0, vxc, fxc, max_memory=max_memory)
                     if with_nlc and mf.do_nlc():
                         pass # fxc = 0, do nothing
@@ -172,9 +182,15 @@ def _gen_rhf_response(mf, mo_coeff=None, mo_occ=None,
 
 
 def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None,
-                      with_j=True, hermi=0, max_memory=None, with_nlc=True):
+                      with_j=True, hermi=0, max_memory=None, with_nlc=True,
+                      grids=None):
     '''Generate a function to compute the product of UHF response function and
     UHF density matrices.
+
+    Kwargs:
+        grids (Grids object) : Grids for the XC response kernel of DFT
+            functionals. If not specified, the secondary grid
+            ``mf.second_grids`` is used if available, otherwise ``mf.grids``.
     '''
     assert isinstance(mf, (uhf.UHF, rohf.ROHF))
     if mo_coeff is None: mo_coeff = mf.mo_coeff
@@ -182,11 +198,17 @@ def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None,
     mol = mf.mol
     if isinstance(mf, hf.KohnShamDFT):
         ni = mf._numint
+        if grids is None:
+            grids = getattr(mf, 'second_grids', None)
+        if grids is None:
+            grids = mf.grids
+        if grids.coords is None:
+            grids.build(with_non0tab=True)
         ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
         hybrid = ni.libxc.is_hybrid_xc(mf.xc)
 
-        rho0, vxc, fxc = ni.cache_xc_kernel(mol, mf.grids, mf.xc,
+        rho0, vxc, fxc = ni.cache_xc_kernel(mol, grids, mf.xc,
                                             mo_coeff, mo_occ, 1)
         dm0 = None
 
@@ -201,7 +223,7 @@ def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None,
             if hermi == 2:
                 v1 = numpy.zeros_like(dm1)
             else:
-                v1 = ni.nr_uks_fxc(mol, mf.grids, mf.xc, dm0, dm1, 0, hermi,
+                v1 = ni.nr_uks_fxc(mol, grids, mf.xc, dm0, dm1, 0, hermi,
                                    rho0, vxc, fxc, max_memory=max_memory)
                 if with_nlc and mf.do_nlc():
                     from pyscf.hessian.rks import get_vnlc_resp # Cannot import at top due to circular dependency
@@ -248,9 +270,15 @@ def _gen_uhf_response(mf, mo_coeff=None, mo_occ=None,
 
 
 def _gen_ghf_response(mf, mo_coeff=None, mo_occ=None,
-                      with_j=True, hermi=0, max_memory=None, with_nlc=True):
+                      with_j=True, hermi=0, max_memory=None, with_nlc=True,
+                      grids=None):
     '''Generate a function to compute the product of GHF response function and
     GHF density matrices.
+
+    Kwargs:
+        grids (Grids object) : Grids for the XC response kernel of DFT
+            functionals. If not specified, the secondary grid
+            ``mf.second_grids`` is used if available, otherwise ``mf.grids``.
     '''
     if mo_coeff is None: mo_coeff = mf.mo_coeff
     if mo_occ is None: mo_occ = mf.mo_occ
@@ -259,11 +287,17 @@ def _gen_ghf_response(mf, mo_coeff=None, mo_occ=None,
         from pyscf.dft import numint2c, r_numint
         ni = mf._numint
         assert isinstance(ni, (numint2c.NumInt2C, r_numint.RNumInt))
+        if grids is None:
+            grids = getattr(mf, 'second_grids', None)
+        if grids is None:
+            grids = mf.grids
+        if grids.coords is None:
+            grids.build(with_non0tab=True)
         ni.libxc.test_deriv_order(mf.xc, 2, raise_error=True)
         omega, alpha, hyb = ni.rsh_and_hybrid_coeff(mf.xc, mol.spin)
         hybrid = ni.libxc.is_hybrid_xc(mf.xc)
 
-        rho0, vxc, fxc = ni.cache_xc_kernel(mol, mf.grids, mf.xc, mo_coeff, mo_occ, 1)
+        rho0, vxc, fxc = ni.cache_xc_kernel(mol, grids, mf.xc, mo_coeff, mo_occ, 1)
         dm0 = None
 
         if max_memory is None:
@@ -277,7 +311,7 @@ def _gen_ghf_response(mf, mo_coeff=None, mo_occ=None,
             if hermi == 2:
                 v1 = numpy.zeros_like(dm1)
             else:
-                v1 = ni.get_fxc(mol, mf.grids, mf.xc, dm0, dm1, 0, 0, hermi,
+                v1 = ni.get_fxc(mol, grids, mf.xc, dm0, dm1, 0, 0, hermi,
                                 rho0, vxc, fxc, max_memory=max_memory)
                 if with_nlc and mf.do_nlc():
                     from pyscf.hessian.rks import get_vnlc_resp
@@ -334,11 +368,13 @@ def _gen_ghf_response(mf, mo_coeff=None, mo_occ=None,
 
 
 def _gen_dhf_response(mf, mo_coeff=None, mo_occ=None,
-                      with_j=True, hermi=0, max_memory=None, with_nlc=True):
+                      with_j=True, hermi=0, max_memory=None, with_nlc=True,
+                      grids=None):
     '''Generate a function to compute the product of DHF response function and
     DHF density matrices.
     '''
-    return _gen_ghf_response(mf, mo_coeff, mo_occ, with_j, hermi, max_memory)
+    return _gen_ghf_response(mf, mo_coeff, mo_occ, with_j, hermi, max_memory,
+                             with_nlc, grids)
 
 
 hf.RHF.gen_response = _gen_rhf_response

--- a/pyscf/scf/test/test_response_function.py
+++ b/pyscf/scf/test/test_response_function.py
@@ -17,10 +17,75 @@ import unittest
 import numpy as np
 import scipy.linalg
 from pyscf import lib
-from pyscf import gto
+from pyscf import dft, gto
 from pyscf.scf import _response_functions
 
+def make_second_grids(mol):
+    '''A coarse (SG1) secondary grid for response functions'''
+    second_grids = dft.gen_grid.Grids(mol)
+    second_grids.prune = dft.gen_grid.sg1_prune
+    second_grids.atom_grid = (50, 194)
+    second_grids.build(with_non0tab=True)
+    return second_grids
+
 class KnownValues(unittest.TestCase):
+    def test_rks_second_grids(self):
+        mol = gto.M(
+            verbose = 5,
+            output = '/dev/null',
+            atom = 'O 0 0 0; H 0 -0.757 0.587; H 0 0.757 0.587',
+            basis = '631g')
+        mf = mol.RKS(xc='b3lyp').run(conv_tol=1e-11)
+
+        td0 = mf.TDA()
+        td0.nstates = 3
+        e_ref = td0.kernel()[0]
+
+        # By default second_grids is None and response functions use mf.grids
+        self.assertIsNone(mf.second_grids)
+
+        # An unbuilt copy of mf.grids gives the same response
+        grids_copy = dft.gen_grid.Grids(mol)
+        grids_copy.level = mf.grids.level
+        grids_copy.prune = mf.grids.prune
+        mf.second_grids = grids_copy
+        td1 = mf.TDA()
+        td1.nstates = 3
+        self.assertAlmostEqual(abs(td1.kernel()[0] - e_ref).max(), 0, 9)
+        mf.second_grids = None
+
+        # A coarse secondary grid gives very similar excitations
+        second_grids = make_second_grids(mol)
+        self.assertTrue(second_grids.coords.shape[0] < mf.grids.coords.shape[0])
+        mf.second_grids = second_grids
+        td2 = mf.TDA()
+        td2.nstates = 3
+        e2 = td2.kernel()[0]
+        self.assertAlmostEqual(abs(e2 - e_ref).max(), 0, 4)
+        mf.second_grids = None
+
+    def test_uks_second_grids_vind(self):
+        mol = gto.M(
+            verbose = 5,
+            output = '/dev/null',
+            atom = 'O 0 0 0; H 0 -0.757 0.587; H 0 0.757 0.587',
+            basis = '631g')
+        mf = mol.UKS(xc='pbe').run()
+        nao = mol.nao
+        np.random.seed(1)
+        dm1 = np.random.rand(2, nao, nao)
+
+        second_grids = make_second_grids(mol)
+        mf.second_grids = second_grids
+        v1 = mf.gen_response()(dm1)
+        mf.second_grids = None
+        # The grids kwarg of gen_response bypasses mf.second_grids
+        v2 = mf.gen_response(grids=second_grids)(dm1)
+        self.assertAlmostEqual(abs(v1 - v2).max(), 0, 12)
+        v3 = mf.gen_response(grids=mf.grids)(dm1)
+        v4 = mf.gen_response()(dm1)
+        self.assertAlmostEqual(abs(v3 - v4).max(), 0, 12)
+
     def test_gks_nlc(self):
         mol = gto.M(
             verbose = 5,

--- a/pyscf/scf/test/test_response_function.py
+++ b/pyscf/scf/test/test_response_function.py
@@ -22,9 +22,7 @@ from pyscf.scf import _response_functions
 
 def make_second_grids(mol):
     '''A coarse (SG1) secondary grid for response functions'''
-    second_grids = dft.gen_grid.sg1_grids(mol)
-    second_grids.build(with_non0tab=True)
-    return second_grids
+    return dft.gen_grid.sg1_grids(mol)
 
 class KnownValues(unittest.TestCase):
     def test_rks_second_grids(self):
@@ -56,11 +54,11 @@ class KnownValues(unittest.TestCase):
         second_grids = make_second_grids(mol)
         self.assertEqual(second_grids.prune, dft.gen_grid.sg1_prune)
         self.assertEqual(second_grids.atom_grid, (50, 194))
-        self.assertTrue(second_grids.coords.shape[0] < mf.grids.coords.shape[0])
         mf.second_grids = second_grids
         td2 = mf.TDA()
         td2.nstates = 3
         e2 = td2.kernel()[0]
+        self.assertTrue(second_grids.coords.shape[0] < mf.grids.coords.shape[0])
         self.assertAlmostEqual(abs(e2 - e_ref).max(), 0, 4)
         mf.second_grids = None
 

--- a/pyscf/scf/test/test_response_function.py
+++ b/pyscf/scf/test/test_response_function.py
@@ -20,10 +20,6 @@ from pyscf import lib
 from pyscf import dft, gto
 from pyscf.scf import _response_functions
 
-def make_second_grids(mol):
-    '''A coarse (SG1) secondary grid for response functions'''
-    return dft.gen_grid.sg1_grids(mol)
-
 class KnownValues(unittest.TestCase):
     def test_rks_second_grids(self):
         mol = gto.M(
@@ -50,16 +46,23 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual(abs(td1.kernel()[0] - e_ref).max(), 0, 9)
         mf.second_grids = None
 
-        # A coarse secondary grid gives very similar excitations
-        second_grids = make_second_grids(mol)
-        self.assertEqual(second_grids.prune, dft.gen_grid.sg1_prune)
-        self.assertEqual(second_grids.atom_grid, (50, 194))
-        mf.second_grids = second_grids
+        # A level-1 secondary grid gives very similar excitations
+        mf.set_second_grids(1)
         td2 = mf.TDA()
         td2.nstates = 3
         e2 = td2.kernel()[0]
-        self.assertTrue(second_grids.coords.shape[0] < mf.grids.coords.shape[0])
+        self.assertTrue(mf.second_grids.coords.shape[0] < mf.grids.coords.shape[0])
         self.assertAlmostEqual(abs(e2 - e_ref).max(), 0, 4)
+        mf.second_grids = None
+
+        # The sg1 scheme builds an SG1 grid
+        mf.set_second_grids('sg1')
+        self.assertEqual(mf.second_grids.prune, dft.gen_grid.sg1_prune)
+        self.assertEqual(mf.second_grids.atom_grid, (50, 194))
+        td3 = mf.TDA()
+        td3.nstates = 3
+        e3 = td3.kernel()[0]
+        self.assertAlmostEqual(abs(e3 - e_ref).max(), 0, 4)
         mf.second_grids = None
 
     def test_uks_second_grids_vind(self):
@@ -73,8 +76,8 @@ class KnownValues(unittest.TestCase):
         np.random.seed(1)
         dm1 = np.random.rand(2, nao, nao)
 
-        second_grids = make_second_grids(mol)
-        mf.second_grids = second_grids
+        mf.set_second_grids(1)
+        second_grids = mf.second_grids
         v1 = mf.gen_response()(dm1)
         mf.second_grids = None
         # The grids kwarg of gen_response bypasses mf.second_grids

--- a/pyscf/scf/test/test_response_function.py
+++ b/pyscf/scf/test/test_response_function.py
@@ -22,9 +22,7 @@ from pyscf.scf import _response_functions
 
 def make_second_grids(mol):
     '''A coarse (SG1) secondary grid for response functions'''
-    second_grids = dft.gen_grid.Grids(mol)
-    second_grids.prune = dft.gen_grid.sg1_prune
-    second_grids.atom_grid = (50, 194)
+    second_grids = dft.gen_grid.sg1_grids(mol)
     second_grids.build(with_non0tab=True)
     return second_grids
 
@@ -56,6 +54,8 @@ class KnownValues(unittest.TestCase):
 
         # A coarse secondary grid gives very similar excitations
         second_grids = make_second_grids(mol)
+        self.assertEqual(second_grids.prune, dft.gen_grid.sg1_prune)
+        self.assertEqual(second_grids.atom_grid, (50, 194))
         self.assertTrue(second_grids.coords.shape[0] < mf.grids.coords.shape[0])
         mf.second_grids = second_grids
         td2 = mf.TDA()

--- a/pyscf/soscf/test/test_newton_ah.py
+++ b/pyscf/soscf/test/test_newton_ah.py
@@ -235,9 +235,8 @@ class KnownValues(unittest.TestCase):
         mf = dft.RKS(h2o_z0)
         mf.xc = 'b3lyp'
         eref = mf.kernel()
-        second_grids = dft.gen_grid.Grids(h2o_z0)
-        second_grids.prune = dft.gen_grid.sg1_prune
-        second_grids.atom_grid = (50, 194)
+        second_grids = dft.gen_grid.sg1_grids(h2o_z0)
+        second_grids.build(with_non0tab=True)
         mf.second_grids = second_grids
         mf.max_cycle = 1
         mf.conv_check = False

--- a/pyscf/soscf/test/test_newton_ah.py
+++ b/pyscf/soscf/test/test_newton_ah.py
@@ -235,8 +235,7 @@ class KnownValues(unittest.TestCase):
         mf = dft.RKS(h2o_z0)
         mf.xc = 'b3lyp'
         eref = mf.kernel()
-        second_grids = dft.gen_grid.sg1_grids(h2o_z0)
-        mf.second_grids = second_grids
+        mf.set_second_grids(1)
         mf.max_cycle = 1
         mf.conv_check = False
         mf.kernel()

--- a/pyscf/soscf/test/test_newton_ah.py
+++ b/pyscf/soscf/test/test_newton_ah.py
@@ -236,7 +236,6 @@ class KnownValues(unittest.TestCase):
         mf.xc = 'b3lyp'
         eref = mf.kernel()
         second_grids = dft.gen_grid.sg1_grids(h2o_z0)
-        second_grids.build(with_non0tab=True)
         mf.second_grids = second_grids
         mf.max_cycle = 1
         mf.conv_check = False

--- a/pyscf/soscf/test/test_newton_ah.py
+++ b/pyscf/soscf/test/test_newton_ah.py
@@ -230,6 +230,24 @@ class KnownValues(unittest.TestCase):
         nr.conv_tol_grad = 1e-5
         self.assertAlmostEqual(nr.kernel(), eref, 9)
 
+    def test_nr_rks_second_grids(self):
+        '''second_grids are used in the orbital hessian of the second order solver'''
+        mf = dft.RKS(h2o_z0)
+        mf.xc = 'b3lyp'
+        eref = mf.kernel()
+        second_grids = dft.gen_grid.Grids(h2o_z0)
+        second_grids.prune = dft.gen_grid.sg1_prune
+        second_grids.atom_grid = (50, 194)
+        mf.second_grids = second_grids
+        mf.max_cycle = 1
+        mf.conv_check = False
+        mf.kernel()
+        nr = scf.newton(mf)
+        nr.max_cycle = 3
+        nr.conv_tol_grad = 1e-5
+        self.assertAlmostEqual(nr.kernel(), eref, 8)
+        mf.second_grids = None
+
     def test_rks_gen_g_hop(self):
         mf = dft.RKS(h2o_z0)
         mf.grids.build()


### PR DESCRIPTION
Resolve #2520. This PR adds an opt-in secondary grid, used by `gen_response` in place of `mf.grids` for all molecular response XC kernels: TDA/TDDFT, Hessian CPHF, TD gradients, second-order SCF, stability analysis, and the KS-CASCI gradient. (For Hessian, it does not change the skeleton derivative part)

This follows gpu4pyscf PR #244 (there named `cphf_grids`, SG1 default-on). Differences: the feature is opt-in (`second_grids` defaults to `None`); and it's named as `second_grids` since it's not only used by cphf.

## Usage

```python
mf.set_second_grids()      # level-1 grid (default)
mf.set_second_grids(2)     # level-2 grid (finer)
mf.set_second_grids('sg1') # SG1 
```

or assign `mf.second_grids = some_grids` directly. The SG1 grid is also available as `dft.gen_grid.sg1_grids(mol)`. 

## Accuracy and performance

RKS/def2-SVP, benzene, TDA (`nstates=3`).

| grid | ngrids | B3LYP speedup | B3LYP max dE | TPSS speedup | TPSS max dE |
|---|---|---|---|---|---|
| default | 143560 | 1.0x | - | 1.0x | - |
| level2  | 99480  | 1.6x | 2.1e-06 eV | 1.4x | 1.3e-06 eV |
| level1  | 45912  | 2.9x | 2.3e-05 eV | 3.0x | 5.0e-04 eV |
| sg1     | 51216  | 2.9x | 4.9e-05 eV | 2.8x | 2.0e-04 eV |

Hessian (freq)

| grid | B3LYP speedup | B3LYP max dfreq | TPSS speedup | TPSS max dfreq |
|---|---|---|---|---|
| default | 1.0x | - | 1.0x | - |
| level2  | 1.2x | 0.0011 cm-1 | 1.3x | 0.0020 cm-1 |
| level1  | 1.5x | 0.0104 cm-1 | 1.9x | 0.0303 cm-1 |
| sg1     | 1.5x | 0.0088 cm-1 | 1.7x | 0.0369 cm-1 |


Level 1 (recommended default) with GGA reproduces TDA within ~2e-5 eV and Hessian frequencies within ~0.01 cm-1. SG1 is equivalent in cost and accuracy but its radii only cover Z <= 18. (reported in #2082) For meta-GGA the accuracy is lower but still acceptable.

The final conclusion of "what level of second grid is best" might need benchmark with grid response, which we don't have currently. But with the no-grid-response benchmark I think the current second grid is at least acceptable in daily use.

## AI Disclosure

GLM 5.3 flash is used for writing all codes and benchmarks.

