### PR TITLE
Fix state-specific mcpdft

### DIFF
--- a/pyscf/mcpdft/_dms.py
+++ b/pyscf/mcpdft/_dms.py
@@ -19,6 +19,7 @@ import numpy as np
 from pyscf import lib
 from pyscf.mcscf.addons import StateAverageFCISolver
 from pyscf.mcscf.addons import StateAverageMixFCISolver
+from pyscf.mcscf.addons import StateSpecificFCISolver
 from scipy import linalg
 
 # DMRG solvers require special handling but dmrgscf is not always installed
@@ -41,7 +42,10 @@ def _get_fcisolver (mc, ci, state=0):
     nroots = getattr (mc.fcisolver, 'nroots', 1)
     fcisolver = mc.fcisolver
     solver_state_index = state
-    if nroots>1: ci = ci[state]
+    # StateSpecificFCISolver stores a single CI vector (the target state)
+    # even though its nroots equals state+1, so do not index it by state.
+    if nroots>1 and not isinstance (fcisolver, StateSpecificFCISolver):
+        ci = ci[state]
     if isinstance (mc.fcisolver, StateAverageMixFCISolver):
         p0 = 0
         fcisolver = None

--- a/pyscf/mcpdft/mcpdft.py
+++ b/pyscf/mcpdft/mcpdft.py
@@ -19,7 +19,9 @@ from pyscf import ao2mo, fci, mcscf, lib, __config__
 from pyscf.lib import logger
 from pyscf.dft import gen_grid
 from pyscf.mcscf import mc1step
-from pyscf.mcscf.addons import StateAverageMCSCFSolver, StateAverageMixFCISolver
+from pyscf.mcscf.addons import (StateAverageMCSCFSolver,
+                                StateAverageMixFCISolver,
+                                StateSpecificFCISolver)
 from pyscf.mcscf.df import _DFCASSCF, _DFCAS
 from pyscf.mcpdft import pdft_veff, pdft_feff
 from pyscf.mcpdft.otfnal import transfnal, get_transfnal
@@ -506,10 +508,17 @@ class _PDFT:
         if len(grids_attr): self.grids.__dict__.update(**grids_attr)
         if verbose is None: verbose = self.verbose
         self.verbose = self.otfnal.verbose = verbose
-        nroots = getattr(self.fcisolver, 'nroots', 1)
-        epdft = [self.energy_tot(mo_coeff=self.mo_coeff, ci=self.ci, state=ix,
-                                 logger_tag='MC-PDFT state {}'.format(ix))
-                 for ix in range(nroots)]
+        if isinstance(self.fcisolver, StateSpecificFCISolver):
+            nroots = 1
+            epdft = [self.energy_tot(mo_coeff=self.mo_coeff, ci=self.ci,
+                                     state=self.fcisolver.state,
+                                     logger_tag='MC-PDFT state {}'.format(
+                                         self.fcisolver.state))]
+        else:
+            nroots = getattr(self.fcisolver, 'nroots', 1)
+            epdft = [self.energy_tot(mo_coeff=self.mo_coeff, ci=self.ci, state=ix,
+                                     logger_tag='MC-PDFT state {}'.format(ix))
+                     for ix in range(nroots)]
         self.e_ot = [e_ot for e_tot, e_ot in epdft]
         if isinstance(self, StateAverageMCSCFSolver):
             e_states = [e_tot for e_tot, e_ot in epdft]

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -31,10 +31,22 @@
 # trying to test the API here; we need tight convergence and grids
 # to reproduce well when OMP is on.
 import h5py
+import os
+import shutil
 import numpy as np
 from pyscf import gto, scf, mcscf, lib, fci, dft
 from pyscf import mcpdft
 import unittest
+
+try:
+    from pyscf import dmrgscf
+    from pyscf.dmrgscf import dmrgci, settings as dmrg_settings
+    _BLOCKEXE = dmrg_settings.BLOCKEXE
+    _HAS_DMRG = _BLOCKEXE is not None and (
+        os.path.isfile(_BLOCKEXE) or
+        (os.path.sep not in _BLOCKEXE and shutil.which(_BLOCKEXE) is not None))
+except Exception:
+    _HAS_DMRG = False
 
 
 mol_nosym = mol_sym = mf_nosym = mf_sym = mc_nosym = mc_sym = mcp = mc_chk = None
@@ -769,6 +781,66 @@ class KnownValues(unittest.TestCase):
         # Reference from OpenMolcas v24.10
         e_ref = -0.74702903
         self.assertAlmostEqual (mc.e_tot, e_ref, 6)
+
+    def test_state_specific(self):
+        # GH#3414: mc.state_specific_(n) must yield a scalar e_tot equal to
+        # the n-th root of a plain multi-root CASCI-PDFT calculation.
+        mol = gto.M(atom="H 0 0 0; H 0 0 1.5; H 0 0 3.0; H 0 0 4.5",
+                    basis="sto3g", verbose=0, output="/dev/null")
+        mf = scf.RHF(mol).run(conv_tol=1e-12)
+
+        mc_ref = mcpdft.CASCI(mf, "tPBE", 4, 4)
+        mc_ref.fcisolver.nroots = 2
+        mc_ref.kernel()
+        e_ref = mc_ref.e_tot
+
+        for state in (0, 1):
+            mc = mcpdft.CASCI(mf, "tPBE", 4, 4).state_specific_(state)
+            mc.kernel()
+            with self.subTest(part="CASCI", state=state):
+                self.assertFalse(isinstance(mc.e_tot, (list, tuple)))
+                self.assertAlmostEqual(mc.e_tot, e_ref[state], delta=1e-9)
+
+    @unittest.skipUnless(_HAS_DMRG, "dmrgscf / block2 not available")
+    def test_state_specific_dmrg(self):
+        # GH#3414: for a state-specific DMRG, mc.ci is a state index (int).
+        # The DMRG RDM of the *target* state must be used, not the ground state.
+        mol = gto.M(atom="H 0 0 0; H 0 0 1.5; H 0 0 3.0; H 0 0 4.5",
+                    basis="sto3g", verbose=0, output="/dev/null")
+        mf = scf.RHF(mol).run(conv_tol=1e-12)
+
+        # FCI singlet S1 reference
+        mc_s1 = mcpdft.CASCI(mf, "tPBE", 4, 4)
+        mc_s1.fix_spin_(ss=0.0)
+        mc_s1 = mc_s1.state_specific_(1)
+        mc_s1.kernel()
+        e_s1 = mc_s1.e_tot
+        mc_s0 = mcpdft.CASCI(mf, "tPBE", 4, 4)
+        mc_s0.fix_spin_(ss=0.0)
+        mc_s0 = mc_s0.state_specific_(0)
+        mc_s0.kernel()
+        e_s0 = mc_s0.e_tot
+
+        e_dmrg = []
+        for state in (0, 1):
+            mc = mcpdft.CASCI(mf, "tPBE", 4, 4)
+            solver = dmrgscf.DMRGCI(mol, maxM=100, tol=1e-6)
+            solver.memory = 8
+            solver.threads = 2
+            mc.fcisolver = solver
+            mc = mc.state_specific_(state)
+            mc.kernel()
+            with self.subTest(part="DMRG", state=state):
+                self.assertFalse(isinstance(mc.e_tot, (list, tuple)))
+            e_dmrg.append(mc.e_tot)
+
+        with self.subTest(part="DMRG state selection"):
+            # Without the fix, state_specific_(1) silently returns the
+            # ground-state energy (DMRG state index 0).
+            self.assertNotAlmostEqual(e_dmrg[0], e_dmrg[1], places=2)
+            self.assertAlmostEqual(e_dmrg[0], e_s0, delta=2e-3)
+            self.assertAlmostEqual(e_dmrg[1], e_s1, delta=2e-3)
+
 
 
 

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -801,6 +801,23 @@ class KnownValues(unittest.TestCase):
                 self.assertFalse(isinstance(mc.e_tot, (list, tuple)))
                 self.assertAlmostEqual(mc.e_tot, e_ref[state], delta=1e-9)
 
+    def test_state_specific_casscf(self):
+        # GH#3414: state-specific CASSCF-PDFT must equal the state-averaged
+        # PDFT energy with the weight concentrated on that one state.
+        mol = gto.M(atom="H 0 0 0; H 0 0 1.5; H 0 0 3.0; H 0 0 4.5",
+                    basis="sto3g", verbose=0, output="/dev/null")
+        mf = scf.RHF(mol).run(conv_tol=1e-12)
+
+        mc_ss = mcpdft.CASSCF(mf, "tPBE", 4, 4).state_specific_(1)
+        mc_ss.conv_tol = 1e-8
+        mc_ss.kernel()
+        mc_sa = mcpdft.CASSCF(mf, "tPBE", 4, 4).state_average_((0.0, 1.0))
+        mc_sa.conv_tol = 1e-8
+        mc_sa.kernel()
+
+        self.assertFalse(isinstance(mc_ss.e_tot, (list, tuple)))
+        self.assertAlmostEqual(mc_ss.e_tot, mc_sa.e_states[1], delta=1e-8)
+
     @unittest.skipUnless(_HAS_DMRG, "dmrgscf / block2 not available")
     def test_state_specific_dmrg(self):
         # GH#3414: for a state-specific DMRG, mc.ci is a state index (int).

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -31,8 +31,6 @@
 # trying to test the API here; we need tight convergence and grids
 # to reproduce well when OMP is on.
 import h5py
-import os
-import shutil
 import numpy as np
 from pyscf import gto, scf, mcscf, lib, fci, dft
 from pyscf import mcpdft
@@ -40,11 +38,9 @@ import unittest
 
 try:
     from pyscf import dmrgscf
-    from pyscf.dmrgscf import dmrgci, settings as dmrg_settings
+    from pyscf.dmrgscf import settings as dmrg_settings
     _BLOCKEXE = dmrg_settings.BLOCKEXE
-    _HAS_DMRG = _BLOCKEXE is not None and (
-        os.path.isfile(_BLOCKEXE) or
-        (os.path.sep not in _BLOCKEXE and shutil.which(_BLOCKEXE) is not None))
+    _HAS_DMRG = _BLOCKEXE is not None
 except Exception:
     _HAS_DMRG = False
 
@@ -782,7 +778,7 @@ class KnownValues(unittest.TestCase):
         e_ref = -0.74702903
         self.assertAlmostEqual (mc.e_tot, e_ref, 6)
 
-    def test_state_specific(self):
+    def test_state_specific_casci(self):
         # GH#3414: mc.state_specific_(n) must yield a scalar e_tot equal to
         # the n-th root of a plain multi-root CASCI-PDFT calculation.
         mol = gto.M(atom="H 0 0 0; H 0 0 1.5; H 0 0 3.0; H 0 0 4.5",

--- a/pyscf/mcpdft/test/test_mcpdft.py
+++ b/pyscf/mcpdft/test/test_mcpdft.py
@@ -779,7 +779,7 @@ class KnownValues(unittest.TestCase):
         self.assertAlmostEqual (mc.e_tot, e_ref, 6)
 
     def test_state_specific_casci(self):
-        # GH#3414: mc.state_specific_(n) must yield a scalar e_tot equal to
+        # issue #3414: mc.state_specific_(n) must yield a scalar e_tot equal to
         # the n-th root of a plain multi-root CASCI-PDFT calculation.
         mol = gto.M(atom="H 0 0 0; H 0 0 1.5; H 0 0 3.0; H 0 0 4.5",
                     basis="sto3g", verbose=0, output="/dev/null")
@@ -798,7 +798,7 @@ class KnownValues(unittest.TestCase):
                 self.assertAlmostEqual(mc.e_tot, e_ref[state], delta=1e-9)
 
     def test_state_specific_casscf(self):
-        # GH#3414: state-specific CASSCF-PDFT must equal the state-averaged
+        # issue #3414: state-specific CASSCF-PDFT must equal the state-averaged
         # PDFT energy with the weight concentrated on that one state.
         mol = gto.M(atom="H 0 0 0; H 0 0 1.5; H 0 0 3.0; H 0 0 4.5",
                     basis="sto3g", verbose=0, output="/dev/null")
@@ -816,7 +816,7 @@ class KnownValues(unittest.TestCase):
 
     @unittest.skipUnless(_HAS_DMRG, "dmrgscf / block2 not available")
     def test_state_specific_dmrg(self):
-        # GH#3414: for a state-specific DMRG, mc.ci is a state index (int).
+        # issue #3414: for a state-specific DMRG, mc.ci is a state index (int).
         # The DMRG RDM of the *target* state must be used, not the ground state.
         mol = gto.M(atom="H 0 0 0; H 0 0 1.5; H 0 0 3.0; H 0 0 4.5",
                     basis="sto3g", verbose=0, output="/dev/null")


### PR DESCRIPTION
Fix #3414. pr #3419 does not actually fix it and has no update, so I decide to fix it myself.

Fix state-specific PDFT on (DMRG-)CASSCF/CASCI wfn.